### PR TITLE
Consolidate DeepSeek/Qwen FP8 performance optimizations

### DIFF
--- a/csrc/musa/cache_kernels.mu
+++ b/csrc/musa/cache_kernels.mu
@@ -1,0 +1,198 @@
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+
+#include <cstdlib>
+
+#include "vec_utils.muh"
+
+namespace vllm_musa {
+
+template <typename T, int BLOCK_X, int TOKENS_PER_BLOCK>
+__global__ void __launch_bounds__(BLOCK_X, 1)
+    reshape_and_cache_flash_nhd_kernel(
+        const T* __restrict__ key, const T* __restrict__ value,
+        T* __restrict__ key_cache, T* __restrict__ value_cache,
+        const int64_t* __restrict__ slot_mapping, int num_tokens,
+        int vecs_per_token, int block_size, int64_t key_stride,
+        int64_t value_stride, int64_t block_stride, int64_t page_stride) {
+  constexpr int VEC_SIZE = 8;
+  const int base_token = blockIdx.x * TOKENS_PER_BLOCK;
+  const int total_vecs = TOKENS_PER_BLOCK * vecs_per_token;
+
+  for (int linear = threadIdx.x; linear < total_vecs; linear += BLOCK_X) {
+    const int local_token = linear / vecs_per_token;
+    const int token_idx = base_token + local_token;
+    if (token_idx >= num_tokens) {
+      continue;
+    }
+
+    const int64_t slot_idx = slot_mapping[token_idx];
+    if (slot_idx < 0) {
+      continue;
+    }
+
+    const int vec_idx = linear - local_token * vecs_per_token;
+    const int elem_offset = vec_idx * VEC_SIZE;
+    const int64_t block_idx = slot_idx / block_size;
+    const int64_t block_offset = slot_idx - block_idx * block_size;
+
+    const int64_t src_k = static_cast<int64_t>(token_idx) * key_stride +
+                          elem_offset;
+    const int64_t src_v = static_cast<int64_t>(token_idx) * value_stride +
+                          elem_offset;
+    const int64_t dst = block_idx * block_stride + block_offset * page_stride +
+                        elem_offset;
+
+    Vec16<T> key_vec = vload16_byp_slc(key + src_k);
+    Vec16<T> value_vec = vload16_byp_slc(value + src_v);
+    vstore16(key_cache + dst, key_vec);
+    vstore16(value_cache + dst, value_vec);
+  }
+}
+
+template <typename T>
+void dispatch_reshape_and_cache_flash_nhd(
+    const T* key, const T* value, T* key_cache, T* value_cache,
+    const int64_t* slot_mapping, int num_tokens, int num_heads, int head_size,
+    int block_size, int64_t key_stride, int64_t value_stride,
+    int64_t block_stride, int64_t page_stride, musaStream_t stream) {
+  constexpr int BLOCK_X = 512;
+  const int vecs_per_token = (num_heads * head_size) / 8;
+
+  static const int forced_tokens_per_block = []() {
+    const char* env = std::getenv("VLLM_MUSA_RESHAPE_CACHE_TOKENS_PER_BLOCK");
+    return env == nullptr ? 0 : std::atoi(env);
+  }();
+
+#define LAUNCH(TPB)                                                        \
+  reshape_and_cache_flash_nhd_kernel<T, BLOCK_X, TPB>                      \
+      <<<(num_tokens + TPB - 1) / TPB, BLOCK_X, 0, stream>>>(              \
+          key, value, key_cache, value_cache, slot_mapping, num_tokens,    \
+          vecs_per_token, block_size, key_stride, value_stride,            \
+          block_stride, page_stride)
+
+  if (forced_tokens_per_block == 1) {
+    LAUNCH(1);
+  } else if (forced_tokens_per_block == 2) {
+    LAUNCH(2);
+  } else if (forced_tokens_per_block == 4) {
+    LAUNCH(4);
+  } else if (forced_tokens_per_block == 8) {
+    LAUNCH(8);
+  } else if (vecs_per_token <= 64) {
+    LAUNCH(8);
+  } else if (vecs_per_token <= 128) {
+    LAUNCH(4);
+  } else if (vecs_per_token <= 256) {
+    LAUNCH(2);
+  } else {
+    LAUNCH(1);
+  }
+
+#undef LAUNCH
+}
+
+}  // namespace vllm_musa
+
+void musa_reshape_and_cache_flash_nhd(torch::Tensor& key, torch::Tensor& value,
+                                      torch::Tensor& key_cache,
+                                      torch::Tensor& value_cache,
+                                      torch::Tensor& slot_mapping) {
+  TORCH_CHECK(key.device().is_privateuseone(), "key must be a MUSA tensor");
+  TORCH_CHECK(value.device().is_privateuseone(), "value must be a MUSA tensor");
+  TORCH_CHECK(key_cache.device().is_privateuseone(),
+              "key_cache must be a MUSA tensor");
+  TORCH_CHECK(value_cache.device().is_privateuseone(),
+              "value_cache must be a MUSA tensor");
+  TORCH_CHECK(slot_mapping.device().is_privateuseone(),
+              "slot_mapping must be a MUSA tensor");
+  TORCH_CHECK(key.dim() == 3, "key must be [tokens, heads, head_size]");
+  TORCH_CHECK(value.dim() == 3, "value must be [tokens, heads, head_size]");
+  TORCH_CHECK(key_cache.dim() == 4,
+              "key_cache must be [blocks, block_size, heads, head_size]");
+  TORCH_CHECK(value_cache.dim() == 4,
+              "value_cache must be [blocks, block_size, heads, head_size]");
+  TORCH_CHECK(slot_mapping.dim() == 1, "slot_mapping must be 1-D");
+  TORCH_CHECK(key.scalar_type() == value.scalar_type(),
+              "key/value dtype mismatch");
+  TORCH_CHECK(key.scalar_type() == key_cache.scalar_type(),
+              "key/key_cache dtype mismatch");
+  TORCH_CHECK(value.scalar_type() == value_cache.scalar_type(),
+              "value/value_cache dtype mismatch");
+  TORCH_CHECK(slot_mapping.scalar_type() == at::ScalarType::Long,
+              "slot_mapping must be int64");
+  TORCH_CHECK(key.stride(2) == 1 && key.stride(1) == key.size(2),
+              "key head/head_size dimensions must be contiguous");
+  TORCH_CHECK(value.stride(2) == 1 && value.stride(1) == value.size(2),
+              "value head/head_size dimensions must be contiguous");
+  TORCH_CHECK(key_cache.size(0) == value_cache.size(0),
+              "key/value cache block count mismatch");
+  TORCH_CHECK(key_cache.size(1) == value_cache.size(1),
+              "key/value cache block size mismatch");
+  TORCH_CHECK(key_cache.size(2) == value_cache.size(2),
+              "key/value cache head count mismatch");
+  TORCH_CHECK(key_cache.size(3) == value_cache.size(3),
+              "key/value cache head size mismatch");
+  TORCH_CHECK(key.size(1) == key_cache.size(2), "head count mismatch");
+  TORCH_CHECK(value.size(1) == value_cache.size(2), "value head count mismatch");
+  TORCH_CHECK(key.size(2) == key_cache.size(3), "head size mismatch");
+  TORCH_CHECK(value.size(2) == value_cache.size(3), "value head size mismatch");
+  TORCH_CHECK(slot_mapping.size(0) <= key.size(0),
+              "slot_mapping longer than key rows");
+  TORCH_CHECK(slot_mapping.size(0) <= value.size(0),
+              "slot_mapping longer than value rows");
+  TORCH_CHECK(key.size(2) % 8 == 0, "head_size must be a multiple of 8");
+  TORCH_CHECK(key_cache.stride(3) == 1 && value_cache.stride(3) == 1,
+              "cache head dimension must be contiguous");
+  TORCH_CHECK(key_cache.stride(2) == key_cache.size(3),
+              "key_cache must use NHD layout");
+  TORCH_CHECK(value_cache.stride(2) == value_cache.size(3),
+              "value_cache must use NHD layout");
+  TORCH_CHECK(key_cache.stride(1) == key_cache.size(2) * key_cache.size(3),
+              "key_cache page stride must be contiguous NHD");
+  TORCH_CHECK(value_cache.stride(1) ==
+                  value_cache.size(2) * value_cache.size(3),
+              "value_cache page stride must be contiguous NHD");
+
+  const c10::musa::OptionalMUSAGuard guard(device_of(key));
+  musaStream_t stream = c10::musa::getCurrentMUSAStream().stream();
+  const int num_tokens = static_cast<int>(slot_mapping.size(0));
+  const int num_heads = static_cast<int>(key.size(1));
+  const int head_size = static_cast<int>(key.size(2));
+  const int block_size = static_cast<int>(key_cache.size(1));
+  const int64_t key_stride = key.stride(0);
+  const int64_t value_stride = value.stride(0);
+  const int64_t block_stride = key_cache.stride(0);
+  const int64_t page_stride = key_cache.stride(1);
+
+  if (num_tokens == 0) {
+    return;
+  }
+
+  if (key.scalar_type() == at::ScalarType::Half) {
+    vllm_musa::dispatch_reshape_and_cache_flash_nhd<__half>(
+        static_cast<const __half*>(key.data_ptr()),
+        static_cast<const __half*>(value.data_ptr()),
+        static_cast<__half*>(key_cache.data_ptr()),
+        static_cast<__half*>(value_cache.data_ptr()),
+        slot_mapping.data_ptr<int64_t>(), num_tokens, num_heads, head_size,
+        block_size, key_stride, value_stride, block_stride, page_stride,
+        stream);
+  } else if (key.scalar_type() == at::ScalarType::BFloat16) {
+    vllm_musa::dispatch_reshape_and_cache_flash_nhd<__mt_bfloat16>(
+        static_cast<const __mt_bfloat16*>(key.data_ptr()),
+        static_cast<const __mt_bfloat16*>(value.data_ptr()),
+        static_cast<__mt_bfloat16*>(key_cache.data_ptr()),
+        static_cast<__mt_bfloat16*>(value_cache.data_ptr()),
+        slot_mapping.data_ptr<int64_t>(), num_tokens, num_heads, head_size,
+        block_size, key_stride, value_stride, block_stride, page_stride,
+        stream);
+  } else {
+    TORCH_CHECK(false, "only fp16 and bf16 are supported");
+  }
+}

--- a/csrc/musa/fused_add_rmsnorm.mu
+++ b/csrc/musa/fused_add_rmsnorm.mu
@@ -1,0 +1,237 @@
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+#include <musa_runtime.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+
+#include <cstdlib>
+
+#include "vec_utils.muh"
+
+extern "C" {
+extern __device__ void __musa_memcpy_g2s(
+    __attribute__((address_space(3))) void* dst,
+    __attribute__((address_space(1))) const void* src, int size, int prefetch);
+extern __device__ void __musa_memcpy_g2s_wait();
+}
+
+namespace vllm_musa {
+
+template <int BLOCK_X>
+__device__ __forceinline__ float block_reduce_sum(float value) {
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_xor_sync(0xffffffff, value, offset);
+  }
+  if constexpr (BLOCK_X <= 32) {
+    return value;
+  }
+
+  __shared__ float shared[BLOCK_X / 32];
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  if (lane == 0) {
+    shared[warp] = value;
+  }
+  __syncthreads();
+
+  value = threadIdx.x < (BLOCK_X / 32) ? shared[threadIdx.x] : 0.0f;
+  if (warp == 0) {
+    for (int offset = (BLOCK_X / 32) >> 1; offset > 0; offset >>= 1) {
+      value += __shfl_xor_sync(0xffffffff, value, offset);
+    }
+    if (threadIdx.x == 0) {
+      shared[0] = value;
+    }
+  }
+  __syncthreads();
+  return shared[0];
+}
+
+template <typename T, int BLOCK_X, int CHUNK>
+__global__ void __launch_bounds__(BLOCK_X, 1) fused_add_rmsnorm_kernel(
+    T* __restrict__ input, T* __restrict__ residual,
+    const T* __restrict__ weight, int hidden_size, int vec_hidden_size,
+    float epsilon) {
+  constexpr int VEC_SIZE = 8;
+  const int row = blockIdx.x;
+  const int tid = threadIdx.x;
+  T* input_row = input + static_cast<size_t>(row) * hidden_size;
+  T* residual_row = residual + static_cast<size_t>(row) * hidden_size;
+
+  __shared__ T shared_weight[CHUNK * BLOCK_X * VEC_SIZE];
+
+#pragma unroll
+  for (int chunk = 0; chunk < CHUNK; ++chunk) {
+    const int vec_idx = chunk * BLOCK_X + tid;
+    if (vec_idx < vec_hidden_size) {
+      __attribute__((address_space(3))) void* smem_ptr =
+          (__attribute__((address_space(3))) void*)(
+              shared_weight + vec_idx * VEC_SIZE);
+      __attribute__((address_space(1))) const void* gmem_ptr =
+          (__attribute__((address_space(1))) const void*)(
+              weight + vec_idx * VEC_SIZE);
+      __musa_memcpy_g2s(smem_ptr, gmem_ptr, 16, 128);
+    }
+  }
+
+  Vec16<T> fused_local[CHUNK];
+  float variance = 0.0f;
+#pragma unroll
+  for (int chunk = 0; chunk < CHUNK; ++chunk) {
+    const int vec_idx = chunk * BLOCK_X + tid;
+    if (vec_idx < vec_hidden_size) {
+      Vec16<T> input_vec = vload16_byp_slc(input_row + vec_idx * VEC_SIZE);
+      Vec16<T> residual_vec =
+          vload16_byp_slc(residual_row + vec_idx * VEC_SIZE);
+      Vec16<T> sum_vec;
+#pragma unroll
+      for (int i = 0; i < VEC_SIZE; ++i) {
+        const float value =
+            static_cast<float>(input_vec.x[i]) + static_cast<float>(residual_vec.x[i]);
+        sum_vec.x[i] = static_cast<T>(value);
+        variance += value * value;
+      }
+      fused_local[chunk] = sum_vec;
+      vstore16(residual_row + vec_idx * VEC_SIZE, sum_vec);
+    }
+  }
+
+  const float total = block_reduce_sum<BLOCK_X>(variance);
+  const float inv_rms = rsqrtf(total / static_cast<float>(hidden_size) + epsilon);
+
+  __musa_memcpy_g2s_wait();
+  __syncthreads();
+
+#pragma unroll
+  for (int chunk = 0; chunk < CHUNK; ++chunk) {
+    const int vec_idx = chunk * BLOCK_X + tid;
+    if (vec_idx < vec_hidden_size) {
+      Vec16<T> weight_vec =
+          *reinterpret_cast<Vec16<T>*>(shared_weight + vec_idx * VEC_SIZE);
+      Vec16<T> out_vec;
+#pragma unroll
+      for (int i = 0; i < VEC_SIZE; ++i) {
+        out_vec.x[i] = static_cast<T>(static_cast<float>(fused_local[chunk].x[i]) *
+                                      inv_rms *
+                                      static_cast<float>(weight_vec.x[i]));
+      }
+      vstore16(input_row + vec_idx * VEC_SIZE, out_vec);
+    }
+  }
+}
+
+template <typename T>
+void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
+                                int rows, int hidden_size, float epsilon,
+                                musaStream_t stream) {
+  const int vec_hidden_size = hidden_size / 8;
+
+  static const int forced_block = []() {
+    const char* env = std::getenv("VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X");
+    return env == nullptr ? 0 : std::atoi(env);
+  }();
+
+  int block_x;
+  if (forced_block > 0) {
+    block_x = forced_block;
+  } else if (rows >= 512 && vec_hidden_size <= 640) {
+    block_x = 128;
+  } else if (rows >= 256) {
+    block_x = 256;
+  } else if (rows >= 128 && vec_hidden_size >= 896) {
+    block_x = 512;
+  } else if (rows >= 128) {
+    block_x = 256;
+  } else if (rows >= 8 && vec_hidden_size >= 1280) {
+    block_x = 512;
+  } else {
+    block_x = 1024;
+  }
+
+#define LAUNCH(BLOCK, CHUNK)                                                \
+  fused_add_rmsnorm_kernel<T, BLOCK, CHUNK>                                 \
+      <<<rows, BLOCK, 0, stream>>>(input, residual, weight, hidden_size,     \
+                                   vec_hidden_size, epsilon)
+
+  if (block_x == 128) {
+    if (vec_hidden_size <= 128) LAUNCH(128, 1);
+    else if (vec_hidden_size <= 256) LAUNCH(128, 2);
+    else if (vec_hidden_size <= 384) LAUNCH(128, 3);
+    else if (vec_hidden_size <= 512) LAUNCH(128, 4);
+    else if (vec_hidden_size <= 640) LAUNCH(128, 5);
+    else if (vec_hidden_size <= 768) LAUNCH(128, 6);
+    else if (vec_hidden_size <= 896) LAUNCH(128, 7);
+    else if (vec_hidden_size <= 1024) LAUNCH(128, 8);
+    else if (vec_hidden_size <= 1536) LAUNCH(128, 12);
+    else TORCH_CHECK(false, "BLOCK=128 hidden_size too large");
+  } else if (block_x == 256) {
+    if (vec_hidden_size <= 256) LAUNCH(256, 1);
+    else if (vec_hidden_size <= 512) LAUNCH(256, 2);
+    else if (vec_hidden_size <= 768) LAUNCH(256, 3);
+    else if (vec_hidden_size <= 1024) LAUNCH(256, 4);
+    else if (vec_hidden_size <= 1536) LAUNCH(256, 6);
+    else if (vec_hidden_size <= 2048) LAUNCH(256, 8);
+    else TORCH_CHECK(false, "BLOCK=256 hidden_size too large");
+  } else if (block_x == 512) {
+    if (vec_hidden_size <= 512) LAUNCH(512, 1);
+    else if (vec_hidden_size <= 1024) LAUNCH(512, 2);
+    else if (vec_hidden_size <= 1536) LAUNCH(512, 3);
+    else if (vec_hidden_size <= 2048) LAUNCH(512, 4);
+    else TORCH_CHECK(false, "BLOCK=512 hidden_size too large");
+  } else {
+    if (vec_hidden_size <= 1024) LAUNCH(1024, 1);
+    else if (vec_hidden_size <= 2048) LAUNCH(1024, 2);
+    else TORCH_CHECK(false, "BLOCK=1024 hidden_size too large");
+  }
+
+#undef LAUNCH
+}
+
+}  // namespace vllm_musa
+
+void musa_fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
+                             torch::Tensor& weight, double epsilon) {
+  TORCH_CHECK(input.device().is_privateuseone(), "input must be a MUSA tensor");
+  TORCH_CHECK(residual.device().is_privateuseone(),
+              "residual must be a MUSA tensor");
+  TORCH_CHECK(weight.device().is_privateuseone(), "weight must be a MUSA tensor");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  TORCH_CHECK(residual.is_contiguous(), "residual must be contiguous");
+  TORCH_CHECK(weight.is_contiguous(), "weight must be contiguous");
+  TORCH_CHECK(input.dim() == 2, "input must be 2-D");
+  TORCH_CHECK(residual.dim() == 2, "residual must be 2-D");
+  TORCH_CHECK(weight.dim() == 1, "weight must be 1-D");
+  TORCH_CHECK(input.sizes() == residual.sizes(), "input/residual shape mismatch");
+  TORCH_CHECK(input.size(1) == weight.size(0), "weight size mismatch");
+  TORCH_CHECK(input.scalar_type() == residual.scalar_type(),
+              "input/residual dtype mismatch");
+  TORCH_CHECK(input.scalar_type() == weight.scalar_type(),
+              "input/weight dtype mismatch");
+  TORCH_CHECK(input.size(1) % 8 == 0,
+              "hidden_size must be a multiple of 8");
+  TORCH_CHECK(input.size(1) <= 16384,
+              "hidden_size must be <= 16384");
+
+  const c10::musa::OptionalMUSAGuard guard(device_of(input));
+  musaStream_t stream = c10::musa::getCurrentMUSAStream().stream();
+  const int rows = static_cast<int>(input.size(0));
+  const int hidden_size = static_cast<int>(input.size(1));
+
+  if (input.scalar_type() == at::ScalarType::Half) {
+    vllm_musa::dispatch_fused_add_rmsnorm<__half>(
+        static_cast<__half*>(input.data_ptr()),
+        static_cast<__half*>(residual.data_ptr()),
+        static_cast<const __half*>(weight.data_ptr()), rows, hidden_size,
+        static_cast<float>(epsilon), stream);
+  } else if (input.scalar_type() == at::ScalarType::BFloat16) {
+    vllm_musa::dispatch_fused_add_rmsnorm<__mt_bfloat16>(
+        static_cast<__mt_bfloat16*>(input.data_ptr()),
+        static_cast<__mt_bfloat16*>(residual.data_ptr()),
+        static_cast<const __mt_bfloat16*>(weight.data_ptr()), rows, hidden_size,
+        static_cast<float>(epsilon), stream);
+  } else {
+    TORCH_CHECK(false, "only fp16 and bf16 are supported");
+  }
+}

--- a/csrc/musa/fused_add_rmsnorm.mu
+++ b/csrc/musa/fused_add_rmsnorm.mu
@@ -135,6 +135,10 @@ void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
 
   int block_x;
   if (forced_block > 0) {
+    TORCH_CHECK(forced_block == 128 || forced_block == 256 ||
+                    forced_block == 512 || forced_block == 1024,
+                "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X must be one of "
+                "128, 256, 512, or 1024");
     block_x = forced_block;
   } else if (rows >= 512 && vec_hidden_size <= 640) {
     block_x = 128;

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -516,6 +516,8 @@ struct BlockConfig {
 };
 
 constexpr const char* kGemvMoeBlockEnv = "VLLM_MUSA_GEMV_MOE_BLOCK";
+constexpr const char* kDeepSeekFp8W1BlockEnv =
+    "VLLM_MUSA_DEEPSEEK_FP8_W1_32X4";
 
 bool ParseForcedBlockConfig(BlockConfig* config) {
     const char* value = std::getenv(kGemvMoeBlockEnv);
@@ -540,6 +542,11 @@ bool IsForcedBlockConfigValid(const BlockConfig& config, int nr_n, int hidden_si
            (hidden_size % (config.block_k * vlen) == 0);
 }
 
+bool IsDeepSeekFp8W1BlockEnabled() {
+    const char* value = std::getenv(kDeepSeekFp8W1BlockEnv);
+    return value == nullptr || value[0] != '0';
+}
+
 bool ShouldUseQwenFp8Moe32x4(
     int current_arch,
     bool is_fp8,
@@ -556,6 +563,30 @@ bool ShouldUseQwenFp8Moe32x4(
     const bool qwen_w2_project = !use_swigelu && hidden_size == 768 && nr_n == 2048;
     const BlockConfig config{32, 4, 0.f, true};
     return (qwen_w1_swiglu || qwen_w2_project) &&
+           IsForcedBlockConfigValid(config, nr_n, hidden_size, vlen);
+}
+
+bool ShouldUseDeepSeekFp8W1Moe32x4(
+    bool is_fp8,
+    bool use_swigelu,
+    bool use_int4_w4a16,
+    int64_t topk,
+    int hidden_size,
+    int reduce_size,
+    int num_experts,
+    int scale_k_group_tile,
+    int nr_n,
+    int vlen) {
+    const BlockConfig config{32, 4, 0.f, true};
+    return IsDeepSeekFp8W1BlockEnabled() &&
+           is_fp8 &&
+           use_swigelu &&
+           !use_int4_w4a16 &&
+           topk == 6 &&
+           hidden_size == 2048 &&
+           reduce_size == 2816 &&
+           num_experts == 64 &&
+           scale_k_group_tile == 128 &&
            IsForcedBlockConfigValid(config, nr_n, hidden_size, vlen);
 }
 
@@ -841,6 +872,7 @@ void musa_fused_gemv_moe(
     }
     BlockConfig forced_config{0, 0, 0.f, false};
     BlockConfig qwen_fp8_moe_config{32, 4, 0.f, true};
+    BlockConfig deepseek_fp8_w1_config{32, 4, 0.f, true};
     BlockConfig* best_config = &fallback_config;
     if (ParseForcedBlockConfig(&forced_config)) {
         TORCH_CHECK(
@@ -858,6 +890,18 @@ void musa_fused_gemv_moe(
                    scale_k_group_tile,
                    vlen)) {
         best_config = &qwen_fp8_moe_config;
+    } else if (ShouldUseDeepSeekFp8W1Moe32x4(
+                   is_fp8,
+                   use_swigelu,
+                   use_int4_w4a16,
+                   topk,
+                   hidden_size,
+                   reduce_size,
+                   num_experts,
+                   scale_k_group_tile,
+                   nr_n,
+                   vlen)) {
+        best_config = &deepseek_fp8_w1_config;
     } else {
         for (auto& config : configs) {
             if (config.valid && config.score > best_config->score) {

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -1,5 +1,7 @@
 #include <musa_runtime.h>
 #include <cassert>
+#include <cstdio>
+#include <cstdlib>
 #include <mutex>
 #include <musa_bf16.h>
 #include <musa_fp16.h>
@@ -513,6 +515,50 @@ struct BlockConfig {
     bool valid;
 };
 
+constexpr const char* kGemvMoeBlockEnv = "VLLM_MUSA_GEMV_MOE_BLOCK";
+
+bool ParseForcedBlockConfig(BlockConfig* config) {
+    const char* value = std::getenv(kGemvMoeBlockEnv);
+    if (value == nullptr || value[0] == '\0') {
+        return false;
+    }
+
+    int block_n = 0;
+    int block_k = 0;
+    if (std::sscanf(value, "%dx%d", &block_n, &block_k) != 2) {
+        TORCH_CHECK(false, kGemvMoeBlockEnv, " must use '<block_n>x<block_k>', got ", value);
+    }
+    TORCH_CHECK(block_n > 0 && block_k > 0, kGemvMoeBlockEnv, " must use positive block sizes, got ", value);
+    TORCH_CHECK(block_n * block_k <= 512, kGemvMoeBlockEnv, " block_n * block_k must be <= 512, got ", value);
+
+    *config = BlockConfig{block_n, block_k, 0.f, true};
+    return true;
+}
+
+bool IsForcedBlockConfigValid(const BlockConfig& config, int nr_n, int hidden_size, int vlen) {
+    return (nr_n % config.block_n == 0) &&
+           (hidden_size % (config.block_k * vlen) == 0);
+}
+
+bool ShouldUseQwenFp8Moe32x4(
+    int current_arch,
+    bool is_fp8,
+    bool use_swigelu,
+    int nr_n,
+    int hidden_size,
+    int scale_k_group_tile,
+    int vlen) {
+    if (current_arch < 300 || !is_fp8 || scale_k_group_tile != 128) {
+        return false;
+    }
+
+    const bool qwen_w1_swiglu = use_swigelu && hidden_size == 2048 && nr_n == 768;
+    const bool qwen_w2_project = !use_swigelu && hidden_size == 768 && nr_n == 2048;
+    const BlockConfig config{32, 4, 0.f, true};
+    return (qwen_w1_swiglu || qwen_w2_project) &&
+           IsForcedBlockConfigValid(config, nr_n, hidden_size, vlen);
+}
+
 void musa_fused_gemv(
     torch::Tensor &A,
     torch::Tensor &B,
@@ -622,13 +668,24 @@ void musa_fused_gemv(
         }
     }
 
-    BlockConfig* best_config = new BlockConfig{32, 1, -1.0f, false};
+    BlockConfig fallback_config{32, 1, -1.0f, false};
     if (current_arch < 300) {
-        best_config = new BlockConfig{128, 1, -1.0f, false};
+        fallback_config = BlockConfig{128, 1, -1.0f, false};
     }
-    for (auto& config : configs) {
-        if (config.valid && config.score > best_config->score) {
-            best_config = &config;
+    BlockConfig forced_config{0, 0, 0.f, false};
+    BlockConfig* best_config = &fallback_config;
+    if (ParseForcedBlockConfig(&forced_config)) {
+        TORCH_CHECK(
+            IsForcedBlockConfigValid(forced_config, nr_n, hidden_size, vlen),
+            kGemvMoeBlockEnv, "=", forced_config.block_n, "x",
+            forced_config.block_k, " is invalid for nr_n=", nr_n,
+            ", hidden_size=", hidden_size, ", vlen=", vlen);
+        best_config = &forced_config;
+    } else {
+        for (auto& config : configs) {
+            if (config.valid && config.score > best_config->score) {
+                best_config = &config;
+            }
         }
     }
 
@@ -642,18 +699,21 @@ void musa_fused_gemv(
         case 8:
             switch (best_config->block_k) {
                 case 16: GEN_LAUNCH_KERN_GEMV(8, 16); break;
+                case 32: GEN_LAUNCH_KERN_GEMV(8, 32); break;
                 default: TORCH_CHECK(false, "Unsupported block_k for block_n=8");
             }
             break;
         case 16:
             switch (best_config->block_k) {
                 case 8: GEN_LAUNCH_KERN_GEMV(16, 8); break;
+                case 16: GEN_LAUNCH_KERN_GEMV(16, 16); break;
                 default: TORCH_CHECK(false, "Unsupported block_k for block_n=16");
             }
             break;
         case 32:
             switch (best_config->block_k) {
                 case 4: GEN_LAUNCH_KERN_GEMV(32, 4); break;
+                case 8: GEN_LAUNCH_KERN_GEMV(32, 8); break;
                 case 1: GEN_LAUNCH_KERN_GEMV(32, 1); break;
                 default: TORCH_CHECK(false, "Unsupported block_k for block_n=32");
             }
@@ -775,14 +835,34 @@ void musa_fused_gemv_moe(
         }
     }
 
-    BlockConfig* best_config = new BlockConfig{32, 1, -1.0f, false};
+    BlockConfig fallback_config{32, 1, -1.0f, false};
     if (current_arch < 300) {
-        best_config = new BlockConfig{128, 1, -1.0f, false};
+        fallback_config = BlockConfig{128, 1, -1.0f, false};
     }
-
-    for (auto& config : configs) {
-        if (config.valid && config.score > best_config->score) {
-            best_config = &config;
+    BlockConfig forced_config{0, 0, 0.f, false};
+    BlockConfig qwen_fp8_moe_config{32, 4, 0.f, true};
+    BlockConfig* best_config = &fallback_config;
+    if (ParseForcedBlockConfig(&forced_config)) {
+        TORCH_CHECK(
+            IsForcedBlockConfigValid(forced_config, nr_n, hidden_size, vlen),
+            kGemvMoeBlockEnv, "=", forced_config.block_n, "x",
+            forced_config.block_k, " is invalid for nr_n=", nr_n,
+            ", hidden_size=", hidden_size, ", vlen=", vlen);
+        best_config = &forced_config;
+    } else if (ShouldUseQwenFp8Moe32x4(
+                   current_arch,
+                   is_fp8,
+                   use_swigelu,
+                   nr_n,
+                   hidden_size,
+                   scale_k_group_tile,
+                   vlen)) {
+        best_config = &qwen_fp8_moe_config;
+    } else {
+        for (auto& config : configs) {
+            if (config.valid && config.score > best_config->score) {
+                best_config = &config;
+            }
         }
     }
 
@@ -796,18 +876,21 @@ void musa_fused_gemv_moe(
         case 8:
             switch (best_config->block_k) {
                 case 16: GEN_LAUNCH_KERN(8, 16); break;
+                case 32: GEN_LAUNCH_KERN(8, 32); break;
                 default: TORCH_CHECK(false, "Unsupported block_k for block_n=8");
             }
             break;
         case 16:
             switch (best_config->block_k) {
                 case 8: GEN_LAUNCH_KERN(16, 8); break;
+                case 16: GEN_LAUNCH_KERN(16, 16); break;
                 default: TORCH_CHECK(false, "Unsupported block_k for block_n=16");
             }
             break;
         case 32:
             switch (best_config->block_k) {
                 case 4: GEN_LAUNCH_KERN(32, 4); break;
+                case 8: GEN_LAUNCH_KERN(32, 8); break;
                 case 1: GEN_LAUNCH_KERN(32, 1); break;
                 default: TORCH_CHECK(false, "Unsupported block_k for block_n=32");
             }

--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -30,6 +30,19 @@ void musa_fused_gemv(
     const c10::optional<torch::Tensor> &gamma,
     double eps);
 
+void musa_fused_add_rms_norm(
+    torch::Tensor &input,
+    torch::Tensor &residual,
+    torch::Tensor &weight,
+    double eps);
+
+void musa_reshape_and_cache_flash_nhd(
+    torch::Tensor &key,
+    torch::Tensor &value,
+    torch::Tensor &key_cache,
+    torch::Tensor &value_cache,
+    torch::Tensor &slot_mapping);
+
 void per_token_group_quant_fp8(
     const torch::Tensor& input,
     torch::Tensor& output_q, torch::Tensor& output_s,
@@ -37,3 +50,9 @@ void per_token_group_quant_fp8(
     double fp8_max, bool scale_ue8m0,
     bool dummy_is_scale_transposed = false,
     bool dummy_is_tma_aligned = false);
+
+void silu_and_mul_per_token_group_fp8_quant(
+    const torch::Tensor& input,
+    torch::Tensor& output_q, torch::Tensor& output_s,
+    int64_t group_size, double eps, double fp8_min,
+    double fp8_max);

--- a/csrc/musa/quantization/per_token_group_quant.cu
+++ b/csrc/musa/quantization/per_token_group_quant.cu
@@ -154,6 +154,124 @@ inline int GetGroupsPerBlock(int64_t num_groups) {
   return 1;
 }
 
+template <typename T, typename DST_DTYPE, int GROUP_SIZE>
+__global__ void silu_and_mul_per_token_group_fp8_quant_kernel(
+    const T* __restrict__ input, void* __restrict__ output_q,
+    float* __restrict__ output_s, const int hidden, const int num_groups,
+    const int groups_per_block, const float eps, const float min_8bit,
+    const float max_8bit) {
+  constexpr int THREADS_PER_GROUP = 16;
+  constexpr int ELEMS_PER_THREAD = GROUP_SIZE / THREADS_PER_GROUP;
+
+  const int local_group_id = threadIdx.x / THREADS_PER_GROUP;
+  const int lane_id = threadIdx.x % THREADS_PER_GROUP;
+  const int global_group_id = blockIdx.x * groups_per_block + local_group_id;
+  if (global_group_id >= num_groups) {
+    return;
+  }
+
+  const int groups_per_row = hidden / GROUP_SIZE;
+  const int row = global_group_id / groups_per_row;
+  const int group = global_group_id - row * groups_per_row;
+  const int input_stride = hidden * 2;
+  const int64_t input_base =
+      static_cast<int64_t>(row) * input_stride + group * GROUP_SIZE;
+  const int64_t output_base =
+      static_cast<int64_t>(row) * hidden + group * GROUP_SIZE;
+
+  float values[ELEMS_PER_THREAD];
+  float local_absmax = eps;
+
+#pragma unroll
+  for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+    const int col = lane_id * ELEMS_PER_THREAD + i;
+    const float gate = static_cast<float>(input[input_base + col]);
+    const float up = static_cast<float>(input[input_base + hidden + col]);
+    const float silu = gate / (1.0f + expf(-gate));
+    const T rounded = static_cast<T>(silu * up);
+    const float value = static_cast<float>(rounded);
+    values[i] = value;
+    local_absmax = fmaxf(local_absmax, fabsf(value));
+  }
+
+  const float group_absmax = GroupReduceMax(local_absmax);
+  const float scale = group_absmax / max_8bit;
+
+  if (lane_id == 0) {
+    output_s[global_group_id] = scale;
+  }
+
+  DST_DTYPE* out = static_cast<DST_DTYPE*>(output_q);
+#pragma unroll
+  for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+    const int col = lane_id * ELEMS_PER_THREAD + i;
+    float q = values[i] / scale;
+    q = fminf(fmaxf(q, min_8bit), max_8bit);
+    out[output_base + col] = DST_DTYPE(q);
+  }
+}
+
+void silu_and_mul_per_token_group_fp8_quant(
+    const torch::Tensor& input, torch::Tensor& output_q,
+    torch::Tensor& output_s, int64_t group_size, double eps, double fp8_min,
+    double fp8_max) {
+  TORCH_CHECK(input.is_contiguous());
+  TORCH_CHECK(output_q.is_contiguous());
+  TORCH_CHECK(output_s.is_contiguous());
+  TORCH_CHECK(input.dim() == 2);
+  TORCH_CHECK(output_q.dim() == 2);
+  TORCH_CHECK(output_s.dim() == 2);
+  TORCH_CHECK(group_size == 128,
+              "MUSA fused SiLU+FP8 quant currently supports group_size=128.");
+
+  const int64_t hidden2 = input.size(1);
+  TORCH_CHECK(hidden2 % 2 == 0, "input last dimension must be 2 * hidden.");
+  const int64_t hidden = hidden2 / 2;
+  TORCH_CHECK(hidden % group_size == 0,
+              "hidden must be divisible by group_size.");
+  TORCH_CHECK(output_q.size(0) == input.size(0) && output_q.size(1) == hidden);
+  TORCH_CHECK(output_s.size(0) == input.size(0) &&
+              output_s.size(1) == hidden / group_size);
+
+  const int64_t num_groups = input.size(0) * (hidden / group_size);
+  if (num_groups == 0) {
+    return;
+  }
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  constexpr int THREADS_PER_GROUP = 16;
+  const int groups_per_block = GetGroupsPerBlock(num_groups);
+  const int num_blocks = (num_groups + groups_per_block - 1) / groups_per_block;
+  const int num_threads = groups_per_block * THREADS_PER_GROUP;
+  auto dst_type = output_q.scalar_type();
+
+#define LAUNCH_SILU_QUANT_KERNEL(T, DST_DTYPE)                            \
+  do {                                                                    \
+    silu_and_mul_per_token_group_fp8_quant_kernel<T, DST_DTYPE, 128>      \
+        <<<num_blocks, num_threads, 0, stream>>>(                         \
+            static_cast<const T*>(input.data_ptr()), output_q.data_ptr(), \
+            static_cast<float*>(output_s.data_ptr()),                     \
+            static_cast<int>(hidden), static_cast<int>(num_groups),       \
+            groups_per_block, static_cast<float>(eps),                    \
+            static_cast<float>(fp8_min), static_cast<float>(fp8_max));    \
+  } while (0)
+
+  VLLM_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "silu_and_mul_per_token_group_fp8_quant", ([&] {
+        if (dst_type == at::ScalarType::Float8_e4m3fn) {
+          LAUNCH_SILU_QUANT_KERNEL(scalar_t, __nv_fp8_e4m3);
+        } else if (dst_type == at::ScalarType::Char) {
+          LAUNCH_SILU_QUANT_KERNEL(scalar_t, int8_t);
+        } else {
+          TORCH_CHECK(false,
+                      "silu_and_mul_per_token_group_fp8_quant only supports "
+                      "FP8/INT8 outputs.");
+        }
+      }));
+
+#undef LAUNCH_SILU_QUANT_KERNEL
+}
+
 void per_token_group_quant_8bit(const torch::Tensor& input,
                                 torch::Tensor& output_q,
                                 torch::Tensor& output_s, int64_t group_size,

--- a/csrc/musa/quantization/per_token_group_quant.cu
+++ b/csrc/musa/quantization/per_token_group_quant.cu
@@ -8,6 +8,8 @@
 
 #include <torch/all.h>
 
+#include <cstdlib>
+
 #include "vectorization.cuh"
 #include "vectorization_utils.cuh"
 #include "dispatch_utils.h"
@@ -152,6 +154,78 @@ inline int GetGroupsPerBlock(int64_t num_groups) {
     return 2;
   }
   return 1;
+}
+
+inline bool UseGroup128RegisterFastPath() {
+  const char* value = std::getenv("VLLM_MUSA_PTGQ128_REGISTER_FASTPATH");
+  if (value == nullptr) {
+    return true;
+  }
+  return value[0] != '0' && value[0] != 'f' && value[0] != 'F' &&
+         value[0] != 'n' && value[0] != 'N';
+}
+
+template <typename T, typename DST_DTYPE, bool IS_COLUMN_MAJOR = false,
+          bool SCALE_UE8M0 = false>
+__global__ void per_token_group_quant_128_register_kernel(
+    const T* __restrict__ input, void* __restrict__ output_q,
+    float* __restrict__ output_s, const int num_groups,
+    const int groups_per_block, const float eps, const float min_8bit,
+    const float max_8bit, const int scale_num_rows = 0,
+    const int scale_stride = 0) {
+  constexpr int GROUP_SIZE = 128;
+  constexpr int THREADS_PER_GROUP = 16;
+  constexpr int ELEMS_PER_THREAD = GROUP_SIZE / THREADS_PER_GROUP;
+
+  const int local_group_id = threadIdx.x / THREADS_PER_GROUP;
+  const int lane_id = threadIdx.x % THREADS_PER_GROUP;
+  const int global_group_id = blockIdx.x * groups_per_block + local_group_id;
+  if (global_group_id >= num_groups) {
+    return;
+  }
+
+  const int64_t block_group_offset =
+      static_cast<int64_t>(global_group_id) * GROUP_SIZE;
+  const T* group_input = input + block_group_offset;
+  DST_DTYPE* group_output =
+      static_cast<DST_DTYPE*>(output_q) + block_group_offset;
+
+  float values[ELEMS_PER_THREAD];
+  float local_absmax = eps;
+
+#pragma unroll
+  for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+    const int col = lane_id * ELEMS_PER_THREAD + i;
+    const float value = static_cast<float>(group_input[col]);
+    values[i] = value;
+    local_absmax = fmaxf(local_absmax, fabsf(value));
+  }
+
+  const float group_absmax = GroupReduceMax(local_absmax);
+  float y_s = group_absmax / max_8bit;
+  if constexpr (SCALE_UE8M0) {
+    y_s = exp2f(ceilf(log2f(fmaxf(fabsf(y_s), 1e-10f))));
+  }
+
+  if (lane_id == 0) {
+    float* scale_output;
+    if constexpr (IS_COLUMN_MAJOR) {
+      const int row_idx = global_group_id / scale_num_rows;
+      const int col_idx = global_group_id % scale_num_rows;
+      scale_output = output_s + col_idx * scale_stride + row_idx;
+    } else {
+      scale_output = output_s + global_group_id;
+    }
+    *scale_output = y_s;
+  }
+
+#pragma unroll
+  for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+    const int col = lane_id * ELEMS_PER_THREAD + i;
+    float q = values[i] / y_s;
+    q = fminf(fmaxf(q, min_8bit), max_8bit);
+    group_output[col] = DST_DTYPE(q);
+  }
 }
 
 template <typename T, typename DST_DTYPE, int GROUP_SIZE>
@@ -299,6 +373,49 @@ void per_token_group_quant_8bit(const torch::Tensor& input,
   const int scale_num_rows = output_s.size(1);
   const int scale_stride = output_s.stride(1);
 
+#define LAUNCH_GROUP128_REGISTER_KERNEL(T, DST_DTYPE)                    \
+  do {                                                                   \
+    dim3 grid(num_blocks);                                               \
+    dim3 block(num_threads);                                             \
+    if (is_column_major) {                                               \
+      if (scale_ue8m0) {                                                 \
+        per_token_group_quant_128_register_kernel<T, DST_DTYPE, true,    \
+                                                  true>                  \
+            <<<grid, block, 0, stream>>>(                                \
+                static_cast<T*>(input.data_ptr()), output_q.data_ptr(),  \
+                static_cast<float*>(output_s.data_ptr()), num_groups,    \
+                groups_per_block, (float)eps, (float)min_8bit,           \
+                (float)max_8bit, scale_num_rows, scale_stride);          \
+      } else {                                                           \
+        per_token_group_quant_128_register_kernel<T, DST_DTYPE, true,    \
+                                                  false>                 \
+            <<<grid, block, 0, stream>>>(                                \
+                static_cast<T*>(input.data_ptr()), output_q.data_ptr(),  \
+                static_cast<float*>(output_s.data_ptr()), num_groups,    \
+                groups_per_block, (float)eps, (float)min_8bit,           \
+                (float)max_8bit, scale_num_rows, scale_stride);          \
+      }                                                                  \
+    } else {                                                             \
+      if (scale_ue8m0) {                                                 \
+        per_token_group_quant_128_register_kernel<T, DST_DTYPE, false,   \
+                                                  true>                  \
+            <<<grid, block, 0, stream>>>(                                \
+                static_cast<T*>(input.data_ptr()), output_q.data_ptr(),  \
+                static_cast<float*>(output_s.data_ptr()), num_groups,    \
+                groups_per_block, (float)eps, (float)min_8bit,           \
+                (float)max_8bit);                                        \
+      } else {                                                           \
+        per_token_group_quant_128_register_kernel<T, DST_DTYPE, false,   \
+                                                  false>                 \
+            <<<grid, block, 0, stream>>>(                                \
+                static_cast<T*>(input.data_ptr()), output_q.data_ptr(),  \
+                static_cast<float*>(output_s.data_ptr()), num_groups,    \
+                groups_per_block, (float)eps, (float)min_8bit,           \
+                (float)max_8bit);                                        \
+      }                                                                  \
+    }                                                                    \
+  } while (0)
+
 #define LAUNCH_KERNEL(T, DST_DTYPE)                                        \
   do {                                                                     \
     dim3 grid(num_blocks);                                                 \
@@ -343,12 +460,21 @@ void per_token_group_quant_8bit(const torch::Tensor& input,
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "per_token_group_quant_8bit", ([&] {
         if (dst_type == at::ScalarType::Float8_e4m3fn) {
-          LAUNCH_KERNEL(scalar_t, __nv_fp8_e4m3);
+          if (group_size == 128 && UseGroup128RegisterFastPath()) {
+            LAUNCH_GROUP128_REGISTER_KERNEL(scalar_t, __nv_fp8_e4m3);
+          } else {
+            LAUNCH_KERNEL(scalar_t, __nv_fp8_e4m3);
+          }
         } else if (dst_type == at::ScalarType::Char) {
-          LAUNCH_KERNEL(scalar_t, int8_t);
+          if (group_size == 128 && UseGroup128RegisterFastPath()) {
+            LAUNCH_GROUP128_REGISTER_KERNEL(scalar_t, int8_t);
+          } else {
+            LAUNCH_KERNEL(scalar_t, int8_t);
+          }
         }
       }));
 
+#undef LAUNCH_GROUP128_REGISTER_KERNEL
 #undef LAUNCH_KERNEL
 }
 

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -23,6 +23,18 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
   musa_ops.impl("musa_fused_gemv", torch::kMUSA, &musa_fused_gemv);
 
   musa_ops.def(
+      "musa_fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, "
+      "float eps) -> ()");
+  musa_ops.impl("musa_fused_add_rms_norm", torch::kMUSA,
+                &musa_fused_add_rms_norm);
+
+  musa_ops.def(
+      "musa_reshape_and_cache_flash_nhd(Tensor key, Tensor value, "
+      "Tensor! key_cache, Tensor! value_cache, Tensor slot_mapping) -> ()");
+  musa_ops.impl("musa_reshape_and_cache_flash_nhd", torch::kMUSA,
+                &musa_reshape_and_cache_flash_nhd);
+
+  musa_ops.def(
       "per_token_group_fp8_quant(Tensor input, Tensor! output_q, Tensor! "
       "output_s, "
       "int group_size, float eps, float fp8_min, float fp8_max, bool "
@@ -30,6 +42,13 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
       ") -> ()");
   musa_ops.impl("per_token_group_fp8_quant", torch::kMUSA,
            &per_token_group_quant_fp8);
+
+  musa_ops.def(
+      "silu_and_mul_per_token_group_fp8_quant(Tensor input, Tensor! output_q, "
+      "Tensor! output_s, int group_size, float eps, float fp8_min, "
+      "float fp8_max) -> ()");
+  musa_ops.impl("silu_and_mul_per_token_group_fp8_quant", torch::kMUSA,
+                &silu_and_mul_per_token_group_fp8_quant);
 #endif
 }
 

--- a/csrc/musa/vec_utils.muh
+++ b/csrc/musa/vec_utils.muh
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <musa_runtime.h>
+
+namespace vllm_musa {
+
+template <typename T>
+struct Vec16 {
+  static_assert(sizeof(T) == 2, "T must be fp16 or bf16");
+  static constexpr int VLEN = 8;
+  T x[VLEN];
+};
+
+template <typename T>
+__device__ __forceinline__ Vec16<T> vload16_byp_slc(const T* ptr) {
+  Vec16<T> dst;
+  asm volatile(
+      "LSU.LD.B128 %0, %1, _, 16, 1, 1, inner_persist=0, "
+      "outer_persist=2, chrnt=l2_l3, slc=byp, persist=0, "
+      "stride_add_first=0"
+      : "=R"(dst)
+      : "R"(ptr));
+  return dst;
+}
+
+template <typename T>
+__device__ __forceinline__ void vstore16(T* ptr, const Vec16<T>& value) {
+  *reinterpret_cast<Vec16<T>*>(ptr) = value;
+}
+
+}  // namespace vllm_musa

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,8 @@ VLLM_CSRC_SOURCES = [
 VLLM_MUSA_CSRC_SOURCES = [
     "csrc/musa/torch_bindings.cpp",
     "csrc/musa/gemv.mu",
+    "csrc/musa/fused_add_rmsnorm.mu",
+    "csrc/musa/cache_kernels.mu",
     # XXX (MUSA): The version used here is vllm 0.18.0, located at csrc/quantization/w8a8/fp8.
     # While in version 0.20.0, the path has changed to csrc/libtorch_stable/quantization/w8a8/fp8,
     # and depends on two header file from PyTorch 2.11's torch/headeronly/core/ScalarType.h and

--- a/tests/test_fused_moe_chunking.py
+++ b/tests/test_fused_moe_chunking.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for MUSA fused MoE chunked execution."""
+
+import torch
+
+
+def test_musa_fused_experts_preserves_output_shape_across_chunks(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    chunk_size = 16384
+    num_tokens = chunk_size + 3
+    hidden_size = 4
+    intermediate_size = 8
+    num_experts = 2
+    top_k = 1
+
+    hidden_states = torch.zeros(num_tokens, hidden_size, dtype=torch.float32)
+    w1 = torch.zeros(num_experts, intermediate_size, hidden_size)
+    w2 = torch.zeros(num_experts, hidden_size, intermediate_size // 2)
+    topk_weights = torch.ones(num_tokens, top_k, dtype=torch.float32)
+    topk_ids = torch.zeros(num_tokens, top_k, dtype=torch.int64)
+
+    second_gemm_calls = 0
+
+    def fake_musa_fused_gemv_moe(
+        input_tensor,
+        weight,
+        output,
+        _bias,
+        _scale,
+        _topk_weights,
+        current_topk_ids,
+        *_args,
+        use_swigelu,
+        **_kwargs,
+    ):
+        nonlocal second_gemm_calls
+        tokens = current_topk_ids.shape[0]
+        if use_swigelu:
+            output[: tokens * top_k].fill_(1)
+        else:
+            fill_value = 11.0 if second_gemm_calls == 0 else 23.0
+            output[:tokens].fill_(fill_value)
+            second_gemm_calls += 1
+
+    def fake_moe_sum(intermediate_cache3, output):
+        required_shape = (
+            intermediate_cache3.shape[0],
+            intermediate_cache3.shape[-1],
+        )
+        if tuple(output.shape) != required_shape:
+            output.resize_(required_shape)
+        output.copy_(intermediate_cache3.sum(dim=1))
+
+    monkeypatch.setattr(
+        fused_moe.musa_ops, "musa_fused_gemv_moe", fake_musa_fused_gemv_moe
+    )
+    monkeypatch.setattr(fused_moe.ops, "moe_sum", fake_moe_sum)
+
+    result = fused_moe.fused_experts_impl(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+
+    assert result.shape == (num_tokens, hidden_size)
+    assert torch.all(result[:chunk_size] == 11.0)
+    assert torch.all(result[chunk_size:] == 23.0)

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -215,10 +215,8 @@ class TestNativeGemvSource:
     def test_deepseek_fp8_w1_uses_32x4_shape_gate(self):
         source = Path("csrc/musa/gemv.mu").read_text()
 
-        assert (
-            'kDeepSeekFp8W1BlockEnv = "VLLM_MUSA_DEEPSEEK_FP8_W1_32X4"'
-            in source
-        )
+        assert "kDeepSeekFp8W1BlockEnv" in source
+        assert '"VLLM_MUSA_DEEPSEEK_FP8_W1_32X4"' in source
         assert "ShouldUseDeepSeekFp8W1Moe32x4(" in source
         assert "topk == 6" in source
         assert "hidden_size == 2048" in source

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -212,6 +212,21 @@ class TestNativeGemvSource:
         assert "BlockConfig qwen_fp8_moe_config{32, 4" in source
         assert "case 4: GEN_LAUNCH_KERN(32, 4)" in source
 
+    def test_deepseek_fp8_w1_uses_32x4_shape_gate(self):
+        source = Path("csrc/musa/gemv.mu").read_text()
+
+        assert (
+            'kDeepSeekFp8W1BlockEnv = "VLLM_MUSA_DEEPSEEK_FP8_W1_32X4"'
+            in source
+        )
+        assert "ShouldUseDeepSeekFp8W1Moe32x4(" in source
+        assert "topk == 6" in source
+        assert "hidden_size == 2048" in source
+        assert "reduce_size == 2816" in source
+        assert "num_experts == 64" in source
+        assert "BlockConfig deepseek_fp8_w1_config{32, 4" in source
+        assert "best_config = &deepseek_fp8_w1_config" in source
+
     def test_gemv_block_override_validates_env_config(self):
         source = Path("csrc/musa/gemv.mu").read_text()
 

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -3,6 +3,7 @@
 """Tests for the MUSA Platform implementation."""
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -197,6 +198,27 @@ class TestMUSAPlatformBase:
 
         assert reason is not None
         assert "Triton float8 conversions" in reason
+
+
+class TestNativeGemvSource:
+    """Source-level checks for native MUSA GEMV dispatch gates."""
+
+    def test_qwen_fp8_moe_uses_32x4_shape_gate(self):
+        source = Path("csrc/musa/gemv.mu").read_text()
+
+        assert "ShouldUseQwenFp8Moe32x4(" in source
+        assert "hidden_size == 2048 && nr_n == 768" in source
+        assert "hidden_size == 768 && nr_n == 2048" in source
+        assert "BlockConfig qwen_fp8_moe_config{32, 4" in source
+        assert "case 4: GEN_LAUNCH_KERN(32, 4)" in source
+
+    def test_gemv_block_override_validates_env_config(self):
+        source = Path("csrc/musa/gemv.mu").read_text()
+
+        assert 'kGemvMoeBlockEnv = "VLLM_MUSA_GEMV_MOE_BLOCK"' in source
+        assert "std::getenv(kGemvMoeBlockEnv)" in source
+        assert "must use '<block_n>x<block_k>'" in source
+        assert "IsForcedBlockConfigValid(forced_config" in source
 
 
 class TestNonMtmlMUSAPlatform:

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -86,6 +86,30 @@ class TestMUSAPlatformBase:
 
         assert MUSAPlatformBase.use_custom_allreduce() is True
 
+    def test_supports_fp8_for_musa_3_1(self):
+        """Test that FP8 is supported on MUSA capability 3.1."""
+        from vllm_musa.platform import MUSAPlatformBase
+        from vllm.platforms.interface import DeviceCapability
+
+        with patch.object(
+            MUSAPlatformBase,
+            "get_device_capability",
+            return_value=DeviceCapability(3, 1),
+        ):
+            assert MUSAPlatformBase.supports_fp8() is True
+
+    def test_supports_fp8_rejects_pre_3_1(self):
+        """Test that pre-3.1 MUSA capability does not support FP8."""
+        from vllm_musa.platform import MUSAPlatformBase
+        from vllm.platforms.interface import DeviceCapability
+
+        with patch.object(
+            MUSAPlatformBase,
+            "get_device_capability",
+            return_value=DeviceCapability(3, 0),
+        ):
+            assert MUSAPlatformBase.supports_fp8() is False
+
     def test_support_hybrid_kv_cache(self):
         """Test that support_hybrid_kv_cache returns True."""
         from vllm_musa.platform import MUSAPlatformBase

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -384,6 +384,8 @@ class TestMUSAPlatformDefaults:
         quantization_config=None,
         max_cudagraph_capture_size=None,
         cudagraph_capture_sizes=None,
+        cudagraph_mode=None,
+        tensor_parallel_size=1,
     ):
         from types import SimpleNamespace
 
@@ -396,9 +398,21 @@ class TestMUSAPlatformDefaults:
                 architectures=architectures,
                 hf_config=hf_config,
                 quantization=quantization,
+                use_mla=False,
+                is_mm_prefix_lm=False,
+            ),
+            parallel_config=SimpleNamespace(
+                tensor_parallel_size=tensor_parallel_size,
+                worker_cls="auto",
+            ),
+            cache_config=SimpleNamespace(block_size=16),
+            scheduler_config=SimpleNamespace(
+                is_multimodal_model=False,
+                disable_chunked_mm_input=False,
             ),
             compilation_config=SimpleNamespace(
                 custom_ops=[],
+                cudagraph_mode=cudagraph_mode,
                 max_cudagraph_capture_size=max_cudagraph_capture_size,
                 cudagraph_capture_sizes=cudagraph_capture_sizes,
             ),
@@ -439,6 +453,40 @@ class TestMUSAPlatformDefaults:
         MUSAPlatformBase.apply_config_platform_defaults(vllm_config)
 
         assert vllm_config.compilation_config.max_cudagraph_capture_size is None
+        assert vllm_config.compilation_config.cudagraph_capture_sizes == [1, 2, 4, 8]
+
+    def test_tp4_disables_musa_cudagraph_capture(self):
+        from vllm.config import CUDAGraphMode
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            cudagraph_mode=CUDAGraphMode.PIECEWISE,
+            max_cudagraph_capture_size=512,
+            cudagraph_capture_sizes=[1, 2, 4, 8],
+            tensor_parallel_size=4,
+        )
+
+        MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+        assert vllm_config.compilation_config.max_cudagraph_capture_size == 0
+        assert vllm_config.compilation_config.cudagraph_capture_sizes == []
+
+    def test_tp2_keeps_musa_cudagraph_capture(self):
+        from vllm.config import CUDAGraphMode
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            cudagraph_mode=CUDAGraphMode.PIECEWISE,
+            max_cudagraph_capture_size=512,
+            cudagraph_capture_sizes=[1, 2, 4, 8],
+            tensor_parallel_size=2,
+        )
+
+        MUSAPlatformBase.check_and_update_config(vllm_config)
+
+        assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.PIECEWISE
+        assert vllm_config.compilation_config.max_cudagraph_capture_size == 512
         assert vllm_config.compilation_config.cudagraph_capture_sizes == [1, 2, 4, 8]
 
     def test_dense_fp8_does_not_cap_cudagraph_capture_size(self):

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -178,6 +178,281 @@ class TestDeepGemmPatch:
             raise AssertionError("deep_gemm patch file was not found")
 
 
+class TestCompilationBackendPatch:
+    """Tests for MUSA torch.compile backend compatibility patches."""
+
+    def test_vllm_backend_patch_accepts_torch_compile_options(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.compilation.backends":
+                patches = _load_patch_config(patch_path)
+                old_source = "\n".join(old for old, _ in patches)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "example_inputs: Sequence[Any]) -> Any" in old_source
+                assert "**kwargs: Any" in new_source
+                assert "autograd_cache_normalize_inputs=True" in old_source
+                assert "functorch_cache_key_ctx" in new_source
+                assert "hasattr(" in new_source
+                break
+        else:
+            raise AssertionError("compilation backend patch file was not found")
+
+    def test_live_vllm_backend_patch_ignores_options_kwarg(self, monkeypatch):
+        import vllm_musa
+
+        class DummyBackend:
+            def __call__(self, graph, example_inputs):
+                return graph, example_inputs
+
+        class DummyModule:
+            VllmBackend = DummyBackend
+
+        monkeypatch.setitem(
+            __import__("sys").modules,
+            "vllm.compilation.backends",
+            DummyModule,
+        )
+
+        vllm_musa._patch_vllm_backend_call_options()
+
+        backend = DummyBackend()
+        assert backend("graph", ["input"], options={"ignored": True}) == (
+            "graph",
+            ["input"],
+        )
+
+    def test_live_functorch_config_patch_skips_missing_keys(self):
+        from contextlib import nullcontext
+
+        import vllm_musa
+
+        calls = []
+
+        def original_patch(*args, **kwargs):
+            calls.append((args, kwargs))
+            return nullcontext()
+
+        functorch_config = SimpleNamespace(existing_key=True)
+        patched = vllm_musa._make_config_patch_filter(original_patch, functorch_config)
+
+        with patched(missing_key=False):
+            pass
+        with patched("missing_key", True):
+            pass
+        with patched({"existing_key": True, "missing_key": False}):
+            pass
+        with patched(existing_key=True):
+            pass
+
+        assert calls == [
+            (({"existing_key": True},), {}),
+            ((), {"existing_key": True}),
+        ]
+
+
+class TestCompilationCachingPatch:
+    """Tests for MUSA torch compile-cache compatibility patches."""
+
+    def test_graph_pickler_options_patch_supports_torch_27(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.compilation.caching":
+                patches = _load_patch_config(patch_path)
+                old_source = "\n".join(old for old, _ in patches)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "GraphPickler, Options" in old_source
+                assert "getattr(_vllm_graph_pickler, \"Options\", None)" in new_source
+                assert "_musa_graph_pickler_dumps" in new_source
+                break
+        else:
+            raise AssertionError("compilation caching patch file was not found")
+
+
+class TestCompilationCompilerInterfacePatch:
+    """Tests for MUSA torch compiler-interface compatibility patches."""
+
+    def test_functorch_config_patch_filters_missing_torch_keys(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.compilation.compiler_interface":
+                patches = _load_patch_config(patch_path)
+                old_source = "\n".join(old for old, _ in patches)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert 'cfg["bundled_autograd_cache"] = False' in old_source
+                assert "hasattr(functorch_config, key)" in new_source
+                break
+        else:
+            raise AssertionError("compilation compiler_interface patch was not found")
+
+    def test_live_functorch_config_patch_filters_missing_keys(self, monkeypatch):
+        import sys
+
+        import vllm_musa
+
+        class DummyCompilerInterface:
+            @staticmethod
+            def _get_vllm_functorch_config():
+                return {"existing_key": True, "missing_key": False}
+
+        monkeypatch.setitem(
+            sys.modules,
+            "vllm.compilation.compiler_interface",
+            DummyCompilerInterface,
+        )
+
+        dummy_functorch_config = SimpleNamespace(existing_key=True)
+        monkeypatch.setattr(
+            vllm_musa,
+            "_filter_existing_config",
+            lambda config, functorch_config: {
+                key: value
+                for key, value in config.items()
+                if hasattr(dummy_functorch_config, key)
+            },
+        )
+
+        vllm_musa._patch_vllm_functorch_config()
+
+        config = DummyCompilerInterface._get_vllm_functorch_config()
+        assert config == {"existing_key": True}
+
+
+class TestCompilationPiecewiseBackendPatch:
+    """Tests for MUSA piecewise backend compile-cache compatibility patches."""
+
+    def test_piecewise_backend_patch_skips_missing_bundled_cache_key(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.compilation.piecewise_backend":
+                patches = _load_patch_config(patch_path)
+                old_source = "\n".join(old for old, _ in patches)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert '"bundled_autograd_cache", True' in old_source
+                assert "functorch_cache_ctx" in new_source
+                assert "nullcontext" in new_source
+                break
+        else:
+            raise AssertionError("compilation piecewise_backend patch was not found")
+
+
+class TestAttentionCompilePatch:
+    """Tests for MUSA attention torch.compile compatibility patches."""
+
+    def test_attention_output_shape_patch_avoids_torch_size_constructor(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.model_executor.layers.attention.attention":
+                patches = _load_patch_config(patch_path)
+                old_source = "\n".join(old for old, _ in patches)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "output_shape = torch.Size(" in old_source
+                assert "output_shape = (num_tokens," in new_source
+                assert "torch.Size(" not in new_source
+                break
+        else:
+            raise AssertionError("attention compile patch file was not found")
+
+
+class TestMUSAPlatformDefaults:
+    """Tests for MUSA platform-level vLLM config defaults."""
+
+    def _make_vllm_config(
+        self,
+        *,
+        architectures=None,
+        quantization="fp8",
+        quantization_config=None,
+        max_cudagraph_capture_size=None,
+        cudagraph_capture_sizes=None,
+    ):
+        from types import SimpleNamespace
+
+        hf_config = SimpleNamespace(
+            architectures=architectures,
+            quantization_config=quantization_config,
+        )
+        return SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=architectures,
+                hf_config=hf_config,
+                quantization=quantization,
+            ),
+            compilation_config=SimpleNamespace(
+                custom_ops=[],
+                max_cudagraph_capture_size=max_cudagraph_capture_size,
+                cudagraph_capture_sizes=cudagraph_capture_sizes,
+            ),
+        )
+
+    def test_qwen3_moe_fp8_caps_default_cudagraph_capture_size(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["Qwen3MoeForCausalLM"],
+        )
+
+        MUSAPlatformBase.apply_config_platform_defaults(vllm_config)
+
+        assert vllm_config.compilation_config.max_cudagraph_capture_size == 64
+        assert vllm_config.compilation_config.custom_ops == ["all"]
+
+    def test_qwen3_moe_fp8_preserves_user_cudagraph_capture_size(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["Qwen3MoeForCausalLM"],
+            max_cudagraph_capture_size=128,
+        )
+
+        MUSAPlatformBase.apply_config_platform_defaults(vllm_config)
+
+        assert vllm_config.compilation_config.max_cudagraph_capture_size == 128
+
+    def test_qwen3_moe_fp8_preserves_user_cudagraph_capture_sizes(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["Qwen3MoeForCausalLM"],
+            cudagraph_capture_sizes=[1, 2, 4, 8],
+        )
+
+        MUSAPlatformBase.apply_config_platform_defaults(vllm_config)
+
+        assert vllm_config.compilation_config.max_cudagraph_capture_size is None
+        assert vllm_config.compilation_config.cudagraph_capture_sizes == [1, 2, 4, 8]
+
+    def test_dense_fp8_does_not_cap_cudagraph_capture_size(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        vllm_config = self._make_vllm_config(
+            architectures=["Qwen3ForCausalLM"],
+        )
+
+        MUSAPlatformBase.apply_config_platform_defaults(vllm_config)
+
+        assert vllm_config.compilation_config.max_cudagraph_capture_size is None
+
+
 class TestMUSAFusedMoEFP8Scales:
     """Tests for MUSA FP8 MoE scale adaptation helpers."""
 
@@ -238,12 +513,36 @@ class TestScaledMMKernelPatch:
         assert '"musa_deepgemm_fp8_op"' in source
         assert "_musa_deepgemm_fp8_op_fake" in source
 
+    def test_musa_swiglu_uses_custom_op_for_compile(self):
+        source = (
+            Path(__file__).parents[1]
+            / "vllm_musa/model_executor/layers/activation.py"
+        ).read_text()
+
+        assert "torch.ops.vllm.musa_swish_glu_op" in source
+        assert "direct_register_custom_op(" in source
+        assert '"musa_swish_glu_op"' in source
+        assert "_musa_swish_glu_op_fake" in source
+
     def test_musa_torch_fp8_scaled_mm_disables_fp8_output_padding(self):
         from vllm_musa.model_executor.kernels.linear.scaled_mm.torch_scaled_mm import (
             MUSAPerTensorTorchFP8ScaledMMLinearKernel,
         )
 
         assert MUSAPerTensorTorchFP8ScaledMMLinearKernel.get_output_padding(None) is None
+
+    def test_musa_unquantized_gemm_materializes_plain_parameter_for_compile(self):
+        source = (
+            Path(__file__).parents[1] / "vllm_musa/model_executor/layers/utils.py"
+        ).read_text()
+
+        assert "BasevLLMParameter" in source
+        assert "torch.nn.Parameter(weight.detach(), requires_grad=False)" in source
+        assert "plain_weight.__dict__.update(weight.__dict__)" in source
+        assert "current_platform.is_musa()" in source
+        assert "process_weights_after_loading" in source
+        assert "_musa_materializes_plain_parameter" in source
+        assert "DisableTorchFunction" not in source
 
     def test_scaled_mm_patch_registers_musa_fp8_kernel_fallbacks(self):
         from vllm_musa.patches import _get_patch_files, _load_patch_config

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -3,8 +3,10 @@
 """Tests for the MUSA platform patches module."""
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 
 
@@ -225,6 +227,17 @@ class TestMUSAFusedMoEFP8Scales:
 class TestScaledMMKernelPatch:
     """Tests for the MUSA scaled-mm kernel registry patch."""
 
+    def test_musa_deepgemm_fp8_uses_custom_op_for_compile(self):
+        source = (
+            Path(__file__).parents[1]
+            / "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+        ).read_text()
+
+        assert "torch.ops.vllm.musa_deepgemm_fp8_op" in source
+        assert "direct_register_custom_op(" in source
+        assert '"musa_deepgemm_fp8_op"' in source
+        assert "_musa_deepgemm_fp8_op_fake" in source
+
     def test_musa_torch_fp8_scaled_mm_disables_fp8_output_padding(self):
         from vllm_musa.model_executor.kernels.linear.scaled_mm.torch_scaled_mm import (
             MUSAPerTensorTorchFP8ScaledMMLinearKernel,
@@ -250,6 +263,93 @@ class TestScaledMMKernelPatch:
                 break
         else:
             raise AssertionError("linear kernel patch file was not found")
+
+
+class TestMUSAFP8ActivationQuant:
+    """Tests for MUSA FP8 activation quantization helpers."""
+
+    def test_per_token_group_quant_accepts_strided_2d_input(self, monkeypatch):
+        from vllm_musa.model_executor.layers.quantization.utils import fp8_utils
+
+        calls = []
+
+        def fake_quant(
+            x,
+            x_q,
+            x_s,
+            group_size,
+            eps,
+            fp8_min,
+            fp8_max,
+            use_ue8m0,
+            column_major_scales,
+            tma_aligned_scales,
+        ):
+            calls.append(
+                {
+                    "x": x,
+                    "x_q": x_q,
+                    "x_s": x_s,
+                    "group_size": group_size,
+                    "column_major_scales": column_major_scales,
+                }
+            )
+
+        monkeypatch.setattr(
+            fp8_utils,
+            "current_platform",
+            SimpleNamespace(
+                is_musa=lambda: True,
+                fp8_dtype=lambda: torch.float8_e4m3fn,
+            ),
+        )
+        monkeypatch.setattr(
+            torch.ops,
+            "_C_musa_ops",
+            SimpleNamespace(per_token_group_fp8_quant=fake_quant),
+            raising=False,
+        )
+
+        base = torch.randn(4, 3, 128, dtype=torch.float32)
+        x = base[:, 1, :]
+        assert x.stride(-1) == 1
+        assert not x.is_contiguous()
+
+        x_q, x_s = fp8_utils.per_token_group_quant_fp8(
+            x,
+            group_size=128,
+            use_ue8m0=False,
+        )
+
+        assert len(calls) == 1
+        assert calls[0]["x"].is_contiguous()
+        assert calls[0]["x"].shape == x.shape
+        assert x_q.shape == x.shape
+        assert x_q.is_contiguous()
+        assert x_s.shape == (4, 1)
+
+    def test_per_token_group_quant_rejects_noncontiguous_groups(self, monkeypatch):
+        from vllm_musa.model_executor.layers.quantization.utils import fp8_utils
+
+        monkeypatch.setattr(
+            fp8_utils,
+            "current_platform",
+            SimpleNamespace(
+                is_musa=lambda: True,
+                fp8_dtype=lambda: torch.float8_e4m3fn,
+            ),
+        )
+
+        x = torch.randn(128, 4, dtype=torch.float32).t()
+        assert x.shape == (4, 128)
+        assert x.stride(-1) != 1
+
+        with pytest.raises(AssertionError, match="groups must be contiguous"):
+            fp8_utils.per_token_group_quant_fp8(
+                x,
+                group_size=128,
+                use_ue8m0=False,
+            )
 
 
 class TestApplyPatches:

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -2,8 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for the MUSA platform patches module."""
 
+import importlib
+import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -371,6 +373,138 @@ class TestAttentionCompilePatch:
                 break
         else:
             raise AssertionError("attention compile patch file was not found")
+
+
+class TestMUSAFlashAttentionReshapeCache:
+    """Tests for MUSA FlashAttention reshape+cache dispatch guards."""
+
+    def _load_fa_utils_with_musa_platform(self, monkeypatch, musa_ops_namespace):
+        import vllm
+        import vllm.platforms as vllm_platforms
+        import vllm_musa
+
+        monkeypatch.setenv("VLLM_MUSA_RESHAPE_CACHE_FLASH", "1")
+        monkeypatch.setattr(
+            vllm_platforms,
+            "current_platform",
+            SimpleNamespace(is_musa=lambda: True),
+        )
+
+        flash_attn = ModuleType("flash_attn_interface")
+        flash_attn.flash_attn_varlen_func = object()
+        flash_attn.flash_attn_with_kvcache = object()
+        flash_attn.get_scheduler_metadata = object()
+        monkeypatch.setitem(sys.modules, "flash_attn_interface", flash_attn)
+
+        vllm_ops = ModuleType("vllm._custom_ops")
+        vllm_ops.reshape_and_cache_flash = lambda *args, **kwargs: None
+        monkeypatch.setitem(sys.modules, "vllm._custom_ops", vllm_ops)
+        monkeypatch.setattr(vllm, "_custom_ops", vllm_ops, raising=False)
+
+        musa_custom_ops = ModuleType("vllm_musa._custom_ops")
+        musa_custom_ops.musa_reshape_and_cache_flash_nhd = (
+            lambda *args, **kwargs: None
+        )
+        monkeypatch.setitem(sys.modules, "vllm_musa._custom_ops", musa_custom_ops)
+        monkeypatch.setattr(vllm_musa, "_custom_ops", musa_custom_ops, raising=False)
+
+        if musa_ops_namespace is None:
+            torch_ops = SimpleNamespace()
+        else:
+            torch_ops = SimpleNamespace(_C_musa_ops=musa_ops_namespace)
+        monkeypatch.setattr(torch, "ops", torch_ops)
+
+        module_name = "vllm_musa.v1.attention.backends.fa_utils"
+        previous_module = sys.modules.pop(module_name, None)
+        try:
+            module = importlib.import_module(module_name)
+        finally:
+            sys.modules.pop(module_name, None)
+            if previous_module is not None:
+                sys.modules[module_name] = previous_module
+        return module
+
+    def test_missing_musa_ops_namespace_disables_native_cache_path(self, monkeypatch):
+        module = self._load_fa_utils_with_musa_platform(
+            monkeypatch, musa_ops_namespace=None
+        )
+
+        assert module._HAS_NATIVE_RESHAPE_CACHE_FLASH is False
+
+    def test_native_cache_path_requires_matching_cache_dtypes(self, monkeypatch):
+        module = self._load_fa_utils_with_musa_platform(
+            monkeypatch,
+            musa_ops_namespace=SimpleNamespace(
+                musa_reshape_and_cache_flash_nhd=object()
+            ),
+        )
+
+        key = torch.empty((2, 4, 64), dtype=torch.float16)
+        value = torch.empty((2, 4, 64), dtype=torch.float16)
+        key_cache = torch.empty((1, 16, 4, 64), dtype=torch.float16)
+        value_cache = torch.empty((1, 16, 4, 64), dtype=torch.float16)
+        slot_mapping = torch.arange(2, dtype=torch.long)
+        k_scale = torch.ones(1, dtype=torch.float32)
+        v_scale = torch.ones(1, dtype=torch.float32)
+
+        assert module._can_use_musa_reshape_and_cache_flash_nhd(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            "auto",
+            k_scale,
+            v_scale,
+        )
+        assert not module._can_use_musa_reshape_and_cache_flash_nhd(
+            key,
+            value.to(torch.bfloat16),
+            key_cache,
+            value_cache,
+            slot_mapping,
+            "auto",
+            k_scale,
+            v_scale,
+        )
+        assert not module._can_use_musa_reshape_and_cache_flash_nhd(
+            key,
+            value,
+            key_cache.to(torch.bfloat16),
+            value_cache,
+            slot_mapping,
+            "auto",
+            k_scale,
+            v_scale,
+        )
+        assert not module._can_use_musa_reshape_and_cache_flash_nhd(
+            key,
+            value,
+            key_cache,
+            value_cache.to(torch.bfloat16),
+            slot_mapping,
+            "auto",
+            k_scale,
+            v_scale,
+        )
+
+
+class TestMUSANativeKernelReviewHardening:
+    """Source-level tests for native MUSA kernel review fixes."""
+
+    def test_fused_rmsnorm_forced_block_env_is_validated(self):
+        source = (
+            Path(__file__).parents[1] / "csrc/musa/fused_add_rmsnorm.mu"
+        ).read_text()
+
+        assert "forced_block == 128" in source
+        assert "forced_block == 256" in source
+        assert "forced_block == 512" in source
+        assert "forced_block == 1024" in source
+        assert (
+            "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X must be one of "
+            "128, 256, 512, or 1024"
+        ) in source
 
 
 class TestMUSAPlatformDefaults:

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -499,6 +499,95 @@ class TestMUSAFusedMoEFP8Scales:
         assert expanded is scale
 
 
+class TestMUSAFp8MoEPadding:
+    """Tests for MUSA FP8 MoE TP padding helpers."""
+
+    def test_musa_fp8_moe_tp_padding_rounds_partition_to_block_lcm(
+        self, monkeypatch
+    ):
+        from vllm_musa.model_executor.layers.quantization import fp8 as musa_fp8
+
+        monkeypatch.setattr(
+            musa_fp8,
+            "current_platform",
+            SimpleNamespace(is_musa=lambda: True),
+        )
+        monkeypatch.setattr(
+            musa_fp8,
+            "_ORIGINAL_FP8_MOE_MAYBE_ROUNDUP_SIZES",
+            lambda self, hidden_size, intermediate_size_per_partition, act_dtype,
+            moe_parallel_config: (
+                hidden_size,
+                intermediate_size_per_partition,
+            ),
+        )
+
+        method = SimpleNamespace(block_quant=True, weight_block_size=(128, 128))
+
+        assert musa_fp8.maybe_roundup_sizes(
+            method,
+            hidden_size=2048,
+            intermediate_size_per_partition=704,
+            act_dtype=torch.bfloat16,
+            moe_parallel_config=SimpleNamespace(tp_size=2),
+        ) == (2048, 768)
+        assert musa_fp8.maybe_roundup_sizes(
+            method,
+            hidden_size=2048,
+            intermediate_size_per_partition=704,
+            act_dtype=torch.bfloat16,
+            moe_parallel_config=SimpleNamespace(tp_size=1),
+        ) == (2048, 704)
+
+    @pytest.mark.skipif(
+        not hasattr(torch, "float8_e4m3fn"),
+        reason="FP8 tensor dtype is not available in this torch build",
+    )
+    def test_musa_fp8_moe_padded_weights_are_zero_initialized(self, monkeypatch):
+        from vllm_musa.model_executor.layers.quantization import fp8 as musa_fp8
+
+        monkeypatch.setattr(
+            musa_fp8,
+            "current_platform",
+            SimpleNamespace(is_musa=lambda: True),
+        )
+
+        layer = SimpleNamespace(
+            moe_config=SimpleNamespace(intermediate_size_per_partition_unpadded=704),
+            prefix="model.layers.0.mlp",
+        )
+
+        def fake_create_weights(self, layer, **kwargs):
+            layer.w13_weight = SimpleNamespace(
+                data=torch.full((8,), 42, dtype=torch.uint8).view(
+                    torch.float8_e4m3fn
+                )
+            )
+            layer.w2_weight = SimpleNamespace(
+                data=torch.full((8,), 43, dtype=torch.uint8).view(
+                    torch.float8_e4m3fn
+                )
+            )
+
+        monkeypatch.setattr(
+            musa_fp8,
+            "_ORIGINAL_FP8_MOE_CREATE_WEIGHTS",
+            fake_create_weights,
+        )
+
+        musa_fp8.create_weights(
+            SimpleNamespace(block_quant=True),
+            layer=layer,
+            num_experts=64,
+            hidden_size=2048,
+            intermediate_size_per_partition=768,
+            params_dtype=torch.bfloat16,
+        )
+
+        assert torch.all(layer.w13_weight.data.view(torch.uint8) == 0)
+        assert torch.all(layer.w2_weight.data.view(torch.uint8) == 0)
+
+
 class TestScaledMMKernelPatch:
     """Tests for the MUSA scaled-mm kernel registry patch."""
 
@@ -512,6 +601,27 @@ class TestScaledMMKernelPatch:
         assert "direct_register_custom_op(" in source
         assert '"musa_deepgemm_fp8_op"' in source
         assert "_musa_deepgemm_fp8_op_fake" in source
+        assert "VLLM_MUSA_DEEPGEMM_ROW_MAJOR_ACT_SCALES" in source
+
+    def test_musa_deepgemm_row_major_scale_gate(self, monkeypatch):
+        from vllm_musa.model_executor.kernels.linear.scaled_mm import deep_gemm
+
+        monkeypatch.setattr(
+            deep_gemm.envs, "VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES", False
+        )
+        monkeypatch.delenv("VLLM_MUSA_DEEPGEMM_ROW_MAJOR_ACT_SCALES", raising=False)
+
+        assert deep_gemm._use_row_major_activation_scales(False) is True
+        assert deep_gemm._use_row_major_activation_scales(True) is False
+
+        monkeypatch.setenv("VLLM_MUSA_DEEPGEMM_ROW_MAJOR_ACT_SCALES", "0")
+        assert deep_gemm._use_row_major_activation_scales(False) is False
+
+        monkeypatch.setenv("VLLM_MUSA_DEEPGEMM_ROW_MAJOR_ACT_SCALES", "1")
+        monkeypatch.setattr(
+            deep_gemm.envs, "VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES", True
+        )
+        assert deep_gemm._use_row_major_activation_scales(False) is True
 
     def test_musa_swiglu_uses_custom_op_for_compile(self):
         source = (

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -5,6 +5,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import torch
+
 
 class TestPatchFileNaming:
     """Tests for patch file naming convention."""
@@ -94,6 +96,160 @@ class TestTritonPatch:
                 old_strs = [old for old, new in patches]
 
                 assert "left: tl.int32 = 0" in old_strs
+
+
+class TestCustomAllReducePatch:
+    """Tests for the MUSA custom all-reduce patch."""
+
+    def test_patch_skips_cuda_p2p_check_on_musa(self):
+        """Test that MUSA custom all-reduce does not run CUDA P2P probing."""
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if "custom_all_reduce" in module_name:
+                patches = _load_patch_config(patch_path)
+                old_strs = [old for old, new in patches]
+                new_strs = [new for old, new in patches]
+
+                assert (
+                    "if ( not current_platform.is_rocm() or not "
+                    "current_platform.is_musa() ) and not _can_p2p(rank, world_size):"
+                ) in old_strs
+                assert (
+                    "if not current_platform.is_rocm() and not "
+                    "current_platform.is_musa() and not _can_p2p(rank, world_size):"
+                ) in new_strs
+                assert all(
+                    "not current_platform.is_rocm() or not current_platform.is_musa()"
+                    not in new
+                    for new in new_strs
+                )
+                break
+        else:
+            raise AssertionError("custom_all_reduce patch file was not found")
+
+
+class TestSamplerPatch:
+    """Tests for the MUSA top-k/top-p sampler patch."""
+
+    def test_sampler_patch_keeps_triton_guard_and_fast_path_gate(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.v1.sample.ops.topk_topp_sampler":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "not current_platform.is_musa()" in new_source
+                assert "VLLM_MUSA_SAMPLER_FAST_PATH" in new_source
+                assert "_apply_top_k_top_p_musa_topk_prefilter" in new_source
+                assert "logits.shape[0] >= 16" in new_source
+                assert "logits.shape[1] >= 65536" in new_source
+                break
+        else:
+            raise AssertionError("topk_topp_sampler patch file was not found")
+
+
+class TestDeepGemmPatch:
+    """Tests for the MUSA DeepGEMM compatibility patch."""
+
+    def test_deep_gemm_patch_disables_unsupported_e8m0_on_musa(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.utils.deep_gemm":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "current_platform.is_musa()" in new_source
+                assert "DeepGEMM E8M0 disabled on MUSA" in new_source
+                assert "grouped FP8 UE8M0 cast is " in new_source
+                assert "not supported by the MUSA DeepGEMM backend" in new_source
+                break
+        else:
+            raise AssertionError("deep_gemm patch file was not found")
+
+
+class TestMUSAFusedMoEFP8Scales:
+    """Tests for MUSA FP8 MoE scale adaptation helpers."""
+
+    def test_static_tensor_fp8_moe_scales_expand_to_block_layout(self):
+        from vllm_musa.model_executor.layers.fused_moe.fused_moe import (
+            _maybe_expand_fp8_moe_per_tensor_scale,
+        )
+
+        weight = torch.empty((2, 260, 320), dtype=torch.float8_e4m3fn)
+        scale = torch.tensor([0.5, 1.5], dtype=torch.float32)
+
+        expanded = _maybe_expand_fp8_moe_per_tensor_scale(scale, weight)
+
+        assert expanded is not None
+        assert expanded.shape == (2, 5, 5)
+        assert expanded.is_contiguous()
+        assert torch.all(expanded[0] == scale[0])
+        assert torch.all(expanded[1] == scale[1])
+
+    def test_static_tensor_fp8_moe_scales_prefer_128_block_layout(self):
+        from vllm_musa.model_executor.layers.fused_moe.fused_moe import (
+            _maybe_expand_fp8_moe_per_tensor_scale,
+        )
+
+        weight = torch.empty((2, 260, 256), dtype=torch.float8_e4m3fn)
+        scale = torch.tensor([0.5, 1.5], dtype=torch.float32)
+
+        expanded = _maybe_expand_fp8_moe_per_tensor_scale(scale, weight)
+
+        assert expanded is not None
+        assert expanded.shape == (2, 3, 2)
+        assert expanded.is_contiguous()
+
+    def test_block_fp8_moe_scales_are_left_unchanged(self):
+        from vllm_musa.model_executor.layers.fused_moe.fused_moe import (
+            _maybe_expand_fp8_moe_per_tensor_scale,
+        )
+
+        weight = torch.empty((2, 256, 256), dtype=torch.float8_e4m3fn)
+        scale = torch.ones((2, 2, 2), dtype=torch.float32)
+
+        expanded = _maybe_expand_fp8_moe_per_tensor_scale(scale, weight)
+
+        assert expanded is scale
+
+
+class TestScaledMMKernelPatch:
+    """Tests for the MUSA scaled-mm kernel registry patch."""
+
+    def test_musa_torch_fp8_scaled_mm_disables_fp8_output_padding(self):
+        from vllm_musa.model_executor.kernels.linear.scaled_mm.torch_scaled_mm import (
+            MUSAPerTensorTorchFP8ScaledMMLinearKernel,
+        )
+
+        assert MUSAPerTensorTorchFP8ScaledMMLinearKernel.get_output_padding(None) is None
+
+    def test_scaled_mm_patch_registers_musa_fp8_kernel_fallbacks(self):
+        from vllm_musa.patches import _get_patch_files, _load_patch_config
+
+        patch_files = _get_patch_files()
+
+        for module_name, patch_path in patch_files:
+            if module_name == "vllm.model_executor.kernels.linear":
+                patches = _load_patch_config(patch_path)
+                new_source = "\n".join(new for _, new in patches)
+
+                assert "possible_kernels is _POSSIBLE_FP8_BLOCK_KERNELS" in new_source
+                assert "MUSADeepGemmFp8BlockScaledMMKernel" in new_source
+                assert "possible_kernels is _POSSIBLE_FP8_KERNELS" in new_source
+                assert "MUSAPerTensorTorchFP8ScaledMMLinearKernel" in new_source
+                assert "MUSAChannelWiseTorchFP8ScaledMMLinearKernel" in new_source
+                break
+        else:
+            raise AssertionError("linear kernel patch file was not found")
 
 
 class TestApplyPatches:

--- a/vllm_musa/__init__.py
+++ b/vllm_musa/__init__.py
@@ -13,6 +13,9 @@ Usage:
 """
 
 import logging
+from contextlib import nullcontext
+from functools import wraps
+from typing import Any
 
 __all__ = [
     "MUSAPlatform",
@@ -94,9 +97,122 @@ def _apply_vllm_patches() -> None:
     _patches_applied = True
 
 
+def _patch_vllm_backend_call_options() -> None:
+    """Accept torch.compile backend keyword options on this vLLM snapshot."""
+    try:
+        from vllm.compilation.backends import VllmBackend
+    except Exception as e:
+        logger.debug("Skipping VllmBackend options patch: %s", e)
+        return
+
+    original_call = VllmBackend.__call__
+    if getattr(original_call, "_musa_accepts_backend_options", False):
+        return
+
+    @wraps(original_call)
+    def call_with_ignored_options(self, graph, example_inputs, **kwargs):
+        return original_call(self, graph, example_inputs)
+
+    call_with_ignored_options._musa_accepts_backend_options = True
+    VllmBackend.__call__ = call_with_ignored_options
+
+
+def _filter_existing_config(
+    config: dict[str, Any], config_module: Any
+) -> dict[str, Any]:
+    """Drop config keys that are absent in the installed Torch."""
+    return {key: value for key, value in config.items() if hasattr(config_module, key)}
+
+
+def _make_config_patch_filter(original_patch: Any, config_module: Any) -> Any:
+    @wraps(original_patch)
+    def patch_existing_config(*args: Any, **kwargs: Any) -> Any:
+        if args and isinstance(args[0], dict):
+            config = _filter_existing_config(args[0], config_module)
+            if not config and not kwargs:
+                return nullcontext()
+            args = (config, *args[1:])
+        elif args and isinstance(args[0], str):
+            if not hasattr(config_module, args[0]):
+                return nullcontext()
+
+        if kwargs:
+            kwargs = _filter_existing_config(kwargs, config_module)
+            if not args and not kwargs:
+                return nullcontext()
+
+        return original_patch(*args, **kwargs)
+
+    patch_existing_config._musa_filters_missing_config_keys = True
+    return patch_existing_config
+
+
+def _patch_functorch_config_patch() -> None:
+    """Ignore missing functorch config keys in vLLM compile contexts."""
+    try:
+        from torch._functorch import config as functorch_config
+    except Exception as e:
+        logger.debug("Skipping functorch config.patch patch: %s", e)
+        return
+
+    original_patch = functorch_config.__dict__.get("patch", functorch_config.patch)
+    if getattr(original_patch, "_musa_filters_missing_config_keys", False):
+        return
+
+    functorch_config.__dict__["patch"] = _make_config_patch_filter(
+        original_patch, functorch_config
+    )
+
+
+def _patch_inductor_config_patch() -> None:
+    """Ignore missing inductor config keys in vLLM compile contexts."""
+    try:
+        from torch._inductor import config as inductor_config
+    except Exception as e:
+        logger.debug("Skipping inductor config.patch patch: %s", e)
+        return
+
+    original_patch = inductor_config.__dict__.get("patch", inductor_config.patch)
+    if getattr(original_patch, "_musa_filters_missing_config_keys", False):
+        return
+
+    inductor_config.__dict__["patch"] = _make_config_patch_filter(
+        original_patch, inductor_config
+    )
+
+
+def _patch_vllm_functorch_config() -> None:
+    """Filter vLLM functorch config overrides for this Torch version."""
+    try:
+        import importlib
+
+        compiler_interface = importlib.import_module(
+            "vllm.compilation.compiler_interface"
+        )
+        from torch._functorch import config as functorch_config
+    except Exception as e:
+        logger.debug("Skipping functorch config patch: %s", e)
+        return
+
+    original_get_config = compiler_interface._get_vllm_functorch_config
+    if getattr(original_get_config, "_musa_filters_functorch_config", False):
+        return
+
+    @wraps(original_get_config)
+    def get_existing_functorch_config() -> dict[str, Any]:
+        return _filter_existing_config(original_get_config(), functorch_config)
+
+    get_existing_functorch_config._musa_filters_functorch_config = True
+    compiler_interface._get_vllm_functorch_config = get_existing_functorch_config
+
+
 def _register_patches() -> None:
     """Apply vLLM source patches for MUSA compatibility."""
     _apply_vllm_patches()
+    _patch_functorch_config_patch()
+    _patch_inductor_config_patch()
+    _patch_vllm_backend_call_options()
+    _patch_vllm_functorch_config()
 
 
 def _register_ops() -> None:

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -124,3 +124,33 @@ def musa_fused_gemv(
             eps,
         )
         return output
+
+
+def musa_fused_add_rms_norm(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> None:
+    return torch.ops._C_musa_ops.musa_fused_add_rms_norm(
+        input,
+        residual,
+        weight,
+        eps,
+    )
+
+
+def musa_reshape_and_cache_flash_nhd(
+    key: torch.Tensor,
+    value: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+) -> None:
+    return torch.ops._C_musa_ops.musa_reshape_and_cache_flash_nhd(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+    )

--- a/vllm_musa/model_executor/__init__.py
+++ b/vllm_musa/model_executor/__init__.py
@@ -5,4 +5,5 @@ import vllm_musa.model_executor.layers.fused_moe.unquantized_fused_moe_method
 import vllm_musa.model_executor.layers.layernorm
 import vllm_musa.model_executor.layers.quantization.fp8
 import vllm_musa.model_executor.layers.quantization.utils.fp8_utils
+import vllm_musa.model_executor.layers.utils
 import vllm_musa.model_executor.warmup.deep_gemm_warmup

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -1,3 +1,4 @@
+import os
 from typing import ClassVar
 
 import torch
@@ -22,6 +23,13 @@ from vllm_musa.model_executor.layers.quantization.utils.fp8_utils import (
 )
 
 
+def _use_row_major_activation_scales(use_deep_gemm_e8m0: bool) -> bool:
+    if use_deep_gemm_e8m0:
+        return False
+    value = os.getenv("VLLM_MUSA_DEEPGEMM_ROW_MAJOR_ACT_SCALES", "1").lower()
+    return value not in ("0", "false", "no", "off")
+
+
 class MUSADeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
     apply_input_quant: ClassVar[bool] = False
 
@@ -35,7 +43,9 @@ class MUSADeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             group_shape=act_scale_descriptor.group_shape,
             use_ue8m0=self.use_deep_gemm_e8m0,
             tma_aligned_scales=envs.VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES,
-            column_major_scales=True,
+            column_major_scales=not _use_row_major_activation_scales(
+                self.use_deep_gemm_e8m0
+            ),
         )
 
     def process_weights_after_loading(self, layer):
@@ -126,7 +136,9 @@ def _musa_deepgemm_fp8_op(
     q_input, input_scale = per_token_group_quant_fp8(
         input,
         group_size=group_size,
-        column_major_scales=True,
+        column_major_scales=not _use_row_major_activation_scales(
+            use_deep_gemm_e8m0
+        ),
         use_ue8m0=use_deep_gemm_e8m0,
     )
     output = torch.empty(

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -14,6 +14,7 @@ from vllm.model_executor.kernels.linear.scaled_mm.deep_gemm import (
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_musa.model_executor.layers.quantization.utils.fp8_utils import (
     deepgemm_post_process_fp8_weight_block,
@@ -106,6 +107,22 @@ def run_deepgemm(
     group_size: int,
     use_deep_gemm_e8m0: bool,
 ) -> torch.Tensor:
+    return torch.ops.vllm.musa_deepgemm_fp8_op(
+        input,
+        weight,
+        weight_scale,
+        group_size,
+        use_deep_gemm_e8m0,
+    )
+
+
+def _musa_deepgemm_fp8_op(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    use_deep_gemm_e8m0: bool,
+) -> torch.Tensor:
     q_input, input_scale = per_token_group_quant_fp8(
         input,
         group_size=group_size,
@@ -125,3 +142,24 @@ def run_deepgemm(
         is_deep_gemm_e8m0_used=use_deep_gemm_e8m0,
     )
     return output
+
+
+def _musa_deepgemm_fp8_op_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    use_deep_gemm_e8m0: bool,
+) -> torch.Tensor:
+    return torch.empty(
+        (input.shape[0], weight.shape[0]),
+        dtype=torch.bfloat16,
+        device=input.device,
+    )
+
+
+direct_register_custom_op(
+    "musa_deepgemm_fp8_op",
+    _musa_deepgemm_fp8_op,
+    fake_impl=_musa_deepgemm_fp8_op_fake,
+)

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/torch_scaled_mm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/torch_scaled_mm.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.model_executor.kernels.linear.scaled_mm.pytorch import (
+    ChannelWiseTorchFP8ScaledMMLinearKernel,
+    PerTensorTorchFP8ScaledMMLinearKernel,
+)
+from vllm.platforms import current_platform
+
+
+class MUSATorchFP8ScaledMMKernelMixin:
+    """Enable torch._scaled_mm-backed FP8 kernels on MUSA.
+
+    The upstream Torch FP8 kernels are written for CUDA/ROCm/CPU and reject low
+    CUDA compute capabilities. S5000 exposes FP8 scaled-mm through torch_musa, so
+    MUSA needs only a platform-specific support gate; the implementation can use
+    the upstream apply/process logic unchanged.
+    """
+
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not current_platform.is_musa():
+            return False, "requires MUSA."
+        return True, None
+
+    def get_output_padding(self) -> int | None:
+        # torch_musa/muDNN cannot currently pad FP8 tensors via torch.nn.functional.pad.
+        # Padding is only a torch._scaled_mm performance hint, so skip it on MUSA.
+        return None
+
+
+class MUSAPerTensorTorchFP8ScaledMMLinearKernel(
+    MUSATorchFP8ScaledMMKernelMixin,
+    PerTensorTorchFP8ScaledMMLinearKernel,
+):
+    pass
+
+
+class MUSAChannelWiseTorchFP8ScaledMMLinearKernel(
+    MUSATorchFP8ScaledMMKernelMixin,
+    ChannelWiseTorchFP8ScaledMMLinearKernel,
+):
+    pass

--- a/vllm_musa/model_executor/layers/activation.py
+++ b/vllm_musa/model_executor/layers/activation.py
@@ -4,6 +4,7 @@
 import torch
 import torch.nn.functional as F
 from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_musa.utils.environ import envs
 
@@ -15,5 +16,24 @@ class MusaSiluAndMul(SiluAndMul):
             return self.forward_native(x)
 
         # ==================== MUSA ADAPTATION ====================
-        return F.swish_glu(x)
+        return torch.ops.vllm.musa_swish_glu_op(x)
         # ========================== END ==========================
+
+
+def _musa_swish_glu_op(x: torch.Tensor) -> torch.Tensor:
+    return F.swish_glu(x)
+
+
+def _musa_swish_glu_op_fake(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty(
+        x.shape[:-1] + (x.shape[-1] // 2,),
+        dtype=x.dtype,
+        device=x.device,
+    )
+
+
+direct_register_custom_op(
+    "musa_swish_glu_op",
+    _musa_swish_glu_op,
+    fake_impl=_musa_swish_glu_op_fake,
+)

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -1,15 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import functools
-
 import torch
 from vllm import _custom_ops as ops
-from vllm.model_executor.layers.fused_moe.config import _get_config_dtype_str
-from vllm.model_executor.layers.fused_moe.fused_moe import (
-    _get_config_quant_dtype,
-    try_get_optimal_moe_config,
-)
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.utils import (
     disable_inplace,
 )
@@ -27,6 +21,62 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl
 
 from vllm_musa import _custom_ops as musa_ops
+
+logger = init_logger(__name__)
+
+
+def _musa_fp8_moe_scale_block_size(input_size: int) -> int:
+    if input_size % 128 == 0:
+        return 128
+    if input_size % 64 == 0:
+        return 64
+    raise ValueError(
+        "MUSA static FP8 MoE scale expansion requires the weight input "
+        f"dimension to be divisible by 64 or 128, got {input_size}."
+    )
+
+
+def _maybe_expand_fp8_moe_per_tensor_scale(
+    scale: torch.Tensor | None,
+    weight: torch.Tensor,
+) -> torch.Tensor | None:
+    """Expand static per-tensor FP8 MoE scales for the native MUSA GEMV op.
+
+    The native op indexes FP8 scales as block scales with shape
+    [expert, output_block, input_block]. Static FP8 checkpoints store one
+    weight scale per expert, so materialize the equivalent block view here.
+    """
+    if (
+        scale is None
+        or weight.dtype != torch.float8_e4m3fn
+        or scale.dim() >= 3
+    ):
+        return scale
+
+    num_experts, output_size, input_size = weight.shape
+
+    if scale.dim() == 0:
+        per_expert_scale = scale.expand(num_experts)
+    elif scale.dim() == 1:
+        if scale.numel() == 1:
+            per_expert_scale = scale.expand(num_experts)
+        elif scale.numel() == num_experts:
+            per_expert_scale = scale
+        else:
+            return scale
+    elif scale.dim() == 2 and scale.shape == (num_experts, 1):
+        per_expert_scale = scale[:, 0]
+    else:
+        return scale
+
+    block_size = _musa_fp8_moe_scale_block_size(input_size)
+    output_blocks = (output_size + block_size - 1) // block_size
+    input_blocks = input_size // block_size
+    return (
+        per_expert_scale.view(num_experts, 1, 1)
+        .expand(num_experts, output_blocks, input_blocks)
+        .contiguous()
+    )
 
 
 def _supports_quant_scheme(
@@ -125,44 +175,12 @@ def fused_experts_impl(
 
     M = num_tokens
 
-    config_dtype = _get_config_dtype_str(
-        use_fp8_w8a8=use_fp8_w8a8,
-        use_int8_w8a16=use_int8_w8a16,
-        use_int4_w4a16=use_int4_w4a16,
-        ocp_mx_scheme=ocp_mx_scheme,
-        dtype=hidden_states.dtype,
+    intermediate_cache3 = torch.empty(
+        (M, top_k_num, K), device=hidden_states.device, dtype=hidden_states.dtype
     )
 
-    # Note: for use_int8_w8a16 or use_int4_w4a16, the activations are
-    # quantized prior to calling fused_experts.
-    quant_dtype = _get_config_quant_dtype(
-        use_fp8_w8a8=use_fp8_w8a8,
-        use_int8_w8a8=use_int8_w8a8,
-        ocp_mx_scheme=ocp_mx_scheme,
-    )
-
-    get_config_func = functools.partial(
-        try_get_optimal_moe_config,
-        w1.size(),
-        w2.size(),
-        top_k_num,
-        config_dtype,
-        block_shape=block_shape,
-    )
-
-    config = get_config_func(M)
-
-    # We can reuse the memory between these because by the time we need
-    # cache3, we're done with cache1
-    cache13 = torch.empty(
-        M * top_k_num * max(N, K),
-        device=hidden_states.device,
-        dtype=hidden_states.dtype,
-    )
-    intermediate_cache1 = cache13[: M * top_k_num * N].view(M, top_k_num, N)
-    intermediate_cache3 = cache13[: M * top_k_num * K].view(M, top_k_num, K)
-
-    # This needs separate memory since it's used concurrently with cache1
+    # The first GEMV writes activation input to cache2; the second GEMV writes
+    # top-k outputs to cache3 for moe_sum.
     intermediate_cache2 = torch.empty(
         (M * top_k_num, N // 2), device=hidden_states.device, dtype=hidden_states.dtype
     )
@@ -175,6 +193,10 @@ def fused_experts_impl(
         compute_type = tl.float32
     else:
         raise ValueError(f"Unsupported compute_type: {hidden_states.dtype}")
+
+    if use_fp8_w8a8:
+        w1_scale = _maybe_expand_fp8_moe_per_tensor_scale(w1_scale, w1)
+        w2_scale = _maybe_expand_fp8_moe_per_tensor_scale(w2_scale, w2)
 
     if inplace and not disable_inplace():
         out_hidden_states = hidden_states
@@ -220,6 +242,11 @@ def fused_experts_impl(
     # Due to the implementation of 0.20.0 relying on per_token_group_quant,
     # which is currently not supported by Musa, please refer to setup.py for details.
     # The version used here is 0.18.0
+    logger.info_once(
+        "MUSA fused MoE uses native GEMV block selection; skipping upstream "
+        "Triton MoE JSON config lookup.",
+        scope="global",
+    )
     CHUNK_SIZE = 16384
     M = min(num_tokens, CHUNK_SIZE)
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
@@ -233,17 +260,11 @@ def fused_experts_impl(
         if tokens_in_chunk == 0:
             break
 
-        if tokens_in_chunk < CHUNK_SIZE and chunk > 0:
-            # Adjust the intermediate cache size and config for the last
-            # chunk. Note that in most cases we only have one chunk
-            # so the cache size and config are already set correctly and
-            # do not need to be adjusted.
-            intermediate_cache1 = intermediate_cache1[:tokens_in_chunk]
-            intermediate_cache2 = intermediate_cache2[
-                : tokens_in_chunk * topk_ids.size(1)
-            ]
-            intermediate_cache3 = intermediate_cache3[:tokens_in_chunk]
-            config = get_config_func(tokens_in_chunk)
+        curr_intermediate_cache2 = intermediate_cache2[
+            : tokens_in_chunk * topk_ids.size(1)
+        ]
+        curr_intermediate_cache3 = intermediate_cache3[:tokens_in_chunk]
+        curr_out_hidden_states = out_hidden_states[begin_chunk_idx:end_chunk_idx]
 
         curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
         curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
@@ -251,7 +272,7 @@ def fused_experts_impl(
         musa_ops.musa_fused_gemv_moe(
             curr_hidden_states,
             w1,
-            intermediate_cache2,
+            curr_intermediate_cache2,
             None,
             w1_scale,
             curr_topk_weights,
@@ -262,9 +283,9 @@ def fused_experts_impl(
             use_swigelu=True,
         )
         musa_ops.musa_fused_gemv_moe(
-            intermediate_cache2,
+            curr_intermediate_cache2,
             w2,
-            intermediate_cache3,
+            curr_intermediate_cache3,
             None,
             w2_scale,
             curr_topk_weights,
@@ -276,8 +297,8 @@ def fused_experts_impl(
         )
         # ========================== END ====================
         ops.moe_sum(
-            intermediate_cache3.view(*intermediate_cache3.size()),
-            out_hidden_states,
+            curr_intermediate_cache3.view(*curr_intermediate_cache3.size()),
+            curr_out_hidden_states,
         )
 
     return out_hidden_states

--- a/vllm_musa/model_executor/layers/layernorm.py
+++ b/vllm_musa/model_executor/layers/layernorm.py
@@ -5,7 +5,37 @@ import torch
 import torch.nn as nn
 from vllm.model_executor.layers.layernorm import RMSNorm, fused_add_rms_norm
 
+from vllm_musa import _custom_ops as musa_ops
 from vllm_musa.utils.environ import envs
+
+
+def _can_use_musa_fused_add_rms_norm(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+) -> bool:
+    hidden_size = x.shape[-1]
+    return (
+        envs.VLLM_MUSA_FUSED_ADD_RMSNORM.get()
+        and x.device.type == "musa"
+        and residual.device.type == "musa"
+        and weight.device.type == "musa"
+        and x.dim() == 2
+        and residual.dim() == 2
+        and weight.dim() == 1
+        and x.shape == residual.shape
+        and hidden_size == weight.numel()
+        and hidden_size % 8 == 0
+        and hidden_size <= 16384
+        and x.dtype in (torch.float16, torch.bfloat16)
+        and residual.dtype == x.dtype
+        and weight.dtype == x.dtype
+        and x.is_contiguous()
+        and residual.is_contiguous()
+        and weight.is_contiguous()
+        and hasattr(torch.ops, "_C_musa_ops")
+        and hasattr(torch.ops._C_musa_ops, "musa_fused_add_rms_norm")
+    )
 
 
 @RMSNorm.register_oot
@@ -24,6 +54,11 @@ class MusaRMSNorm(RMSNorm):
 
         add_residual = residual is not None
         if add_residual:
+            if _can_use_musa_fused_add_rms_norm(x, residual, self.weight.data):
+                musa_ops.musa_fused_add_rms_norm(
+                    x, residual, self.weight.data, self.variance_epsilon
+                )
+                return x, residual
             return fused_add_rms_norm(
                 x, residual, self.weight.data, self.variance_epsilon
             )

--- a/vllm_musa/model_executor/layers/quantization/fp8.py
+++ b/vllm_musa/model_executor/layers/quantization/fp8.py
@@ -1,6 +1,113 @@
+import math
+
 import torch
+import vllm.model_executor.layers.quantization.fp8 as vllm_fp8
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import FusedMoE, fused_experts
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+logger = init_logger(__name__)
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _zero_fp8_weight(weight: torch.Tensor) -> None:
+    # MUSA muDNN fill does not support FP8_E4M3 directly.
+    weight.view(torch.uint8).zero_()
+
+
+_ORIGINAL_FP8_MOE_MAYBE_ROUNDUP_SIZES = vllm_fp8.Fp8MoEMethod.maybe_roundup_sizes
+_ORIGINAL_FP8_MOE_CREATE_WEIGHTS = vllm_fp8.Fp8MoEMethod.create_weights
+
+
+def maybe_roundup_sizes(
+    self,
+    hidden_size: int,
+    intermediate_size_per_partition: int,
+    act_dtype: torch.dtype,
+    moe_parallel_config,
+) -> tuple[int, int]:
+    hidden_size, intermediate_size_per_partition = (
+        _ORIGINAL_FP8_MOE_MAYBE_ROUNDUP_SIZES(
+            self,
+            hidden_size,
+            intermediate_size_per_partition,
+            act_dtype,
+            moe_parallel_config,
+        )
+    )
+
+    if not (
+        current_platform.is_musa()
+        and getattr(self, "block_quant", False)
+        and getattr(moe_parallel_config, "tp_size", 1) > 1
+    ):
+        return hidden_size, intermediate_size_per_partition
+
+    weight_block_size = getattr(self, "weight_block_size", None)
+    if weight_block_size is None:
+        return hidden_size, intermediate_size_per_partition
+
+    block_n, block_k = int(weight_block_size[0]), int(weight_block_size[1])
+    block_multiple = math.lcm(block_n, block_k)
+    padded_intermediate = _round_up(
+        intermediate_size_per_partition,
+        block_multiple,
+    )
+    if padded_intermediate != intermediate_size_per_partition:
+        logger.info_once(
+            "Padding MUSA FP8 MoE intermediate partition from %d to %d "
+            "for block_shape=[%d, %d].",
+            intermediate_size_per_partition,
+            padded_intermediate,
+            block_n,
+            block_k,
+        )
+    return hidden_size, padded_intermediate
+
+
+def create_weights(
+    self,
+    layer: torch.nn.Module,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size_per_partition: int,
+    params_dtype: torch.dtype,
+    **extra_weight_attrs,
+):
+    _ORIGINAL_FP8_MOE_CREATE_WEIGHTS(
+        self,
+        layer=layer,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size_per_partition=intermediate_size_per_partition,
+        params_dtype=params_dtype,
+        **extra_weight_attrs,
+    )
+
+    if not (current_platform.is_musa() and getattr(self, "block_quant", False)):
+        return
+
+    unpadded_intermediate = getattr(
+        layer.moe_config,
+        "intermediate_size_per_partition_unpadded",
+        intermediate_size_per_partition,
+    )
+    if intermediate_size_per_partition == unpadded_intermediate:
+        return
+
+    _zero_fp8_weight(layer.w13_weight.data)
+    _zero_fp8_weight(layer.w2_weight.data)
+    logger.debug(
+        "Zero initialized padded MUSA FP8 MoE weights for %s "
+        "(intermediate=%d, unpadded=%d).",
+        getattr(layer, "prefix", "<unknown>"),
+        intermediate_size_per_partition,
+        unpadded_intermediate,
+    )
 
 
 def apply(
@@ -43,6 +150,6 @@ def apply(
         )
 
 
-import vllm.model_executor.layers.quantization.fp8
-
-vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod.apply = apply
+vllm_fp8.Fp8MoEMethod.maybe_roundup_sizes = maybe_roundup_sizes
+vllm_fp8.Fp8MoEMethod.create_weights = create_weights
+vllm_fp8.Fp8MoEMethod.apply = apply

--- a/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+
 import torch
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     get_fp8_min_max,
@@ -114,6 +116,92 @@ def per_token_group_quant_fp8(
         f"per_token_group_fp8_quant is not supported for platform: {current_platform} or input is not contiguous. "
         "MUSA Triton fallback is currently not supported."
     )
+
+
+def _silu_fp8_fusion_enabled() -> bool:
+    value = os.getenv("VLLM_MUSA_SILU_FP8_QUANT_FUSION", "1").lower()
+    return value not in ("0", "false", "no", "off")
+
+
+def _silu_fp8_fusion_max_tokens() -> int:
+    try:
+        return int(os.getenv("VLLM_MUSA_SILU_FP8_QUANT_MAX_TOKENS", "512"))
+    except ValueError:
+        return 512
+
+
+def silu_mul_per_token_group_quant_fp8_musa(
+    input: torch.Tensor,
+    output: torch.Tensor | None = None,
+    use_ue8m0: bool | None = None,
+    eps: float = 1e-10,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """MUSA small-M SiLU+mul plus FP8 group-quant fast path.
+
+    This mirrors vLLM's DeepGEMM helper contract for gate-up tensors shaped
+    ``[tokens, 2 * hidden]`` but only returns row-major contiguous FP32 scales.
+    Unsupported shapes fall back to the upstream helper.
+    """
+
+    from vllm.model_executor.layers.quantization.utils import (
+        fp8_utils as upstream_fp8_utils,
+    )
+
+    if use_ue8m0 is None:
+        use_ue8m0 = is_deep_gemm_e8m0_used()
+
+    def fallback() -> tuple[torch.Tensor, torch.Tensor]:
+        return upstream_fp8_utils.silu_mul_per_token_group_quant_fp8_colmajor(
+            input=input,
+            output=output,
+            use_ue8m0=use_ue8m0,
+            eps=eps,
+        )
+
+    group_size = 128
+    if (
+        not _silu_fp8_fusion_enabled()
+        or not current_platform.is_musa()
+        or use_ue8m0
+        or input.dim() != 2
+        or not input.is_contiguous()
+        or input.dtype not in (torch.bfloat16, torch.float16)
+        or input.shape[0] > _silu_fp8_fusion_max_tokens()
+        or input.shape[-1] % (2 * group_size) != 0
+    ):
+        return fallback()
+
+    tokens = input.shape[0]
+    hidden = input.shape[-1] // 2
+    if output is None:
+        output = torch.empty(
+            (tokens, hidden),
+            device=input.device,
+            dtype=current_platform.fp8_dtype(),
+        )
+    elif (
+        output.shape != (tokens, hidden)
+        or not output.is_contiguous()
+        or output.dtype != current_platform.fp8_dtype()
+    ):
+        return fallback()
+
+    output_s = torch.empty(
+        (tokens, hidden // group_size),
+        device=input.device,
+        dtype=torch.float32,
+    )
+    fp8_min, fp8_max = get_fp8_min_max()
+    torch.ops._C_musa_ops.silu_and_mul_per_token_group_fp8_quant(
+        input,
+        output,
+        output_s,
+        group_size,
+        eps,
+        fp8_min,
+        fp8_max,
+    )
+    return output, output_s
 
 
 import vllm.model_executor.layers.quantization.utils.fp8_utils

--- a/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
@@ -87,17 +87,18 @@ def per_token_group_quant_fp8(
         shape = x.shape[:-1] + (x.shape[-1] // group_size,)
         x_s = torch.empty(shape, device=x.device, dtype=torch.float32)
 
-    # prefer CUDA kernel if available
-    # TODO(bnell): this causes some fp8 moe test to fail.
-    if current_platform.is_musa() and x.is_contiguous():
+    # Prefer the MUSA kernel when possible. MUSA Triton fallback is unavailable,
+    # so materialize supported strided 2D activations before dispatching.
+    if current_platform.is_musa():
         if x.dim() != 2:
             raise NotImplementedError(
                 f"MUSA backend currently only supports 2D tensors for per_token_group_fp8_quant. "
                 f"Got tensor with {x.dim()} dimensions, shape={x.shape}"
             )
+        x_kernel = x if x.is_contiguous() else x.contiguous()
 
         torch.ops._C_musa_ops.per_token_group_fp8_quant(
-            x,
+            x_kernel,
             x_q,
             x_s,
             group_size,

--- a/vllm_musa/model_executor/layers/utils.py
+++ b/vllm_musa/model_executor/layers/utils.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from vllm.model_executor.layers import linear as vllm_linear
+from vllm.model_executor.parameter import BasevLLMParameter
+
+
+def _materialize_plain_parameter(layer: torch.nn.Module) -> None:
+    weight = getattr(layer, "weight", None)
+    if not isinstance(weight, BasevLLMParameter):
+        return
+
+    plain_weight = torch.nn.Parameter(weight.detach(), requires_grad=False)
+    plain_weight.__dict__.update(weight.__dict__)
+    layer.weight = plain_weight
+
+
+_ORIGINAL_UNQUANTIZED_LINEAR_PROCESS_WEIGHTS = (
+    vllm_linear.UnquantizedLinearMethod.process_weights_after_loading
+)
+
+
+def _musa_process_unquantized_linear_weights_after_loading(
+    self: vllm_linear.UnquantizedLinearMethod,
+    layer: torch.nn.Module,
+) -> None:
+    from vllm.platforms import current_platform
+
+    if current_platform.is_musa():
+        _materialize_plain_parameter(layer)
+        return
+
+    _ORIGINAL_UNQUANTIZED_LINEAR_PROCESS_WEIGHTS(self, layer)
+
+
+if not getattr(
+    vllm_linear.UnquantizedLinearMethod.process_weights_after_loading,
+    "_musa_materializes_plain_parameter",
+    False,
+):
+    setattr(
+        _musa_process_unquantized_linear_weights_after_loading,
+        "_musa_materializes_plain_parameter",
+        True,
+    )
+    vllm_linear.UnquantizedLinearMethod.process_weights_after_loading = (
+        _musa_process_unquantized_linear_weights_after_loading
+    )

--- a/vllm_musa/patches/README.md
+++ b/vllm_musa/patches/README.md
@@ -148,7 +148,15 @@ AttributeError("'AnnAssign' object has no attribute 'targets'")
 
 **Issue:** Triton-based sampling kernel not compatible with MUSA Triton compiler
 
-**Fix:** Disable Triton path for MUSA and use PyTorch fallback implementation
+**Fix:** Disable Triton path for MUSA and use PyTorch fallback implementation.
+For large decode batches, enable `VLLM_MUSA_SAMPLER_FAST_PATH` by default to
+use a MUSA-safe top-k prefilter path:
+- top-k only: use the existing `apply_top_k_only` path for batch >= 16,
+  vocab >= 65536, and `max_k <= 1024`.
+- top-k + top-p: prefilter with `torch.topk` only for batch >= 16,
+  vocab >= 65536, and `max_k <= 1024`; fall back to the PyTorch sort path for
+  top-k-disabled rows, large `k`, or kth-logit ties.
+- top-p only and unsupported shapes stay on the current PyTorch fallback.
 
 ### vllm__v1__sample__ops__topk_topp_triton.patch.py
 

--- a/vllm_musa/patches/vllm__compilation__backends.patch.py
+++ b/vllm_musa/patches/vllm__compilation__backends.patch.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch for vllm.compilation.backends.
+"""
+
+PATCHES = [
+    (
+        "from contextlib import contextmanager\n",
+        "from contextlib import contextmanager, nullcontext\n",
+    ),
+    (
+        "def __call__(self, graph: fx.GraphModule, example_inputs: Sequence[Any]) -> Any:",
+        "def __call__(self, graph: fx.GraphModule, example_inputs: Sequence[Any], **kwargs: Any) -> Any:",
+    ),
+    (
+        """            with (
+                # Graphs that are isometric (different node names but same
+                # structure) should be treated as the same.
+                torch._functorch.config.patch(autograd_cache_normalize_inputs=True),
+                patch(
+""",
+        """            functorch_cache_key_ctx = (
+                torch._functorch.config.patch(autograd_cache_normalize_inputs=True)
+                if hasattr(
+                    torch._functorch.config, "autograd_cache_normalize_inputs"
+                )
+                else nullcontext()
+            )
+            with (
+                # Graphs that are isometric (different node names but same
+                # structure) should be treated as the same.
+                functorch_cache_key_ctx,
+                patch(
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__compilation__caching.patch.py
+++ b/vllm_musa/patches/vllm__compilation__caching.patch.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch for vllm.compilation.caching.
+"""
+
+_GRAPH_PICKLER_COMPAT = """import torch.fx._graph_pickler as _vllm_graph_pickler
+GraphPickler = _vllm_graph_pickler.GraphPickler
+Options = getattr(_vllm_graph_pickler, "Options", None)
+
+
+def _musa_graph_pickler_dumps(graph_module):
+    if Options is None:
+        return GraphPickler.dumps(graph_module)
+    return GraphPickler.dumps(graph_module, Options(ops_filter=None))
+"""
+
+_BROKEN_GRAPH_PICKLER_COMPAT = """try:
+    try:
+    from torch.fx._graph_pickler import GraphPickler, Options
+except ImportError:
+    from torch.fx._graph_pickler import GraphPickler
+
+    Options = None
+
+except ImportError:
+    from torch.fx._graph_pickler import GraphPickler
+
+    Options = None
+"""
+
+_BROKEN_DUMPS_BLOCK = """            if Options is None:
+                return GraphPickler.dumps(graph_module)
+            if Options is None:
+                return GraphPickler.dumps(graph_module)
+            return GraphPickler.dumps(graph_module, Options(ops_filter=None))"""
+
+PATCHES = [
+    (
+        _BROKEN_GRAPH_PICKLER_COMPAT,
+        _GRAPH_PICKLER_COMPAT,
+    ),
+    (
+        "from torch.fx._graph_pickler import GraphPickler, Options",
+        _GRAPH_PICKLER_COMPAT,
+    ),
+    (
+        _BROKEN_DUMPS_BLOCK,
+        "            return _musa_graph_pickler_dumps(graph_module)",
+    ),
+    (
+        "            return GraphPickler.dumps(graph_module, Options(ops_filter=None))",
+        "            return _musa_graph_pickler_dumps(graph_module)",
+    ),
+]

--- a/vllm_musa/patches/vllm__compilation__compiler_interface.patch.py
+++ b/vllm_musa/patches/vllm__compilation__compiler_interface.patch.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch for vllm.compilation.compiler_interface.
+"""
+
+PATCHES = [
+    (
+        """    if not envs.VLLM_USE_MEGA_AOT_ARTIFACT:
+        cfg["bundled_autograd_cache"] = False
+    return cfg
+""",
+        """    if not envs.VLLM_USE_MEGA_AOT_ARTIFACT:
+        cfg["bundled_autograd_cache"] = False
+
+    from torch._functorch import config as functorch_config
+
+    return {
+        key: value
+        for key, value in cfg.items()
+        if hasattr(functorch_config, key)
+    }
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__compilation__piecewise_backend.patch.py
+++ b/vllm_musa/patches/vllm__compilation__piecewise_backend.patch.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch for vllm.compilation.piecewise_backend.
+"""
+
+PATCHES = [
+    (
+        "import pickle\nfrom collections.abc import Callable\nfrom pickle import Pickler",
+        "import pickle\nfrom collections.abc import Callable\nfrom contextlib import nullcontext\nfrom pickle import Pickler",
+    ),
+    (
+        """            with torch._functorch.config.patch("bundled_autograd_cache", True):
+                entry = fn.serialize()
+""",
+        """            functorch_cache_ctx = (
+                torch._functorch.config.patch("bundled_autograd_cache", True)
+                if hasattr(torch._functorch.config, "bundled_autograd_cache")
+                else nullcontext()
+            )
+            with functorch_cache_ctx:
+                entry = fn.serialize()
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__distributed__device_communicators__custom_all_reduce.patch.py
+++ b/vllm_musa/patches/vllm__distributed__device_communicators__custom_all_reduce.patch.py
@@ -18,6 +18,11 @@ PATCHES = [
     # Patch CustomAllreduce enable musa's custom_allreduce
     (
         "if not current_platform.is_rocm() and not _can_p2p(rank, world_size):",
+        "if not current_platform.is_rocm() and not current_platform.is_musa() and not _can_p2p(rank, world_size):",
+    ),
+    # Upgrade the previous MUSA patch if it was already persisted on disk.
+    (
         "if ( not current_platform.is_rocm() or not current_platform.is_musa() ) and not _can_p2p(rank, world_size):",
+        "if not current_platform.is_rocm() and not current_platform.is_musa() and not _can_p2p(rank, world_size):",
     ),
 ]

--- a/vllm_musa/patches/vllm__model_executor__kernels__linear.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__kernels__linear.patch.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-_MUSA_FP8_FALLBACK = """    platform_kernels = possible_kernels.get(current_platform._enum)
+_OLD_MUSA_FP8_FALLBACK = """    platform_kernels = possible_kernels.get(current_platform._enum)
     if platform_kernels is None and current_platform.is_musa():
         from vllm_musa.model_executor.kernels.linear.scaled_mm.deep_gemm import (
             MUSADeepGemmFp8BlockScaledMMKernel,
@@ -20,10 +20,43 @@ _MUSA_FP8_FALLBACK = """    platform_kernels = possible_kernels.get(current_plat
     for kernel in platform_kernels:
 """
 
+_MUSA_FP8_FALLBACK = """    platform_kernels = possible_kernels.get(current_platform._enum)
+    if platform_kernels is None and current_platform.is_musa():
+        if possible_kernels is _POSSIBLE_FP8_BLOCK_KERNELS:
+            from vllm_musa.model_executor.kernels.linear.scaled_mm.deep_gemm import (
+                MUSADeepGemmFp8BlockScaledMMKernel,
+            )
+
+            platform_kernels = [MUSADeepGemmFp8BlockScaledMMKernel]
+        elif possible_kernels is _POSSIBLE_FP8_KERNELS:
+            from vllm_musa.model_executor.kernels.linear.scaled_mm.torch_scaled_mm import (
+                MUSAChannelWiseTorchFP8ScaledMMLinearKernel,
+                MUSAPerTensorTorchFP8ScaledMMLinearKernel,
+            )
+
+            platform_kernels = [
+                MUSAPerTensorTorchFP8ScaledMMLinearKernel,
+                MUSAChannelWiseTorchFP8ScaledMMLinearKernel,
+            ]
+
+    if platform_kernels is None:
+        raise ValueError(
+            "Failed to find a kernel that can implement the "
+            "ScaledMM linear layer. No kernels are registered for "
+            f"platform {current_platform._enum.name}."
+        )
+
+    for kernel in platform_kernels:
+"""
+
 PATCHES = [
     (
         """    for kernel in possible_kernels[current_platform._enum]:
 """,
+        _MUSA_FP8_FALLBACK,
+    ),
+    (
+        _OLD_MUSA_FP8_FALLBACK,
         _MUSA_FP8_FALLBACK,
     ),
 ]

--- a/vllm_musa/patches/vllm__model_executor__layers__attention__attention.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__attention__attention.patch.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch for vllm.model_executor.layers.attention.attention.
+"""
+
+PATCHES = [
+    (
+        """            output_shape = torch.Size((num_tokens, self.num_heads * self.head_size_v))
+""",
+        """            output_shape = (num_tokens, self.num_heads * self.head_size_v)
+""",
+    ),
+]

--- a/vllm_musa/patches/vllm__model_executor__layers__fused_moe__experts__deep_gemm_moe.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__fused_moe__experts__deep_gemm_moe.patch.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch for vllm.model_executor.layers.fused_moe.experts.deep_gemm_moe.
+"""
+
+_OLD = """        if activation == MoEActivation.SILU:
+            use_ue8m0 = scale_fmt == DeepGemmQuantScaleFMT.FLOAT32_CEIL_UE8M0
+            return silu_mul_per_token_group_quant_fp8_colmajor(
+                input=input,
+                output=output,
+                use_ue8m0=use_ue8m0,
+            )
+"""
+
+_NEW = """        if activation == MoEActivation.SILU:
+            use_ue8m0 = scale_fmt == DeepGemmQuantScaleFMT.FLOAT32_CEIL_UE8M0
+            from vllm.platforms import current_platform
+
+            if current_platform.is_musa():
+                from vllm_musa.model_executor.layers.quantization.utils.fp8_utils import (
+                    silu_mul_per_token_group_quant_fp8_musa,
+                )
+
+                return silu_mul_per_token_group_quant_fp8_musa(
+                    input=input,
+                    output=output,
+                    use_ue8m0=use_ue8m0,
+                )
+            return silu_mul_per_token_group_quant_fp8_colmajor(
+                input=input,
+                output=output,
+                use_ue8m0=use_ue8m0,
+            )
+"""
+
+PATCHES = [
+    (_OLD, _NEW),
+]

--- a/vllm_musa/patches/vllm__utils__deep_gemm.patch.py
+++ b/vllm_musa/patches/vllm__utils__deep_gemm.patch.py
@@ -20,4 +20,40 @@ PATCHES = [
         "mk_align_size = _get_mk_alignment_for_contiguous_layout_impl()",
         "mk_align_size = 128",
     ),
+    # MUSA DeepGEMM does not support grouped FP8 UE8M0 casts yet. Keep the
+    # default DeepGEMM FP8 path enabled, but force the oracle to use FLOAT32
+    # scales on MUSA so MoE warmup and runtime do not select UE8M0 layouts.
+    (
+        """        if not use_e8m0:
+            cls._oracle_cache = cls.FLOAT32  # type: ignore
+            return
+""",
+        """        if use_e8m0 and current_platform.is_musa():
+            logger.info_once(
+                "DeepGEMM E8M0 disabled on MUSA: grouped FP8 UE8M0 cast is "
+                "not supported by the MUSA DeepGEMM backend."
+            )
+            use_e8m0 = False
+
+        if not use_e8m0:
+            cls._oracle_cache = cls.FLOAT32  # type: ignore
+            return
+""",
+    ),
+    (
+        """    if envs.VLLM_USE_DEEP_GEMM_E8M0:
+        logger.info_once("DeepGEMM E8M0 enabled on current platform.")
+        return True
+""",
+        """    if envs.VLLM_USE_DEEP_GEMM_E8M0:
+        if current_platform.is_musa():
+            logger.info_once(
+                "DeepGEMM E8M0 disabled on MUSA: grouped FP8 UE8M0 cast is "
+                "not supported by the MUSA DeepGEMM backend."
+            )
+            return False
+        logger.info_once("DeepGEMM E8M0 enabled on current platform.")
+        return True
+""",
+    ),
 ]

--- a/vllm_musa/patches/vllm__v1__sample__ops__topk_topp_sampler.patch.py
+++ b/vllm_musa/patches/vllm__v1__sample__ops__topk_topp_sampler.patch.py
@@ -4,11 +4,150 @@
 # Patch for vllm.v1.sample.ops.topk_topp_sampler.
 # """
 
+_ORIGINAL_APPLY_TOP_K_TOP_P = """def apply_top_k_top_p(
+    logits: torch.Tensor, k: torch.Tensor | None, p: torch.Tensor | None
+) -> torch.Tensor:
+    if p is None and k is None:
+        return logits
+
+    if HAS_TRITON and logits.shape[0] >= 8:
+        return apply_top_k_top_p_triton(logits, k, p)
+
+    # Use pytorch sort implementation for small batch sizes.
+    return apply_top_k_top_p_pytorch(logits, k, p)
+"""
+
+_MUSA_GUARDED_APPLY_TOP_K_TOP_P = """def apply_top_k_top_p(
+    logits: torch.Tensor, k: torch.Tensor | None, p: torch.Tensor | None
+) -> torch.Tensor:
+    if p is None and k is None:
+        return logits
+
+    if HAS_TRITON and logits.shape[0] >= 8 and not current_platform.is_musa():
+        return apply_top_k_top_p_triton(logits, k, p)
+
+    # Use pytorch sort implementation for small batch sizes.
+    return apply_top_k_top_p_pytorch(logits, k, p)
+"""
+
+_MUSA_FAST_APPLY_TOP_K_TOP_P_WITHOUT_VOCAB_GATE = """def apply_top_k_top_p(
+    logits: torch.Tensor, k: torch.Tensor | None, p: torch.Tensor | None
+) -> torch.Tensor:
+    if p is None and k is None:
+        return logits
+
+    if current_platform.is_musa() and _musa_sampler_fast_path_enabled():
+        if k is not None and logits.shape[0] >= 16:
+            if p is None:
+                max_top_k = int(k.to(torch.long).max().item())
+                if 0 < max_top_k <= 1024:
+                    return apply_top_k_only(logits, k)
+            elif logits.shape[1] >= 65536:
+                return _apply_top_k_top_p_musa_topk_prefilter(logits, k, p)
+
+    if HAS_TRITON and logits.shape[0] >= 8 and not current_platform.is_musa():
+        return apply_top_k_top_p_triton(logits, k, p)
+
+    # Use pytorch sort implementation for small batch sizes.
+    return apply_top_k_top_p_pytorch(logits, k, p)
+"""
+
+_MUSA_FAST_APPLY_TOP_K_TOP_P_FUNCTION_ONLY = """def apply_top_k_top_p(
+    logits: torch.Tensor, k: torch.Tensor | None, p: torch.Tensor | None
+) -> torch.Tensor:
+    if p is None and k is None:
+        return logits
+
+    if current_platform.is_musa() and _musa_sampler_fast_path_enabled():
+        if k is not None and logits.shape[0] >= 16:
+            if p is None and logits.shape[1] >= 65536:
+                max_top_k = int(k.to(torch.long).max().item())
+                if 0 < max_top_k <= 1024:
+                    return apply_top_k_only(logits, k)
+            elif logits.shape[1] >= 65536:
+                return _apply_top_k_top_p_musa_topk_prefilter(logits, k, p)
+
+    if HAS_TRITON and logits.shape[0] >= 8 and not current_platform.is_musa():
+        return apply_top_k_top_p_triton(logits, k, p)
+
+    # Use pytorch sort implementation for small batch sizes.
+    return apply_top_k_top_p_pytorch(logits, k, p)
+"""
+
+_MUSA_FAST_APPLY_TOP_K_TOP_P = """def _musa_sampler_fast_path_enabled() -> bool:
+    value = __import__("os").environ.get("VLLM_MUSA_SAMPLER_FAST_PATH", "1")
+    return value.lower() not in ("0", "false", "no", "off")
+
+
+def _apply_top_k_top_p_musa_topk_prefilter(
+    logits: torch.Tensor, k: torch.Tensor, p: torch.Tensor
+) -> torch.Tensor:
+    vocab_size = logits.shape[1]
+    k_long = k.to(torch.long)
+    if bool((k_long >= vocab_size).any().item()):
+        return apply_top_k_top_p_pytorch(logits, k, p)
+
+    max_top_k = int(k_long.max().item())
+    if max_top_k <= 0 or max_top_k > 1024:
+        return apply_top_k_top_p_pytorch(logits, k, p)
+
+    values, indices = logits.topk(max_top_k, dim=-1, largest=True, sorted=True)
+    gather_idx = (k_long.clamp_min(1) - 1).unsqueeze(1)
+    threshold = values.gather(1, gather_idx)
+
+    # Preserve the current strict tie semantics: the PyTorch fallback keeps
+    # every token equal to the kth logit. If a row has ties, use the fallback.
+    num_ge = (logits >= threshold).sum(dim=-1)
+    if bool((num_ge != k_long).any().item()):
+        return apply_top_k_top_p_pytorch(logits, k, p)
+
+    valid = torch.arange(max_top_k, device=logits.device).unsqueeze(0)
+    values = values.masked_fill(~(valid < k_long.unsqueeze(1)), -float("inf"))
+    logits_sort = values.flip(dims=(-1,))
+    logits_idx = indices.flip(dims=(-1,))
+
+    probs_sort = logits_sort.softmax(dim=-1)
+    probs_sum = torch.cumsum(probs_sort, dim=-1, out=probs_sort)
+    top_p_mask = probs_sum <= 1 - p.unsqueeze(dim=1)
+    top_p_mask[:, -1] = False
+    logits_sort.masked_fill_(top_p_mask, -float("inf"))
+
+    output = logits.new_full(logits.shape, -float("inf"))
+    output.scatter_(dim=-1, index=logits_idx, src=logits_sort)
+    logits.copy_(output)
+    return logits
+
+
+def apply_top_k_top_p(
+    logits: torch.Tensor, k: torch.Tensor | None, p: torch.Tensor | None
+) -> torch.Tensor:
+    if p is None and k is None:
+        return logits
+
+    if current_platform.is_musa() and _musa_sampler_fast_path_enabled():
+        if k is not None and logits.shape[0] >= 16:
+            if p is None and logits.shape[1] >= 65536:
+                max_top_k = int(k.to(torch.long).max().item())
+                if 0 < max_top_k <= 1024:
+                    return apply_top_k_only(logits, k)
+            elif logits.shape[1] >= 65536:
+                return _apply_top_k_top_p_musa_topk_prefilter(logits, k, p)
+
+    if HAS_TRITON and logits.shape[0] >= 8 and not current_platform.is_musa():
+        return apply_top_k_top_p_triton(logits, k, p)
+
+    # Use pytorch sort implementation for small batch sizes.
+    return apply_top_k_top_p_pytorch(logits, k, p)
+"""
+
+
 PATCHES = [
-    # Patch to use apply_top_k_top_p_pytorch instead of triton.
-    # For vLLM 0.13+
+    # Patch to keep unsafe Triton sampling disabled on MUSA and add a
+    # correctness-preserving top-k prefilter for large decode batches.
+    (_ORIGINAL_APPLY_TOP_K_TOP_P, _MUSA_FAST_APPLY_TOP_K_TOP_P),
+    (_MUSA_GUARDED_APPLY_TOP_K_TOP_P, _MUSA_FAST_APPLY_TOP_K_TOP_P),
     (
-        "if HAS_TRITON and logits.shape[0] >= 8:",
-        "if HAS_TRITON and logits.shape[0] >= 8 and not current_platform.is_musa():",
-    )
+        _MUSA_FAST_APPLY_TOP_K_TOP_P_WITHOUT_VOCAB_GATE,
+        _MUSA_FAST_APPLY_TOP_K_TOP_P_FUNCTION_ONLY,
+    ),
 ]

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -417,7 +417,7 @@ class MUSAPlatformBase(Platform):
 
     @classmethod
     def supports_fp8(cls) -> bool:
-        return cls.has_device_capability(89)
+        return cls.has_device_capability((3, 1))
 
     @classmethod
     def use_custom_allreduce(cls) -> bool:

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -7,7 +7,7 @@ pymtml. However, it should not initialize musa context.
 import os
 from collections.abc import Callable
 from functools import cache, wraps
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 # isort: off
 import torchada  # noqa: F401
@@ -33,6 +33,28 @@ logger = init_logger(__name__)
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
+_QWEN3_MOE_FP8_MAX_CUDAGRAPH_CAPTURE_SIZE = 64
+
+
+def _is_qwen3_moe_fp8_model(model_config: Any | None) -> bool:
+    if model_config is None:
+        return False
+
+    hf_config = getattr(model_config, "hf_config", None)
+    architectures = getattr(model_config, "architectures", None)
+    if architectures is None and hf_config is not None:
+        architectures = getattr(hf_config, "architectures", None)
+    if not any("Qwen3Moe" in str(arch) for arch in architectures or ()):
+        return False
+
+    if getattr(model_config, "quantization", None) == "fp8":
+        return True
+
+    quantization_config = getattr(hf_config, "quantization_config", None)
+    if isinstance(quantization_config, dict):
+        return quantization_config.get("quant_method") == "fp8"
+
+    return False
 
 
 @cache
@@ -170,6 +192,19 @@ class MUSAPlatformBase(Platform):
         compilation_config = vllm_config.compilation_config
         if all(s not in compilation_config.custom_ops for s in ("all", "none")):
             compilation_config.custom_ops.append("all")
+
+        if (
+            compilation_config.max_cudagraph_capture_size is None
+            and compilation_config.cudagraph_capture_sizes is None
+            and _is_qwen3_moe_fp8_model(vllm_config.model_config)
+        ):
+            compilation_config.max_cudagraph_capture_size = (
+                _QWEN3_MOE_FP8_MAX_CUDAGRAPH_CAPTURE_SIZE
+            )
+            logger.info(
+                "Capping MUSA Qwen3 MoE FP8 cudagraph capture size to %d.",
+                compilation_config.max_cudagraph_capture_size,
+            )
 
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -279,6 +279,22 @@ class MUSAPlatformBase(Platform):
             )
             scheduler_config.disable_chunked_mm_input = True
 
+        compilation_config = vllm_config.compilation_config
+        cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
+        if parallel_config.tensor_parallel_size > 2 and cudagraph_mode is not None:
+            from vllm.config import CUDAGraphMode
+
+            if cudagraph_mode != CUDAGraphMode.NONE:
+                logger.warning(
+                    "Disabling MUSA cudagraph capture for tensor parallel "
+                    "size %d because MCCL collectives are not safe during "
+                    "stream capture on this platform.",
+                    parallel_config.tensor_parallel_size,
+                )
+                compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+                compilation_config.max_cudagraph_capture_size = 0
+                compilation_config.cudagraph_capture_sizes = []
+
     @classmethod
     def get_current_memory_usage(
         cls, device: torch.types.Device | None = None

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -88,6 +88,8 @@ class EnvBool(EnvField):
 
 class Envs:
     VLLM_MUSA_CUSTOM_OP_USE_NATIVE = EnvBool(False)
+    VLLM_MUSA_FUSED_ADD_RMSNORM = EnvBool(True)
+    VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
 
 
 envs = Envs()

--- a/vllm_musa/v1/attention/backends/fa_utils.py
+++ b/vllm_musa/v1/attention/backends/fa_utils.py
@@ -17,8 +17,9 @@ if current_platform.is_musa():
     from vllm_musa.utils.environ import envs
 
     _USE_NATIVE_RESHAPE_CACHE_FLASH = envs.VLLM_MUSA_RESHAPE_CACHE_FLASH.get()
+    _MUSA_OPS_NAMESPACE = getattr(torch.ops, "_C_musa_ops", None)
     _HAS_NATIVE_RESHAPE_CACHE_FLASH = hasattr(
-        torch.ops._C_musa_ops, "musa_reshape_and_cache_flash_nhd"
+        _MUSA_OPS_NAMESPACE, "musa_reshape_and_cache_flash_nhd"
     )
 
     def _can_use_musa_reshape_and_cache_flash_nhd(
@@ -39,6 +40,9 @@ if current_platform.is_musa():
             and _HAS_NATIVE_RESHAPE_CACHE_FLASH
             and kv_cache_dtype in ("auto", "float16", "bfloat16")
             and key.dtype in (torch.float16, torch.bfloat16)
+            and value.dtype == key.dtype
+            and key_cache.dtype == key.dtype
+            and value_cache.dtype == value.dtype
             and key.dim() == 3
             and value.dim() == 3
             and head_size is not None

--- a/vllm_musa/v1/attention/backends/fa_utils.py
+++ b/vllm_musa/v1/attention/backends/fa_utils.py
@@ -2,6 +2,7 @@
 # 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import torch
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.fa_utils import logger
 
@@ -12,8 +13,93 @@ if current_platform.is_musa():
         get_scheduler_metadata,
     )
     from vllm import _custom_ops as ops
+    from vllm_musa import _custom_ops as musa_ops
+    from vllm_musa.utils.environ import envs
 
-    reshape_and_cache_flash = ops.reshape_and_cache_flash
+    _USE_NATIVE_RESHAPE_CACHE_FLASH = envs.VLLM_MUSA_RESHAPE_CACHE_FLASH.get()
+    _HAS_NATIVE_RESHAPE_CACHE_FLASH = hasattr(
+        torch.ops._C_musa_ops, "musa_reshape_and_cache_flash_nhd"
+    )
+
+    def _can_use_musa_reshape_and_cache_flash_nhd(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    ) -> bool:
+        # Keep this guard cheap: the native op has full TORCH_CHECK coverage.
+        # Python only filters known fallback cases that are valid upstream.
+        head_size = key.shape[2] if key.dim() == 3 else None
+        return (
+            _USE_NATIVE_RESHAPE_CACHE_FLASH
+            and _HAS_NATIVE_RESHAPE_CACHE_FLASH
+            and kv_cache_dtype in ("auto", "float16", "bfloat16")
+            and key.dtype in (torch.float16, torch.bfloat16)
+            and key.dim() == 3
+            and value.dim() == 3
+            and head_size is not None
+            and head_size % 8 == 0
+            and key.stride(2) == 1
+            and value.stride(2) == 1
+            and key.stride(1) == head_size
+            and value.stride(1) == value.shape[2]
+            and k_scale.numel() == 1
+            and v_scale.numel() == 1
+            and key_cache.dim() == 4
+            and value_cache.dim() == 4
+            and key_cache.stride(3) == 1
+            and value_cache.stride(3) == 1
+            and key_cache.stride(2) == key_cache.shape[3]
+            and value_cache.stride(2) == value_cache.shape[3]
+            and key_cache.stride(1) == key_cache.shape[2] * key_cache.shape[3]
+            and (
+                value_cache.stride(1)
+                == value_cache.shape[2] * value_cache.shape[3]
+            )
+        )
+
+    def reshape_and_cache_flash(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    ) -> None:
+        if _can_use_musa_reshape_and_cache_flash_nhd(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+            v_scale,
+        ):
+            musa_ops.musa_reshape_and_cache_flash_nhd(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                slot_mapping,
+            )
+            return
+        ops.reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+            v_scale,
+        )
 
 
 def get_flash_attn_version(


### PR DESCRIPTION
## Summary

This PR consolidates the recent MUSA S5000 FP8 performance work for DeepSeek-V2-Lite-Chat-FP8 and Qwen FP8 models onto `xd/ds_qwen_fp8`.

- Adds and hardens MUSA FP8 runtime support paths, including FP8 quantization utilities, DeepGEMM dispatch, scaled-mm fallback handling, fused MoE chunking, layernorm/activation wrappers, and custom op bindings.
- Adds MUSA torch.compile compatibility patches and graph policy handling for vLLM compile/CUDAGraph paths.
- Adds the register FP8 group quant fast path and Qwen/DeepSeek FP8 MoE GEMV tuning.
- Adds TP padding and CUDAGraph policy handling needed for the DeepSeek/Qwen FP8 serving paths.
- Rebuilds the optimization stack on top of `6376eac0aa2e1a72e91d2ea855c83b6f5db1f953`; current pushed head is `a70cbe8e1e8aa505c9084aa25e94ee98c1e9efc4`.
- The explicitly dropped commit `4c0aafdbd7ff63d4e1f697a44a8e52310c4d4149` is not part of the final branch history.

## Unit Test Coverage

Remote validation environment:

- Host/container: `mccxadmin@10.18.32.18`, container `yeahdongcn50`
- Repo: `/ws`
- Verified SHA: `a70cbe8e1e8aa505c9084aa25e94ee98c1e9efc4`

Command:

```bash
python -m pytest -q tests/test_musa.py tests/test_patches.py tests/test_fused_moe_chunking.py
```

Result:

```text
79 passed, 1 skipped, 3 warnings in 9.33s
```

Coverage added or extended in this stack:

- `tests/test_musa.py`: MUSA platform behavior, FP8 support gates, custom op/platform checks.
- `tests/test_patches.py`: vLLM patch behavior for compile/CUDAGraph policy, MUSA wrappers, sampler behavior, DeepGEMM and FP8-related patch coverage.
- `tests/test_fused_moe_chunking.py`: fused MoE chunking and source coverage assertions.

Remote test log:

```text
/tmp/vllm_omni_musa_logs/ds_qwen_fp8_a70cbe8e1_unit_20260514_094300/unit_pytest.log
```

## Performance Policy

Accepted performance evidence below uses the normal vLLM serving path. It does not use `--enforce-eager`, `enforce_eager=True`, `TORCHDYNAMO_DISABLE=1`, or `TORCH_COMPILE_DISABLE=1`.

The performance artifacts were collected on S5000 in the same remote container family and reused where the final rebuilt tree is code-equivalent to the previously performance-validated tree.

## Single-Batch E2E Performance Summary

### DeepSeek-V2-Lite-Chat-FP8

Final accepted row: `MUSA-0044` closeout reusing accepted `MUSA-0043` no-eager rows.

| Workload | Baseline | Final | Output tok/s | TTFT p50 | TPOT p50 | E2E p50 | E2E change |
|---|---|---|---:|---:|---:|---:|---:|
| `dsfp8_batch1_i512_o128` | MUSA-0035 best TP1/GPU1 | MUSA-0044 default TP2/GPU2 | 54.82 -> 65.10 (+18.75%) | 880.14 -> 503.03 ms (-42.85%) | 11.45 -> 11.52 ms (+0.61%) | 2334.52 -> 1965.69 ms | -15.80% |

Notes:

- Final default result is TP2/GPU2. TP4/TP8 remain skipped for this model because dense RowParallel FP8 partitioning still hits the `block_k=128` compatibility blocker.
- This is a useful trend comparison against the prior accepted tracker milestone, not an 8-GPU SOTA claim.

Evidence:

- `generated/musa0044/deepseek-fp8-sota-v3-final.md`
- `generated/perf-tracker/musa0044_perf_rows.jsonl`

### Qwen3-8B-FP8

Final accepted high-TP rows: `MUSA-0045`.

| Workload | Baseline | Final | Output tok/s | TTFT p99 | TPOT p99 | E2E p99 | Change |
|---|---|---|---:|---:|---:|---:|---|
| `qwen3_8b_fp8_tp4_gpu4_batch1_i512_o128` | MUSA-0034 TP4 server health failed | MUSA-0045 TP4/GPU4 | 27.10 | 65.65 ms | 36.68 ms | 4723.48 ms | fail-to-pass |
| `qwen3_8b_fp8_tp8_gpu8_batch1_i512_o128` | MUSA-0034 TP8 server health failed | MUSA-0045 TP8/GPU8 | 26.22 | 74.73 ms | 37.85 ms | 4882.04 ms | fail-to-pass |

Notes:

- This PR unblocks Qwen3-8B-FP8 TP4/TP8 startup and accepted perf collection by disabling CUDAGraph capture for MUSA tensor parallel sizes greater than 2 while keeping `CompilationMode.VLLM_COMPILE`.
- TP4/TP8 are valid rows now, but they are not faster than the best MUSA-0034 TP1/TP2 accepted rows. The MUSA-0045 report records TP4 batch1 as -70.9% versus the best MUSA-0034 accepted row for the same stage.

Evidence:

- `generated/musa0045/qwen-fp8-tp4-tp8-graph-capture-final.md`
- `generated/perf-tracker/musa0045_perf_rows.jsonl`

### Qwen3-30B-A3B-FP8

Best accepted single-batch rows are from `MUSA-0034`; TP4/TP8 remain blocked by the known MoE FP8 `block_n=128` tensor-parallel partition compatibility limit.

| Workload | Baseline | Final | Output tok/s | TTFT p50 | TPOT p50 | E2E p50 | E2E change |
|---|---|---|---:|---:|---:|---:|---:|
| `qwen3_30b_a3b_fp8_tp*_gpu*_batch1_i512_o128` | MUSA-0034 TP1/GPU1 | MUSA-0034 TP2/GPU2 | 57.21 -> 58.05 (+1.47%) | 809.18 -> 623.64 ms (-22.93%) | 11.24 -> 12.45 ms (+10.77%) | 2236.99 -> 2204.38 ms | -1.46% |

Notes:

- The Qwen3-30B-A3B-FP8 accepted single-batch evidence is TP1/TP2 only.
- TP4/TP8 should not be claimed as fixed for this model in this PR. The tracker recorded those rows as skipped due to the `block_n=128` MoE FP8 partition compatibility blocker.

Evidence:

- `generated/musa0034/qwen-fp8-8gpu-sota-final.md`
- `generated/perf-tracker/musa0034_perf_rows.jsonl`

## Tracker Headline Versus Existing SGLang Rows

For context, the latest tracker still shows strong vLLM-MUSA advantage over the available SGLang rows on the common `i512/o128` burst serving workload:

| Model | Workload | vLLM output tok/s | SGLang output tok/s | Output advantage | Median E2E advantage |
|---|---|---:|---:|---:|---:|
| DeepSeek-V2-Lite-Chat-FP8 | `dsfp8_i512_o128_burst` | 445.96 | 3.92 | 113.77x | 112.52x lower |
| Qwen3-8B-FP8 | `qwen3_8b_fp8_i512_o128_burst` | 1238.76 | 110.46 | 11.21x | 11.15x lower |
| Qwen3-30B-A3B-FP8 | `qwen3_30b_a3b_fp8_i512_o128_burst` | 425.98 | 73.87 | 5.77x | 5.72x lower |

Source:

- `generated/perf-tracker/musa0045_perf_report.md`

## Risk And Follow-Ups

- DeepSeek-V2-Lite-Chat-FP8: TP2 is the final accepted default evidence; TP4/TP8 are still partition-blocked.
- Qwen3-8B-FP8: TP4/TP8 now pass semantic and perf gates, but high-TP performance is slower than TP1/TP2. This PR fixes startup/perf coverage, not high-TP SOTA throughput.
- Qwen3-30B-A3B-FP8: TP4/TP8 remain blocked by MoE FP8 partition compatibility and should stay as follow-up work.
