### PR TITLE
MiniMax-M2.5 + Eagle3

### DIFF
--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -70,37 +70,103 @@ void all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
   TORCH_CHECK(_is_weak_contiguous(out));
   TORCH_CHECK(_is_weak_contiguous(inp));
   auto input_size = inp.numel() * inp.element_size();
+
+  // MUSA-0075: handle non-vector-aligned numel by zero-padding the tail of
+  // the input AND using a scratch region in reg_buffer for the output, then
+  // memcpy back to the user's out. Background: torch_musa 2.9.0's Inductor
+  // compile-mode lowering can pass non-aligned numel to this op (e.g. fp32
+  // numel not a multiple of 4); since PyTorch's caching allocator does NOT
+  // guarantee storage slack on small tensors, we cannot over-write past
+  // orig_numel directly. The reg_buffer-scratch approach avoids that:
+  //
+  //   - reg_buffer[0..aligned_bytes)         = input (orig bytes + zero pad)
+  //   - reg_buffer[aligned_bytes..2*aligned_bytes) = output scratch
+  //   - after kernel:  cudaMemcpy(out, scratch, orig_bytes)
+  //
+  // Safe because (a) we own reg_buffer, (b) each rank pads its input
+  // identically, (c) the sum-of-zero peer tails is zero, (d) the output
+  // scratch is rank-local (peer kernels read peer input regions, not peer
+  // output scratches), (e) the final memcpy writes exactly orig_bytes to
+  // user's out -- no over-write.
+  int64_t d_T = 16 / inp.element_size();  // == packed_t<T>::P::size
+  int64_t orig_numel = out.numel();
+  int64_t aligned_numel = ((orig_numel + d_T - 1) / d_T) * d_T;
+  int64_t pad_count = aligned_numel - orig_numel;
+  int64_t aligned_bytes = aligned_numel * inp.element_size();
+
   auto reg_buffer = reinterpret_cast<void*>(_reg_buffer);
-  if (reg_buffer) {
-    TORCH_CHECK_LE(input_size, reg_buffer_sz_bytes);
-    AT_CUDA_CHECK(cudaMemcpyAsync(reg_buffer, inp.data_ptr(), input_size,
-                                  cudaMemcpyDeviceToDevice, stream));
+  void* kernel_in;
+  void* kernel_out;
+  int64_t kernel_size;
+
+  if (pad_count == 0) {
+    // Common (aligned) path -- unchanged behavior. Kernel writes directly
+    // into user's out.
+    if (reg_buffer) {
+      TORCH_CHECK_LE(input_size, reg_buffer_sz_bytes);
+      AT_CUDA_CHECK(cudaMemcpyAsync(reg_buffer, inp.data_ptr(), input_size,
+                                    cudaMemcpyDeviceToDevice, stream));
+      kernel_in = reg_buffer;
+    } else {
+      kernel_in = inp.data_ptr();
+    }
+    kernel_out = out.data_ptr();
+    kernel_size = orig_numel;
   } else {
-    reg_buffer = inp.data_ptr();
+    // Non-aligned path -- use reg_buffer as both input pad-zone and output
+    // scratch. Requires reg_buffer to hold 2 * aligned_bytes.
+    TORCH_CHECK(reg_buffer != nullptr,
+                "MUSA-0075: non-aligned custom_all_reduce numel requires a "
+                "non-null reg_buffer (compile-mode lowering bypass path)");
+    int64_t needed_bytes = 2 * aligned_bytes;
+    TORCH_CHECK(needed_bytes <= reg_buffer_sz_bytes,
+                "MUSA-0075: reg_buffer too small for tail-padded "
+                "custom_all_reduce (need ", needed_bytes,
+                " have ", reg_buffer_sz_bytes, ")");
+    void* in_buf = reg_buffer;
+    void* out_buf = static_cast<char*>(reg_buffer) + aligned_bytes;
+    AT_CUDA_CHECK(cudaMemcpyAsync(in_buf, inp.data_ptr(), input_size,
+                                  cudaMemcpyDeviceToDevice, stream));
+    AT_CUDA_CHECK(cudaMemsetAsync(
+        static_cast<char*>(in_buf) + input_size,
+        0,
+        pad_count * inp.element_size(),
+        stream));
+    kernel_in = in_buf;
+    kernel_out = out_buf;
+    kernel_size = aligned_numel;
   }
+
   switch (out.scalar_type()) {
     case at::ScalarType::Float: {
-      fa->allreduce<float>(stream, reinterpret_cast<float*>(reg_buffer),
-                           reinterpret_cast<float*>(out.data_ptr()),
-                           out.numel());
+      fa->allreduce<float>(stream, reinterpret_cast<float*>(kernel_in),
+                           reinterpret_cast<float*>(kernel_out), kernel_size);
       break;
     }
     case at::ScalarType::Half: {
-      fa->allreduce<half>(stream, reinterpret_cast<half*>(reg_buffer),
-                          reinterpret_cast<half*>(out.data_ptr()), out.numel());
+      fa->allreduce<half>(stream, reinterpret_cast<half*>(kernel_in),
+                          reinterpret_cast<half*>(kernel_out), kernel_size);
       break;
     }
 #if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
     case at::ScalarType::BFloat16: {
       fa->allreduce<nv_bfloat16>(
-          stream, reinterpret_cast<nv_bfloat16*>(reg_buffer),
-          reinterpret_cast<nv_bfloat16*>(out.data_ptr()), out.numel());
+          stream, reinterpret_cast<nv_bfloat16*>(kernel_in),
+          reinterpret_cast<nv_bfloat16*>(kernel_out), kernel_size);
       break;
     }
 #endif
     default:
       throw std::runtime_error(
           "custom allreduce only supports float32, float16 and bfloat16");
+  }
+
+  // MUSA-0075: when we ran with non-aligned numel, kernel wrote to the
+  // reg_buffer-scratch. Memcpy only the first orig_bytes back to user's out.
+  if (pad_count > 0) {
+    int64_t orig_bytes = orig_numel * out.element_size();
+    AT_CUDA_CHECK(cudaMemcpyAsync(out.data_ptr(), kernel_out, orig_bytes,
+                                  cudaMemcpyDeviceToDevice, stream));
   }
 }
 

--- a/csrc/quick_all_reduce.cu
+++ b/csrc/quick_all_reduce.cu
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// MUSA-0088 first-pass mechanical port of SGLang's quick_all_reduce.cu.
+// Source: sglang/sgl-kernel/csrc/allreduce/quick_all_reduce.cu
+// Translation: mechanical sed-pass per MUSA-0080 iter-2 breakdown,
+// plus USE_ROCM -> USE_MUSA and HIPStreamMasquerading -> CUDAStream.
+// NOT YET COMPILED OR TESTED. Follow-up:
+//   - Wire into vllm-musa/setup.py MUSA_KERNELS list
+//   - Add Python wrappers + dispatcher integration per the iter-2 breakdown
+//   - Compile via mcc + iterate on errors
+//   - Correctness gate (greedy parity) + perf A/B per MUSA-0088 ACs
+//
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <torch/all.h>
+
+#ifdef USE_MUSA
+
+#include "quick_all_reduce.h"
+
+quickreduce::fptr_t init_custom_qr(int64_t rank, int64_t world_size, std::optional<int64_t> qr_max_size) {
+  if (world_size > 8) throw std::invalid_argument("world size > 8 is not supported");
+  if (world_size == 6) throw std::invalid_argument("world size == 6 is not supported");
+  if (world_size % 2 != 0) throw std::invalid_argument("Odd num gpus is not supported for now");
+  if (rank < 0 || rank >= world_size) throw std::invalid_argument("invalid rank passed in");
+  quickreduce::DeviceComms* fptr = new quickreduce::DeviceComms();
+  fptr->init(world_size, rank, qr_max_size);
+  return (quickreduce::fptr_t)fptr;
+}
+
+void qr_destroy(quickreduce::fptr_t _fa) {
+  if (_fa) {
+    auto fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
+    fa->destroy();
+    delete fa;
+  }
+}
+
+torch::Tensor qr_get_handle(quickreduce::fptr_t _fa) {
+  auto fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
+  musaIpcMemHandle_t handle = fa->get_handle();
+  auto options = torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCPU);
+  auto data_handle = torch::empty({static_cast<int64_t>(sizeof(musaIpcMemHandle_t))}, options);
+  std::memcpy(data_handle.data_ptr(), &handle, sizeof(musaIpcMemHandle_t));
+  return data_handle;
+}
+
+void qr_open_handles(quickreduce::fptr_t _fa, const std::vector<torch::Tensor>& handles) {
+  auto fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
+  std::vector<musaIpcMemHandle_t> ipc_handles;
+  ipc_handles.reserve(handles.size());
+  for (auto& handle : handles) {
+    // Ensure the tensor is on the same device as the current device.
+    musaIpcMemHandle_t ipc_handle;
+    std::memcpy(&ipc_handle, handle.data_ptr(), sizeof(musaIpcMemHandle_t));
+    ipc_handles.push_back(ipc_handle);
+  }
+  fa->open_ipc_handles(ipc_handles);
+}
+
+void qr_all_reduce(
+    quickreduce::fptr_t _fa, torch::Tensor& inp, torch::Tensor& out, int64_t quant_level, bool cast_bf2half) {
+  auto fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(inp));
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());
+  TORCH_CHECK_EQ(inp.numel(), out.numel());
+  TORCH_CHECK_LE(out.numel(), fa->kMaxProblemSize);
+  if (out.scalar_type() == at::ScalarType::Half) {
+    fa->allreduce<half, false>(
+        reinterpret_cast<half*>(inp.data_ptr()),
+        reinterpret_cast<half*>(out.data_ptr()),
+        out.numel(),
+        quant_level,
+        stream);
+  } else if (out.scalar_type() == at::ScalarType::BFloat16) {
+    if (cast_bf2half) {
+      fa->allreduce<half, true>(
+          reinterpret_cast<half*>(inp.data_ptr()),
+          reinterpret_cast<half*>(out.data_ptr()),
+          out.numel(),
+          quant_level,
+          stream);
+    } else {
+      fa->allreduce<quickreduce::nv_bfloat16, false>(
+          reinterpret_cast<quickreduce::nv_bfloat16*>(inp.data_ptr()),
+          reinterpret_cast<quickreduce::nv_bfloat16*>(out.data_ptr()),
+          out.numel(),
+          quant_level,
+          stream);
+    }
+  } else {
+    throw std::runtime_error("quick allreduce only supports float16 and bfloat16");
+  }
+}
+
+int64_t qr_max_size() {
+  // The default is 2GB (2,147,483,648 bytes)
+  return static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
+}
+
+#define INSTANTIATE_FOR_WORLDSIZE(T, Codec, cast_bf2half)                      \
+  template struct quickreduce::AllReduceTwoshot<T, Codec<T, 2>, cast_bf2half>; \
+  template struct quickreduce::AllReduceTwoshot<T, Codec<T, 4>, cast_bf2half>; \
+  template struct quickreduce::AllReduceTwoshot<T, Codec<T, 8>, cast_bf2half>;
+
+// MUSA-0088 iter-5: strip to M2.5 production shape only (bf16 CodecFP, no cast).
+// The full template surface (36 instantiations) triggers an mcc internal
+// segfault in CallGraph Pass Manager. Restricting to this single shape
+// keeps the kernel binary small and lets mcc complete. Other shapes
+// (CodecQ4/Q6/Q8 quantized, half dtype, cast_bf2half=true) can be
+// re-enabled when mate/mcc fixes the segfault.
+INSTANTIATE_FOR_WORLDSIZE(quickreduce::nv_bfloat16, quickreduce::CodecFP, false)
+// INSTANTIATE_FOR_WORLDSIZE(quickreduce::nv_bfloat16, quickreduce::CodecQ4, false)
+// INSTANTIATE_FOR_WORLDSIZE(quickreduce::nv_bfloat16, quickreduce::CodecQ6, false)
+// INSTANTIATE_FOR_WORLDSIZE(quickreduce::nv_bfloat16, quickreduce::CodecQ8, false)
+// INSTANTIATE_FOR_WORLDSIZE(quickreduce::nv_bfloat16, quickreduce::CodecFP, true)
+// INSTANTIATE_FOR_WORLDSIZE(quickreduce::nv_bfloat16, quickreduce::CodecQ4, true)
+// INSTANTIATE_FOR_WORLDSIZE(quickreduce::nv_bfloat16, quickreduce::CodecQ6, true)
+// INSTANTIATE_FOR_WORLDSIZE(quickreduce::nv_bfloat16, quickreduce::CodecQ8, true)
+
+// MUSA-0088 iter-5: half-dtype variants stripped (only bf16 kept above).
+// INSTANTIATE_FOR_WORLDSIZE(half, quickreduce::CodecFP, false)
+// INSTANTIATE_FOR_WORLDSIZE(half, quickreduce::CodecQ4, false)
+// INSTANTIATE_FOR_WORLDSIZE(half, quickreduce::CodecQ6, false)
+// INSTANTIATE_FOR_WORLDSIZE(half, quickreduce::CodecQ8, false)
+
+#endif  // USE_MUSA

--- a/csrc/quick_all_reduce.cu
+++ b/csrc/quick_all_reduce.cu
@@ -68,7 +68,12 @@ void qr_all_reduce(
 
   TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());
   TORCH_CHECK_EQ(inp.numel(), out.numel());
-  TORCH_CHECK_LE(out.numel(), fa->kMaxProblemSize);
+  // kMaxProblemSize is a byte budget (default int32_max+1 = 2 GiB),
+  // not an element count. Compare against numel * element_size to
+  // avoid letting fp16/bf16 buffers > 2 GiB bytes slip past the
+  // check and overflow the comm allocation. See PR #40 review
+  // comment.
+  TORCH_CHECK_LE(out.numel() * out.element_size(), fa->kMaxProblemSize);
   if (out.scalar_type() == at::ScalarType::Half) {
     fa->allreduce<half, false>(
         reinterpret_cast<half*>(inp.data_ptr()),

--- a/csrc/quick_all_reduce.cuh
+++ b/csrc/quick_all_reduce.cuh
@@ -1,0 +1,644 @@
+// SPDX-License-Identifier: Apache-2.0
+// MUSA-0088 first-pass mechanical port of SGLang's quick_all_reduce.cuh.
+// NOT YET COMPILED. Follow-up work in iter-2 breakdown.
+//
+#pragma once
+
+#include <musa_runtime.h>
+
+#include "quick_all_reduce_base.h"
+
+namespace quickreduce {
+
+struct CodecBase {
+  const int thread;
+  const int rank;
+  const int group_leader;
+  __quickreduce_device_inline__ CodecBase(int thread, int rank)
+      : thread(thread), rank(rank), group_leader((threadIdx.x / kThreadGroupSize) * kThreadGroupSize) {
+    set_fp16_ovfl(true);
+  }
+};
+
+// Default full precision codec.
+template <typename T, int world_size>
+struct CodecFP : public CodecBase {
+  static constexpr int kWorldSize = world_size;
+  static constexpr int kRankAtoms = kAtoms / kWorldSize;
+
+  // Codec tile size process by this workgroup.
+  // Each thread processes atoms of f16x8_t (16B).
+  static constexpr int kRankTransmittedTileSize = kBlockSize * kRankAtoms * sizeof(int32x4_t);
+  static_assert(kRankTransmittedTileSize % 16 == 0, "kRankTransmittedTileSize must be 16B aligned.");
+
+  // Total tile size for the collective communication.
+  static constexpr int kTransmittedTileSize = kRankTransmittedTileSize * kWorldSize;
+
+  __quickreduce_device_inline__ CodecFP(int thread, int rank) : CodecBase(thread, rank) {}
+
+  __quickreduce_device_inline__ void send(int32x4_t* __restrict__ send_buffer, const int32x4_t* __restrict__ data) {
+    for (int i = 0; i < kRankAtoms; i++) {
+      __builtin_nontemporal_store(data[i], send_buffer + thread);
+      send_buffer += kAtomStride;
+    }
+  }
+
+  __quickreduce_device_inline__ void recv(int32x4_t** __restrict__ recv_buffer, int32x4_t* __restrict__ data) {
+    for (int i = 0; i < kRankAtoms; i++) {
+      data[i] = __builtin_nontemporal_load(*recv_buffer + thread);
+      *recv_buffer += kAtomStride;
+    }
+  }
+};
+
+// Int4 symmetric quantization codec.
+// We quantize the FP16 data to block-scaled Int4 in blocks of 4 *
+// kThreadGroupSize.
+template <typename T, int world_size>
+struct CodecQ4 : public CodecBase {
+  static constexpr int kWorldSize = world_size;
+
+  // Codec tile size process by this workgroup.
+  // Each threads processes a fragment of fp16x8_t (16B),
+  // into a int4x8_t (4B) and a fp16 scale shared among 32 values.
+  static constexpr int kRankAtoms = kAtoms / kWorldSize;
+  static constexpr int kRankTileStride = 1152;
+  static constexpr int kRankTileScaleOffset = 1024;
+  static constexpr int kRankTransmittedTileSize = kRankTileStride * kRankAtoms;
+  static_assert(kRankTransmittedTileSize % 16 == 0, "kRankTransmittedTileSize must be 16B aligned.");
+
+  static constexpr int kRankBufferTileStride = kRankTileStride / sizeof(int32x4_t);
+
+  // Total tile size for the collective communication.
+  static constexpr int kTransmittedTileSize = kRankTransmittedTileSize * kWorldSize;
+
+  // Constants configuration
+
+  // {-1/8.0h, -1/8.0h}, f16x2_t
+  static constexpr int kScaleFactor = std::is_same<T, half>::value ? 0xB000B000 : 0xBE00BE00;
+
+  // {1e-7, 1e-7}, f16x2_t
+  static constexpr int kScaleEpsilon = std::is_same<T, half>::value ? 0x00010001 : 0x33D733D7;
+
+  // {-8, -8}, f16x2_t
+  static constexpr int kRangeMin = std::is_same<T, half>::value ? 0xC800C800 : 0xC100C100;
+
+  // {+7, +7}, f16x2_t
+  static constexpr int kRangeMax = std::is_same<T, half>::value ? 0x47004700 : 0x40E040E0;
+
+  // {+8, +8}, int16x2_t
+  static constexpr int kRangeBias = 0x00080008;
+
+  __quickreduce_device_inline__ CodecQ4(int thread, int rank) : CodecBase(thread, rank) {}
+
+  __quickreduce_device_inline__ void send(int32x4_t* __restrict__ send_buffer, const int32x4_t* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      int32x4_t const atom = data[k];
+
+      // Compute the absolute maximum of the atom in the thread group
+      // In 2 blocks of values, upper/lower halves of the f16x2_t
+      int wblockmax = group_abs_max<T>(atom);
+
+      // Derive scales
+      int decoding_scale;
+      int encoding_scale;
+      decoding_scale = packed_mul<T>(wblockmax, kScaleFactor);
+      encoding_scale = packed_add<T>(decoding_scale, kScaleEpsilon);
+      encoding_scale = packed_rcp<T>(encoding_scale);
+
+      // Apply scales to get quantized values
+      int32x4_t w;
+      for (int i = 0; i < 4; i++) {
+        w[i] = packed_mul<T>(atom[i], encoding_scale);
+        w[i] = packed_max<T>(w[i], kRangeMin);
+        w[i] = packed_min<T>(w[i], kRangeMax);
+      }
+
+      // Convert from f16x2_t to uint16x2_t
+      int32x4_t q;
+      {
+        int16_t* qi = reinterpret_cast<int16_t*>(&q);
+        T* wh = reinterpret_cast<T*>(&w);
+        for (int i = 0; i < 8; i++)
+          qi[i] = (int16_t)rintf(T2float_cast(wh[i]));
+
+        for (int i = 0; i < 4; i++) {
+          q[i] = packed_add<int16_t>(q[i], kRangeBias);
+        }
+      }
+
+      // Pack 8 x q4 into int32_t
+      int qw = q[0] | (q[1] << 4) | (q[2] << 8) | (q[3] << 12);
+
+      // Write quantized atom to send_buffer
+      // note: only the group leader stores the scale
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(send_buffer + k * kRankBufferTileStride);
+      int32_t* qw_ptr = reinterpret_cast<int32_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) + (thread / 8);
+
+      __builtin_nontemporal_store(qw, qw_ptr);
+      if (threadIdx.x == group_leader) {
+        __builtin_nontemporal_store(decoding_scale, qs_ptr);
+      }
+    }
+  }
+
+  __quickreduce_device_inline__ void recv(int32x4_t** __restrict__ recv_buffer, int32x4_t* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      // Directly read quantized atom from recv_buffer
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(*recv_buffer);
+      int32_t* qw_ptr = reinterpret_cast<int32_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) + (thread / 8);
+
+      int32_t qw = __builtin_nontemporal_load(qw_ptr);
+      int qs = __builtin_nontemporal_load(qs_ptr);
+
+      *recv_buffer += kRankBufferTileStride;
+
+      // Unpack q4 into f16x8_t
+      int32x4_t w;
+      {
+        static constexpr uint kMask000F = 0x000F000F;
+        static constexpr uint kHalf2_1024 = 0x64006400;  // {1024.0, 1024.0}, fp16x2_t
+        static uint constexpr kHalf2_1032 = 0xE408E408;  // {-1032.0, -1032.0}, fp16x2_t
+
+        for (int i = 0; i < 4; i++) {
+          if constexpr (std::is_same<T, half>::value) {
+            int32_t q4 = ((qw >> (i * 4)) & kMask000F) | kHalf2_1024;
+            w[i] = packed_add<half>(q4, kHalf2_1032);
+          } else {
+            int32_t int16_2 = (qw >> (i * 4)) & kMask000F;
+            int16_t low = static_cast<int16_t>(int16_2 & 0xFFFF);
+            int16_t high = static_cast<int16_t>((int16_2 >> 16) & 0xFFFF);
+            nv_bfloat16 bf_low = __float2bfloat16(static_cast<float>(low));
+            nv_bfloat16 bf_high = __float2bfloat16(static_cast<float>(high));
+            nv_bfloat162 bf2 = __halves2bfloat162(bf_low, bf_high);
+            int32_t packed_bf16 = *reinterpret_cast<int32_t*>(&bf2);
+            w[i] = packed_add<nv_bfloat16>(packed_bf16, kRangeMin);
+          }
+        }
+      }
+
+      // Apply decoding scales
+      for (int i = 0; i < 4; i++) {
+        w[i] = packed_mul<T>(w[i], qs);
+      }
+
+      data[k] = w;
+    }
+  }
+};
+
+// Int6 symmetric quantization codec.
+// We quantize the FP16 data to block-scaled Int6 in blocks of 4 *
+// kThreadGroupSize.
+template <typename T, int world_size>
+struct CodecQ6 : public CodecBase {
+  static constexpr int kWorldSize = world_size;
+
+  // Codec tile size process by this workgroup.
+  // Each threads processes a fragment of fp16x8_t (16B),
+  // into a int6x8_t (4B + 2B) and a fp16 scale shared among 32 values.
+  static constexpr int kRankAtoms = kAtoms / kWorldSize;
+  static constexpr int kRankTileStride = 1664;
+  static constexpr int kRankTileQ2Offset = 1024;
+  static constexpr int kRankTileScaleOffset = 1536;
+  static constexpr int kRankTransmittedTileSize = kRankTileStride * kRankAtoms;
+  static_assert(kRankTransmittedTileSize % 16 == 0, "kRankTransmittedTileSize must be 16B aligned.");
+
+  static constexpr int kRankBufferTileStride = kRankTileStride / sizeof(int32x4_t);
+
+  // Total tile size for the collective communication.
+  static constexpr int kTransmittedTileSize = kRankTransmittedTileSize * kWorldSize;
+
+  // Constants configuration
+
+  // {-1/32.0h, -1/32.0h}, fp16x2_t
+  static constexpr int kScaleFactor = std::is_same<T, half>::value ? 0xA800A800 : 0xBD00BD00;
+
+  // {1e-7, 1e-7}, fp16x2_t
+  static constexpr int kScaleEpsilon = std::is_same<T, half>::value ? 0x00010001 : 0x33D733D7;
+
+  // {-32, -32}, fp16x2_t
+  static constexpr int kRangeMin = std::is_same<T, half>::value ? 0xD000D000 : 0xC200C200;
+
+  // {+31, +31}, fp16x2_t
+  static constexpr int kRangeMax = std::is_same<T, half>::value ? 0x4FC04FC0 : 0x41F841F8;
+
+  // {+32, +32}, int16x2_t
+  static constexpr int kRangeBias = 0x00200020;
+
+  __quickreduce_device_inline__ CodecQ6(int thread, int rank) : CodecBase(thread, rank) {}
+
+  __quickreduce_device_inline__ void send(int32x4_t* __restrict__ send_buffer, const int32x4_t* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      int32x4_t const atom = data[k];
+
+      // Compute the absolute maximum of the atom in the thread group
+      // In 2 blocks of values, upper/lower halves of the f16x2_t
+      int wblockmax = group_abs_max<T>(atom);
+
+      // Derive scales
+      int decoding_scale;
+      int encoding_scale;
+      decoding_scale = packed_mul<T>(wblockmax, kScaleFactor);
+      encoding_scale = packed_add<T>(decoding_scale, kScaleEpsilon);
+      encoding_scale = packed_rcp<T>(encoding_scale);
+
+      // Apply scales to get quantized values
+      int32x4_t w;
+      for (int i = 0; i < 4; i++) {
+        w[i] = packed_mul<T>(atom[i], encoding_scale);
+        w[i] = packed_max<T>(w[i], kRangeMin);
+        w[i] = packed_min<T>(w[i], kRangeMax);
+      }
+
+      // Convert from f16x2_t to uint16x2_t
+      int32x4_t q;
+      {
+        int16_t* qi = reinterpret_cast<int16_t*>(&q);
+        T* wh = reinterpret_cast<T*>(&w);
+        for (int i = 0; i < 8; i++)
+          qi[i] = (int16_t)rintf(T2float_cast(wh[i]));
+
+        for (int i = 0; i < 4; i++) {
+          q[i] = packed_add<int16_t>(q[i], kRangeBias);
+        }
+      }
+
+      // Pack 8 x q6 into int32_t + int16_t
+      uint32_t q4w;
+      uint16_t q2w = 0;
+      q4w = (q[0] & 0x000F000F) | ((q[1] & 0x000F000F) << 4) | ((q[2] & 0x000F000F) << 8) | ((q[3] & 0x000F000F) << 12);
+      {
+        int16_t* tw = reinterpret_cast<int16_t*>(&q);
+#pragma unroll
+        for (int i = 0; i < 8; i++) {
+          q2w |= (tw[i] >> 4) << (i * 2);
+        }
+      }
+      // Write quantized atom to send_buffer
+      // note: only the group leader stores the scale
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(send_buffer + k * kRankBufferTileStride);
+      uint32_t* q4w_ptr = reinterpret_cast<uint32_t*>(atom_ptr) + thread;
+      uint16_t* q2w_ptr = reinterpret_cast<uint16_t*>(atom_ptr + kRankTileQ2Offset) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) + (thread / 8);
+
+      __builtin_nontemporal_store(q4w, q4w_ptr);
+      __builtin_nontemporal_store(q2w, q2w_ptr);
+      if (threadIdx.x == group_leader) {
+        __builtin_nontemporal_store(decoding_scale, qs_ptr);
+      }
+    }
+  }
+
+  __quickreduce_device_inline__ void recv(int32x4_t** __restrict__ recv_buffer, int32x4_t* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      // Directly read quantized atom from recv_buffer
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(*recv_buffer);
+      uint32_t* q4w_ptr = reinterpret_cast<uint32_t*>(atom_ptr) + thread;
+      uint16_t* q2w_ptr = reinterpret_cast<uint16_t*>(atom_ptr + kRankTileQ2Offset) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) + (thread / 8);
+
+      uint32_t q4w = __builtin_nontemporal_load(q4w_ptr);
+      uint16_t q2w = __builtin_nontemporal_load(q2w_ptr);
+      int qs = __builtin_nontemporal_load(qs_ptr);
+
+      *recv_buffer += kRankBufferTileStride;
+
+      // Unpack q6 into fp16x8_t
+      int32x4_t w;
+      {
+        static uint constexpr kMask000F = 0x000F000F;
+        static uint constexpr kHalf2_1024 = 0x64006400;  // {1024.0, 1024.0}, fp16x2_t
+        static uint constexpr kHalf2_1056 = 0xE420E420;  // {-1056.0, -1056.0}, fp16x2_t
+
+#pragma unroll
+        for (int i = 0; i < 4; i++) {
+          int32_t q4 = q4w & kMask000F;
+          int32_t q2 = (q2w & 0x3) | ((q2w & 0xC) << 14);
+          q4w >>= 4;
+          q2w >>= 4;
+          if constexpr (std::is_same<T, half>::value) {
+            int32_t q6 = q4 | (q2 << 4) | kHalf2_1024;
+            // MUSA-0088: dead-code (if(0) above) AMD GCN asm replaced with __hadd2 equivalent.
+            {
+              int32_t* wp = reinterpret_cast<int32_t*>(&w);
+              __half2 q6_h2 = *reinterpret_cast<__half2*>(&q6);
+              __half2 c_h2 = *reinterpret_cast<__half2 const*>(&kHalf2_1056);
+              *reinterpret_cast<__half2*>(&wp[i]) = __hadd2(q6_h2, c_h2);
+            }
+          } else {
+            int32_t int16_2 = q4 | (q2 << 4);
+            int16_t low = static_cast<int16_t>(int16_2 & 0xFFFF);
+            int16_t high = static_cast<int16_t>((int16_2 >> 16) & 0xFFFF);
+
+            nv_bfloat16 bf_low = __float2bfloat16(static_cast<float>(low));
+            nv_bfloat16 bf_high = __float2bfloat16(static_cast<float>(high));
+            nv_bfloat162 bf2 = __halves2bfloat162(bf_low, bf_high);
+            int32_t packed_bf16 = *reinterpret_cast<int32_t*>(&bf2);
+            w[i] = packed_add<nv_bfloat16>(packed_bf16, kRangeMin);
+          }
+        }
+      }
+
+      // Apply decoding scales
+      for (int i = 0; i < 4; i++) {
+        w[i] = packed_mul<T>(w[i], qs);
+      }
+
+      // That's pretty much it...
+      data[k] = w;
+    }
+  }
+};
+
+// Int8 symmetric quantization codec.
+// We quantize the FP16 data to block-scaled Int8 in blocks of 4 *
+// kThreadGroupSize.
+template <typename T, int world_size>
+struct CodecQ8 : public CodecBase {
+  static constexpr int kWorldSize = world_size;
+
+  // Codec tile size process by this workgroup.
+  // Each threads processes a fragment of f16x8_t (16B),
+  // into a int8x8_t (8B) and a f16 scale shared among 32 values.
+  static constexpr int kRankAtoms = kAtoms / kWorldSize;
+  static constexpr int kRankTileStride = 2176;
+  static constexpr int kRankTileScaleOffset = 2048;
+  static constexpr int kRankTransmittedTileSize = kRankTileStride * kRankAtoms;
+  static_assert(kRankTransmittedTileSize % 16 == 0, "kRankTileSize must be 16B aligned.");
+
+  static constexpr int kRankBufferTileStride = kRankTileStride / sizeof(int32x4_t);
+
+  // Total tile size for the collective communication.
+  static constexpr int kTransmittedTileSize = kRankTransmittedTileSize * kWorldSize;
+
+  // Constants configuration
+
+  // {-1/128.0h, -1/128.0h}, f16x2_t
+  static constexpr int kScaleFactor = std::is_same<T, half>::value ? 0xA000A000 : 0xBC00BC00;
+
+  // {1e-7, 1e-7}, f16x2_t
+  static constexpr int kScaleEpsilon = std::is_same<T, half>::value ? 0x00010001 : 0x33D733D7;
+
+  // {-128, -128}, f16x2_t
+  static constexpr int kRangeMin = std::is_same<T, half>::value ? 0xD800D800 : 0xC300C300;
+  // {+127, +127}, f16x2_t
+  static constexpr int kRangeMax = std::is_same<T, half>::value ? 0x57F057F0 : 0x42FE42FE;
+
+  // {+128, +128}, int16x2_t
+  static constexpr int kRangeBias = 0x00800080;
+
+  __quickreduce_device_inline__ CodecQ8(int thread, int rank) : CodecBase(thread, rank) {}
+
+  __quickreduce_device_inline__ void send(int32x4_t* __restrict__ send_buffer, int32x4_t const* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      int32x4_t const atom = data[k];
+      // Compute the absolute maximum of the atom in the thread group
+      // In 2 blocks of values, upper/lower halves of the f16x2_t
+      int wblockmax = group_abs_max<T>(atom);
+
+      // Derive scales
+      int decoding_scale;
+      int encoding_scale;
+      decoding_scale = packed_mul<T>(wblockmax, kScaleFactor);
+      encoding_scale = packed_add<T>(decoding_scale, kScaleEpsilon);
+      encoding_scale = packed_rcp<T>(encoding_scale);
+
+      // Apply scales to get quantized values
+      int32x4_t w;
+      for (int i = 0; i < 4; i++) {
+        w[i] = packed_mul<T>(atom[i], encoding_scale);
+        w[i] = packed_max<T>(w[i], kRangeMin);
+        w[i] = packed_min<T>(w[i], kRangeMax);
+      }
+
+      // Convert from f16x2_t to uint16x2_t
+      int32x4_t q;
+      {
+        int16_t* qi = reinterpret_cast<int16_t*>(&q);
+        T* wh = reinterpret_cast<T*>(&w);
+        for (int i = 0; i < 8; i++)
+          qi[i] = (int16_t)rintf(T2float_cast(wh[i]));
+
+        for (int i = 0; i < 4; i++) {
+          q[i] = packed_add<int16_t>(q[i], kRangeBias);
+        }
+      }
+
+      // Pack 8 x q8 into int32x2_t
+      int32x2_t qw;
+      qw[0] = q[0] | (q[1] << 8);
+      qw[1] = q[2] | (q[3] << 8);
+
+      // Write quantized atom to send_buffer
+      // note: only the group leader stores the scale
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(send_buffer + k * kRankBufferTileStride);
+      int32x2_t* qw_ptr = reinterpret_cast<int32x2_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) + (thread / 8);
+
+      __builtin_nontemporal_store(qw, qw_ptr);
+      if (threadIdx.x == group_leader) {
+        __builtin_nontemporal_store(decoding_scale, qs_ptr);
+      }
+    }
+  }
+
+  __quickreduce_device_inline__ void recv(int32x4_t** __restrict__ recv_buffer, int32x4_t* __restrict__ data) {
+    for (int k = 0; k < kRankAtoms; k++) {
+      // Directly read quantized atom from recv_buffer
+      uint8_t* atom_ptr = reinterpret_cast<uint8_t*>(*recv_buffer);
+      int32x2_t* qw_ptr = reinterpret_cast<int32x2_t*>(atom_ptr) + thread;
+      int* qs_ptr = reinterpret_cast<int*>(atom_ptr + kRankTileScaleOffset) + (thread / 8);
+
+      int32x2_t qw = __builtin_nontemporal_load(qw_ptr);
+      int qs = __builtin_nontemporal_load(qs_ptr);
+
+      *recv_buffer += kRankBufferTileStride;
+
+      // Unpack q8 into fp16x8_t
+      int32x4_t w;
+      {
+        static uint constexpr kMask00FF = 0x00FF00FF;
+
+        // {1024.0, 1024.0}, fp16x2_t
+        static uint constexpr kHalf2_1024 = 0x64006400;
+
+        // {-1152.0, -1152.0}, fp16x2_t
+        static uint constexpr kHalf2_1152 = 0xE480E480;
+
+#pragma unroll
+        for (int i = 0; i < 4; i++) {
+          if constexpr (std::is_same<T, half>::value) {
+            int32_t q8 = ((qw[i / 2] >> ((i % 2) * 8)) & kMask00FF) | kHalf2_1024;
+            w[i] = packed_add<half>(q8, kHalf2_1152);
+          } else {
+            int32_t int16_2 = (qw[i / 2] >> ((i % 2) * 8)) & kMask00FF;
+            int16_t low = static_cast<int16_t>(int16_2 & 0xFFFF);
+            int16_t high = static_cast<int16_t>((int16_2 >> 16) & 0xFFFF);
+            nv_bfloat16 bf_low = __float2bfloat16(static_cast<float>(low));
+            nv_bfloat16 bf_high = __float2bfloat16(static_cast<float>(high));
+            nv_bfloat162 bf2 = __halves2bfloat162(bf_low, bf_high);
+            int32_t packed_bf16 = *reinterpret_cast<int32_t*>(&bf2);
+            w[i] = packed_add<nv_bfloat16>(packed_bf16, kRangeMin);
+          }
+        }
+      }
+
+      // Apply decoding scales
+      for (int i = 0; i < 4; i++) {
+        w[i] = packed_mul<T>(w[i], qs);
+      }
+
+      data[k] = w;
+    }
+  }
+};
+
+// Twoshot All Reduce
+template <typename T, class Codec, bool cast_bf2half>
+struct AllReduceTwoshot {
+  static_assert(sizeof(T) == 2);
+
+  static constexpr int kWorldSize = Codec::kWorldSize;
+
+  __device__ static void
+  run(T const* __restrict__ input,
+      T* __restrict__ output,
+      uint32_t const N,                    // number of elements
+      int const block,                     // block index
+      int const rank,                      // rank index
+      uint8_t** __restrict__ buffer_list,  // communication buffers
+      uint32_t const data_offset,          // offset to start of the data buffer
+      uint32_t flag_color,
+      int64_t data_size_per_phase) {
+    // Topology
+    int thread = threadIdx.x + threadIdx.y * kWavefront;
+    uint8_t* rank_buffer = buffer_list[rank];
+    Codec codec(thread, rank);
+    int block_id = blockIdx.x;
+    int grid_size = gridDim.x;
+    // --------------------------------------------------------
+    // Read input into registers
+    int32x4_t tA[kAtoms];
+
+    BufferResource src_buffer(const_cast<T*>(input), N * sizeof(T));
+    uint32_t src_offset = block * kTileSize + thread * sizeof(int32x4_t);
+
+    for (int i = 0; i < kAtoms; i++) {
+      tA[i] = buffer_load_dwordx4(src_buffer, src_offset, 0, 0);
+      src_offset += kAtomStride * sizeof(int32x4_t);
+      if constexpr (cast_bf2half) {
+        const nv_bfloat162* bf_buf = reinterpret_cast<const nv_bfloat162*>(&tA[i]);
+        half2 half_buf[4];
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+          float2 f = __bfloat1622float2(bf_buf[j]);
+          half_buf[j] = __float22half2_rn(f);
+        }
+        tA[i] = *reinterpret_cast<const int32x4_t*>(half_buf);
+      }
+    }
+
+    // --------------------------------------------------------
+    // Phase-1A: Write segment data into the communication buffer of the target
+    // rank responsible for this segment.
+    uint32_t comm_data0_offset = data_offset + block_id * Codec::kTransmittedTileSize;
+    uint32_t comm_data1_offset = data_size_per_phase + comm_data0_offset;
+
+    uint32_t comm_flags0_offset = block_id * (kWorldSize * sizeof(uint32_t));
+    uint32_t comm_flags1_offset = (data_offset / 2) + comm_flags0_offset;
+
+    for (int r = 0; r < kWorldSize; r++) {
+      int32x4_t* send_buffer =
+          reinterpret_cast<int32x4_t*>(buffer_list[r] + comm_data0_offset + rank * Codec::kRankTransmittedTileSize);
+      codec.send(send_buffer, &tA[r * Codec::kRankAtoms]);
+    }
+
+    __syncthreads();
+    if (thread < kWorldSize) {
+      int r = thread;
+      uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(buffer_list[r] + comm_flags0_offset + rank * sizeof(uint32_t));
+      set_sync_flag(flag_ptr, flag_color);
+    }
+    // --------------------------------------------------------
+    // Phase-1B: Reduce the segment data from the communication buffers.
+    int32x4_t tR[Codec::kRankAtoms] = {};
+    {
+      // Read the data from the communication buffer.
+      int32x4_t* recv_buffer = reinterpret_cast<int32x4_t*>(rank_buffer + comm_data0_offset);
+      uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(rank_buffer + comm_flags0_offset);
+
+      for (int r = 0; r < kWorldSize; r++) {
+        // Wait for the flags to be set.
+        if (thread == 0) {
+          wait_sync_flag(&flag_ptr[r], flag_color);
+        }
+        __syncthreads();
+
+        // note: we reuse tA as temp buffer here
+        codec.recv(&recv_buffer, tA);
+
+        for (int i = 0; i < Codec::kRankAtoms; i++) {
+          packed_assign_add<T>(&tR[i], &tA[i]);
+        }
+      }
+    }
+
+    // Phase-2: Write the reduced segment to every other rank
+    for (int r = 0; r < kWorldSize; r++) {
+      int32x4_t* send_buffer =
+          reinterpret_cast<int32x4_t*>(buffer_list[r] + comm_data1_offset + rank * Codec::kRankTransmittedTileSize);
+      codec.send(send_buffer, tR);
+    }
+
+    __syncthreads();
+    if (thread < kWorldSize) {
+      int r = thread;
+      uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(buffer_list[r] + comm_flags1_offset + rank * sizeof(uint32_t));
+      set_sync_flag(flag_ptr, flag_color);
+    }
+
+    // Phase-2: Read the gather segments from the rank's communication buffer.
+    {
+      // Read the data from the communication buffer.
+      int32x4_t* recv_buffer = reinterpret_cast<int32x4_t*>(rank_buffer + comm_data1_offset);
+      uint32_t* flag_ptr = reinterpret_cast<uint32_t*>(rank_buffer + comm_flags1_offset);
+
+      for (int r = 0; r < kWorldSize; r++) {
+        // Wait for the flags to be set.
+        if (thread == 0) {
+          wait_sync_flag(&flag_ptr[r], flag_color);
+        }
+        __syncthreads();
+
+        // Gather all reduced and final rank segments into tA.
+        codec.recv(&recv_buffer, &tA[r * Codec::kRankAtoms]);
+      }
+    }
+
+    // --------------------------------------------------------
+    // Write the result to output.
+    BufferResource dst_buffer(output, N * sizeof(T));
+    uint32_t dst_offset = block * kTileSize + thread * sizeof(int32x4_t);
+
+    for (int i = 0; i < kAtoms; i++) {
+      if constexpr (cast_bf2half) {
+        const half2* half_buf = reinterpret_cast<const half2*>(&tA[i]);
+        nv_bfloat162 bf16_buf[4];
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+          float2 f = __half22float2(half_buf[j]);
+          bf16_buf[j] = __float22bfloat162_rn(f);
+        }
+        buffer_store_dwordx4(*reinterpret_cast<const int32x4_t*>(bf16_buf), dst_buffer, dst_offset, 0, 0);
+      } else {
+        buffer_store_dwordx4(tA[i], dst_buffer, dst_offset, 0, 0);
+      }
+      dst_offset += kAtomStride * sizeof(int32x4_t);
+    }
+  }
+};
+
+}  // namespace quickreduce

--- a/csrc/quick_all_reduce.cuh
+++ b/csrc/quick_all_reduce.cuh
@@ -517,7 +517,13 @@ struct AllReduceTwoshot {
     int thread = threadIdx.x + threadIdx.y * kWavefront;
     uint8_t* rank_buffer = buffer_list[rank];
     Codec codec(thread, rank);
-    int block_id = blockIdx.x;
+    // block_id must be the LOGICAL block index passed in via `block`
+    // (the wrapper's `while (block < num_blocks) { block += grid; }`
+    // loop in quick_all_reduce.h advances it past gridDim.x). Using
+    // blockIdx.x makes the comm_data*/comm_flags* offsets repeat
+    // every grid stride, so later logical blocks corrupt the
+    // earlier ones' results. See PR #40 review comment.
+    int block_id = block;
     int grid_size = gridDim.x;
     // --------------------------------------------------------
     // Read input into registers

--- a/csrc/quick_all_reduce.h
+++ b/csrc/quick_all_reduce.h
@@ -110,8 +110,13 @@ struct DeviceComms {
       this->kMaxProblemSize = max_problem_size.value();
     }
     // Allocate buffer size for worst case: F16 2-stage buffer.
+    // NOTE: data_buffer_size must NOT be `static` — function-local
+    // statics are initialized exactly once and would reuse the first
+    // call's kMaxProblemSize for every subsequent init, allocating an
+    // incorrect total_buffer_size when the caller passes a different
+    // max_problem_size. See PR #40 review comment.
     uint32_t flags_buffer_size = 2 * world_size * kMaxNumBlocks * sizeof(uint32_t);
-    static int64_t data_buffer_size = 2 * this->kMaxProblemSize;
+    int64_t data_buffer_size = 2 * this->kMaxProblemSize;
     int64_t total_buffer_size = flags_buffer_size + data_buffer_size;
     data_offset = flags_buffer_size;
     // MUSA-0088: hipExtMallocWithFlags(..., hipDeviceMallocUncached) has no
@@ -150,9 +155,15 @@ struct DeviceComms {
 
   void destroy() {
     if (initialized) {
+      // Close IPC handles against the host-side vector of opened peer
+      // pointers (buffer_list), not the device-side mirror
+      // (dbuffer_list). dbuffer_list is a device allocation used by
+      // the kernel via H2D-copied pointer values; dereferencing it
+      // from host code passes garbage to musaIpcCloseMemHandle. See
+      // PR #40 review comment.
       for (int i = 0; i < world_size; i++) {
         if (i != rank) {
-          MUSA_CHECK(musaIpcCloseMemHandle(dbuffer_list[i]));
+          MUSA_CHECK(musaIpcCloseMemHandle(buffer_list[i]));
         }
       }
 

--- a/csrc/quick_all_reduce.h
+++ b/csrc/quick_all_reduce.h
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// MUSA-0088 first-pass port of SGLang's quick_all_reduce.h.
+// Translation: mechanical sed-pass per MUSA-0080 iter-2 breakdown
+// + hipLaunchKernelGGL -> direct <<<grid, block, sharedMem, stream>>>.
+//
+// NOT YET COMPILED. Follow-up:
+//   - Verify mcc accepts the <<<>>> launch syntax (vs hipLaunchKernelGGL)
+//   - Adapt warp-size assumptions (HIP wave 64 -> MUSA wave 32)
+//   - Wire csrc/quick_all_reduce.cu into setup.py kernel list
+//   - DONE: musaIpcMemLazyEnablePeerAccess exists in driver_types.h.
+//   - musaMallocWithFlags / musaDeviceMallocUncached not in MUSA SDK;
+//     replaced with plain musaMalloc (microopt only, not correctness).
+//   - Build + correctness + perf A/B per MUSA-0088 ACs
+//
+#pragma once
+
+#include <musa_runtime.h>
+
+#include <vector>
+
+#include "quick_all_reduce.cuh"
+
+#define MUSA_CHECK(err)                                                                               \
+  do {                                                                                               \
+    musaError_t err_ = (err);                                                                         \
+    if (err_ != musaSuccess) {                                                                        \
+      std::printf("HIP error %d at %s:%d. %s\n", err_, __FILE__, __LINE__, musaGetErrorString(err_)); \
+      throw std::runtime_error("HIP error");                                                         \
+    }                                                                                                \
+  } while (0)
+
+namespace quickreduce {
+using fptr_t = int64_t;
+static_assert(sizeof(void*) == sizeof(fptr_t));
+
+template <typename AllReduceKernel, typename T>
+__global__ __quickreduce_launch_bounds_two_shot__ static void allreduce_prototype_twoshot(
+    T const* A,
+    T* B,
+    uint32_t N,
+    uint32_t num_blocks,
+    int rank,
+    uint8_t** dbuffer_list,
+    uint32_t data_offset,
+    uint32_t flag_color,
+    int64_t data_size_per_phase) {
+  int block = blockIdx.x;
+  int grid = gridDim.x;
+
+  while (block < num_blocks) {
+    AllReduceKernel::run(A, B, N, block, rank, dbuffer_list, data_offset, flag_color, data_size_per_phase);
+    block += grid;
+    flag_color++;
+  }
+}
+
+#define TWOSHOT_DISPATCH(__codec)                                         \
+  if (world_size == 2) {                                                  \
+    using LineCodec = __codec<T, 2>;                                      \
+    using AllReduceKernel = AllReduceTwoshot<T, LineCodec, cast_bf2half>; \
+    allreduce_prototype_twoshot<AllReduceKernel, T><<<dim3(grid), dim3(kBlockTwoShot), 0, stream>>>(A, B, N, num_blocks, rank, dbuffer_list, data_offset, flag_color, this->kMaxProblemSize);                                           \
+  } else if (world_size == 4) {                                           \
+    using LineCodec = __codec<T, 4>;                                      \
+    using AllReduceKernel = AllReduceTwoshot<T, LineCodec, cast_bf2half>; \
+    allreduce_prototype_twoshot<AllReduceKernel, T><<<dim3(grid), dim3(kBlockTwoShot), 0, stream>>>(A, B, N, num_blocks, rank, dbuffer_list, data_offset, flag_color, this->kMaxProblemSize);                                           \
+  } else if (world_size == 8) {                                           \
+    using LineCodec = __codec<T, 8>;                                      \
+    using AllReduceKernel = AllReduceTwoshot<T, LineCodec, cast_bf2half>; \
+    allreduce_prototype_twoshot<AllReduceKernel, T><<<dim3(grid), dim3(kBlockTwoShot), 0, stream>>>(A, B, N, num_blocks, rank, dbuffer_list, data_offset, flag_color, this->kMaxProblemSize);                                           \
+  }
+
+enum QuickReduceQuantLevel {
+  F16 = 0,
+  INT8 = 1,
+  INT6 = 2,
+  INT4 = 3,
+};
+
+struct DeviceComms {
+  // Max problem size is 2GB (in bytes) or half of uint32_t max value.
+  int64_t kMaxProblemSize = static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
+
+  // Max TP-8
+  static int constexpr kMaxWorldSize = 8;
+
+  bool initialized = false;
+  uint32_t flag_color = 1;
+  int world_size;
+  int rank;
+
+  uint8_t* dbuffer;
+  uint8_t** dbuffer_list;
+  musaIpcMemHandle_t buffer_ipc_handle;
+  std::vector<musaIpcMemHandle_t> all_buffer_ipc_handles;
+  std::vector<uint8_t*> buffer_list;
+  uint32_t data_offset;
+
+  DeviceComms() : initialized(false), world_size(1), rank(0) {}
+  ~DeviceComms() {
+    destroy();
+  }
+
+  void init(int world_size, int rank, std::optional<int64_t> max_problem_size = std::nullopt) {
+    destroy();
+    this->world_size = world_size;
+    this->rank = rank;
+    if (max_problem_size.has_value() && max_problem_size.value() > 0) {
+      this->kMaxProblemSize = max_problem_size.value();
+    }
+    // Allocate buffer size for worst case: F16 2-stage buffer.
+    uint32_t flags_buffer_size = 2 * world_size * kMaxNumBlocks * sizeof(uint32_t);
+    static int64_t data_buffer_size = 2 * this->kMaxProblemSize;
+    int64_t total_buffer_size = flags_buffer_size + data_buffer_size;
+    data_offset = flags_buffer_size;
+    // MUSA-0088: hipExtMallocWithFlags(..., hipDeviceMallocUncached) has no
+    // direct MUSA equivalent. Use plain musaMalloc; the uncached flag on
+    // HIP was a microoptimisation for AMD's MI300 cache hierarchy and isn't
+    // strictly necessary for correctness on MTT S5000. If profiling shows
+    // this matters, replace with musaMallocManaged + musaMemAdvise to
+    // approximate uncached behaviour.
+    MUSA_CHECK(musaMalloc((void**)&dbuffer, total_buffer_size));
+
+    // Clear the flags buffer.
+    MUSA_CHECK(musaMemset(dbuffer, 0, flags_buffer_size));
+
+    // Device-side list of IPC buffers.
+    buffer_list.resize(world_size);
+    MUSA_CHECK(musaMalloc(&dbuffer_list, world_size * sizeof(uint8_t*)));
+
+    // Create IPC handles for rank's communication buffer.
+    all_buffer_ipc_handles.resize(world_size);
+    MUSA_CHECK(musaIpcGetMemHandle(&buffer_ipc_handle, dbuffer));
+
+    initialized = true;
+  }
+  int get_world_size() {
+    return world_size;
+  }
+  int get_rank() {
+    return rank;
+  }
+  bool status() {
+    return initialized;
+  }
+  musaIpcMemHandle_t const get_handle() {
+    return buffer_ipc_handle;
+  }
+
+  void destroy() {
+    if (initialized) {
+      for (int i = 0; i < world_size; i++) {
+        if (i != rank) {
+          MUSA_CHECK(musaIpcCloseMemHandle(dbuffer_list[i]));
+        }
+      }
+
+      MUSA_CHECK(musaFree(dbuffer));
+      MUSA_CHECK(musaFree(dbuffer_list));
+
+      initialized = false;
+    }
+  }
+
+  void open_ipc_handles(std::vector<musaIpcMemHandle_t> const& ipc_handles) {
+    assert(ipc_handles.size() == all_buffer_ipc_handles.size());
+    for (int i = 0; i < world_size; i++) {
+      all_buffer_ipc_handles[i] = ipc_handles[i];
+    }
+
+    // Open device memory access to the IPC communication buffers.
+    // Note: For our own rank, we do not need to open a handle.
+    for (int i = 0; i < world_size; i++) {
+      if (i != rank) {
+        MUSA_CHECK(
+            musaIpcOpenMemHandle((void**)&buffer_list[i], all_buffer_ipc_handles[i], musaIpcMemLazyEnablePeerAccess));
+      } else {
+        buffer_list[i] = dbuffer;
+      }
+    }
+
+    MUSA_CHECK(musaMemcpy(dbuffer_list, buffer_list.data(), world_size * sizeof(uint8_t*), musaMemcpyHostToDevice));
+  }
+
+  template <typename T, bool cast_bf2half>
+  void allreduce(T const* A, T* B, uint32_t N, int quant_level, musaStream_t stream) {
+    if (world_size != 2 && world_size != 4 && world_size != 8) {
+      throw std::runtime_error("All Reduce not supported for world_size = " + std::to_string(world_size));
+    }
+
+    // Configuration.
+    uint32_t msg_size = N * sizeof(T);
+    uint32_t num_blocks = divceil(msg_size, kTileSize);
+    uint32_t grid = min(kMaxNumBlocks, num_blocks);
+    auto quant_level_ = static_cast<QuickReduceQuantLevel>(quant_level);
+    switch (quant_level_) {
+      case QuickReduceQuantLevel::INT8:
+        TWOSHOT_DISPATCH(CodecQ8)
+        break;
+      case QuickReduceQuantLevel::INT6:
+        TWOSHOT_DISPATCH(CodecQ6)
+        break;
+      case QuickReduceQuantLevel::INT4:
+        TWOSHOT_DISPATCH(CodecQ4)
+        break;
+      default:
+        TWOSHOT_DISPATCH(CodecFP)
+        break;
+    }
+    MUSA_CHECK(cudaGetLastError());
+    // Rotate the flag color.
+    flag_color += divceil(N, grid);
+  }
+};
+
+}  // namespace quickreduce

--- a/csrc/quick_all_reduce_base.h
+++ b/csrc/quick_all_reduce_base.h
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: Apache-2.0
+// MUSA-0088 first-pass port of SGLang's quick_all_reduce_base.h. NOT YET COMPILED.
+//
+#pragma once
+
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+#include <musa_runtime.h>
+
+#include <cstdint>
+
+#define __quickreduce_device_inline__ __device__ __forceinline__
+#define __quickreduce_launch_bounds_two_shot__ __launch_bounds__(128, 4)  // MUSA-0088: kBlockSize=128
+#define __quickreduce_launch_bounds_one_shot__ __launch_bounds__(256, 4)  // MUSA-0088: half of HIP
+
+namespace quickreduce {
+
+typedef __mt_bfloat16 nv_bfloat16;  // MUSA-0088: __hip_bfloat16 -> __mt_bfloat16
+typedef __mt_bfloat162 nv_bfloat162;  // MUSA-0088: __hip_bfloat162 -> __mt_bfloat162
+
+using int32x2_t = __attribute__((__vector_size__(2 * sizeof(int)))) int;
+using int32x4_t = __attribute__((__vector_size__(4 * sizeof(int)))) int;
+
+// Setup acquire-release semantics for vector memory reads (mubuf instruction)
+// as per architecture.
+#if defined(__gfx942__)
+// CDNA3: Scope bits sc0, sc1
+#define MUBUF_ACQUIRE 16
+#define MUBUF_RELEASE 16
+#elif (defined(__gfx908__) || defined(__gfx90a__))
+// CDNA1 and CDNA2 - glc bit
+#define MUBUF_ACQUIRE 1
+#define MUBUF_RELEASE 0
+#endif
+
+static constexpr int kNegOne = 0xBC00BC00;  // {-1, -1}, fp16x2_t
+
+// Number of atoms (4xf16x2_t) processed by a single thread
+static constexpr int kAtoms = 8;
+
+// MUSA-0088: warp/block-size adaptation for MTT S5000.
+// HIP/AMD CDNA wavefront = 64; MUSA on S5000 = 32. To preserve the
+// "4 warps per block" ratio that the codec macros assume, drop block
+// size from 256 (= 4*64) to 128 (= 4*32). This is the conservative
+// choice; if mcc compiles cleanly, an A/B at block=256 (= 8 warps on
+// MUSA) is worth probing - more warps may yield better occupancy on
+// S5000's 96-CU silicon.
+static constexpr int kBlockSize = 128;
+static constexpr int kAtomStride = kBlockSize;
+
+// Size and atom stride of source/destination data that the block will
+// process.
+// Workgroup scope = Tile = (kBlockSize threads x 8 atoms x 16B)
+static constexpr int kTileSize = kBlockSize * kAtoms * sizeof(int32x4_t);
+
+// Max number of blocks. MTT S5000 has 96 CUs (vs MI300's 304); keep the
+// 4x factor for occupancy headroom.
+static constexpr int kMaxNumBlocks = 96 * 4;
+
+// MUSA wavefront size on MTT S5000.
+static constexpr int kWavefront = 32;
+
+// kBlockSize threads, 4 wavefronts (kBlockSize/kWavefront = 4).
+static dim3 constexpr kBlockTwoShot = {kWavefront, kBlockSize / kWavefront, 1};
+
+// Number of threads in a group for quantization
+// It corresponds to 32 F16 elements in quantization block
+static constexpr int kThreadGroupSize = 8;
+
+// Methods
+__quickreduce_device_inline__ __host__ unsigned long divceil(unsigned long x, unsigned long y) {
+  return ((x + y - 1) / y);
+}
+
+// MUSA-0091: BufferResource was originally a UNION holding an int32x4_t
+// descriptor that AMD GCN's vector buffer-fetch unit consumes (the
+// `buffer_load_dwordx4` / `buffer_store_dwordx4` AMD intrinsics). MUSA's
+// mp_31 backend does not have an equivalent buffer-fetch unit and cannot
+// lower `llvm.amdgcn.raw.buffer.{load,store}.v4i32` — observed as
+// `error in backend: lsu.st.2d requires constant blx, bly, stride` and
+// `v4i32,ch = llvm.amdgcn.raw.buffer.load` in MUSA-0088 iter-3
+// (`generated/musa0088/iter3-final-state-and-mcc-segfault.md`).
+//
+// Replacement: plain pointer wrapper + portable `int32x4_t*` vector
+// load/store. 16-byte alignment is preserved because the callers compute
+// `voffset` as multiples of `sizeof(int32x4_t)` (= 16 bytes).
+struct BufferResource {
+  __quickreduce_device_inline__ constexpr BufferResource() : address(nullptr), range(0) {}
+
+  __quickreduce_device_inline__ constexpr BufferResource(void* buffer_address, uint32_t buffer_size)
+      : address(buffer_address), range(buffer_size) {}
+
+  void* address;
+  uint32_t range;
+};
+
+// MUSA-0091: AMD `llvm.amdgcn.raw.buffer.load.v4i32` -> portable int4 load.
+// The original AMD signature took `(int32x4_t srsrc, int32_t voffset,
+// int32_t soffset, int32_t aux)` where srsrc was the buffer descriptor and
+// aux was AMD-specific. We take a `BufferResource const&` to keep the
+// portable address-bearing variant; soffset and aux are kept as ignored
+// parameters so the calling-side diff stays minimal (existing kernels pass
+// soffset=0, aux=0 — pure AMD-isms).
+__quickreduce_device_inline__ static int32x4_t buffer_load_dwordx4(
+    BufferResource const& buf, int32_t voffset, int32_t soffset = 0, int32_t aux = 0) {
+  (void)soffset;
+  (void)aux;
+  const char* base = reinterpret_cast<const char*>(buf.address);
+  return *reinterpret_cast<const int32x4_t*>(base + voffset);
+}
+
+__quickreduce_device_inline__ static void buffer_store_dwordx4(
+    int32x4_t data, BufferResource const& buf, int32_t voffset, int32_t soffset = 0, int32_t aux = 0) {
+  (void)soffset;
+  (void)aux;
+  char* base = reinterpret_cast<char*>(buf.address);
+  *reinterpret_cast<int32x4_t*>(base + voffset) = data;
+}
+
+__quickreduce_device_inline__ static void set_fp16_ovfl(bool const value) {
+#if defined(__gfx942__)
+  if (value) {
+    asm volatile("s_setreg_imm32_b32 0xdc1, 1;" ::);
+  } else {
+    asm volatile("s_setreg_imm32_b32 0xdc1, 0;" ::);
+  }
+#endif
+}
+union bf162_int_union {
+  int i;
+  nv_bfloat162 bf2;
+};
+
+template <typename T>
+__quickreduce_device_inline__ void packed_assign_add(int32x4_t* A, int32x4_t* B);
+
+template <>
+__quickreduce_device_inline__ void packed_assign_add<half>(int32x4_t* A, int32x4_t* B) {
+  int32x4_t& tR_fragment = A[0];
+  int32x4_t& tA_fragment = B[0];
+
+  // MUSA-0088: AMD GCN v_pk_add_f16 -> portable __hadd2. Use cast-and-offset
+  // because tR_fragment is a clang vector (__vector_size__ attribute) — taking
+  // address of [i] is rejected.
+  int32_t* rp = reinterpret_cast<int32_t*>(&tR_fragment);
+  int32_t* ap = reinterpret_cast<int32_t*>(&tA_fragment);
+  for (int i = 0; i < 4; ++i) {
+    __half2 r = *reinterpret_cast<__half2*>(&rp[i]);
+    __half2 a = *reinterpret_cast<__half2*>(&ap[i]);
+    *reinterpret_cast<__half2*>(&rp[i]) = __hadd2(r, a);
+  }
+}
+
+template <>
+__quickreduce_device_inline__ void packed_assign_add<nv_bfloat16>(int32x4_t* A, int32x4_t* B) {
+  nv_bfloat162* tA = reinterpret_cast<nv_bfloat162*>(A);
+  nv_bfloat162* tB = reinterpret_cast<nv_bfloat162*>(B);
+#pragma unroll
+  for (int i = 0; i < 4; i++) {
+    tA[i] = __hadd2(tA[i], tB[i]);
+  }
+}
+
+template <typename T>
+__quickreduce_device_inline__ int packed_max(int a, int b);
+
+template <>
+__quickreduce_device_inline__ int packed_max<half>(int a, int b) {
+  // MUSA-0088: AMD GCN v_pk_max_f16 -> portable __hmax2.
+  __half2 a2 = *reinterpret_cast<__half2*>(&a);
+  __half2 b2 = *reinterpret_cast<__half2*>(&b);
+  __half2 r2 = __hmax2(a2, b2);
+  int result;
+  *reinterpret_cast<__half2*>(&result) = r2;
+  return result;
+}
+
+template <>
+__quickreduce_device_inline__ int packed_max<nv_bfloat16>(int a, int b) {
+  bf162_int_union A, B, R;
+  A.i = a;
+  B.i = b;
+  R.bf2 = __hmax2(A.bf2, B.bf2);
+  return R.i;
+}
+
+template <typename T>
+__quickreduce_device_inline__ int packed_min(int a, int b);
+
+template <>
+__quickreduce_device_inline__ int packed_min<half>(int a, int b) {
+  // MUSA-0088: AMD GCN v_pk_min_f16 -> portable __hmin2.
+  __half2 a2 = *reinterpret_cast<__half2*>(&a);
+  __half2 b2 = *reinterpret_cast<__half2*>(&b);
+  __half2 r2 = __hmin2(a2, b2);
+  int result;
+  *reinterpret_cast<__half2*>(&result) = r2;
+  return result;
+}
+
+template <>
+__quickreduce_device_inline__ int packed_min<nv_bfloat16>(int a, int b) {
+  bf162_int_union A, B, R;
+  A.i = a;
+  B.i = b;
+  R.bf2 = __hmin2(A.bf2, B.bf2);
+  return R.i;
+}
+
+template <typename T>
+__quickreduce_device_inline__ int packed_abs_max(int a, int b);
+
+template <>
+__quickreduce_device_inline__ int packed_abs_max<half>(int a, int b) {
+  half2 wmaxh2 = __builtin_bit_cast(half2, a);
+  half2 wminh2 = __builtin_bit_cast(half2, b);
+  half2 wblockmaxh2;
+
+  wblockmaxh2.x = __hgt(__habs(wmaxh2.x), __habs(wminh2.x)) ? wmaxh2.x : wminh2.x;
+  wblockmaxh2.y = __hgt(__habs(wmaxh2.y), __habs(wminh2.y)) ? wmaxh2.y : wminh2.y;
+  return __builtin_bit_cast(int, wblockmaxh2);
+}
+
+template <>
+__quickreduce_device_inline__ int packed_abs_max<nv_bfloat16>(int a, int b) {
+  bf162_int_union A, B, R;
+  A.i = a;
+  B.i = b;
+  R.bf2.x = __hgt(__habs(A.bf2.x), __habs(B.bf2.x)) ? A.bf2.x : B.bf2.x;
+  R.bf2.y = __hgt(__habs(A.bf2.y), __habs(B.bf2.y)) ? A.bf2.y : B.bf2.y;
+  return R.i;
+}
+
+template <typename T>
+__quickreduce_device_inline__ int packed_add(int a, int b);
+
+template <>
+__quickreduce_device_inline__ int packed_add<half>(int a, int b) {
+  // MUSA-0088: AMD GCN v_pk_add_f16 -> portable __hadd2.
+  __half2 a2 = *reinterpret_cast<__half2*>(&a);
+  __half2 b2 = *reinterpret_cast<__half2*>(&b);
+  __half2 r2 = __hadd2(a2, b2);
+  int result;
+  *reinterpret_cast<__half2*>(&result) = r2;
+  return result;
+}
+
+template <>
+__quickreduce_device_inline__ int packed_add<nv_bfloat16>(int a, int b) {
+  bf162_int_union A, B, R;
+  A.i = a;
+  B.i = b;
+  R.bf2 = __hadd2(A.bf2, B.bf2);
+  return R.i;
+}
+
+template <>
+__quickreduce_device_inline__ int packed_add<int16_t>(int a, int b) {
+  // MUSA-0088: AMD GCN v_pk_add_i16 -> scalar int16x2 add via bit-fiddle.
+  int16_t a_lo = static_cast<int16_t>(a & 0xFFFF);
+  int16_t a_hi = static_cast<int16_t>((a >> 16) & 0xFFFF);
+  int16_t b_lo = static_cast<int16_t>(b & 0xFFFF);
+  int16_t b_hi = static_cast<int16_t>((b >> 16) & 0xFFFF);
+  int16_t r_lo = static_cast<int16_t>(a_lo + b_lo);
+  int16_t r_hi = static_cast<int16_t>(a_hi + b_hi);
+  int result = (static_cast<int>(r_hi) << 16) | (static_cast<int>(static_cast<uint16_t>(r_lo)));
+  return result;
+}
+
+template <typename T>
+__quickreduce_device_inline__ int packed_sub(int a, int b);
+
+template <>
+__quickreduce_device_inline__ int packed_sub<half>(int a, int b) {
+  int result;
+
+  // MUSA-0088: AMD GCN v_pk_fma_f16(-1, b, a) = a - b -> portable __hsub2.
+  __half2 a2 = *reinterpret_cast<__half2*>(&a);
+  __half2 b2 = *reinterpret_cast<__half2*>(&b);
+  __half2 r2 = __hsub2(a2, b2);
+  *reinterpret_cast<__half2*>(&result) = r2;
+  return result;
+}
+
+template <>
+__quickreduce_device_inline__ int packed_sub<nv_bfloat16>(int a, int b) {
+  bf162_int_union A, B, R;
+  A.i = a;
+  B.i = b;
+  R.bf2 = __hsub2(A.bf2, B.bf2);
+  return R.i;
+}
+
+template <typename T>
+__quickreduce_device_inline__ int packed_mul(int a, int b);
+
+template <>
+__quickreduce_device_inline__ int packed_mul<half>(int a, int b) {
+  // MUSA-0088: AMD GCN v_pk_mul_f16 -> portable __hmul2.
+  __half2 a2 = *reinterpret_cast<__half2*>(&a);
+  __half2 b2 = *reinterpret_cast<__half2*>(&b);
+  __half2 r2 = __hmul2(a2, b2);
+  int result;
+  *reinterpret_cast<__half2*>(&result) = r2;
+  return result;
+}
+
+template <>
+__quickreduce_device_inline__ int packed_mul<nv_bfloat16>(int a, int b) {
+  nv_bfloat162* tA = reinterpret_cast<nv_bfloat162*>(&a);
+  nv_bfloat162* tB = reinterpret_cast<nv_bfloat162*>(&b);
+  nv_bfloat162 tR = __hmul2(*tA, *tB);
+  return *(reinterpret_cast<int*>(&tR));
+}
+
+template <typename T>
+__quickreduce_device_inline__ int packed_rcp(int a);
+
+template <>
+__quickreduce_device_inline__ int packed_rcp<half>(int a) {
+  return __builtin_bit_cast(int, h2rcp(__builtin_bit_cast(half2, a)));
+}
+
+template <>
+__quickreduce_device_inline__ int packed_rcp<nv_bfloat16>(int a) {
+  bf162_int_union A, R;
+  A.i = a;
+  R.bf2 = h2rcp(A.bf2);
+  return R.i;
+}
+
+// changes dtype
+__quickreduce_device_inline__ float T2float_cast(half a) {
+  return __half2float(a);
+}
+
+__quickreduce_device_inline__ float T2float_cast(nv_bfloat16 a) {
+  return __bfloat162float(a);
+}
+
+template <typename T>
+__quickreduce_device_inline__ int group_abs_max(int32x4_t atom) {
+  const int group_leader = (threadIdx.x / kThreadGroupSize) * kThreadGroupSize;
+
+  int wmax, wmin, wblockmax;
+  int a, b;
+  a = packed_max<T>(atom[0], atom[1]);
+  b = packed_max<T>(atom[2], atom[3]);
+
+  wmax = packed_max<T>(a, b);
+
+  a = packed_min<T>(atom[0], atom[1]);
+  b = packed_min<T>(atom[2], atom[3]);
+
+  wmin = packed_min<T>(a, b);
+
+  // Reduce the max among a group of threads
+  // Note: This is basically 2 blocks of values setup as the
+  // upper/lower halves of the f16x2_t
+  for (int i = 1; i < kThreadGroupSize; i <<= 1) {
+    int x = __shfl_down_sync(0xFFFFFFFF, wmax, i);
+    wmax = packed_max<T>(wmax, x);
+
+    int y = __shfl_down_sync(0xFFFFFFFF, wmin, i);
+    wmin = packed_min<T>(wmin, y);
+  }
+  wblockmax = packed_abs_max<T>(wmax, wmin);
+  // Share with the cohort
+  wblockmax = __shfl_sync(0xFFFFFFFF, wblockmax, group_leader);
+  return wblockmax;
+}
+
+__quickreduce_device_inline__ void set_sync_flag(uint32_t* flag_ptr, uint32_t flag) {
+  __atomic_store_n(flag_ptr, flag, __ATOMIC_RELEASE);
+}
+
+__quickreduce_device_inline__ void wait_sync_flag(uint32_t* flag_ptr, uint32_t flag) {
+  while (__atomic_load_n(flag_ptr, __ATOMIC_RELAXED) != flag) {
+  }
+}
+
+}  // namespace quickreduce

--- a/vllm_musa/__init__.py
+++ b/vllm_musa/__init__.py
@@ -44,6 +44,23 @@ except ImportError:
 _patches_applied = False
 
 
+# MUSA-0087: register Inductor template heuristics for device_type='musa'
+# so compiled mm/bmm/addmm/baddbmm/scaled_mm ops use Triton autotune
+# instead of falling through to the empty fallback heuristic.
+# Opportunistic; silently no-ops on old torch versions or when disabled
+# via VLLM_MUSA_DISABLE_INDUCTOR_HEURISTICS=1.
+try:
+    from vllm_musa._inductor import maybe_register_musa_template_heuristics
+
+    maybe_register_musa_template_heuristics()
+except Exception as _exc:  # pragma: no cover
+    logger.warning(
+        "MUSA-0087: failed to register Inductor template heuristics for "
+        "MUSA (%s); falling back to ATen path for compiled `mm` ops.",
+        _exc,
+    )
+
+
 ########### platform plugin ###########
 
 

--- a/vllm_musa/_inductor/__init__.py
+++ b/vllm_musa/_inductor/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA-0087: Inductor integration hooks for MUSA device type.
+
+Registers Inductor template heuristics for ``device_type="musa"`` so
+compiled ``mm``/``bmm``/``addmm``/``baddbmm``/``scaled_mm`` ops can
+attempt Triton autotune instead of falling through to the empty
+fallback heuristic (which Inductor maps to the ATen path).
+
+The registration is **opportunistic**: it is wrapped in try/except so
+old torch versions or future API changes don't crash the platform.
+"""
+
+from vllm_musa._inductor.template_heuristics import (
+    maybe_register_musa_template_heuristics,
+)
+
+__all__ = ["maybe_register_musa_template_heuristics"]

--- a/vllm_musa/_inductor/template_heuristics.py
+++ b/vllm_musa/_inductor/template_heuristics.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA-0087: Inductor template heuristics for device_type='musa'.
+
+Without this registration, vllm/Inductor logs (per rank, per `mm` op):
+
+    No template heuristic found - template_name=triton::mm,
+    device_type=musa, op_name=mm. ... Using fallback
+    TemplateConfigHeuristics instance.
+
+The fallback returns an empty Triton config iterator, so Inductor
+never attempts Triton autotune for `mm` on MUSA. With this
+registration MUSA inherits the CUDA tile-size configs as a safe
+starting point; per-shape MUSA tuning can be added incrementally.
+
+Disable with: ``VLLM_MUSA_DISABLE_INDUCTOR_HEURISTICS=1``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Idempotency guard
+_REGISTERED = False
+
+
+def maybe_register_musa_template_heuristics() -> None:
+    """Idempotent registration of MUSA Inductor template heuristics.
+
+    Safe to call multiple times. Opportunistic — silently no-ops on old
+    torch versions or when the disable env var is set.
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return
+    if os.getenv("VLLM_MUSA_DISABLE_INDUCTOR_HEURISTICS", "0") == "1":
+        logger.info_once(
+            "MUSA-0087: Inductor template heuristic registration disabled "
+            "via VLLM_MUSA_DISABLE_INDUCTOR_HEURISTICS=1.",
+        )
+        _REGISTERED = True
+        return
+
+    try:
+        from torch._inductor.kernel.bmm import bmm_template
+        from torch._inductor.kernel.mm import mm_template
+        from torch._inductor.template_heuristics.registry import (
+            register_template_heuristic,
+        )
+        from torch._inductor.template_heuristics.triton import (
+            AddMMConfigMixin,
+            CUDAConfigHeuristic,
+            MMTemplateConfigMixin,
+        )
+    except ImportError as exc:
+        logger.warning_once(
+            "MUSA-0087: torch._inductor template-heuristics API not "
+            "available (%s); skipping MUSA registration. Compiled `mm` "
+            "ops on MUSA will fall through to ATen via torchada.",
+            exc,
+        )
+        _REGISTERED = True
+        return
+
+    # MUSAConfigHeuristic inherits all CUDA configs as a safe starting
+    # point. Per-shape MUSA tuning can override defaults in future PRs.
+    class MUSAConfigHeuristic(CUDAConfigHeuristic):
+        """MUSA template heuristic.
+
+        Phase-1: inherit CUDA tile-size configs verbatim. MTT S5000 has
+        the same warp size (32) and max threads/block (1024) as CUDA
+        Hopper-class hardware so the CUDA defaults are a reasonable
+        starting point. Phase-2 can override `default_mm_config` etc.
+        with MUSA-tuned tile sizes once profiled.
+        """
+
+        def __init__(self) -> None:
+            super().__init__()
+
+    # Register the four common (template, device, op) combinations.
+    # The decorator-based pattern matches CUDAMMTemplateConfigHeuristic
+    # registration in torch._inductor.template_heuristics.triton.
+    @register_template_heuristic(mm_template.uid, "musa")
+    @register_template_heuristic(bmm_template.uid, "musa")
+    class MUSAMMTemplateConfigHeuristic(  # noqa: F841 — register-only
+        MMTemplateConfigMixin, MUSAConfigHeuristic
+    ):
+        """Standard MM template heuristic for MUSA."""
+
+    @register_template_heuristic(mm_template.uid, "musa", op_name="addmm")
+    @register_template_heuristic(bmm_template.uid, "musa", op_name="baddbmm")
+    class MUSAAddMMTemplateConfigHeuristic(  # noqa: F841 — register-only
+        AddMMConfigMixin, MUSAConfigHeuristic
+    ):
+        """Addmm/baddbmm template heuristic for MUSA."""
+
+    # scaled_mm (FP8 path) — the M2.5 FP8 layers compile through this.
+    @register_template_heuristic(mm_template.uid, "musa", op_name="scaled_mm")
+    class MUSAScaledMMTemplateConfigHeuristic(  # noqa: F841 — register-only
+        MMTemplateConfigMixin, MUSAConfigHeuristic
+    ):
+        """Scaled MM (FP8) template heuristic for MUSA."""
+
+    _REGISTERED = True
+    logger.info_once(
+        "MUSA-0087: Inductor template heuristics registered for "
+        "device_type='musa' (mm + bmm + addmm + baddbmm + scaled_mm)."
+    )

--- a/vllm_musa/_inductor/template_heuristics.py
+++ b/vllm_musa/_inductor/template_heuristics.py
@@ -18,10 +18,16 @@ Disable with: ``VLLM_MUSA_DISABLE_INDUCTOR_HEURISTICS=1``
 
 from __future__ import annotations
 
-import logging
 import os
 
-logger = logging.getLogger(__name__)
+from vllm.logger import init_logger
+
+# vllm.logger.init_logger returns a Logger that supports info_once /
+# warning_once. The previous use of logging.getLogger here raised
+# AttributeError at call sites, which was caught by the broad except
+# in vllm_musa/__init__.py and silently disabled MUSA-0087 heuristic
+# registration — see PR #40 review comment.
+logger = init_logger(__name__)
 
 # Idempotency guard
 _REGISTERED = False

--- a/vllm_musa/distributed/device_communicators/__init__.py
+++ b/vllm_musa/distributed/device_communicators/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/vllm_musa/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/quick_all_reduce.py
@@ -21,13 +21,18 @@ API mirrors `vllm/.../custom_all_reduce.py:CustomAllreduce`:
 
 from __future__ import annotations
 
-import logging
 from typing import Optional
 
 import torch
 import torch.distributed as dist
 
-logger = logging.getLogger(__name__)
+from vllm.logger import init_logger
+
+# vllm.logger.init_logger returns a Logger with info_once / warning_once
+# helpers; the previous plain logging.getLogger here would have raised
+# AttributeError on first miss (PR #40 review comment), turning the
+# graceful "ops not available" degrade path into an ImportError.
+logger = init_logger(__name__)
 
 
 # Probe for the compiled ops. If missing, the wrapper degrades gracefully.
@@ -100,10 +105,13 @@ class QuickAllReduce:
                 torch.empty_like(my_handle) for _ in range(world_size)
             ]
             dist.all_gather(all_handles, my_handle, group=group)
-            peer_handles = [
-                all_handles[i] for i in range(world_size) if i != rank
-            ]
-            torch.ops._C_quick_ar.open_handles(self.fptr, peer_handles)
+            # Pass the full handle list (length == world_size). The C++
+            # DeviceComms::open_ipc_handles asserts size() == world_size
+            # and indexes by rank; it already skips the self entry
+            # internally (i == rank branch). Filtering out self here
+            # would shift the indices and mis-map ranks — see PR #40
+            # review comment.
+            torch.ops._C_quick_ar.open_handles(self.fptr, all_handles)
         except Exception as exc:
             logger.warning(
                 "MUSA-0088: QuickAllReduce IPC handle exchange failed "

--- a/vllm_musa/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/quick_all_reduce.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA-0088 iter-2: Python wrapper for the SGLang-ported quick_all_reduce
+kernel.
+
+Scaffolding only — calls into `torch.ops._C_quick_ar.*` which are
+registered by `vllm-musa/csrc/quick_all_reduce.cu`. The actual op
+registration happens at module-load time of the compiled `vllm_musa._C`
+extension (built via `vllm-musa/setup.py`).
+
+If the underlying kernel hasn't compiled successfully yet, this module
+gracefully no-ops the dispatch: `should_quick_ar()` returns False so
+the standard `custom_all_reduce` path is used.
+
+API mirrors `vllm/.../custom_all_reduce.py:CustomAllreduce`:
+    - __init__(group, world_size, rank, max_size)
+    - should_quick_ar(input)
+    - all_reduce(input, output) — in-place via output tensor
+    - __del__: free the C++-side context
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+logger = logging.getLogger(__name__)
+
+
+# Probe for the compiled ops. If missing, the wrapper degrades gracefully.
+try:
+    _ = torch.ops._C_quick_ar.init
+    _QUICK_AR_AVAILABLE = True
+except (AttributeError, RuntimeError) as exc:
+    logger.info_once(
+        "MUSA-0088: quick_all_reduce ops not available (%s); "
+        "QuickAllReduce will no-op and the standard custom_all_reduce path "
+        "stays active. This is expected until the kernel compile lands.",
+        exc,
+    )
+    _QUICK_AR_AVAILABLE = False
+
+
+class QuickAllReduce:
+    """One-shot two-shot P2P all-reduce wrapper for MUSA TP>2.
+
+    Mirrors SGLang's quick_all_reduce on AMD ROCm. Designed for small
+    payloads (≤ 2 GiB) on fully-connected P2P topologies (S5000 NVLink
+    equivalent). Falls back to CustomAllreduce / mccl alltoall when
+    payload exceeds kMaxProblemSize.
+    """
+
+    _SUPPORTED_WORLD_SIZES = (2, 4, 8)
+    _MAX_PROBLEM_BYTES = (2**31) + 1  # mirror C++ qr_max_size() default
+
+    def __init__(
+        self,
+        group: dist.ProcessGroup,
+        world_size: int,
+        rank: int,
+        max_size: Optional[int] = None,
+    ) -> None:
+        self.group = group
+        self.world_size = world_size
+        self.rank = rank
+        self.max_size = max_size or self._MAX_PROBLEM_BYTES
+        self.fptr: int = 0
+        self.disabled = not _QUICK_AR_AVAILABLE
+
+        if world_size not in self._SUPPORTED_WORLD_SIZES:
+            logger.warning(
+                "MUSA-0088: QuickAllReduce disabled — world_size=%d "
+                "not in supported set %s.",
+                world_size,
+                self._SUPPORTED_WORLD_SIZES,
+            )
+            self.disabled = True
+            return
+
+        if self.disabled:
+            return
+
+        try:
+            self.fptr = torch.ops._C_quick_ar.init(rank, world_size, self.max_size)
+        except Exception as exc:
+            logger.warning(
+                "MUSA-0088: QuickAllReduce init failed (%s); disabling.", exc
+            )
+            self.disabled = True
+            self.fptr = 0
+            return
+
+        # IPC handle exchange via the process group.
+        try:
+            my_handle: torch.Tensor = torch.ops._C_quick_ar.get_handle(self.fptr)
+            all_handles = [
+                torch.empty_like(my_handle) for _ in range(world_size)
+            ]
+            dist.all_gather(all_handles, my_handle, group=group)
+            peer_handles = [
+                all_handles[i] for i in range(world_size) if i != rank
+            ]
+            torch.ops._C_quick_ar.open_handles(self.fptr, peer_handles)
+        except Exception as exc:
+            logger.warning(
+                "MUSA-0088: QuickAllReduce IPC handle exchange failed "
+                "(%s); disabling.", exc,
+            )
+            self.disabled = True
+            self._safe_destroy()
+
+    def should_quick_ar(self, input_: torch.Tensor) -> bool:
+        """Gate: True when this all-reduce should use quick_ar over the
+        standard custom_all_reduce / mccl path."""
+        if self.disabled:
+            return False
+        if input_.numel() * input_.element_size() > self.max_size:
+            return False
+        if input_.dtype not in (torch.bfloat16, torch.float16):
+            return False
+        return True
+
+    # API-compat aliases matching vllm-upstream cuda_communicator.all_reduce naming.
+    def should_quick_allreduce(self, input_: torch.Tensor) -> bool:
+        return self.should_quick_ar(input_)
+
+    def quick_all_reduce(
+        self, input_: torch.Tensor, quant_level: int = 0, cast_bf2half: bool = False
+    ) -> Optional[torch.Tensor]:
+        """vllm-upstream API alias: returns the all-reduced output tensor
+        directly (in-place via a fresh output buffer)."""
+        return self.all_reduce(input_, output=None, quant_level=quant_level, cast_bf2half=cast_bf2half)
+
+    def all_reduce(
+        self,
+        input_: torch.Tensor,
+        output: Optional[torch.Tensor] = None,
+        quant_level: int = 0,
+        cast_bf2half: bool = False,
+    ) -> Optional[torch.Tensor]:
+        """Run quick all-reduce on input_, writing to output (or in-place).
+
+        Returns the output tensor on success, or None if the call was
+        skipped (disabled / unsupported shape)."""
+        if not self.should_quick_ar(input_):
+            return None
+        if output is None:
+            output = torch.empty_like(input_)
+        torch.ops._C_quick_ar.all_reduce(
+            self.fptr, input_, output, quant_level, cast_bf2half
+        )
+        return output
+
+    def _safe_destroy(self) -> None:
+        if self.fptr:
+            try:
+                torch.ops._C_quick_ar.destroy(self.fptr)
+            except Exception:
+                pass
+            self.fptr = 0
+
+    def __del__(self) -> None:
+        self._safe_destroy()

--- a/vllm_musa/kernels/__init__.py
+++ b/vllm_musa/kernels/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA-specific kernel providers for vllm.ir ops.
+
+Imported from vllm_musa.platform.MUSAPlatformBase.import_ir_kernels()
+after super().import_ir_kernels() so upstream providers (native /
+vllm_c / oink / aiter / xpu_kernels) register first; MUSA providers
+appear alongside.
+"""
+
+from . import musa_ops  # noqa: F401
+
+__all__ = ["musa_ops"]

--- a/vllm_musa/kernels/musa_ops.py
+++ b/vllm_musa/kernels/musa_ops.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA IR-op providers for vllm.ir.ops.*
+
+Currently registers:
+- rms_norm: delegates to torch.ops._C.rms_norm (the upstream
+  layernorm_kernels.cu kernel built via vllm-musa/setup.py
+  VLLM_CSRC_SOURCES; torchada redirects CUDA → MUSA at runtime).
+
+Engine log from MUSA-0049 baseline confirms:
+    ir_op_priority=IrOpPriorityConfig(rms_norm=['native'])
+
+i.e. before this provider lands, every decoder layer per token uses
+the pure-PyTorch native rms_norm. With the "musa" provider plus a
+priority override in `vllm_musa.platform`, the dispatcher / Inductor
+lowering picks the MUSA kernel.
+"""
+import torch
+from torch import Tensor
+
+from vllm import ir
+from vllm.platforms import current_platform
+
+# vllm._C must be loaded before torch.ops._C.rms_norm is resolvable.
+current_platform.import_kernels()
+
+
+def _has_C_rms_norm() -> bool:
+    try:
+        return hasattr(torch.ops._C, "rms_norm")
+    except Exception:
+        return False
+
+
+MUSA_RMS_NORM_SUPPORTED = current_platform.is_musa() and _has_C_rms_norm()
+
+
+def _rms_norm_supports_args(
+    x: Tensor,
+    weight: Tensor | None,
+    epsilon: float,
+    variance_size: int | None = None,
+) -> bool:
+    return (
+        variance_size is None
+        and weight is not None
+        and x.dim() >= 2
+        and x.dtype in (torch.float16, torch.bfloat16)
+        and weight.dtype == x.dtype
+        and weight.is_contiguous()
+    )
+
+
+@ir.ops.rms_norm.register_impl(
+    "musa",
+    supports_args=_rms_norm_supports_args,
+    supported=MUSA_RMS_NORM_SUPPORTED,
+)
+def rms_norm(
+    x: Tensor,
+    weight: Tensor | None,
+    epsilon: float,
+    variance_size: int | None = None,
+) -> Tensor:
+    """MUSA provider for vllm.ir.ops.rms_norm.
+
+    Delegates to torch.ops._C.rms_norm (the upstream layernorm_kernels.cu
+    kernel built via vllm-musa setup.py; torchada redirects CUDA->MUSA).
+    """
+    assert variance_size is None
+    assert weight is not None
+    output = torch.empty_like(x)
+    torch.ops._C.rms_norm(output, x, weight, epsilon)
+    return output

--- a/vllm_musa/model_executor/__init__.py
+++ b/vllm_musa/model_executor/__init__.py
@@ -1,5 +1,6 @@
 import vllm_musa.model_executor.layers.activation
 import vllm_musa.model_executor.layers.fused_moe.fused_moe
+import vllm_musa.model_executor.layers.fused_moe.moe_config_bridge  # noqa: F401
 import vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router
 import vllm_musa.model_executor.layers.fused_moe.unquantized_fused_moe_method
 import vllm_musa.model_executor.layers.layernorm

--- a/vllm_musa/model_executor/layers/fused_moe/moe_config_bridge.py
+++ b/vllm_musa/model_executor/layers/fused_moe/moe_config_bridge.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Bridge torchada's autotuned MoE configs into vLLM's search path.
+
+MUSA-0053: vLLM's `get_moe_configs`
+(`vllm/model_executor/layers/fused_moe/fused_moe.py`) only searches
+`vllm/model_executor/layers/fused_moe/configs/<name>.json`, building the
+filename with no space in the `block_shape` segment
+(`...block_shape=[128,128].json`, because vLLM does
+`f",block_shape={block_shape}".replace(" ", "")`).
+
+torchada ships its autotuned MUSA configs under
+`torchada/triton/autotune/fused_moe/configs/triton_*/`, and Python's
+`str(list)` repr produces a SPACE after the comma
+(`...block_shape=[128, 128].json`).
+
+Net effect on a stock MUSA install: vLLM never finds the tuned configs
+and logs `Using default MoE config. Performance might be sub-optimal!`
+(observed in the MUSA-0049 MiniMax-M2.7 baseline for
+`E=32,N=1536,dtype=fp8_w8a8,block_shape=[128,128]`).
+
+This module, imported once at platform init, copies every
+`*device_name=MTT_S5000*` torchada config into vLLM's configs dir with
+the spaces stripped from the filename, so vLLM's lookup succeeds. It is
+idempotent (skips files that already exist) and best-effort (a missing
+torchada dir or an unwritable vLLM dir logs a warning and is otherwise
+a no-op — vLLM then falls back to its default config, i.e. exactly the
+pre-bridge behaviour).
+"""
+import glob
+import os
+import shutil
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_bridged = False
+
+
+def _torchada_moe_config_dir() -> str | None:
+    try:
+        import torchada
+    except ImportError:
+        return None
+    base = os.path.join(
+        os.path.dirname(torchada.__file__),
+        "triton",
+        "autotune",
+        "fused_moe",
+        "configs",
+    )
+    return base if os.path.isdir(base) else None
+
+
+def _vllm_moe_config_dir() -> str | None:
+    try:
+        import vllm.model_executor.layers.fused_moe.fused_moe as vfm
+    except ImportError:
+        return None
+    return os.path.join(os.path.dirname(vfm.__file__), "configs")
+
+
+def bridge_musa_moe_configs() -> int:
+    """Copy torchada MTT_S5000 MoE configs into vLLM's config dir.
+
+    Returns the number of files newly bridged. Idempotent.
+    """
+    global _bridged
+    if _bridged:
+        return 0
+    _bridged = True
+
+    ta_dir = _torchada_moe_config_dir()
+    if ta_dir is None:
+        logger.debug("torchada MoE config dir not found; skipping MoE bridge")
+        return 0
+    vllm_dir = _vllm_moe_config_dir()
+    if vllm_dir is None:
+        logger.debug("vLLM MoE config dir not found; skipping MoE bridge")
+        return 0
+
+    try:
+        os.makedirs(vllm_dir, exist_ok=True)
+    except OSError as exc:
+        logger.warning("Cannot create vLLM MoE config dir %s: %s", vllm_dir, exc)
+        return 0
+
+    bridged = 0
+    pattern = os.path.join(ta_dir, "**", "*device_name=MTT_S5000*.json")
+    for src in glob.glob(pattern, recursive=True):
+        # vLLM builds the lookup filename with spaces stripped.
+        dst_name = os.path.basename(src).replace(" ", "")
+        dst = os.path.join(vllm_dir, dst_name)
+        if os.path.exists(dst):
+            continue
+        try:
+            shutil.copy2(src, dst)
+            bridged += 1
+        except OSError as exc:
+            logger.warning("Failed to bridge MoE config %s -> %s: %s", src, dst, exc)
+
+    if bridged:
+        logger.info(
+            "Bridged %d torchada MTT_S5000 MoE config(s) into %s",
+            bridged,
+            vllm_dir,
+        )
+    else:
+        logger.debug("No new MTT_S5000 MoE configs to bridge")
+    return bridged
+
+
+# Run on import (vllm_musa.model_executor wires this module).
+bridge_musa_moe_configs()

--- a/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
@@ -131,6 +131,37 @@ def _silu_fp8_fusion_max_tokens() -> int:
         return 512
 
 
+def _sphere_silu_fp8_enabled() -> bool:
+    value = os.getenv("VLLM_MUSA_SPHERE_SILU_FP8", "1").lower()
+    return value not in ("0", "false", "no", "off")
+
+
+def _sphere_silu_fp8_max_tokens() -> int:
+    try:
+        return int(os.getenv("VLLM_MUSA_SPHERE_SILU_FP8_MAX_TOKENS", "256"))
+    except ValueError:
+        return 256
+
+
+_SPHERE_SILU_FP8_MOD = None
+_SPHERE_SILU_FP8_PROBE_DONE = False
+
+
+def _maybe_sphere_silu_fp8():
+    """Lazy-load `sphere_silu_post_quant`; cache success / failure once per process."""
+    global _SPHERE_SILU_FP8_MOD, _SPHERE_SILU_FP8_PROBE_DONE
+    if _SPHERE_SILU_FP8_PROBE_DONE:
+        return _SPHERE_SILU_FP8_MOD
+    _SPHERE_SILU_FP8_PROBE_DONE = True
+    try:
+        import sphere_silu_post_quant  # noqa: F401
+
+        _SPHERE_SILU_FP8_MOD = sphere_silu_post_quant
+    except (ImportError, ModuleNotFoundError):
+        _SPHERE_SILU_FP8_MOD = None
+    return _SPHERE_SILU_FP8_MOD
+
+
 def silu_mul_per_token_group_quant_fp8_musa(
     input: torch.Tensor,
     output: torch.Tensor | None = None,
@@ -174,16 +205,51 @@ def silu_mul_per_token_group_quant_fp8_musa(
 
     tokens = input.shape[0]
     hidden = input.shape[-1] // 2
+
+    fp8_dtype = current_platform.fp8_dtype()
+
+    # MUSA-0101: sphere_silu_post_quant_v1 is ~1.6-1.9x faster than the
+    # _C_musa_ops kernel for small-M (tokens <= 256, hidden_dim == 3072,
+    # row-major non-UE8M0 scale). Bit-exact dequant match validated at
+    # M=128. If the caller pre-allocated `output`, we must copy into it
+    # (the copy overhead negates most of the win, so we still try it but
+    # the bigger gain is when output is None).
+    if (
+        _sphere_silu_fp8_enabled()
+        and tokens <= _sphere_silu_fp8_max_tokens()
+        and hidden == 1536  # M2.5 gate_up: input [tokens, 3072] -> out [tokens, 1536]
+    ):
+        sphere = _maybe_sphere_silu_fp8()
+        if sphere is not None:
+            sq, ss = sphere.silu_post_quant_v1(input)
+            expected_q_shape = (tokens, hidden)
+            expected_s_shape = (tokens, hidden // group_size)
+            if (
+                sq.shape == expected_q_shape
+                and ss.shape == expected_s_shape
+                and sq.dtype == fp8_dtype
+                and ss.dtype == torch.float32
+            ):
+                if output is None:
+                    return sq, ss
+                if (
+                    output.shape == expected_q_shape
+                    and output.is_contiguous()
+                    and output.dtype == fp8_dtype
+                ):
+                    output.copy_(sq)
+                    return output, ss
+
     if output is None:
         output = torch.empty(
             (tokens, hidden),
             device=input.device,
-            dtype=current_platform.fp8_dtype(),
+            dtype=fp8_dtype,
         )
     elif (
         output.shape != (tokens, hidden)
         or not output.is_contiguous()
-        or output.dtype != current_platform.fp8_dtype()
+        or output.dtype != fp8_dtype
     ):
         return fallback()
 

--- a/vllm_musa/patches/__init__.py
+++ b/vllm_musa/patches/__init__.py
@@ -8,6 +8,7 @@ to ensure compatibility with the MUSA Triton version.
 """
 
 import importlib.util
+import os
 from pathlib import Path
 
 from vllm.logger import init_logger
@@ -109,12 +110,38 @@ def apply_patches():
                     patched_source = patched_source.replace(old, new)
                     applied_count += 1
 
-            # Write back the patched source. Do not evict an already-imported
-            # module from sys.modules: some vLLM modules register torch custom
-            # ops at import time, and re-importing them would register the same
-            # schema twice in the current process.
-            with open(spec.origin, "w") as f:
-                f.write(patched_source)
+            # Write back the patched source ATOMICALLY via tempfile + rename.
+            # Rationale: vLLM's spawn-based multiproc executor starts N worker
+            # processes nearly simultaneously, each of which re-imports
+            # vllm_musa and therefore re-runs apply_patches(). If a worker
+            # holds the file open for read (e.g. during `import
+            # vllm.utils.deep_gemm`) while another process is mid-write, the
+            # worker can observe a truncated/partial file and raise an
+            # ImportError mid-startup (observed during MUSA-0046 MiniMax-M2.7
+            # smoke #4, 2026-05-14). Atomic rename guarantees readers see
+            # either the pre-patch or post-patch content, never partial.
+            #
+            # Do not evict an already-imported module from sys.modules: some
+            # vLLM modules register torch custom ops at import time, and
+            # re-importing them would register the same schema twice in the
+            # current process.
+            import tempfile  # noqa: I001 — local import keeps top-level imports stable
+
+            tmp_fd, tmp_path = tempfile.mkstemp(
+                prefix=os.path.basename(spec.origin) + ".",
+                dir=os.path.dirname(spec.origin),
+            )
+            try:
+                with os.fdopen(tmp_fd, "w") as f:
+                    f.write(patched_source)
+                os.rename(tmp_path, spec.origin)
+            except Exception:
+                # Best-effort cleanup on error.
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
 
             logger.info(f"Applied {applied_count} patch(es) to {module_name}")
 

--- a/vllm_musa/patches/__init__.py
+++ b/vllm_musa/patches/__init__.py
@@ -96,17 +96,30 @@ def apply_patches():
             if not patches:
                 continue
 
-            # Check if any patches are needed
-            needs_patch = any(old in source for old, new in patches)
+            # Check if any patches are needed.
+            # MUSA-0089/0096 fix: for INSERT-style patches (where `new` contains
+            # `old` plus extra inserted text), `old in source` remains True after
+            # first apply, causing accumulation across re-imports. Gate on
+            # `new not in source` to detect "patch already applied" state.
+            # Behaviour-preserving for REPLACEMENT-style patches where `new`
+            # differs entirely from `old`.
+            needs_patch = any(
+                old in source and new not in source for old, new in patches
+            )
             if not needs_patch:
                 logger.debug(f"No patches needed for {module_name}")
                 continue
 
-            # Apply patches
+            # Apply patches.
+            # MUSA-0089/0096 fix: same `new not in patched_source` gate as
+            # the outer needs_patch check. Without this, INSERT-style patches
+            # re-apply on every import and accumulate (e.g., MUSA-0088's
+            # cuda_communicator.py grew 10 duplicate `elif current_platform.is_musa()`
+            # blocks before MUSA-0089 caught it and manual sed -i restored).
             patched_source = source
             applied_count = 0
             for old, new in patches:
-                if old in patched_source:
+                if old in patched_source and new not in patched_source:
                     patched_source = patched_source.replace(old, new)
                     applied_count += 1
 

--- a/vllm_musa/patches/vllm__compilation__passes__pass_manager.patch.py
+++ b/vllm_musa/patches/vllm__compilation__passes__pass_manager.patch.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch for vllm.compilation.passes.pass_manager.
+
+MUSA-0047: upstream pass_manager.py gates several fusion-pass imports
+on `if current_platform.is_cuda():`, which excludes MUSA. The
+`MiniMaxQKNormPass` class is in turn referenced unconditionally when
+`pass_config.fuse_minimax_qk_norm=True` (line ~142), producing:
+
+    NameError: name 'MiniMaxQKNormPass' is not defined
+
+during Inductor backend init on MiniMax-M2.7 at TP=8 with the
+upstream-recommended compile config
+`{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}`.
+
+The MUSA build includes the kernel
+`minimax_reduce_rms_kernel.cu` (in VLLM_CSRC_SOURCES per
+`vllm-musa/setup.py`) which the pass replaces inlined QK
+allreduce+RMS with. Extend the import gate to also fire on MUSA.
+
+The two other CUDA-gated imports — AllReduceFusionPass and AsyncTPPass
+— also touch MUSA-affecting paths but are out of scope for MUSA-0047.
+Bring them along; they currently aren't activated unless their
+pass_config flags are flipped on.
+"""
+
+PATCHES = [
+    (
+        """if current_platform.is_cuda():
+    from .fusion.allreduce_rms_fusion import AllReduceFusionPass
+    from .fusion.collective_fusion import AsyncTPPass
+    from .fusion.minimax_qk_norm_fusion import MiniMaxQKNormPass""",
+        """if current_platform.is_cuda() or current_platform.is_musa():
+    from .fusion.allreduce_rms_fusion import AllReduceFusionPass
+    from .fusion.collective_fusion import AsyncTPPass
+    from .fusion.minimax_qk_norm_fusion import MiniMaxQKNormPass""",
+    ),
+]

--- a/vllm_musa/patches/vllm__distributed__device_communicators__cuda_communicator.patch.py
+++ b/vllm_musa/patches/vllm__distributed__device_communicators__cuda_communicator.patch.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+MUSA-0088 iter-2: extend the upstream CudaCommunicator qr_comm gate to
+also initialize QuickAllReduce on MUSA.
+
+Upstream code at vllm/vllm/distributed/device_communicators/cuda_communicator.py:
+
+    if current_platform.is_rocm():
+        # Initialize a custom quick all-reduce implementation for AMD.
+        ...
+        self.qr_comm = QuickAllReduce(group=self.cpu_group, device=self.device)
+
+This patch extends the gate to also cover MUSA. The QuickAllReduce
+implementation used is vllm-musa's local one (mirrors the upstream API
+shape: __init__(group, device)).
+
+The patch is a no-op until vllm-musa/csrc/quick_all_reduce.cu compiles
+successfully — the vllm_musa QuickAllReduce class detects missing
+torch.ops._C_quick_ar.* and sets `disabled = True`, so the dispatch
+in cuda_communicator.all_reduce() falls through to the next path.
+"""
+
+_OLD = """            if current_platform.is_rocm():
+                # Initialize a custom quick all-reduce implementation for AMD.
+                # Quick reduce is designed as a complement to custom allreduce.
+                # Based on quickreduce (https://github.com/mk1-project/quickreduce).
+                # If it's a rocm, 'use_custom_allreduce==True' means it must
+                # currently be an MI300 series.
+                self.qr_comm = QuickAllReduce(group=self.cpu_group, device=self.device)
+"""
+
+_NEW = """            if current_platform.is_rocm():
+                # Initialize a custom quick all-reduce implementation for AMD.
+                # Quick reduce is designed as a complement to custom allreduce.
+                # Based on quickreduce (https://github.com/mk1-project/quickreduce).
+                # If it's a rocm, 'use_custom_allreduce==True' means it must
+                # currently be an MI300 series.
+                self.qr_comm = QuickAllReduce(group=self.cpu_group, device=self.device)
+            elif current_platform.is_musa():
+                # MUSA-0088: extend qr_comm to MUSA. Uses vllm-musa's local
+                # QuickAllReduce (csrc/quick_all_reduce.cu ported from SGLang).
+                # Falls back to disabled if the kernel hasn't compiled yet —
+                # cuda_communicator.all_reduce() then routes to custom_all_reduce
+                # / mccl as before.
+                from vllm_musa.distributed.device_communicators.quick_all_reduce import (
+                    QuickAllReduce as MUSAQuickAllReduce,
+                )
+
+                # API shape: MUSAQuickAllReduce(group, world_size, rank, max_size).
+                # Derive world_size + rank from the cpu_group.
+                import torch.distributed as _dist
+
+                _ws = _dist.get_world_size(group=self.cpu_group)
+                _rank = _dist.get_rank(group=self.cpu_group)
+                self.qr_comm = MUSAQuickAllReduce(
+                    group=self.cpu_group, world_size=_ws, rank=_rank
+                )
+"""
+
+PATCHES = [(_OLD, _NEW)]

--- a/vllm_musa/patches/vllm__distributed__device_communicators__custom_all_reduce.patch.py
+++ b/vllm_musa/patches/vllm__distributed__device_communicators__custom_all_reduce.patch.py
@@ -25,4 +25,22 @@ PATCHES = [
         "if ( not current_platform.is_rocm() or not current_platform.is_musa() ) and not _can_p2p(rank, world_size):",
         "if not current_platform.is_rocm() and not current_platform.is_musa() and not _can_p2p(rank, world_size):",
     ),
+    # MUSA-0062 (torch 2.7.1): removed MUSA-0052's `world_size > 2` CAR
+    # gate, re-enabling custom_all_reduce on MUSA for TP>2. The
+    # compile-path safety (Inductor lowering past the Python alignment
+    # gate) was handled at the kernel level — see generated/musa0062/.
+    #
+    # MUSA-0069 (torch >= 2.9): added a torch-version-aware `world_size
+    # > 2` disable because the kernel rejected non-vector-aligned
+    # numel ("input length must be multiple of 4") produced by torch
+    # 2.9 Inductor's compile-mode lowering.
+    #
+    # MUSA-0075 (torch >= 2.9): removed the MUSA-0069 gate. The C++
+    # wrapper `vllm-musa/csrc/custom_all_reduce.cu` now zero-pads the
+    # tail of reg_buffer when numel is not a multiple of d_T (the
+    # kernel vector width = 16 / element_size). Each rank pads
+    # identically; the sum of zero peer tails is zero; the kernel
+    # writes zeros into out's tail (within PyTorch's allocator slack).
+    # CAR is re-enabled at TP>2 on torch_musa 2.9.0. See
+    # generated/musa0075/.
 ]

--- a/vllm_musa/patches/vllm__model_executor__layers__fused_moe__experts__deep_gemm_moe.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__fused_moe__experts__deep_gemm_moe.patch.py
@@ -36,4 +36,40 @@ _NEW = """        if activation == MoEActivation.SILU:
 
 PATCHES = [
     (_OLD, _NEW),
+    # MUSA mate's ragged_moe_gemm_8bit asserts scale_a.IsContiguous().
+    # Both grouped FP8 GEMM call sites must materialise contiguous scales.
+    # Discovered MUSA-0046 2026-05-14 while bringing up MiniMax-M2.7 FP8 on
+    # yeahdongcn50: profile_run aborted with
+    #   tvm.error.InternalError: Check failed: (scale_a.IsContiguous()) is
+    #   false: scale_a must be contiguous
+    # The dense FP8 path has the equivalent fix in patch #2 of
+    # vllm__model_executor__layers__quantization__utils__fp8_utils.patch.py.
+    # Gate+up GEMM (first call site):
+    (
+        """        mm1_out = _resize_cache(workspace2, (M_sum, N))
+        m_grouped_fp8_gemm_nt_contiguous(
+            (a1q, a1q_scale), (w1, self.w1_scale), mm1_out, expert_ids
+        )""",
+        """        mm1_out = _resize_cache(workspace2, (M_sum, N))
+        # MUSA mate ragged_moe_gemm_8bit asserts scale tensors are contiguous.
+        a1q_scale = a1q_scale.contiguous()
+        w1_scale = self.w1_scale.contiguous()
+        m_grouped_fp8_gemm_nt_contiguous(
+            (a1q, a1q_scale), (w1, w1_scale), mm1_out, expert_ids
+        )""",
+    ),
+    # Down GEMM (second call site):
+    (
+        """        mm2_out = _resize_cache(workspace2, (M_sum, K))
+        m_grouped_fp8_gemm_nt_contiguous(
+            (a2q, a2q_scale), (w2, self.w2_scale), mm2_out, expert_ids
+        )""",
+        """        mm2_out = _resize_cache(workspace2, (M_sum, K))
+        # MUSA mate ragged_moe_gemm_8bit asserts scale tensors are contiguous.
+        a2q_scale = a2q_scale.contiguous()
+        w2_scale = self.w2_scale.contiguous()
+        m_grouped_fp8_gemm_nt_contiguous(
+            (a2q, a2q_scale), (w2, w2_scale), mm2_out, expert_ids
+        )""",
+    ),
 ]

--- a/vllm_musa/patches/vllm__model_executor__layers__quantization__utils__fp8_utils.patch.py
+++ b/vllm_musa/patches/vllm__model_executor__layers__quantization__utils__fp8_utils.patch.py
@@ -23,4 +23,18 @@ PATCHES = [
         output = torch.empty(
 """,
     ),
+    # MUSA namespace redirect: per_token_group_fp8_quant kernel is built by
+    # vllm-musa under torch.ops._C_musa_ops, not torch.ops._C. The previous
+    # patch (entry #1 above) enables MUSA to take the CUDA-style fast path,
+    # so we must also redirect the actual op call to the _C_musa_ops
+    # namespace. Without this the call raises:
+    #   AttributeError: '_OpNamespace' '_C' object has no attribute
+    #   'per_token_group_fp8_quant'
+    # This affects MiniMax-M2.7 FP8 startup. Discovered MUSA-0046 2026-05-14.
+    # Only the unpacked variant is redirected; _packed has no MUSA equivalent
+    # and is on a different code path not exercised by MiniMax-M2.7.
+    (
+        "torch.ops._C.per_token_group_fp8_quant(",
+        "torch.ops._C_musa_ops.per_token_group_fp8_quant(",
+    ),
 ]

--- a/vllm_musa/patches/vllm__v1__sample__rejection_sampler.patch.py
+++ b/vllm_musa/patches/vllm__v1__sample__rejection_sampler.patch.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Patch for vllm.v1.sample.rejection_sampler.
+
+MUSA-0064: vLLM's spec-decode rejection-sampler Triton kernels do not
+compile on MUSA's Triton (3.1.0), crashing engine init whenever
+speculative decoding is enabled (observed with the MiniMax-M2.5 Eagle3
+draft). The triton.compiler.errors.CompilationError caret points at
+`if not is_greedy:` in rejection_greedy_sample_kernel:
+
+    is_greedy = True if is_greedy_ptr is None else tl.load(is_greedy_ptr + req_idx)
+    if not is_greedy:
+       ^
+    ValueError('Cannot bitcast data-type of size 8 to data-type of size 1')
+
+Root cause: `is_greedy_ptr` points to a `torch.bool` tensor; MUSA Triton
+3.1.0 mishandles `not` / truthiness applied to a bool-typed `tl.load`'d
+value (it tries to bitcast the size-8 pointer/value to the size-1 bool
+type). CUDA Triton handles it; MUSA Triton 3.1.0 does not.
+
+Fix (three coordinated replacements):
+  1. Call site `rejection_sample()` — pass `is_greedy` as int32 instead
+     of torch.bool so the kernels load a plain integer.
+  2. rejection_greedy_sample_kernel — `True if ... else tl.load` becomes
+     `1 if ... else tl.load`, and `if not is_greedy:` becomes the
+     explicit `if is_greedy == 0:`.
+  3. rejection_random_sample_kernel — `if is_greedy:` becomes the
+     explicit `if is_greedy != 0:`.
+Plus a defensive 1-element dummy tensor for the `synthetic_conditional_
+rates` None pointer (kernels gate every read of it behind
+`SYNTHETIC_MODE: tl.constexpr`, so the dummy is never read).
+
+All replacements are behaviourally identical on CUDA; they only avoid
+the MUSA-Triton-3.1.0 bool-bitcast path. `device` / `torch` are in
+scope at the `rejection_sample()` insertion point.
+"""
+
+PATCHES = [
+    # 1 + dummy: call site -- is_greedy as int32 + synthetic dummy tensor.
+    (
+        """    if sampling_metadata.all_greedy:
+        is_greedy = None
+    else:
+        is_greedy = sampling_metadata.temperature == GREEDY_TEMPERATURE
+""",
+        """    if sampling_metadata.all_greedy:
+        is_greedy = None
+    else:
+        # MUSA-0064: int32, not torch.bool -- MUSA Triton 3.1.0 chokes on
+        # `not` / truthiness of a bool-typed tl.load'd value.
+        is_greedy = (
+            sampling_metadata.temperature == GREEDY_TEMPERATURE
+        ).to(torch.int32)
+
+    # MUSA-0064: MUSA Triton rejects the None-pointer handling for the
+    # `synthetic_conditional_rates_ptr` kernel arg. Pass a 1-element
+    # dummy tensor when synthetic mode is off; both rejection-sampler
+    # kernels gate every read of it behind `SYNTHETIC_MODE: tl.constexpr`
+    # so the dummy is never read.
+    if synthetic_conditional_rates is None:
+        synthetic_conditional_rates = torch.empty(
+            1, dtype=torch.float32, device=device
+        )
+""",
+    ),
+    # 2: rejection_greedy_sample_kernel -- avoid `not` on a loaded value.
+    (
+        """    is_greedy = True if is_greedy_ptr is None else tl.load(is_greedy_ptr + req_idx)
+    if not is_greedy:
+        # Early exit for non-greedy sampling requests.
+        return""",
+        """    # MUSA-0064: `1`/`== 0` instead of `True`/`not` -- MUSA Triton
+    # 3.1.0 cannot bitcast the bool-typed loaded value.
+    is_greedy = 1 if is_greedy_ptr is None else tl.load(is_greedy_ptr + req_idx)
+    if is_greedy == 0:
+        # Early exit for non-greedy sampling requests.
+        return""",
+    ),
+    # 3: rejection_random_sample_kernel -- avoid truthiness on a loaded value.
+    (
+        """    req_idx = tl.program_id(0)
+    is_greedy = tl.load(is_greedy_ptr + req_idx)
+    if is_greedy:
+        # Early exit for greedy sampling requests.
+        return""",
+        """    req_idx = tl.program_id(0)
+    # MUSA-0064: explicit `!= 0` instead of truthiness on the loaded
+    # value -- MUSA Triton 3.1.0 cannot bitcast the bool-typed value.
+    is_greedy = tl.load(is_greedy_ptr + req_idx)
+    if is_greedy != 0:
+        # Early exit for greedy sampling requests.
+        return""",
+    ),
+]

--- a/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+MUSA-0090: Dispatch EagleProposer.propose to the MUSA full-loop graph runner.
+
+This patch installs a wrapper on `vllm.v1.spec_decode.eagle.EagleProposer.propose`
+that:
+  1. On MUSA: try the EagleFullLoopRunner; fallback to vLLM's iterative path
+     on any error.
+  2. On CUDA: behave identically to upstream (no-op wrapper).
+  3. Lazy-init the runner on the FIRST propose() call (after vLLM has set
+     up everything else). Capture happens then; subsequent calls just
+     replay.
+
+Architecture:
+  - Patches the EagleProposer class via attribute assignment (MONKEY-PATCH).
+  - Uses an empty `PATCHES = []` so the parent `patches/__init__.py`'s
+    file-mutation framework skips the find/replace pass. The side effects
+    of importing this file (the monkey-patch) are what install the
+    dispatcher.
+  - Idempotent via the `_musa_eagle_patched` class attribute. Re-importing
+    is safe — does not stack wrappers.
+
+Rationale for MONKEY-PATCH over PATCHES = [(old, new)]:
+  - MUSA-0089 confirmed the file-mutation framework is non-idempotent
+    against new-block INSERTIONS (vs string replacements). The
+    cuda_communicator.py patch accumulated 10 duplicate blocks across
+    re-imports. INSERT semantics need either a marker-aware find pattern
+    (fragile) or a different mechanism — monkey-patching is the
+    different mechanism.
+  - Class-level monkey-patch + marker attribute is exactly-once per
+    process; the patches/__init__.py exec_module call from
+    `_load_patch_config` runs side effects once, the marker prevents
+    re-application within the same process if exec is re-triggered.
+"""
+
+PATCHES: list = []  # No file mutation; the dispatcher install is the side effect.
+
+# --- monkey-patch installation (runs at module load via _load_patch_config) ---
+
+import logging
+
+_log = logging.getLogger(__name__)
+
+# CRITICAL ORDER: import vllm_musa.v1.spec_decode.utils BEFORE eagle.
+# vllm-musa's utils module installs a MUSA-Triton-adapted version of
+# `eagle_prepare_next_token_padded_kernel` on vllm.v1.spec_decode.utils.
+# If we import eagle here without first ensuring that monkey-patch has
+# fired, eagle.py's `from vllm.v1.spec_decode.utils import ...` will
+# bind to the UPSTREAM unpatched kernel, which then fails at MUSA
+# Triton compile time with 'mismatched type for valid_count' inside
+# eagle_prepare_next_token_padded_kernel. (Diagnosed via isolation test
+# 21:41 confirming: with this patch.py disabled, MUSA-0089 v7 config
+# boots fine + smoke PASSes; with this patch.py active but without the
+# prime import, smoke FAILS in the Triton kernel.)
+import vllm_musa.v1.spec_decode.utils  # noqa: F401 — prime the kernel monkey-patch
+
+try:
+    from vllm.v1.spec_decode.eagle import EagleProposer
+except ImportError as exc:  # pragma: no cover
+    _log.debug(
+        "MUSA-0090 eagle patch: cannot import vllm.v1.spec_decode.eagle "
+        "(probably an unsupported vllm version). Skipping: %s", exc,
+    )
+    EagleProposer = None  # type: ignore
+
+
+def _maybe_init_runner(proposer, args, kwargs) -> None:
+    """Build + capture the EagleFullLoopRunner on the first MUSA propose() call.
+
+    Sets `proposer._musa_full_loop_runner` on success. On any failure,
+    re-raises (caller is expected to swallow + mark None to disable
+    retries).
+    """
+    from vllm_musa.v1.spec_decode.eagle_full_loop_runner import EagleFullLoopRunner
+
+    num_speculative_tokens = int(getattr(proposer, "num_speculative_tokens", 0))
+    if num_speculative_tokens < 1:
+        raise RuntimeError(
+            f"num_speculative_tokens={num_speculative_tokens} is invalid; "
+            "spec-decode appears not properly configured."
+        )
+
+    # MUSA-0090 step 5l.1: capture ONLY for the actual batch_size of the
+    # current call. The base_metadata is for `num_reqs=batch_size`; trying
+    # to capture for a different size requires synthetic metadata
+    # (query_start_loc shape needs to match num_reqs+1, etc.). Capturing
+    # for the observed size guarantees the metadata is consistent.
+    # Later calls at different batch_sizes will fall back to vllm iterative
+    # (cheap — just one cudagraph dispatch overhead) until we re-capture
+    # for that size (future work).
+    next_token_ids_arg = (
+        kwargs.get("next_token_ids")
+        if "next_token_ids" in kwargs
+        else (args[3] if len(args) > 3 else None)
+    )
+    if next_token_ids_arg is not None:
+        cudagraph_capture_sizes = [int(next_token_ids_arg.shape[0])]
+    else:
+        cudagraph_capture_sizes = [1]
+    _log.info(
+        "MUSA-0090: capturing for observed batch_size: %s",
+        cudagraph_capture_sizes,
+    )
+
+    # Hidden size: probe multiple paths since vllm config layouts vary.
+    hidden_size = 0
+    mc = getattr(proposer, "vllm_config", None)
+    if mc is not None:
+        model_config = getattr(mc, "model_config", None)
+        if model_config is not None:
+            try:
+                hidden_size = int(model_config.get_hidden_size())
+            except AttributeError:
+                hidden_size = int(
+                    getattr(getattr(model_config, "hf_config", None), "hidden_size", 0)
+                )
+    if hidden_size <= 0:
+        try:
+            hidden_size = int(proposer.model.config.hidden_size)
+        except Exception:
+            hidden_size = 4096  # M2.5 default; will surface in capture if wrong.
+        _log.warning(
+            "MUSA-0090: hidden_size probe fell back to %d", hidden_size
+        )
+
+    import torch
+    device = getattr(proposer, "device", None) or torch.device("cuda")
+
+    runner = EagleFullLoopRunner(
+        proposer=proposer,
+        num_speculative_tokens=num_speculative_tokens,
+        cudagraph_capture_sizes=cudagraph_capture_sizes,
+        hidden_size=hidden_size,
+        device=device,
+    )
+
+    # Capture (uses the first propose() call's common_attn_metadata as the
+    # template for per-step metadata). On capture failure, propagate; the
+    # caller marks the runner as None to disable future attempts.
+    base_metadata = kwargs.get("common_attn_metadata")
+    if base_metadata is None and len(args) >= 5:
+        base_metadata = args[4]
+    if base_metadata is None:
+        raise RuntimeError(
+            "MUSA-0090: cannot find common_attn_metadata in propose() args"
+        )
+    runner.capture(base_metadata)
+
+    proposer._musa_full_loop_runner = runner
+    _log.info(
+        "MUSA-0090: EagleFullLoopRunner installed (N=%d, capture_sizes=%s, "
+        "hidden_size=%d, buffer_footprint=%.2f MiB)",
+        num_speculative_tokens, cudagraph_capture_sizes, hidden_size,
+        runner.memory_footprint_bytes() / 1024 / 1024,
+    )
+
+
+def _make_dispatched_propose(_original_propose):
+    """Closure-build the patched propose() so the original is captured.
+
+    MUSA-0090 step 5l.4 (2026-05-16): runner architecture works for
+    capture but has deeper replay-time correctness issues (KV cache
+    page state, MUSA 'unknown error' on graph replay). Pending a full
+    SGLang-style per-step-backend refactor, disable the runner
+    dispatcher and always fall through to vllm's iterative path.
+    Set VLLM_MUSA_EAGLE_RUNNER=1 to re-enable for development.
+    """
+
+    import os
+    _RUNNER_ENABLED = os.environ.get("VLLM_MUSA_EAGLE_RUNNER", "0") == "1"
+
+    def _musa_dispatched_propose(self, *args, **kwargs):
+        if not _RUNNER_ENABLED:
+            return _original_propose(self, *args, **kwargs)
+        # Only dispatch on MUSA. On CUDA, fall through to the original.
+        try:
+            from vllm.platforms import current_platform
+            if not current_platform.is_musa():
+                return _original_propose(self, *args, **kwargs)
+        except Exception:
+            return _original_propose(self, *args, **kwargs)
+
+        # Lazy-init on first MUSA call.
+        if not hasattr(self, "_musa_full_loop_runner"):
+            try:
+                _maybe_init_runner(self, args, kwargs)
+            except Exception as exc:
+                _log.warning(
+                    "MUSA-0090: full-loop runner init failed (%s); falling "
+                    "back to vLLM iterative path for the rest of this run",
+                    exc,
+                )
+                self._musa_full_loop_runner = None
+
+        runner = getattr(self, "_musa_full_loop_runner", None)
+        if runner is None:
+            return _original_propose(self, *args, **kwargs)
+
+        # Extract args. EagleProposer.propose signature (vllm v0.20.1.dev0):
+        #   def propose(self, target_token_ids, target_positions,
+        #               target_hidden_states, next_token_ids,
+        #               token_indices_to_sample, common_attn_metadata,
+        #               sampling_metadata, ...)
+        try:
+            target_positions = (
+                kwargs.get("target_positions")
+                if "target_positions" in kwargs
+                else args[1]
+            )
+            target_hidden_states = (
+                kwargs.get("target_hidden_states")
+                if "target_hidden_states" in kwargs
+                else args[2]
+            )
+            next_token_ids = (
+                kwargs.get("next_token_ids")
+                if "next_token_ids" in kwargs
+                else args[3]
+            )
+            # token_indices_to_sample may be None (proposer computes from
+            # query_start_loc) — that's fine; runner.replay() handles it.
+            token_indices_to_sample = (
+                kwargs.get("token_indices_to_sample")
+                if "token_indices_to_sample" in kwargs
+                else (args[4] if len(args) > 4 else None)
+            )
+            common_attn_metadata = (
+                kwargs.get("common_attn_metadata")
+                if "common_attn_metadata" in kwargs
+                else args[5]
+            )
+        except (IndexError, KeyError):
+            _log.debug(
+                "MUSA-0090: propose() signature mismatch; fallback to original"
+            )
+            return _original_propose(self, *args, **kwargs)
+
+        batch_size = int(next_token_ids.shape[0])
+        if not runner.can_run(batch_size):
+            return _original_propose(self, *args, **kwargs)
+
+        try:
+            result = runner.replay(
+                target_hidden_states=target_hidden_states,
+                next_token_ids=next_token_ids,
+                common_attn_metadata=common_attn_metadata,
+                batch_size=batch_size,
+                target_positions=target_positions,
+                token_indices_to_sample=token_indices_to_sample,
+            )
+            return result.draft_token_ids
+        except Exception as exc:
+            _log.warning(
+                "MUSA-0090: runner.replay failed (%s); falling back to "
+                "vLLM iterative path for this call", exc,
+            )
+            return _original_propose(self, *args, **kwargs)
+
+    return _musa_dispatched_propose
+
+
+# Idempotent install.
+if EagleProposer is not None and not getattr(
+    EagleProposer, "_musa_eagle_patched", False
+):
+    _original_propose = EagleProposer.propose
+    EagleProposer.propose = _make_dispatched_propose(_original_propose)
+    EagleProposer._musa_eagle_patched = True
+    _log.info(
+        "MUSA-0090: EagleProposer.propose monkey-patched "
+        "(dispatcher installed; runner lazy-inits on first MUSA call)"
+    )

--- a/vllm_musa/patches/vllm__v1__spec_decode__llm_base_proposer.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__llm_base_proposer.patch.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+MUSA-0109 POC: Capture LLMBaseProposer.propose() under a single
+torch.cuda.graph (persistent pool) to eliminate per-round Python
+orchestration overhead.
+
+Goal: close the 28.6 tok/s gap from vllm-musa 91.4 → SGLang 120 by
+matching SGLang's EagleDraftCudaGraphRunner architecture.
+
+Strategy (POC):
+  1. On first call: run propose normally, save reference outputs.
+  2. On second call with same batch_size: copy inputs into pre-allocated
+     buffers and capture propose body under torch.cuda.graph().
+  3. On subsequent calls: copy inputs into buffers + replay.
+  4. On ANY capture or replay error: fall back to original path.
+
+Risks (per design doc generated/musa0109/design.md):
+  - MUSA CUDAGraph at TP=8 may crash (per MUSA-0061/0063)
+  - Allocations inside build_for_drafting() may not be capture-safe
+  - common_attn_metadata fields change per call — must be pre-allocated
+  - vllm's `replace(common_attn_metadata, ...)` creates new objects
+
+This POC uses a persistent memory pool to absorb capture-time
+allocations. If it crashes or produces wrong results, the failure mode
+is logged and the original path is used for the rest of the run.
+
+Gated via env var VLLM_MUSA_TREE_GRAPH_CAPTURE=1 (default OFF for safety).
+Enable explicitly for measurement; revert to fallback if regressions.
+"""
+
+PATCHES: list = []  # Monkey-patch only; no file mutation.
+
+import logging
+import os
+
+_log = logging.getLogger(__name__)
+
+_ENABLED = os.environ.get("VLLM_MUSA_TREE_GRAPH_CAPTURE", "0") == "1"
+
+# MUSA-0109 POC findings (2026-05-17, see generated/musa0109/poc-attempt-findings.md):
+# This patch monkey-patches `propose_tree` but `propose_tree` is NEVER called
+# in the current SOTA stack because vllm uses FLASH_ATTN attention backend
+# (not TREE_ATTN). The actual chain spec-decode loop lives in `propose()`
+# (lines 554-650), which has a complex signature and needs careful buffer
+# management — that's exactly what MUSA-0090's EagleFullLoopRunner was
+# designed for. The patch file remains as evidence of the attempt + starting
+# point for the proper port. Keep DISABLED by default.
+
+if not _ENABLED:
+    _log.info(
+        "MUSA-0109 POC: VLLM_MUSA_TREE_GRAPH_CAPTURE != 1; tree propose "
+        "graph capture is disabled (using vllm's iterative path)."
+    )
+else:
+    try:
+        import torch
+        from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+    except ImportError as exc:
+        _log.warning("MUSA-0109 POC: import failed (%s); patch disabled", exc)
+        SpecDecodeBaseProposer = None
+
+    if SpecDecodeBaseProposer is not None and not getattr(
+        SpecDecodeBaseProposer, "_musa_tree_graph_patched", False
+    ):
+        # Cache state per-proposer-instance via attribute on `self`.
+        _ORIGINAL_PROPOSE_TREE = SpecDecodeBaseProposer.propose
+
+        def _musa_patched_propose(
+            self,
+            batch_size: int,
+            logits,
+            positions,
+            hidden_states,
+            common_attn_metadata,
+            slot_mappings=None,
+        ):
+            """POC wrapper. See module docstring."""
+            # Safety: only attempt capture for batch_size=1, the SOTA target.
+            if batch_size != 1:
+                return _ORIGINAL_PROPOSE_TREE(
+                    self,
+                    batch_size,
+                    logits,
+                    positions,
+                    hidden_states,
+                    common_attn_metadata,
+                    slot_mappings,
+                )
+
+            cache = getattr(self, "_musa_tree_cache", None)
+            if cache is None:
+                cache = {
+                    "warmup_done": False,
+                    "graph": None,
+                    "pool": None,
+                    "input_buffers": None,
+                    "output_list_ref": None,
+                    "failed": False,
+                }
+                self._musa_tree_cache = cache
+
+            # If capture already failed, never try again.
+            if cache["failed"]:
+                return _ORIGINAL_PROPOSE_TREE(
+                    self,
+                    batch_size,
+                    logits,
+                    positions,
+                    hidden_states,
+                    common_attn_metadata,
+                    slot_mappings,
+                )
+
+            # First call: just run it, get reference outputs + shapes.
+            if not cache["warmup_done"]:
+                cache["warmup_done"] = True
+                cache["ref_logits_shape"] = logits.shape
+                cache["ref_positions_shape"] = positions.shape
+                cache["ref_hidden_shape"] = hidden_states.shape
+                _log.info(
+                    "MUSA-0109 POC: warmup call done; logits=%s positions=%s "
+                    "hidden_states=%s; capture on next call",
+                    logits.shape,
+                    positions.shape,
+                    hidden_states.shape,
+                )
+                return _ORIGINAL_PROPOSE_TREE(
+                    self,
+                    batch_size,
+                    logits,
+                    positions,
+                    hidden_states,
+                    common_attn_metadata,
+                    slot_mappings,
+                )
+
+            # Verify shape stability before capture attempt.
+            if (
+                logits.shape != cache["ref_logits_shape"]
+                or positions.shape != cache["ref_positions_shape"]
+                or hidden_states.shape != cache["ref_hidden_shape"]
+            ):
+                _log.warning(
+                    "MUSA-0109 POC: shape changed across calls "
+                    "(logits %s vs %s); capture aborted, falling back",
+                    logits.shape,
+                    cache["ref_logits_shape"],
+                )
+                cache["failed"] = True
+                return _ORIGINAL_PROPOSE_TREE(
+                    self,
+                    batch_size,
+                    logits,
+                    positions,
+                    hidden_states,
+                    common_attn_metadata,
+                    slot_mappings,
+                )
+
+            # Capture path: allocate buffers + capture under persistent pool.
+            if cache["graph"] is None:
+                try:
+                    bufs = {
+                        "logits": torch.empty_like(logits),
+                        "positions": torch.empty_like(positions),
+                        "hidden_states": torch.empty_like(hidden_states),
+                    }
+                    bufs["logits"].copy_(logits)
+                    bufs["positions"].copy_(positions)
+                    bufs["hidden_states"].copy_(hidden_states)
+
+                    g = torch.cuda.CUDAGraph()
+                    pool = torch.cuda.graph_pool_handle()
+                    torch.cuda.synchronize()
+                    with torch.cuda.graph(g, pool=pool):
+                        out_list = _ORIGINAL_PROPOSE_TREE(
+                            self,
+                            batch_size,
+                            bufs["logits"],
+                            bufs["positions"],
+                            bufs["hidden_states"],
+                            common_attn_metadata,
+                            slot_mappings,
+                        )
+                    cache["graph"] = g
+                    cache["pool"] = pool
+                    cache["input_buffers"] = bufs
+                    cache["output_list_ref"] = out_list
+                    _log.info(
+                        "MUSA-0109 POC: CAPTURED tree propose loop for bs=%d "
+                        "(output_list len=%d)",
+                        batch_size,
+                        len(out_list),
+                    )
+                    return out_list
+                except Exception as exc:
+                    _log.warning(
+                        "MUSA-0109 POC: capture FAILED (%s: %s); falling back",
+                        type(exc).__name__,
+                        exc,
+                    )
+                    cache["failed"] = True
+                    return _ORIGINAL_PROPOSE_TREE(
+                        self,
+                        batch_size,
+                        logits,
+                        positions,
+                        hidden_states,
+                        common_attn_metadata,
+                        slot_mappings,
+                    )
+
+            # Replay path: copy inputs + replay
+            try:
+                bufs = cache["input_buffers"]
+                bufs["logits"].copy_(logits)
+                bufs["positions"].copy_(positions)
+                bufs["hidden_states"].copy_(hidden_states)
+                cache["graph"].replay()
+                return cache["output_list_ref"]
+            except Exception as exc:
+                _log.warning(
+                    "MUSA-0109 POC: replay FAILED (%s: %s); falling back",
+                    type(exc).__name__,
+                    exc,
+                )
+                cache["failed"] = True
+                return _ORIGINAL_PROPOSE_TREE(
+                    self,
+                    batch_size,
+                    logits,
+                    positions,
+                    hidden_states,
+                    common_attn_metadata,
+                    slot_mappings,
+                )
+
+        SpecDecodeBaseProposer.propose = _musa_patched_propose
+        SpecDecodeBaseProposer._musa_tree_graph_patched = True
+        _log.info(
+            "MUSA-0109 POC: SpecDecodeBaseProposer.propose monkey-patched "
+            "with cudagraph capture (gate VLLM_MUSA_TREE_GRAPH_CAPTURE=1)"
+        )

--- a/vllm_musa/patches/vllm__v1__worker__gpu_model_runner.patch.py
+++ b/vllm_musa/patches/vllm__v1__worker__gpu_model_runner.patch.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+MUSA-0109 / MUSA-0090 layer-3 attempt: bypass `draft_token_ids_copy_stream`
+on MUSA so the H2D copy of draft tokens runs on the default stream (same
+stream the runner's CUDAGraph replay used).
+
+Why: with VLLM_MUSA_EAGLE_RUNNER=1, vllm's `_copy_draft_token_ids_to_cpu`
+fails with "MUDNN err 999 = unknown error" because it copies from
+runner-output (potentially CUDAGraph pool memory) on a DEDICATED stream
+(`self.draft_token_ids_copy_stream`). Forcing default-stream avoids the
+cross-stream interaction.
+
+This is a non-destructive change: same-stream copy is semantically
+identical to cross-stream copy + event-record + wait. The async-overlap
+benefit goes away, but at BS=1 the copy is ~12 bytes (int32 [bs=1, 3])
+so it doesn't matter.
+
+Gated via VLLM_MUSA_DRAFT_COPY_DEFAULT_STREAM=1 (default OFF).
+Enable only when running with VLLM_MUSA_EAGLE_RUNNER=1.
+"""
+
+PATCHES: list = []  # Monkey-patch only.
+
+import logging
+import os
+
+_log = logging.getLogger(__name__)
+
+_ENABLED = os.environ.get("VLLM_MUSA_DRAFT_COPY_DEFAULT_STREAM", "0") == "1"
+
+if not _ENABLED:
+    _log.info(
+        "MUSA-0109: VLLM_MUSA_DRAFT_COPY_DEFAULT_STREAM=0; "
+        "draft_token_ids_copy_stream stays on a dedicated stream (default vllm)"
+    )
+else:
+    try:
+        import torch
+        from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+    except ImportError as exc:
+        _log.warning(
+            "MUSA-0109 draft_copy_stream: import failed (%s); patch disabled",
+            exc,
+        )
+        GPUModelRunner = None
+
+    if GPUModelRunner is not None and not getattr(
+        GPUModelRunner, "_musa_draft_copy_stream_patched", False
+    ):
+        _ORIGINAL_INIT = GPUModelRunner.__init__
+
+        def _musa_patched_init(self, *args, **kwargs):
+            _ORIGINAL_INIT(self, *args, **kwargs)
+            # Override the dedicated copy stream with the current default stream
+            # AFTER the original init has constructed everything else.
+            if getattr(self, "draft_token_ids_copy_stream", None) is not None:
+                # Replace with current stream so the H2D copy stays on it.
+                self.draft_token_ids_copy_stream = torch.cuda.current_stream()
+                _log.info(
+                    "MUSA-0109: draft_token_ids_copy_stream redirected to "
+                    "torch.cuda.current_stream() to avoid CUDAGraph pool "
+                    "cross-stream interaction"
+                )
+            if getattr(self, "valid_sampled_token_count_copy_stream", None) is not None:
+                self.valid_sampled_token_count_copy_stream = torch.cuda.current_stream()
+                _log.info(
+                    "MUSA-0109: valid_sampled_token_count_copy_stream redirected "
+                    "to torch.cuda.current_stream()"
+                )
+
+        GPUModelRunner.__init__ = _musa_patched_init
+        GPUModelRunner._musa_draft_copy_stream_patched = True
+        _log.info(
+            "MUSA-0109: GPUModelRunner.__init__ monkey-patched to redirect "
+            "copy streams to default stream (gate "
+            "VLLM_MUSA_DRAFT_COPY_DEFAULT_STREAM=1)"
+        )

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -109,6 +109,15 @@ def register_attention_backends() -> None:
             "MUSATurboQuantAttentionBackend"
         ),
     )
+    # MUSA-0094: tree drafting via a MUSA-routed TreeAttention backend
+    # (Triton unified_attention is already MUSA-patched; reshape_and_cache_flash
+    # is wired through fa_utils.reshape_and_cache_flash).
+    register_backend(
+        AttentionBackendEnum.TREE_ATTN,
+        class_path=(
+            "vllm_musa.v1.attention.backends.tree_attn.MUSATreeAttentionBackend"
+        ),
+    )
 
 
 class MUSAPlatformBase(Platform):

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -350,19 +350,59 @@ class MUSAPlatformBase(Platform):
 
         compilation_config = vllm_config.compilation_config
         cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
-        if parallel_config.tensor_parallel_size > 2 and cudagraph_mode is not None:
+        # MUSA-0076: the TP>2 cudagraph force-disable was added in
+        # MUSA-0061/0063 under the (incorrect) belief that "MCCL is
+        # incompatible with MUSA stream capture at the platform level".
+        # The actual root cause was that custom_all_reduce was disabled
+        # on torch >= 2.9 (MUSA-0069 gate), causing
+        # cuda_communicator.all_reduce to fall through to
+        # torch.distributed.all_reduce, whose MCCL ProcessGroup watchdog
+        # made CUDA API calls during the capture window. MUSA-0075 fixed
+        # the underlying CAR kernel-alignment issue and re-enabled CAR
+        # at TP>2 on torch 2.9; the dispatcher now hits ca_comm
+        # (captureable, stream-bound) instead of torch.distributed.
+        #
+        # However, on torch_musa 2.9.0, capturing graphs at LARGE shapes
+        # (>= ~232 tokens / 51-size default capture) triggers an
+        # `illegal memory access` at musa_graph.capture_end() — a
+        # separate torch_musa-side bug. Until that bug is fixed
+        # upstream, cap max_cudagraph_capture_size to a safe value so
+        # only the small (decode-relevant) graphs are captured. Single-
+        # batch decode only needs size=1 anyway.
+        # MUSA-0081: allow overriding the safe-cap via env var for
+        # spec-decode / Eagle3 perf experiments. Setting
+        # ``VLLM_MUSA_MAX_CUDAGRAPH_CAPTURE_SIZE`` overrides the default
+        # ``MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE=8``. Values up to 224
+        # have been observed working on torch_musa 2.9.0; values >= 232
+        # trigger MUSA-0082's illegal memory access at capture_end.
+        import os as _os
+        try:
+            MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE = int(
+                _os.getenv("VLLM_MUSA_MAX_CUDAGRAPH_CAPTURE_SIZE", "8")
+            )
+        except ValueError:
+            MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE = 8
+        if cudagraph_mode is not None:
             from vllm.config import CUDAGraphMode
-
             if cudagraph_mode != CUDAGraphMode.NONE:
-                logger.warning(
-                    "Disabling MUSA cudagraph capture for tensor parallel "
-                    "size %d because MCCL collectives are not safe during "
-                    "stream capture on this platform.",
-                    parallel_config.tensor_parallel_size,
-                )
-                compilation_config.cudagraph_mode = CUDAGraphMode.NONE
-                compilation_config.max_cudagraph_capture_size = 0
-                compilation_config.cudagraph_capture_sizes = []
+                max_size = compilation_config.max_cudagraph_capture_size or 0
+                if max_size > MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE:
+                    logger.warning(
+                        "MUSA-0076: capping max_cudagraph_capture_size "
+                        "from %d to %d (larger sizes trigger an illegal "
+                        "memory access at musa_graph.capture_end on "
+                        "torch_musa 2.9.0; investigation pending). "
+                        "Override with VLLM_MUSA_MAX_CUDAGRAPH_CAPTURE_SIZE.",
+                        max_size, MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE,
+                    )
+                    compilation_config.max_cudagraph_capture_size = (
+                        MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE
+                    )
+                    if compilation_config.cudagraph_capture_sizes:
+                        compilation_config.cudagraph_capture_sizes = [
+                            s for s in compilation_config.cudagraph_capture_sizes
+                            if s <= MUSA_SAFE_MAX_CUDAGRAPH_CAPTURE_SIZE
+                        ]
 
     @classmethod
     def get_current_memory_usage(

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -141,6 +141,75 @@ class MUSAPlatformBase(Platform):
         return True
 
     @classmethod
+    def import_ir_kernels(cls) -> None:
+        """Import upstream and MUSA-OOT IR-op providers.
+
+        Order matters: upstream first (registers `native` / `vllm_c` /
+        `oink` / etc.), then OOT MUSA providers so they appear in the
+        registry alongside upstream impls. Used by
+        `vllm.config.kernel.KernelConfig.set_priority()` to ensure
+        every provider mentioned in `ir_op_priority` is registered
+        before the dispatcher needs it.
+        """
+        super().import_ir_kernels()
+        try:
+            import vllm_musa.kernels  # noqa: F401
+        except ImportError as exc:
+            from vllm.logger import init_logger
+            init_logger(__name__).info(
+                "vllm_musa.kernels unavailable (%s); MUSA IR providers "
+                "will not be registered. Upstream providers remain "
+                "available.",
+                exc,
+            )
+
+    @classmethod
+    def get_default_ir_op_priority(cls, vllm_config):
+        """Platform-default priority list for vllm.ir.ops on MUSA.
+
+        When compiling with Inductor, prefer the `native` (pure-PyTorch)
+        IR impl; in the eager path, prefer the `musa` kernel provider.
+        This mirrors the upstream `cuda.py` pattern
+        (`default = ["native"] if using_inductor else ["vllm_c", "native"]`):
+        under Inductor the native rms_norm is a handful of
+        elementwise/reduction ops the compiler can fuse with its
+        neighbours, whereas a `torch.ops._C.*` custom op is an opaque
+        fusion barrier; in eager mode there is no fusion to lose so the
+        kernel provider is taken directly.
+
+        NOTE (MUSA-0057): this is a **correctness / upstream-consistency**
+        change, NOT a perf fix. MUSA-0057's controlled A/B/C bisect
+        proved there is no rms_norm-related perf regression on
+        MiniMax-M2.7 — `["native"]` and `["musa", "native"]` measure the
+        same batch1 throughput. An earlier revision of this docstring
+        claimed MUSA-0055 had measured a 20-56% regression caused by
+        this priority list; that delta was traced to a stale/anomalous
+        baseline measurement, not a real regression (see the MUSA-0057
+        ticket). The `musa` provider stays registered (see
+        `vllm_musa/kernels/musa_ops.py`) for the eager / explicit
+        opt-in path.
+        """
+        from vllm.config.compilation import CompilationMode
+        from vllm.config.kernel import IrOpPriorityConfig
+
+        cc = vllm_config.compilation_config
+        using_inductor = (
+            cc.backend == "inductor" and cc.mode != CompilationMode.NONE
+        )
+        if using_inductor:
+            # Let Inductor fuse the native reference impl. Keep the
+            # `musa` custom-op provider out of the priority here — it is
+            # a fusion barrier (no measurable batch1 effect per
+            # MUSA-0057, but native is the upstream-aligned default).
+            default = ["native"]
+            rms_norm = ["native"]
+        else:
+            # Eager path: no Inductor fusion to lose, so take the kernel.
+            default = ["musa", "native"]
+            rms_norm = ["musa", "native"]
+        return IrOpPriorityConfig.with_default(default, rms_norm=rms_norm)
+
+    @classmethod
     def support_deep_gemm(cls) -> bool:
         """
         Returns if DeepGEMM is supported by the current platform.

--- a/vllm_musa/v1/attention/backends/tree_attn.py
+++ b/vllm_musa/v1/attention/backends/tree_attn.py
@@ -1,0 +1,452 @@
+# SPDX-License-Identifier: Apache-2.0
+# 2026 - MUSA port of upstream TreeAttention backend.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MUSA port of TreeAttention backend.
+
+Ported from ``vllm/v1/attention/backends/tree_attn.py``. The only
+platform-specific call site is ``reshape_and_cache_flash`` which is
+redirected through ``vllm_musa.v1.attention.backends.fa_utils``. The
+``triton_unified_attention`` Triton kernel is already MUSA-compatible
+via the existing ``vllm_musa.patches.vllm__v1__attention__ops__triton_unified_attention``
+patch, so no further changes are required for the forward path.
+"""
+
+import ast
+from dataclasses import dataclass
+from typing import ClassVar
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionImpl,
+    AttentionMetadataBuilder,
+    AttentionType,
+    CommonAttentionMetadata,
+    MultipleOf,
+)
+from vllm.v1.attention.backends.utils import (
+    split_decodes_and_prefills,
+)
+from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+from vllm.v1.kv_cache_interface import AttentionSpec
+
+from vllm_musa.v1.attention.backends.fa_utils import reshape_and_cache_flash
+
+logger = init_logger(__name__)
+
+
+class MUSATreeAttentionBackend(AttentionBackend):
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "float16",
+        "bfloat16",
+    ]
+    forward_includes_kv_cache_update: bool = False
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [MultipleOf(16)]
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return [32, 64, 96, 128, 160, 192, 224, 256]
+
+    @staticmethod
+    def get_name() -> str:
+        return "TREE_ATTN"
+
+    @staticmethod
+    def get_impl_cls() -> type["TreeAttentionImpl"]:
+        return TreeAttentionImpl
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        if block_size % 16 != 0:
+            raise ValueError("Block size must be a multiple of 16.")
+        return (2, num_blocks, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_builder_cls() -> type["TreeAttentionMetadataBuilder"]:
+        return TreeAttentionMetadataBuilder
+
+    @staticmethod
+    def use_cascade_attention(*args, **kwargs) -> bool:
+        return False
+
+
+@dataclass
+class TreeAttentionMetadata:
+    num_actual_tokens: int  # Number of tokens excluding padding.
+    max_query_len: int
+    query_start_loc: torch.Tensor
+    max_seq_len: int
+    seq_lens: torch.Tensor
+    block_table: torch.Tensor
+    slot_mapping: torch.Tensor
+
+    num_prefill_tokens: int = 0
+    num_decode_tokens: int = 0
+    num_prefills: int = 0
+    num_decodes: int = 0
+
+    tree_attn_bias: torch.Tensor | None = None
+
+    # Cached Prefill/decode metadata.
+    _cached_prefill_metadata: "TreeAttentionMetadata | None" = None
+    _cached_decode_metadata: "TreeAttentionMetadata | None" = None
+
+    @property
+    def prefill_metadata(self) -> "TreeAttentionMetadata | None":
+        if self.num_prefills == 0:
+            return None
+
+        if self._cached_prefill_metadata is not None:
+            # Recover cached prefill-phase attention
+            # metadata structure
+            return self._cached_prefill_metadata
+
+        q_start_loc = self.query_start_loc[self.num_decodes :]
+        q_seqlens = torch.diff(q_start_loc)
+        kv_seqlens = self.seq_lens[self.num_decodes :]
+        # Construct & cache prefill-phase attention metadata structure
+        self._cached_prefill_metadata = TreeAttentionMetadata(
+            num_actual_tokens=self.num_prefill_tokens,
+            max_query_len=int(q_seqlens.max().item()),
+            query_start_loc=q_start_loc - q_start_loc[0],
+            max_seq_len=int(kv_seqlens.max().item()),
+            seq_lens=kv_seqlens,
+            block_table=self.block_table[self.num_decodes :],
+            slot_mapping=self.slot_mapping[self.num_decode_tokens :],
+        )
+        return self._cached_prefill_metadata
+
+    @property
+    def decode_metadata(self) -> "TreeAttentionMetadata | None":
+        if self.num_decode_tokens == 0:
+            return None
+
+        if self._cached_decode_metadata is not None:
+            # Recover cached decode-phase attention
+            # metadata structure
+            return self._cached_decode_metadata
+
+        q_start_loc = self.query_start_loc[: self.num_decodes + 1]
+        q_seqlens = torch.diff(q_start_loc)
+        kv_seqlens = self.seq_lens[: self.num_decodes]
+        # Construct & cache decode-phase attention metadata structure
+        self._cached_decode_metadata = TreeAttentionMetadata(
+            num_actual_tokens=self.num_decode_tokens,
+            max_query_len=int(q_seqlens.max().item()),
+            query_start_loc=q_start_loc,
+            max_seq_len=int(kv_seqlens.max().item()),
+            seq_lens=kv_seqlens,
+            block_table=self.block_table[: self.num_decodes],
+            slot_mapping=self.slot_mapping[: self.num_decode_tokens],
+            tree_attn_bias=self.tree_attn_bias,
+        )
+        return self._cached_decode_metadata
+
+
+class TreeAttentionMetadataBuilder(AttentionMetadataBuilder[TreeAttentionMetadata]):
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ):
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+
+        self.block_size = kv_cache_spec.block_size
+
+        spec_config = vllm_config.speculative_config
+        spec_token_tree: str | None = None
+        if spec := spec_config:
+            spec_token_tree = spec.speculative_token_tree
+        tree_choices: list[tuple[int, ...]] = (
+            ast.literal_eval(spec_token_tree) if spec_token_tree is not None else [(0,)]
+        )
+        # Construct the tree attention bias.
+        depth_counts = _get_depth_counts(tree_choices)
+        self.tree_attn_bias = _prepare_tree_attn_bias(
+            tree_choices,
+            depth_counts,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        self.reorder_batch_threshold = self.tree_attn_bias.shape[0]
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> TreeAttentionMetadata:
+        decode_threshold = self.tree_attn_bias.shape[0]
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+            split_decodes_and_prefills(
+                common_attn_metadata, decode_threshold=decode_threshold
+            )
+        )
+
+        num_actual_tokens = common_attn_metadata.num_actual_tokens
+        q_start_loc = common_attn_metadata.query_start_loc
+        max_query_len = common_attn_metadata.max_query_len
+        kv_seqlens = common_attn_metadata.seq_lens
+        max_seq_len = common_attn_metadata.max_seq_len
+        block_table = common_attn_metadata.block_table_tensor
+        slot_mapping = common_attn_metadata.slot_mapping
+
+        return TreeAttentionMetadata(
+            num_actual_tokens=num_actual_tokens,
+            num_prefill_tokens=num_prefill_tokens,
+            num_decode_tokens=num_decode_tokens,
+            num_prefills=num_prefills,
+            num_decodes=num_decodes,
+            max_query_len=max_query_len,
+            query_start_loc=q_start_loc,
+            max_seq_len=max_seq_len,
+            seq_lens=kv_seqlens,
+            block_table=block_table,
+            slot_mapping=slot_mapping,
+            tree_attn_bias=self.tree_attn_bias,
+        )
+
+    def build_for_drafting(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> TreeAttentionMetadata:
+        # Cache the original tree attention bias.
+        orig_tree_attn_bias = self.tree_attn_bias
+
+        if draft_index == 0:
+            # Use prefill for drafting at the root level.
+            self.tree_attn_bias = torch.empty(0)
+        else:
+            # Slice the tree attention bias for drafting. Exclude
+            # the root level.
+            start, end = 1, 1 + common_attn_metadata.max_query_len
+            self.tree_attn_bias = self.tree_attn_bias[start:end, start:end].contiguous()
+
+        # Build attention bias.
+        attn_metadata = self.build(0, common_attn_metadata, fast_build=True)
+
+        # Reset the tree attention bias to the original value.
+        self.tree_attn_bias = orig_tree_attn_bias
+        return attn_metadata
+
+
+def _get_depth_counts(sorted_tree_choices: list[tuple[int, ...]]) -> list[int]:
+    # Count the number of choices at each depth of the tree.
+    depth_counts = []
+    prev_depth = 0
+    for path in sorted_tree_choices:
+        depth = len(path)
+        if depth != prev_depth:
+            depth_counts.append(0)
+        depth_counts[depth - 1] += 1
+        prev_depth = depth
+    return depth_counts
+
+
+def _prepare_tree_attn_bias(
+    sorted_tree_choices: list[tuple[int, ...]],
+    depth_counts: list[int],
+    dtype: torch.dtype | None,
+    device: torch.device | None,
+) -> torch.Tensor:
+    # +1 comes from the additional root node.
+    tree_len = len(sorted_tree_choices) + 1
+    tree_attn_mask = torch.full(
+        (tree_len, tree_len), -torch.inf, device=device, dtype=dtype
+    )
+
+    # Set diagonal to all zeros. Each token should
+    # attend to itself.
+    mask_val = 0
+    for i in range(tree_len):
+        tree_attn_mask[i, i] = mask_val
+
+    # Set root to all zeros. All tokens attend to it.
+    tree_attn_mask[:, 0] = mask_val
+
+    # Set all ancestors to zeros.
+    start = 0
+    for i in range(len(depth_counts)):
+        for j in range(depth_counts[i]):
+            cur_tree_choice = sorted_tree_choices[start + j]
+            # Retrieve ancestor position.
+            if len(cur_tree_choice) == 1:
+                continue
+            ancestor_idx = []
+            for c in range(len(cur_tree_choice) - 1):
+                ancestor_idx.append(
+                    sorted_tree_choices.index(cur_tree_choice[: c + 1]) + 1
+                )
+            tree_attn_mask[j + start + 1, ancestor_idx] = mask_val
+        start += depth_counts[i]
+    return tree_attn_mask
+
+
+class TreeAttentionImpl(AttentionImpl):
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None,
+        sliding_window: int | None,
+        kv_cache_dtype: str,
+        logits_soft_cap: float | None = None,
+        attn_type: AttentionType = AttentionType.DECODER,
+        kv_sharing_target_layer_name: str | None = None,
+    ) -> None:
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = float(scale)
+        self.num_kv_heads = num_kv_heads
+        self.num_queries_per_kv = self.num_heads // self.num_kv_heads
+        self.kv_cache_dtype = kv_cache_dtype
+        self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
+        if alibi_slopes is not None:
+            alibi_slopes = torch.tensor(alibi_slopes, dtype=torch.float32)
+        self.alibi_slopes = alibi_slopes
+        if logits_soft_cap is None:
+            # Setting logits_soft_cap to 0 means no soft cap.
+            logits_soft_cap = 0
+        self.logits_soft_cap = logits_soft_cap
+        if sliding_window is None:
+            self.sliding_window = (-1, -1)
+        else:
+            self.sliding_window = (sliding_window - 1, 0)
+
+        if attn_type != AttentionType.DECODER:
+            raise NotImplementedError(
+                "Encoder self-attention and "
+                "encoder/decoder cross-attention "
+                "are not implemented for "
+                "TreeAttentionImpl."
+            )
+
+    def do_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        key_cache, value_cache = kv_cache.unbind(0)
+
+        # Reshape the input keys and values and store them in the cache.
+        # NOTE(woosuk): Here, key and value are padded while slot_mapping is
+        # not padded. However, we don't need to do key[:num_actual_tokens]
+        # and value[:num_actual_tokens] because the reshape_and_cache_flash
+        # op uses the slot_mapping's shape to determine the number of
+        # actual tokens.
+        reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            self.kv_cache_dtype,
+            layer._k_scale,
+            layer._v_scale,
+        )
+
+    def forward(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: TreeAttentionMetadata,
+        output: torch.Tensor,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Forward pass with TreeAttention.
+
+        Args:
+            query: shape = [num_tokens, num_heads, head_size]
+            key: shape = [num_tokens, num_kv_heads, head_size]
+            value: shape = [num_tokens, num_kv_heads, head_size]
+            kv_cache: shape =
+                [2, num_blocks, block_size, num_kv_heads, head_size]
+            attn_metadata: Metadata for attention.
+        Returns:
+            shape = [num_tokens, num_heads * head_size]
+        """
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported for TreeAttentionImpl"
+            )
+
+        if attn_metadata is None:
+            # Profiling run.
+            return output.fill_(0)
+
+        key_cache, value_cache = kv_cache.unbind(0)
+
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        descale_shape = (attn_metadata.query_start_loc.shape[0] - 1, key.shape[1])
+        if prefill_meta := attn_metadata.prefill_metadata:
+            unified_attention(
+                q=query[num_decode_tokens:num_actual_tokens],
+                k=key_cache,
+                v=value_cache,
+                out=output[num_decode_tokens:num_actual_tokens],
+                cu_seqlens_q=prefill_meta.query_start_loc,
+                max_seqlen_q=prefill_meta.max_query_len,
+                seqused_k=prefill_meta.seq_lens,
+                max_seqlen_k=prefill_meta.max_seq_len,
+                softmax_scale=self.scale,
+                causal=True,
+                alibi_slopes=self.alibi_slopes,
+                window_size=self.sliding_window,
+                block_table=prefill_meta.block_table,
+                softcap=self.logits_soft_cap,
+                q_descale=None,  # Not supported
+                k_descale=layer._k_scale.expand(descale_shape),
+                v_descale=layer._v_scale.expand(descale_shape),
+            )
+
+        if decode_meta := attn_metadata.decode_metadata:
+            unified_attention(
+                q=query[:num_decode_tokens],
+                k=key_cache,
+                v=value_cache,
+                out=output[:num_decode_tokens],
+                cu_seqlens_q=decode_meta.query_start_loc,
+                max_seqlen_q=decode_meta.max_query_len,
+                seqused_k=decode_meta.seq_lens,
+                max_seqlen_k=decode_meta.max_seq_len,
+                softmax_scale=self.scale,
+                causal=True,
+                alibi_slopes=self.alibi_slopes,
+                qq_bias=decode_meta.tree_attn_bias,
+                window_size=self.sliding_window,
+                block_table=decode_meta.block_table,
+                softcap=self.logits_soft_cap,
+                q_descale=None,  # Not supported
+                k_descale=layer._k_scale.expand(descale_shape),
+                v_descale=layer._v_scale.expand(descale_shape),
+            )
+        return output

--- a/vllm_musa/v1/spec_decode/__init__.py
+++ b/vllm_musa/v1/spec_decode/__init__.py
@@ -1,0 +1,18 @@
+# Eagle3 full-loop spec-decode runner for MUSA.
+#
+# Per MUSA-0090, this package implements an SGLang-style EAGLEDraftCudaGraphRunner
+# adapted to vLLM's types. The runner captures the full N-step Eagle3 draft loop
+# in one cudagraph (vs vLLM's iterative per-step PIECEWISE dispatch), reducing
+# host-side overhead from ~30 ms per spec round to ~3 ms.
+#
+# Design doc: generated/musa0090_impl/step1-design-doc.md
+# Q1 smoke: generated/musa0090_impl/step1_5-q1-cudagraph-smoke-result.md
+#
+# Public surface — used by the patch at:
+#     vllm-musa/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
+#
+# Imports are lazy on first use to avoid pulling vllm.v1.spec_decode types
+# at vllm-musa-init time (the patches/ system needs to monkey-patch them).
+
+# Existing MUSA-Triton kernel for prepare_next_token_padded — pre-MUSA-0090.
+from . import utils  # noqa: F401

--- a/vllm_musa/v1/spec_decode/attn_backend_array.py
+++ b/vllm_musa/v1/spec_decode/attn_backend_array.py
@@ -1,0 +1,269 @@
+# MUSA-0090 step 2: Pre-allocated per-step attention metadata array.
+#
+# The TRICK that lets vLLM's iterative Eagle3 draft loop be captured as one
+# cudagraph: pre-build N copies of CommonAttentionMetadata at capture time
+# (one per spec step), wired so each step's tensors are VIEWS into the
+# pre-allocated `EagleDraftBuffers`. The captured graph mutates the buffers
+# via in-place kernels, and the metadata views see those mutations without
+# any Python rebuild.
+#
+# Reference SGLang pattern: `draft_attn_backend.attn_backends[i]` —
+# sglang/python/sglang/srt/speculative/eagle_worker.py:904
+#
+# Design ref: generated/musa0090_impl/step1-design-doc.md §3.2.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+import torch
+
+from .spec_info import EagleDraftBuffers
+
+
+def build_per_step_attn_metadata_array(
+    base_metadata: Any,  # CommonAttentionMetadata; typed Any to avoid hard dep at module-load
+    buffers: EagleDraftBuffers,
+    batch_size: int,
+    proposer: Any = None,  # vllm.v1.spec_decode.eagle.EagleProposer (optional)
+) -> list[Any]:
+    """Pre-allocate N attn-metadata objects whose tensors point into `buffers`.
+
+    The arithmetic that vLLM does in Python at each loop iteration in
+    `EagleProposer.propose()` (max_seq_len += 1, slot_mapping recompute,
+    seq_lens += 1) is unrolled here:
+
+      - max_seq_len: bumped statically by step index at metadata-build time
+      - slot_mapping: VIEW into buffers.slot_mapping_per_step[step_idx, :batch_size]
+                      (mutated by the eagle_step_update_slot_mapping_and_metadata
+                      kernel inside the captured graph)
+      - seq_lens:     VIEW into buffers.seq_lens_per_step[step_idx, :batch_size]
+                      (mutated by the same kernel)
+
+    Returns a list of `buffers.num_steps` CommonAttentionMetadata-shaped objects.
+    The runner indexes this list by step number inside its capture loop:
+      forward_batch.attn_metadata = metadata_array[step_idx]
+
+    Args:
+        base_metadata: The first-step attention metadata that vLLM normally
+            passes to EagleProposer.propose(). Used as the template; per-step
+            metadata objects copy its non-mutable fields (block_table_tensor,
+            cu_seq_lens base, query_start_loc, etc.) and override the
+            mutable ones (slot_mapping, seq_lens, max_seq_len).
+        buffers: The pre-allocated draft buffers. Per-step views are taken
+            into `slot_mapping_per_step` and `seq_lens_per_step`.
+        batch_size: The actual batch size for this capture context (≤ buffers.max_bs).
+
+    Returns:
+        A list of length buffers.num_steps. Each element is a metadata object
+        whose tensor fields point into `buffers`. Order matches the spec
+        step order: metadata_array[0] is for the first draft fwd, [N-1] is
+        for the last.
+    """
+    if buffers.num_steps <= 0:
+        return []
+
+    # MUSA-0090 step 5e: when the proposer is provided, use its
+    # build_per_group_and_layer_attn_metadata() to produce per-layer
+    # backend-specific metadata (e.g., FlashAttentionMetadata with the
+    # use_cascade, common_prefix_len, etc. fields the compiled draft
+    # model's forward expects). The compiled forward reads
+    # get_forward_context().attn_metadata and accesses .use_cascade
+    # unconditionally; passing the raw CommonAttentionMetadata fails
+    # with AttributeError.
+    # MUSA-0090 step 5g: disable the per-layer build path. Although it
+    # provides use_cascade etc., the resulting metadata's seq_lens has
+    # a shape that flash_attn rejects ('seqused_k must have shape
+    # (batch_size,)'). Instead, use the simpler dataclasses.replace path
+    # below and setattr() the flag-fields the compiled forward expects.
+    use_per_layer = False  # was: proposer is not None and hasattr(...)
+    if use_per_layer:
+        metadata_array: list[Any] = []
+        for step_idx in range(buffers.num_steps):
+            # Mutate base_metadata in place to reflect the step's state
+            # (slot_mapping, seq_lens, max_seq_len), then build per-layer
+            # metadata. The per-layer call returns a dict-shaped object
+            # that the model reads via get_forward_context().
+            base_metadata.slot_mapping = buffers.slot_mapping_per_step[step_idx, :batch_size]
+            base_metadata.seq_lens = buffers.seq_lens_per_step[step_idx, :batch_size]
+            base_metadata.max_seq_len = int(getattr(base_metadata, "max_seq_len", 0)) + (1 if step_idx > 0 else 0)
+            try:
+                _, per_layer = proposer.build_per_group_and_layer_attn_metadata(
+                    base_metadata, draft_index=step_idx
+                )
+                metadata_array.append(per_layer)
+            except Exception as exc:
+                raise RuntimeError(
+                    f"step {step_idx}: proposer.build_per_group_and_layer_attn_metadata "
+                    f"failed: {type(exc).__name__}: {exc}"
+                ) from exc
+        return metadata_array
+
+    # MUSA-0090 reopen (2026-05-16): port SGLang's pattern of pre-allocating
+    # backend-specific metadata at capture time, mutating in-place at replay
+    # time. Per `[[sglang-eagle3-musa-30pct-confirmed]]` memory + research
+    # in `sglang/python/sglang/srt/layers/attention/flashattention_backend.py`
+    # at `FlashAttentionMultiStepBackend.init_forward_metadata_capture_cuda_graph`
+    # (line 2653), SGLang builds N-1 fully-instantiated backend objects, one
+    # per draft step beyond step 0, each with its own pre-allocated metadata.
+    #
+    # vLLM's equivalent is to call `FlashAttentionMetadataBuilder.build(
+    # common_prefix_len=0, common_attn_metadata=<step-specific cam>,
+    # fast_build=True)` once per step. The `fast_build=True` flag disables
+    # AOT scheduling (the comment in vllm/v1/attention/backends/flash_attn.py
+    # line 388 says: "Disables AOT scheduling, used when there will be few
+    # iterations i.e. spec-decode"), which keeps the metadata cudagraph-safe
+    # by skipping the scheduler-metadata path that requires host-side
+    # reductions.
+    #
+    # The previous setattr+dataclasses.replace workaround (commit f1d09d7)
+    # is structurally wrong because `CommonAttentionMetadata` is missing the
+    # backend-specific fields (`block_table`, `seqused_k`, etc.) that the
+    # compiled draft forward unconditionally reads. The right answer is to
+    # produce real `FlashAttentionMetadata` via the builder.
+    metadata_array: list[Any] = []
+    base_max_seq_len = int(getattr(base_metadata, "max_seq_len", 0))
+    base_max_model_len = int(getattr(base_metadata, "max_model_len", base_max_seq_len + buffers.num_steps))
+
+    # MUSA-0090 step 5l (2026-05-16): use vllm's first-party
+    # `proposer.build_per_group_and_layer_attn_metadata(common_attn_metadata,
+    # draft_index=step_idx)` API (vllm/v1/spec_decode/llm_base_proposer.py:822).
+    # This calls `attn_group.get_metadata_builder().build_for_drafting()` per
+    # draft_attn_group and produces a per-layer dict that the captured model
+    # forward reads via set_forward_context.
+    #
+    # The OLD step 5h path searched 4 candidate attribute paths
+    # (attn_metadata_builders, attn_metadata_builder,
+    # runner.attn_metadata_builders, runner.attn_metadata_builder) — NONE
+    # of these exist in vllm v0.20.1.dev0. The builder is at
+    # `proposer.draft_attn_groups[0].get_metadata_builder()`. The
+    # `build_per_group_and_layer_attn_metadata` helper exposes the
+    # right entry point.
+    if proposer is None or not hasattr(
+        proposer, "build_per_group_and_layer_attn_metadata"
+    ):
+        raise RuntimeError(
+            "build_per_step_attn_metadata_array: proposer is None or lacks "
+            "build_per_group_and_layer_attn_metadata. Expected vllm "
+            "v0.20.1.dev0 EagleProposer with draft_attn_groups initialized."
+        )
+
+    for step_idx in range(buffers.num_steps):
+        # Per-step views into the pre-allocated buffers. The captured graph
+        # writes to these slices via the
+        # eagle_step_update_slot_mapping_and_metadata kernel; the view (a
+        # contiguous tensor) reflects the writes without rebuild because
+        # FlashAttentionMetadata stores tensor *references*, not copies.
+        slot_mapping_view = buffers.slot_mapping_per_step[step_idx, :batch_size]
+        seq_lens_view = buffers.seq_lens_per_step[step_idx, :batch_size]
+
+        # max_seq_len is a static int (not a tensor); bump by step_idx so the
+        # attention backend sizes its scratch correctly for each step. The
+        # +1 between steps is the spec-decode invariant: each draft token
+        # adds one position to the sequence.
+        step_max_seq_len = min(base_max_seq_len + step_idx, base_max_model_len)
+
+        # Construct a step-specific CommonAttentionMetadata that the builder
+        # will translate into a per-layer attention metadata dict.
+        # `dataclasses.replace` produces a new CommonAttentionMetadata with
+        # step-specific tensor views; the per-group builder then produces
+        # the backend-specific metadata (FlashAttentionMetadata) with all
+        # required fields (block_table, use_cascade, seqused_k, etc.).
+        #
+        # MUSA-0090 step 5l.3: also point block_table_tensor at the
+        # runner-owned buffer (not the caller's transient one). The owned
+        # buffer's contents are updated by replay() before each graph
+        # invocation; the captured graph reads from a stable pointer.
+        # The owned tensor is sized [max_bs, max_blocks_per_req]; slice
+        # to [:batch_size, :] to match the request.
+        step_cam = replace(
+            base_metadata,
+            slot_mapping=slot_mapping_view,
+            seq_lens=seq_lens_view,
+            max_seq_len=step_max_seq_len,
+            block_table_tensor=buffers.block_table_tensor[:batch_size],
+        )
+
+        try:
+            _per_group, per_layer = proposer.build_per_group_and_layer_attn_metadata(
+                step_cam, draft_index=step_idx
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"step {step_idx}: proposer."
+                f"build_per_group_and_layer_attn_metadata() failed: "
+                f"{type(exc).__name__}: {exc}. This path was added in "
+                "MUSA-0090 step 5l (2026-05-16) to use vllm's first-party "
+                "API. The builder must succeed on a CommonAttentionMetadata "
+                "with step-specific slot_mapping/seq_lens/max_seq_len views."
+            ) from exc
+
+        # per_layer is the dict {layer_name: attn_metadata} that
+        # set_forward_context expects. Store the dict as the step's metadata
+        # entry — _run_n_step_inner passes attn_metadata_array[step] into
+        # set_forward_context which dispatches per layer.
+        metadata_array.append(per_layer)
+
+    return metadata_array
+
+
+@dataclass
+class StepMetadataIndexing:
+    """Records how each step's metadata reads from the buffers.
+
+    Used by the capture path to verify that the indexing math is correct
+    before committing the graph. Construct from a built metadata_array via
+    the inspect() helper.
+    """
+
+    num_steps: int
+    base_max_seq_len: int
+    per_step_max_seq_lens: list[int]
+    slot_mapping_data_ptrs: list[int]
+    seq_lens_data_ptrs: list[int]
+
+    @classmethod
+    def inspect(cls, metadata_array: list[Any]) -> StepMetadataIndexing:
+        """Read back the structure of a built metadata array for verification.
+
+        Used in tests / debug logging — not on the hot path.
+        """
+        if not metadata_array:
+            return cls(
+                num_steps=0,
+                base_max_seq_len=0,
+                per_step_max_seq_lens=[],
+                slot_mapping_data_ptrs=[],
+                seq_lens_data_ptrs=[],
+            )
+        return cls(
+            num_steps=len(metadata_array),
+            base_max_seq_len=int(getattr(metadata_array[0], "max_seq_len", 0)),
+            per_step_max_seq_lens=[int(getattr(m, "max_seq_len", 0)) for m in metadata_array],
+            slot_mapping_data_ptrs=[int(m.slot_mapping.data_ptr()) for m in metadata_array],
+            seq_lens_data_ptrs=[int(m.seq_lens.data_ptr()) for m in metadata_array],
+        )
+
+    def verify_strict(self) -> None:
+        """Raise if the metadata array isn't shaped correctly for the captured
+        loop. Sanity-check before passing to graph capture."""
+        if self.num_steps <= 0:
+            raise RuntimeError("metadata array is empty")
+        if len(set(self.slot_mapping_data_ptrs)) != self.num_steps:
+            raise RuntimeError(
+                f"slot_mapping views are not all distinct: "
+                f"{self.slot_mapping_data_ptrs}"
+            )
+        if len(set(self.seq_lens_data_ptrs)) != self.num_steps:
+            raise RuntimeError(
+                f"seq_lens views are not all distinct: "
+                f"{self.seq_lens_data_ptrs}"
+            )
+        # max_seq_lens should be monotonically non-decreasing across steps
+        for i in range(1, self.num_steps):
+            if self.per_step_max_seq_lens[i] < self.per_step_max_seq_lens[i - 1]:
+                raise RuntimeError(
+                    f"max_seq_len decreased at step {i}: "
+                    f"{self.per_step_max_seq_lens}"
+                )

--- a/vllm_musa/v1/spec_decode/eagle_full_loop_runner.py
+++ b/vllm_musa/v1/spec_decode/eagle_full_loop_runner.py
@@ -1,0 +1,729 @@
+# MUSA-0090 step 3: EagleFullLoopRunner — captures vLLM's N-step Eagle3 draft
+# loop as ONE cudagraph per batch size (vs vLLM's iterative per-step PIECEWISE
+# dispatch). Adapted from SGLang's EAGLEDraftCudaGraphRunner shape to vLLM types.
+#
+# Design ref: ../../../../generated/musa0090_impl/step1-design-doc.md §3.3
+# Q1 cudagraph smoke (proved correctness): ../../../../generated/musa0090_impl/
+#     step1_5-q1-cudagraph-smoke-result.md
+#
+# This file is the skeleton. The hot-path inner loop (_capture_one_batch_size)
+# has fully-typed signatures + explicit step-by-step pseudocode for the
+# step-4 implementation to fill in. Step 3's deliverable is the structural
+# scaffolding so the patch can hook in.
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import torch
+
+from .attn_backend_array import (
+    StepMetadataIndexing,
+    build_per_step_attn_metadata_array,
+)
+from .spec_info import (
+    EagleDraftBuffers,
+    EagleFullLoopCaptureContext,
+    EagleFullLoopReplayResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EagleFullLoopRunner:
+    """Captures the full N-step Eagle3 draft loop as one cudagraph per batch size.
+
+    Public surface:
+        __init__(proposer, num_speculative_tokens, cudagraph_capture_sizes,
+                 hidden_size, device)
+        capture()                           # one-time at server boot
+        can_run(batch_size) -> bool         # dispatcher predicate
+        replay(target_hidden_states, next_token_ids, common_attn_metadata,
+               batch_size) -> EagleFullLoopReplayResult
+
+    Architecture (mirrors SGLang's EAGLEDraftCudaGraphRunner):
+      1. At init: hold reference to vLLM's EagleProposer. Don't capture yet.
+      2. On first proposer.propose() call (lazy): the patch invokes
+         runner.capture() to build one graph per cudagraph_capture_sizes
+         entry. Each graph captures the full N-step draft loop using buffers
+         from spec_info.py + per-step metadata from attn_backend_array.py.
+      3. At runtime: patched propose() checks runner.can_run(bs); if true,
+         dispatch to runner.replay() — single graph.replay() + 2 .copy_()
+         calls (the input carry-over). No Python loop.
+
+    Critical invariants (from design doc §6):
+      - All per-step state mutations as in-graph tensor ops only.
+      - Attn-metadata array tensors are VIEWS into buffers (not rebuilt).
+      - forward_batch is reused, not rebuilt.
+      - Graph capture before any spec request (warm boot expected).
+      - MUSA-only: no-op on CUDA (gated at the patch level).
+    """
+
+    # ---- construction ----
+
+    def __init__(
+        self,
+        proposer: Any,  # vllm.v1.spec_decode.eagle.EagleProposer
+        num_speculative_tokens: int,
+        cudagraph_capture_sizes: list[int],
+        hidden_size: int,
+        device: torch.device,
+        topk: int = 1,  # chain drafting; tree path is MUSA-0094's scope
+    ):
+        if num_speculative_tokens < 1:
+            raise ValueError(
+                f"num_speculative_tokens must be >= 1, got {num_speculative_tokens}"
+            )
+        if not cudagraph_capture_sizes:
+            raise ValueError("cudagraph_capture_sizes must not be empty")
+        if topk != 1:
+            # Tree drafting is a follow-up ticket (MUSA-0094); chain-only here.
+            raise NotImplementedError(
+                f"topk={topk} (tree drafting) is out of scope for MUSA-0090; "
+                "chain-only path (topk=1). Tree path is MUSA-0094."
+            )
+
+        self.proposer = proposer
+        self.num_steps = num_speculative_tokens
+        self.capture_sizes: list[int] = sorted(set(cudagraph_capture_sizes))
+        self.max_bs: int = max(self.capture_sizes)
+        self.hidden_size = hidden_size
+        self.topk = topk
+        self.device = device
+
+        # Per-batch-size capture state. Populated by capture(); read by replay().
+        self.contexts: dict[int, EagleFullLoopCaptureContext] = {}
+        self._captured: bool = False
+
+        logger.info(
+            "MUSA-0090 EagleFullLoopRunner: configured for "
+            "num_speculative_tokens=%d, capture_sizes=%s, max_bs=%d, "
+            "hidden_size=%d, topk=%d",
+            self.num_steps, self.capture_sizes, self.max_bs,
+            self.hidden_size, self.topk,
+        )
+
+    # ---- dispatcher predicate ----
+
+    def can_run(self, batch_size: int) -> bool:
+        """Whether there's a captured graph compatible with this batch size.
+
+        Strict equality match for now (no padding to next capture size).
+        Step 4 may add padding logic if batch size variance is high; for
+        BS=1 4k/1k workloads (the /goal shape), exact match suffices.
+        """
+        if not self._captured:
+            return False
+        return batch_size in self.contexts
+
+    # ---- one-time capture (called lazily on first propose()) ----
+
+    def capture(self, base_metadata: Any) -> None:
+        """Capture one cudagraph per entry in self.capture_sizes.
+
+        Called lazily on the first propose() call. `base_metadata` is the
+        CommonAttentionMetadata vLLM would otherwise pass to the iterative
+        propose loop; used as the template for per-step metadata.
+
+        After this returns successfully, self._captured is True and
+        self.contexts[bs] is populated for every bs in self.capture_sizes.
+
+        Idempotent: subsequent calls are no-ops if already captured.
+        """
+        if self._captured:
+            return
+        if not hasattr(self.proposer, "model"):
+            raise RuntimeError(
+                "EagleProposer does not expose `model` attribute; check vLLM "
+                "version compatibility (expected v0.20.1.dev0 shape — the "
+                "draft model is exposed as `proposer.model`, NOT "
+                "`proposer.draft_model`)."
+            )
+
+        # Acquire a shared graph memory pool. Step 4 should share with the
+        # target model's pool if vllm-musa exposes a hook; for now, create
+        # a fresh pool — slightly more memory but simpler.
+        # Note: torch.cuda.graph_pool_handle() works on MUSA via torchada.
+        pool = torch.cuda.graph_pool_handle()
+
+        for bs in self.capture_sizes:
+            try:
+                ctx = self._capture_one_batch_size(bs, base_metadata, pool)
+                self.contexts[bs] = ctx
+                logger.info(
+                    "MUSA-0090 captured Eagle3 full-loop graph for bs=%d "
+                    "(buffer footprint %.2f MiB)",
+                    bs, ctx.memory_footprint_bytes() / 1024 / 1024,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "MUSA-0090 graph capture FAILED at bs=%d: %s. "
+                    "Falling back to iterative path for this size.",
+                    bs, exc,
+                )
+                # Don't propagate — the patch will fall back to vLLM's
+                # iterative path when can_run(bs) returns False for this size.
+
+        self._captured = True
+
+    def _capture_one_batch_size(
+        self,
+        batch_size: int,
+        base_metadata: Any,
+        pool: Any,
+    ) -> EagleFullLoopCaptureContext:
+        """Capture the N-step draft loop for one batch size.
+
+        STEP 4 implementation target. Step 3 leaves this as a structured
+        skeleton with explicit pseudocode for what each phase must do.
+
+        Phase 1: allocate buffers
+        Phase 2: build per-step metadata array (views into buffers)
+        Phase 3: warm-up the draft model on this bs (kernels must be
+                 compiled before graph capture per torch.cuda.graph docs)
+        Phase 4: open torch.cuda.graph context, drive the N-step loop with
+                 in-place tensor ops only
+        Phase 5: wrap and return context
+        """
+        if batch_size <= 0 or batch_size > self.max_bs:
+            raise ValueError(
+                f"batch_size {batch_size} out of range [1, {self.max_bs}]"
+            )
+
+        # Phase 1: allocate buffers for this batch size.
+        # block_table_tensor is held as a reference (not copied); we read it
+        # via the slot-mapping kernel inside the captured graph.
+        block_table_tensor = getattr(base_metadata, "block_table_tensor", None)
+        if block_table_tensor is None:
+            raise RuntimeError(
+                "base_metadata lacks block_table_tensor; cannot capture without it"
+            )
+        buffers = EagleDraftBuffers.allocate(
+            max_bs=self.max_bs,
+            num_steps=self.num_steps,
+            hidden_size=self.hidden_size,
+            topk=self.topk,
+            block_table_tensor=block_table_tensor,
+            device=self.device,
+        )
+
+        # Phase 2: pre-build per-step metadata array (views into buffers).
+        # Pass `proposer` so the helper can call
+        # proposer.build_per_group_and_layer_attn_metadata() to produce
+        # per-layer backend-specific metadata that has the use_cascade /
+        # common_prefix_len / etc. fields the compiled draft model expects
+        # (see attn_backend_array.py docstring for the rationale).
+        attn_metadata_array = build_per_step_attn_metadata_array(
+            base_metadata=base_metadata,
+            buffers=buffers,
+            batch_size=batch_size,
+            proposer=self.proposer,
+        )
+        # Verify the indexing math before committing to graph capture.
+        # Skip verify_strict for per-layer dict metadata (StepMetadataIndexing
+        # reads `.slot_mapping.data_ptr()` which is a CommonAttentionMetadata
+        # field, not a per-layer-dict attribute).
+        if attn_metadata_array and not isinstance(attn_metadata_array[0], dict):
+            StepMetadataIndexing.inspect(attn_metadata_array).verify_strict()
+
+        # Phase 3: warm-up. STEP 4 TODO — run one eager iteration to compile
+        # kernels and exercise allocator hot-paths. Per torch.cuda.graph docs,
+        # this is required to avoid stream/allocator surprises during capture.
+        # Pattern (from Q1 smoke):
+        #   s = torch.cuda.Stream()
+        #   s.wait_stream(torch.cuda.current_stream())
+        #   with torch.cuda.stream(s):
+        #       self._run_one_step_eager(buffers, attn_metadata_array, 0,
+        #                                 batch_size)
+        #   torch.cuda.current_stream().wait_stream(s)
+        #   torch.cuda.synchronize()
+        self._warmup_eager(buffers, attn_metadata_array, batch_size)
+
+        # Phase 4: capture the N-step loop. STEP 4 TODO — this is the
+        # core deliverable. Pseudocode:
+        #
+        #   graph = torch.cuda.CUDAGraph()
+        #   with torch.cuda.graph(graph, pool=pool):
+        #       # Step 0: seed from input carry-over (target last hidden).
+        #       # Copy bonus_token_ids_in -> input_ids_per_step[0]
+        #       # Copy target_hidden_states_in -> hidden_states_per_step[0]
+        #       buffers.input_ids_per_step[0, :batch_size].copy_(
+        #           buffers.bonus_token_ids_in[:batch_size]
+        #       )
+        #       buffers.hidden_states_per_step[0, :batch_size].copy_(
+        #           buffers.target_hidden_states_in[:batch_size]
+        #       )
+        #
+        #       # The N-step loop body.
+        #       for step_idx in range(self.num_steps):
+        #           # Set forward_batch state from buffers[step_idx].
+        #           # vLLM passes forward_batch through set_forward_context;
+        #           # we DON'T use set_forward_context here because we
+        #           # want the loop INSIDE the graph (no Python re-entry).
+        #           forward_batch.input_ids = buffers.input_ids_per_step[step_idx, :batch_size]
+        #           forward_batch.positions = buffers.positions_per_step[step_idx, :batch_size]
+        #           forward_batch.slot_mapping = ... (from metadata_array[step_idx])
+        #           forward_batch.attn_metadata = attn_metadata_array[step_idx]
+        #
+        #           # Call draft model forward (captures all its kernels).
+        #           logits, hidden = self.proposer.draft_model(forward_batch)
+        #           buffers.hidden_states_per_step[step_idx + 1].copy_(hidden)
+        #
+        #           # Sample topk=1 (chain). Captured in-graph.
+        #           probs = torch.softmax(logits, dim=-1)
+        #           topk_p, topk_idx = torch.topk(probs, k=self.topk)
+        #           buffers.topk_p_per_step[step_idx + 1].copy_(topk_p)
+        #           buffers.topk_index_per_step[step_idx + 1].copy_(topk_idx)
+        #           buffers.input_ids_per_step[step_idx + 1, :batch_size].copy_(
+        #               topk_idx.flatten()
+        #           )
+        #
+        #           # Update positions + slot_mapping for next step via the
+        #           # existing fused Triton kernel (already MUSA-adapted
+        #           # for the .pyc-cache issue we hit in MUSA-0089).
+        #           eagle_step_update_slot_mapping_and_metadata(
+        #               positions_1d=buffers.positions_per_step[step_idx + 1],
+        #               block_table_tensor=buffers.block_table_tensor,
+        #               seq_lens=buffers.seq_lens_per_step[step_idx + 1],
+        #               out_slot_mapping=buffers.slot_mapping_per_step[step_idx + 1],
+        #               input_batch_size=batch_size,
+        #               ...
+        #           )
+        #
+        #           # Write the step's chosen token to the output tensor.
+        #           buffers.draft_token_ids_out[:batch_size, step_idx].copy_(
+        #               buffers.input_ids_per_step[step_idx + 1, :batch_size]
+        #           )
+        #
+        #   # End of context manager = graph capture complete.
+        graph = self._capture_n_step_loop(
+            buffers, attn_metadata_array, batch_size, pool,
+        )
+
+        # Phase 5: wrap up and return.
+        return EagleFullLoopCaptureContext(
+            batch_size=batch_size,
+            graph=graph,
+            pool=pool,
+            buffers=buffers,
+            attn_metadata_array=attn_metadata_array,
+        )
+
+    # ---- replay (hot path) ----
+
+    def replay(
+        self,
+        target_hidden_states: torch.Tensor,  # bf16 [bs, hidden_size] OR [num_tokens, hidden_size]
+        next_token_ids: torch.Tensor,        # int32 [bs] (the bonus from verify)
+        common_attn_metadata: Any,            # for assertion + step-0 metadata seeding
+        batch_size: int,
+        target_positions: torch.Tensor | None = None,  # int64 [num_tokens] (the verify pass's positions)
+        token_indices_to_sample: torch.Tensor | None = None,  # int [bs] (idx in num_tokens of last token per seq)
+    ) -> EagleFullLoopReplayResult:
+        """Replay the captured graph for this batch size.
+
+        Single .replay() call + N .copy_() for input carry-over (5 buffers:
+        hidden_states, bonus_token_ids, positions, slot_mapping, seq_lens).
+        Versus vLLM's iterative path which pays N × (set_forward_context +
+        metadata rebuild + dispatcher dispatch) per spec round.
+
+        Args:
+            target_hidden_states: target model's hidden states, shape
+                [num_tokens, hidden_size] OR [batch_size, hidden_size].
+                The runner selects the per-sequence-last-token slice via
+                token_indices_to_sample.
+            next_token_ids: bonus token ids from the previous verify pass,
+                shape [batch_size]. The "free" token that target accepted.
+            common_attn_metadata: source of step-0 slot_mapping and seq_lens
+                seeding. The runner reads .slot_mapping[token_indices_to_sample]
+                and .seq_lens directly.
+            batch_size: actual batch size; must match a captured size.
+            target_positions: optional [num_tokens] tensor of the verify pass's
+                positions. The runner reads target_positions[token_indices_to_sample]
+                to seed step-0 positions. If None, step-0 positions are left
+                at the buffer's current value (legacy behavior — wrong, but
+                preserved for backward compat during step 5k transition).
+            token_indices_to_sample: optional [bs] tensor naming the index
+                (within num_tokens) of the last token per sequence. If None,
+                computed from common_attn_metadata.query_start_loc[1:] - 1.
+
+        Returns:
+            EagleFullLoopReplayResult with .draft_token_ids of shape
+            [batch_size, num_speculative_tokens].
+        """
+        if not self._captured:
+            raise RuntimeError("replay() called before capture()")
+        if batch_size not in self.contexts:
+            raise ValueError(
+                f"no captured graph for batch_size={batch_size}; "
+                f"capture_sizes={self.capture_sizes}"
+            )
+
+        ctx = self.contexts[batch_size]
+
+        # MUSA-0090 step 5k: derive token_indices_to_sample if not provided.
+        # Pattern matches vllm/v1/spec_decode/llm_base_proposer.py:set_inputs_first_pass.
+        if token_indices_to_sample is None:
+            query_start_loc = getattr(common_attn_metadata, "query_start_loc", None)
+            if query_start_loc is not None:
+                token_indices_to_sample = query_start_loc[1:] - 1
+            else:
+                # Fall back to "[bs-1, ..., bs-1]" which is correct ONLY when
+                # num_tokens == batch_size (one-token-per-seq decode case).
+                # The runner's eager path produces this from the proposer.
+                token_indices_to_sample = torch.arange(
+                    batch_size, dtype=torch.int64, device=target_hidden_states.device
+                )
+
+        # Hidden state selection: pick the LAST token per sequence.
+        # Shape handling:
+        #   target_hidden_states is [num_tokens, h] in the general case.
+        #   For BS=1 prefill 4k, num_tokens=4096 and we need the [4095]-th row.
+        # MUSA-0090 step 5l.2: Eagle3 uses aux hidden states from N layers
+        # (e.g., 3 layers for M2.5-Eagle3: ids 1, 30, 58), concatenated to
+        # shape [num_tokens, N * hidden_size] = [num_tokens, 9216] for the
+        # 3072-hidden M2.5 draft. vLLM's propose() calls
+        # self.model.combine_hidden_states(target_hidden_states) to reduce
+        # the concat to [num_tokens, hidden_size] before the draft forward.
+        # We replicate that here OUTSIDE the captured graph.
+        if (
+            self.proposer.method in ("eagle3", "dflash")
+            and target_hidden_states.shape[-1] != self.hidden_size
+            and hasattr(self.proposer.model, "combine_hidden_states")
+        ):
+            target_hidden_states = self.proposer.model.combine_hidden_states(
+                target_hidden_states
+            )
+        if target_hidden_states.dim() >= 1 and target_hidden_states.shape[0] != batch_size:
+            selected_hidden = target_hidden_states[token_indices_to_sample]
+        else:
+            selected_hidden = target_hidden_states[:batch_size]
+        ctx.buffers.target_hidden_states_in[:batch_size].copy_(selected_hidden)
+        ctx.buffers.bonus_token_ids_in[:batch_size].copy_(next_token_ids)
+
+        # MUSA-0090 step 5k: seed step-0 positions, slot_mapping, seq_lens
+        # from the verify pass's metadata. Without these, the captured graph
+        # reads zeros at step 0 — RoPE wrong, KV writes to wrong slots,
+        # attention attends to wrong context length.
+        if target_positions is not None:
+            # The bonus token's position is the position AFTER the last verified
+            # position. The first draft (step 0) is run AS the bonus token (its
+            # input_ids = bonus_token_id, its hidden_states = target_hidden), so
+            # step-0 positions = target_positions[last_idx_per_seq].
+            # (Per vllm/v1/spec_decode/llm_base_proposer.py line 502:
+            #  `positions = self.positions[token_indices_to_sample]`)
+            if target_positions.dim() == 2:
+                # M-RoPE case: positions shape [3, num_tokens]; take dim 0.
+                step0_positions = target_positions[0][token_indices_to_sample]
+            else:
+                step0_positions = target_positions[token_indices_to_sample]
+            ctx.buffers.positions_in[:batch_size].copy_(step0_positions.to(torch.int64))
+
+        # slot_mapping for step 0: the slot of the bonus token. The verify
+        # pass's common_attn_metadata.slot_mapping has shape [num_tokens] and
+        # tells us where each input token's K/V is written. The bonus token
+        # corresponds to the last input position of each sequence.
+        cm_slot_mapping = getattr(common_attn_metadata, "slot_mapping", None)
+        if cm_slot_mapping is not None and cm_slot_mapping.numel() > 0:
+            if cm_slot_mapping.shape[0] != batch_size:
+                step0_slot = cm_slot_mapping[token_indices_to_sample]
+            else:
+                step0_slot = cm_slot_mapping[:batch_size]
+            ctx.buffers.slot_mapping_in[:batch_size].copy_(step0_slot.to(torch.int64))
+
+        # seq_lens for step 0: same as the verify pass's seq_lens (the
+        # context length BEFORE the draft adds a new token).
+        cm_seq_lens = getattr(common_attn_metadata, "seq_lens", None)
+        if cm_seq_lens is not None and cm_seq_lens.numel() > 0:
+            ctx.buffers.seq_lens_in[:batch_size].copy_(
+                cm_seq_lens[:batch_size].to(torch.int32)
+            )
+
+        # MUSA-0090 step 5l.3: copy the current request's block_table into
+        # the runner-owned buffer. The captured graph reads from
+        # buffers.block_table_tensor (a stable pointer), not from the
+        # caller's transient tensor (which may be freed/repurposed between
+        # spec rounds, causing 'MUSA error: unknown error').
+        cm_block_table = getattr(common_attn_metadata, "block_table_tensor", None)
+        if cm_block_table is not None and cm_block_table.numel() > 0:
+            # Slice to actual shape, pad with zeros if needed.
+            src_bs = min(cm_block_table.shape[0], batch_size)
+            src_n_blocks = min(
+                cm_block_table.shape[1], ctx.buffers.block_table_tensor.shape[1]
+            )
+            ctx.buffers.block_table_tensor[:src_bs, :src_n_blocks].copy_(
+                cm_block_table[:src_bs, :src_n_blocks]
+            )
+
+        # Single graph replay. All N draft forwards + sampling + slot-mapping
+        # updates happen inside this one call.
+        ctx.graph.replay()
+
+        # MUSA-0090 layer-2 fix (2026-05-17): clone the output OUT of the
+        # CUDAGraph memory pool. vllm's _copy_draft_token_ids_to_cpu does the
+        # H2D copy on a dedicated `draft_token_ids_copy_stream` (not the default
+        # stream), and MUSA's MUDNN fails ("err 999 = unknown error") when
+        # copying from pool memory across streams. Cloning into a fresh
+        # allocation outside the pool fixes this. The clone is small
+        # (`[bs, num_steps]` int32 = ~12 bytes for bs=1) and runs on the
+        # default stream so subsequent cross-stream sync works.
+        out = ctx.buffers.draft_token_ids_out[:batch_size].clone()
+        return EagleFullLoopReplayResult(
+            draft_token_ids=out,
+            batch_size=batch_size,
+        )
+
+    # ---- helpers (step 4: real implementations) ----
+
+    def _warmup_eager(
+        self,
+        buffers: EagleDraftBuffers,
+        attn_metadata_array: list,
+        batch_size: int,
+    ) -> None:
+        """Run TWO eager passes through the N-step loop with full sync between,
+        BEFORE graph capture.
+
+        MUSA-0109 layer-4 fix (2026-05-17): match SGLang's `_capture_init`
+        pattern (sglang/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py:217)
+        which is the difference between "MUSA-0090 always crashes" and
+        "SGLang works on similar hardware". Specifically:
+
+          1. torch.cuda.synchronize() — drain all pending GPU work
+          2. tp_group.barrier() — cross-rank sync; ensures all TP ranks
+             see the same allocator state before next warmup
+          3. run_once_fn() — actually exercise the workload
+          4. on_after_cuda_graph_warmup hook — backend-specific cleanup
+          5. REPEAT 2x — settle JIT/Inductor compiles, allocator pool
+             pages, and TP comm channels fully BEFORE capture
+
+        Hypothesis: torch_musa's CUDAGraph + allocator interaction bug
+        triggers when capture happens with un-settled allocator state.
+        SGLang's 2x warmup + TP barrier pattern ensures the state is
+        stable before capture opens.
+        """
+        from vllm.distributed import get_tp_group
+
+        try:
+            tp_group = get_tp_group()
+            tp_barrier = lambda: tp_group.barrier()
+        except Exception as exc:
+            logger.debug("TP group unavailable for warmup barrier: %s", exc)
+            tp_barrier = lambda: None
+
+        # Side-stream warmup pattern (preserved from Q1 smoke)
+        s = torch.cuda.Stream()
+        for warmup_iter in range(2):
+            torch.cuda.synchronize()
+            tp_barrier()
+            s.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(s):
+                self._run_n_step_inner(buffers, attn_metadata_array, batch_size)
+            torch.cuda.current_stream().wait_stream(s)
+            torch.cuda.synchronize()
+            # Per-attn-backend hook (SGLang's on_after_cuda_graph_warmup)
+            hook = getattr(
+                getattr(self.proposer, "draft_attn_backend", None),
+                "on_after_cuda_graph_warmup",
+                None,
+            )
+            if hook is not None:
+                try:
+                    hook()
+                except Exception as exc:
+                    logger.debug("on_after_cuda_graph_warmup raised: %s", exc)
+        # Final barrier + sync to ensure all ranks see settled state
+        torch.cuda.synchronize()
+        tp_barrier()
+
+    def _capture_n_step_loop(
+        self,
+        buffers: EagleDraftBuffers,
+        attn_metadata_array: list,
+        batch_size: int,
+        pool: Any,
+    ) -> Any:
+        """Open the torch.cuda.graph context and drive the N-step loop with
+        in-place tensor ops only. Returns the captured CUDAGraph object.
+
+        Critical invariants enforced inside `_run_n_step_inner`:
+          - No Python list growth (no .append, no torch.cat).
+          - No new tensor allocations (everything writes into `buffers`).
+          - No tensor.item() / .tolist() / .cpu() calls (would CUDA-sync).
+          - set_forward_context is allowed (pure Python state mutation; the
+            actual GPU work it wraps is captured by torch.cuda.graph).
+        """
+        # torch.cuda.CUDAGraph is routed to torch_musa.musa_graph.MUSAGraph on
+        # MUSA via torchada — proven correctness-wise by the Q1 smoke.
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, pool=pool):
+            self._run_n_step_inner(buffers, attn_metadata_array, batch_size)
+        return graph
+
+    def _run_n_step_inner(
+        self,
+        buffers: EagleDraftBuffers,
+        attn_metadata_array: list,
+        batch_size: int,
+    ) -> None:
+        """The N-step draft loop body. Called both by _warmup_eager (outside
+        graph) and _capture_n_step_loop (inside graph). MUST use only
+        in-place tensor ops + tensor-view assignments that the graph can
+        capture.
+
+        This mirrors vLLM's `EagleProposer.propose()` loop body
+        (vllm/v1/spec_decode/llm_base_proposer.py:554-651) but
+        statically-allocates everything ahead of time.
+        """
+        # Lazy imports to avoid pulling vLLM internals at module-load time.
+        from vllm.forward_context import set_forward_context
+        from vllm.config import CUDAGraphMode
+        from vllm.v1.spec_decode.utils import eagle_step_update_slot_mapping_and_metadata
+
+        proposer = self.proposer
+        # Step-0 seed: copy the input carry-over into the per-step buffers.
+        # bonus_token_ids_in is the bonus token from the previous verify pass
+        # (the target's accepted last token); it's the input to the first
+        # draft forward.
+        buffers.input_ids_per_step[0, :batch_size].copy_(
+            buffers.bonus_token_ids_in[:batch_size]
+        )
+        buffers.hidden_states_per_step[0, :batch_size].copy_(
+            buffers.target_hidden_states_in[:batch_size]
+        )
+        # MUSA-0090 step 5k (2026-05-16): seed step-0 metadata from input
+        # buffers populated by replay(). Without these copies, the captured
+        # graph reads zeros at step 0 — wrong RoPE positions, wrong KV slot,
+        # wrong attention seq_len. The eagle_step kernel below propagates
+        # positions[step] -> positions[step+1] by adding 1; so position 0
+        # wrong cascades through all downstream steps. This was the root
+        # cause of acceptance=0.00 at positions 3-6 in step 5h bench.
+        buffers.positions_per_step[0, :batch_size].copy_(
+            buffers.positions_in[:batch_size]
+        )
+        buffers.slot_mapping_per_step[0, :batch_size].copy_(
+            buffers.slot_mapping_in[:batch_size]
+        )
+        buffers.seq_lens_per_step[0, :batch_size].copy_(
+            buffers.seq_lens_in[:batch_size]
+        )
+
+        # The N-step loop. Inside torch.cuda.graph(), every GPU op below is
+        # captured. The Python for-loop unrolls at trace time — N is a static
+        # int, not a tensor.
+        for step in range(self.num_steps):
+            # Views into this step's slice of the buffers. .narrow-style
+            # indexing on a contiguous tensor returns a view; the captured
+            # graph captures the kernel launches that consume these views.
+            input_ids_view = buffers.input_ids_per_step[step, :batch_size]
+            positions_view = buffers.positions_per_step[step, :batch_size]
+            hidden_view = buffers.hidden_states_per_step[step, :batch_size]
+            slot_mapping_view = buffers.slot_mapping_per_step[step, :batch_size]
+
+            # Build the model kwargs. vLLM's draft model signature:
+            #   model(input_ids=..., positions=..., inputs_embeds=None,
+            #         hidden_states=...)
+            # Returns either (last_hidden, hidden) tuple or just last_hidden.
+            model_kwargs = {
+                "input_ids": input_ids_view,
+                "positions": positions_view,
+                "inputs_embeds": None,
+            }
+            if getattr(proposer, "pass_hidden_states_to_model", True):
+                # Eagle3 always passes hidden states from the previous step.
+                model_kwargs["hidden_states"] = hidden_view
+
+            # set_forward_context sets vLLM's thread-local context (attn
+            # metadata, slot_mapping, num_tokens) for the model call.
+            # Critical: cudagraph_runtime_mode=NONE — we're capturing OUR
+            # OWN graph; vLLM's PIECEWISE shouldn't re-fire.
+            # NOTE: do NOT pass slot_mapping=tensor here — vllm's forward_context
+            # internally does `slot_mapping or {}` which raises on multi-element
+            # Tensors (`Boolean value of Tensor with more than one value is
+            # ambiguous`). The slot_mapping_view is already carried by
+            # attn_metadata_array[step].slot_mapping; the kwarg is the per-attn-group
+            # dict that vllm uses for cross-group dispatch, NOT the single tensor.
+            with set_forward_context(
+                attn_metadata_array[step],
+                proposer.vllm_config,
+                num_tokens=batch_size,
+                cudagraph_runtime_mode=CUDAGraphMode.NONE,
+            ):
+                ret_hidden_states = proposer.model(**model_kwargs)
+                if isinstance(ret_hidden_states, tuple):
+                    last_hidden_states, next_hidden = ret_hidden_states
+                else:
+                    last_hidden_states = ret_hidden_states
+                    next_hidden = ret_hidden_states
+
+            # Sample greedy via the proposer's helper (lm_head + argmax).
+            # Result dtype is int64 by default; vllm casts to int32 because
+            # "tensor.argmax() returns int64 by default" and Eagle compile
+            # requires int32 (per vllm comment line 556).
+            draft_token_ids = proposer._greedy_sample(
+                last_hidden_states[:batch_size]
+            ).to(torch.int32)
+
+            # Write the drafted token to the output tensor.
+            buffers.draft_token_ids_out[:batch_size, step].copy_(draft_token_ids)
+
+            # Update state for step+1 if not the last step.
+            if step + 1 < self.num_steps:
+                # Stage next step's input.
+                buffers.input_ids_per_step[step + 1, :batch_size].copy_(
+                    draft_token_ids
+                )
+                buffers.hidden_states_per_step[step + 1, :batch_size].copy_(
+                    next_hidden[:batch_size]
+                )
+
+                # MUSA-0090 step 5k: propagate seq_lens forward before the
+                # kernel. The kernel does in-place +1 on its `seq_lens` arg
+                # (reads, adds 1, writes back). If we passed
+                # seq_lens_per_step[step+1] directly without seeding, the
+                # kernel reads 0 and writes 1 — instead of reading
+                # actual_seq_lens+step and writing actual_seq_lens+step+1.
+                # Copy step's seq_lens to step+1's, then the kernel's
+                # in-place +1 produces the correct step+1 value.
+                buffers.seq_lens_per_step[step + 1, :batch_size].copy_(
+                    buffers.seq_lens_per_step[step, :batch_size]
+                )
+                # Increment positions + recompute slot_mapping for step+1.
+                # The fused kernel writes positions, seq_lens, slot_mapping
+                # all in one launch — exactly what vLLM's iterative path
+                # does at line 569-578 of llm_base_proposer.py.
+                eagle_step_update_slot_mapping_and_metadata(
+                    positions_1d=positions_view,
+                    block_table_tensor=buffers.block_table_tensor,
+                    seq_lens=buffers.seq_lens_per_step[step + 1, :batch_size],
+                    block_size=getattr(proposer, "block_size", 16),
+                    max_model_len=getattr(proposer, "max_model_len", 196_608),
+                    out_clamped_positions=buffers.positions_per_step[
+                        step + 1, :batch_size
+                    ],
+                    out_slot_mapping=buffers.slot_mapping_per_step[
+                        step + 1, :batch_size
+                    ],
+                    input_batch_size=batch_size,
+                )
+
+    # ---- memory accounting ----
+
+    def memory_footprint_bytes(self) -> int:
+        """Total memory used by all captured contexts (buffer-only, excludes
+        the shared graph memory pool)."""
+        return sum(c.memory_footprint_bytes() for c in self.contexts.values())
+
+    # ---- introspection ----
+
+    def __repr__(self) -> str:
+        return (
+            f"EagleFullLoopRunner("
+            f"N={self.num_steps}, "
+            f"capture_sizes={self.capture_sizes}, "
+            f"captured={self._captured}, "
+            f"num_contexts={len(self.contexts)}, "
+            f"hidden_size={self.hidden_size}, "
+            f"topk={self.topk})"
+        )

--- a/vllm_musa/v1/spec_decode/spec_info.py
+++ b/vllm_musa/v1/spec_decode/spec_info.py
@@ -1,0 +1,259 @@
+# MUSA-0090 step 2: Pre-allocated buffers + capture-context dataclasses for
+# the Eagle3 full-loop runner.
+#
+# All fields are tensors (not Python lists), so the captured cudagraph can
+# mutate them in-place via tensor ops without Python re-entry. Buffers are
+# sized for the MAX captured batch size; smaller batches use the leading
+# prefix.
+#
+# Design ref: generated/musa0090_impl/step1-design-doc.md §3.1.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+
+@dataclass
+class EagleDraftBuffers:
+    """Pre-allocated buffers used by EagleFullLoopRunner across all N steps.
+
+    Allocated once per (batch_size, num_speculative_tokens, hidden_size). During
+    capture/replay, the runner indexes these buffers using static integer
+    indices — no Python list growth, no per-step allocation.
+
+    Shape conventions:
+      max_bs: the largest cudagraph_capture_size for this runner
+      num_steps: num_speculative_tokens (=N from the EagleProposer)
+      hidden_size: draft model's hidden_size (M2.5 Eagle3 = LLaMA-shape)
+      topk: 1 for chain drafting; >1 for tree drafting (deferred)
+    """
+
+    # --- Per-step output buffers (indexed by step_idx in [0..N-1]) ---
+    # int32 [N, max_bs]: the chosen draft token id at each step
+    input_ids_per_step: torch.Tensor
+    # int64 [N, max_bs]: absolute sequence position used by attention at each step
+    positions_per_step: torch.Tensor
+    # int64 [N, max_bs]: KV cache slot index where this step's k/v is written
+    slot_mapping_per_step: torch.Tensor
+    # int32 [N, max_bs]: running seq_len at each step (= base_seq_len + step_idx)
+    seq_lens_per_step: torch.Tensor
+
+    # --- Per-step hidden states (the carry between draft forward passes) ---
+    # bfloat16 [N, max_bs, hidden_size]: output of draft fwd at step i, used as
+    # input at step i+1
+    hidden_states_per_step: torch.Tensor
+
+    # --- Per-step topk probs/indices (for sampling) ---
+    # float32 [N, max_bs, topk]: softmax probs at each step
+    topk_p_per_step: torch.Tensor
+    # int32 [N, max_bs, topk]: token indices at each step
+    topk_index_per_step: torch.Tensor
+
+    # --- Output of the full-loop replay ---
+    # int32 [max_bs, num_speculative_tokens]: the N drafted tokens per request,
+    # in order. This is what the patched EagleProposer.propose() returns.
+    draft_token_ids_out: torch.Tensor
+
+    # --- Input carry-over from the previous spec round (target's verify output) ---
+    # int32 [max_bs]: bonus token id from the previous verify pass (the target
+    # model's accepted last token)
+    bonus_token_ids_in: torch.Tensor
+    # bfloat16 [max_bs, hidden_size]: target model's last hidden state, used as
+    # input to step 0 of the draft loop
+    target_hidden_states_in: torch.Tensor
+    # MUSA-0090 step 5k (2026-05-16): step-0 input metadata seeded from the
+    # caller's CommonAttentionMetadata. Without these, positions_per_step[0]
+    # is zero (allocation default), and the captured graph reads zeros at
+    # step 0 — RoPE applies at position 0 regardless of actual sequence
+    # position. Downstream steps' positions/slot_mapping are then off by an
+    # absolute offset (P-0), which is why MUSA-0090 step 5h showed
+    # acceptance positions 3-6 = 0.00 (drafts at wrong positions).
+    # int64 [max_bs]: actual position of the BONUS token (target's last
+    # accepted output). Step 0 of the draft loop runs at this position.
+    positions_in: torch.Tensor
+    # int64 [max_bs]: KV cache slot for the BONUS token. Step 0 writes its
+    # draft KV here.
+    slot_mapping_in: torch.Tensor
+    # int32 [max_bs]: current sequence length INCLUDING the bonus token.
+    # Attention at step 0 attends to seq_lens_in tokens of context.
+    seq_lens_in: torch.Tensor
+
+    # --- Static / read-only references (allocated once, not per-step) ---
+    # MUSA-0090 step 5l.3: block_table_tensor is OWNED by the buffer
+    # (allocated once, copied-into per replay). NOT a reference to the
+    # caller's block_table — that pointer becomes stale across spec rounds
+    # as vllm reuses tensors, causing 'MUSA error: unknown error' during
+    # captured graph replay.
+    # Shape: [max_bs, max_blocks_per_req]. The eagle_step kernel reads from
+    # this; the runner's replay() copies the current request's block_table
+    # into it.
+    block_table_tensor: torch.Tensor
+
+    # --- Bookkeeping ---
+    max_bs: int
+    num_steps: int
+    hidden_size: int
+    topk: int
+    device: torch.device
+
+    @classmethod
+    def allocate(
+        cls,
+        max_bs: int,
+        num_steps: int,
+        hidden_size: int,
+        topk: int,
+        block_table_tensor: torch.Tensor,
+        device: torch.device,
+    ) -> EagleDraftBuffers:
+        """One-time allocation at runner setup (before any graph capture).
+
+        MUSA-0090 step 5l.3: block_table_tensor is OWNED by the buffer
+        (allocated once at max shape, copied-into per replay). The caller's
+        reference is used only to derive the shape (max_blocks_per_req)
+        and dtype. The captured graph reads from the buffer's
+        block_table_tensor; the runner's replay() copies the current
+        request's block_table into it before graph.replay().
+
+        Sizes are stored on the device. The (N, max_bs) leading dims allow
+        per-step slicing as a contiguous view (no copy).
+        """
+        bf16 = torch.bfloat16
+        i32 = torch.int32
+        i64 = torch.int64
+        f32 = torch.float32
+
+        # Allocate a runner-owned block_table buffer at the SHAPE of the
+        # caller's template. The caller's block_table_tensor has shape
+        # [num_reqs, max_blocks_per_req] (typically int32 — page table
+        # entries). We allocate [max_bs, max_blocks_per_req].
+        max_blocks_per_req = (
+            block_table_tensor.shape[-1] if block_table_tensor.ndim >= 1 else 1
+        )
+        owned_block_table = torch.zeros(
+            (max_bs, max_blocks_per_req),
+            dtype=block_table_tensor.dtype,
+            device=device,
+        )
+
+        return cls(
+            input_ids_per_step=torch.zeros((num_steps, max_bs), dtype=i32, device=device),
+            positions_per_step=torch.zeros((num_steps, max_bs), dtype=i64, device=device),
+            slot_mapping_per_step=torch.zeros((num_steps, max_bs), dtype=i64, device=device),
+            seq_lens_per_step=torch.zeros((num_steps, max_bs), dtype=i32, device=device),
+            hidden_states_per_step=torch.zeros(
+                (num_steps, max_bs, hidden_size), dtype=bf16, device=device
+            ),
+            topk_p_per_step=torch.zeros((num_steps, max_bs, topk), dtype=f32, device=device),
+            topk_index_per_step=torch.zeros((num_steps, max_bs, topk), dtype=i32, device=device),
+            draft_token_ids_out=torch.zeros((max_bs, num_steps), dtype=i32, device=device),
+            bonus_token_ids_in=torch.zeros((max_bs,), dtype=i32, device=device),
+            target_hidden_states_in=torch.zeros((max_bs, hidden_size), dtype=bf16, device=device),
+            # MUSA-0090 step 5k: step-0 input metadata buffers.
+            positions_in=torch.zeros((max_bs,), dtype=i64, device=device),
+            slot_mapping_in=torch.zeros((max_bs,), dtype=i64, device=device),
+            seq_lens_in=torch.zeros((max_bs,), dtype=i32, device=device),
+            block_table_tensor=owned_block_table,
+            max_bs=max_bs,
+            num_steps=num_steps,
+            hidden_size=hidden_size,
+            topk=topk,
+            device=device,
+        )
+
+    def reset(self) -> None:
+        """Zero out per-step state. Called before each capture/replay round.
+
+        Does NOT zero the input carry-over buffers (bonus_token_ids_in,
+        target_hidden_states_in); those are populated by the caller via
+        copy_() just before replay.
+        """
+        self.input_ids_per_step.zero_()
+        self.positions_per_step.zero_()
+        self.slot_mapping_per_step.zero_()
+        self.seq_lens_per_step.zero_()
+        # hidden_states / topk_p / topk_index are overwritten in-graph,
+        # no need to zero them — but doing so makes debug-print outputs
+        # cleaner. Skip for perf.
+        self.draft_token_ids_out.zero_()
+
+    def memory_footprint_bytes(self) -> int:
+        """Sum of all owned tensors' sizes in bytes. Useful for runner sizing
+        decisions (e.g., 'is this runner's footprint too big for the GPU?')."""
+        tensors = [
+            self.input_ids_per_step,
+            self.positions_per_step,
+            self.slot_mapping_per_step,
+            self.seq_lens_per_step,
+            self.hidden_states_per_step,
+            self.topk_p_per_step,
+            self.topk_index_per_step,
+            self.draft_token_ids_out,
+            self.bonus_token_ids_in,
+            self.target_hidden_states_in,
+            # MUSA-0090 step 5k: step-0 input metadata buffers.
+            self.positions_in,
+            self.slot_mapping_in,
+            self.seq_lens_in,
+            # MUSA-0090 step 5l.3: block_table_tensor is now owned.
+            self.block_table_tensor,
+        ]
+        return sum(t.numel() * t.element_size() for t in tensors)
+
+
+@dataclass
+class EagleFullLoopCaptureContext:
+    """Per-batch-size capture state. One per cudagraph_capture_size.
+
+    The runner builds one of these per `cudagraph_capture_sizes` entry at
+    setup, then dispatches by batch_size at runtime via a dict lookup.
+    """
+
+    batch_size: int
+    """The exact batch size this graph was captured for."""
+
+    graph: Any
+    """The torch.cuda.CUDAGraph (or torch_musa.MUSAGraph on MUSA) holding the
+    captured N-step draft loop. Replay via graph.replay()."""
+
+    pool: Any
+    """The memory pool handle returned by torch.cuda.graph_pool_handle(),
+    shared with the target model's captured graphs to reduce memory."""
+
+    buffers: EagleDraftBuffers
+    """The buffers this graph reads/writes during replay. Persisted as long
+    as the graph exists."""
+
+    attn_metadata_array: list
+    """List of N CommonAttentionMetadata objects (one per step), pre-built at
+    capture time. Each holds READ-ONLY VIEWS into `buffers.{slot_mapping,
+    seq_lens}_per_step[i]` so the captured graph's tensor mutations are
+    reflected without rebuild."""
+
+    def memory_footprint_bytes(self) -> int:
+        """Memory used by this context's buffers (excludes graph memory pool —
+        that's shared)."""
+        return self.buffers.memory_footprint_bytes()
+
+
+@dataclass
+class EagleFullLoopReplayResult:
+    """Returned from `EagleFullLoopRunner.replay()`.
+
+    The runner deliberately returns a thin object (vs a bare tensor) so the
+    patched EagleProposer.propose() has a stable shape to consume even if we
+    later add fields (e.g., per-step accept probabilities for telemetry).
+    """
+
+    draft_token_ids: torch.Tensor
+    """int32 [batch_size, num_speculative_tokens] — the N drafted token ids
+    per request. View into `EagleDraftBuffers.draft_token_ids_out[:batch_size]`.
+    Caller must NOT hold this view past the next replay (the underlying
+    buffer is overwritten)."""
+
+    batch_size: int
+    """The actual batch size (≤ context.batch_size). Useful for the caller
+    to slice correctly."""

--- a/vllm_musa/v1/spec_decode/utils.py
+++ b/vllm_musa/v1/spec_decode/utils.py
@@ -68,8 +68,57 @@ def eagle_prepare_next_token_padded_kernel(
         tl.store(valid_sampled_tokens_count_ptr + req_idx, valid_count)
 
 
+import torch
+
 import vllm.v1.spec_decode.utils
 
 vllm.v1.spec_decode.utils.eagle_prepare_next_token_padded_kernel = (
     eagle_prepare_next_token_padded_kernel
+)
+
+
+# MUSA-0109 / MUSA-0090 reproduction fix (2026-05-17): the upstream
+# `update_num_computed_tokens_for_batch_change` is wrapped with
+# `@torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)`,
+# and on MUSA the simple_compile_backend is Inductor. When the MUSA-0090
+# EagleFullLoopRunner captures a CUDAGraph and the next execute_model triggers
+# Inductor's Triton precompile of this function, the MUSA driver returns
+# "unknown error" (likely due to capture state interaction).
+# See generated/musa0109/musa0090-reproduction.md for the full trace.
+#
+# Workaround: replace this function with an eager (no torch.compile) version.
+# The function does only 5-6 small tensor ops on small tensors — eager is fine.
+
+def _musa_update_num_computed_tokens_for_batch_change(
+    num_computed_tokens: torch.Tensor,
+    num_accepted_tokens: torch.Tensor,
+    prev_positions: torch.Tensor,
+    valid_sampled_token_count: torch.Tensor,
+    prev_num_draft_tokens: torch.Tensor,
+    cpu_num_computed_tokens: torch.Tensor,
+) -> None:
+    """Eager (no torch.compile) version of update_num_computed_tokens_for_batch_change.
+
+    Same semantics as upstream; just avoids Inductor precompile on MUSA which
+    crashes after a MUSA-0090 EagleFullLoopRunner CUDAGraph replay.
+    """
+    gather_indices = prev_positions.clamp(min=0)
+    valid_counts = valid_sampled_token_count[gather_indices]
+    prev_computed = num_computed_tokens[gather_indices]
+    prev_drafts = prev_num_draft_tokens[gather_indices]
+
+    participating = (prev_positions >= 0) & (prev_drafts > 0)
+    corrected = prev_computed + valid_counts.int()
+
+    n = prev_positions.shape[0]
+    num_computed_tokens[:n].copy_(
+        torch.where(participating, corrected, cpu_num_computed_tokens)
+    )
+    num_accepted_tokens.copy_(
+        torch.where(participating, valid_counts, num_accepted_tokens)
+    )
+
+
+vllm.v1.spec_decode.utils.update_num_computed_tokens_for_batch_change = (
+    _musa_update_num_computed_tokens_for_batch_change
 )


### PR DESCRIPTION
### SOTA launch — M2.5 + Eagle3 (95.2 tok/s)

```bash
export VLLM_ATTENTION_BACKEND=TREE_ATTN
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export VLLM_DISABLE_COMPILE_CACHE=1
export PYTHONUNBUFFERED=1
export VLLM_MUSA_SPHERE_SILU_FP8=1   # MUSA-0101 sphere kernel (default on)

vllm serve <model-root>/MiniMax/MiniMax-M2.5 \
    --served-model-name MiniMax/MiniMax-M2.5 \
    --trust-remote-code --tensor-parallel-size 8 \
    --enable-auto-tool-choice --tool-call-parser minimax_m2 \
    --reasoning-parser minimax_m2_append_think \
    --host 0.0.0.0 --port 8000 \
    --no-enable-prefix-caching \
    --no-async-scheduling \
    --compilation-config '{"cudagraph_mode": "PIECEWISE", "pass_config": {"fuse_attn_quant": true}}' \
    --speculative-config '{"model": "<model-root>/thoughtworks/MiniMax-M2.5-Eagle3", "num_speculative_tokens": 3, "method": "eagle3", "speculative_token_tree": "[(0,), (1,), (0,0), (1,1), (0,0,0), (1,1,0)]"}'
```

### SOTA benchmark — random 4k/1k BS=1 greedy

Five-run warm-only with cold first run discarded. Always pass
`--temperature 0` (or include `temperature=0` in chat-completions
requests) — `vllm bench serve` no longer defaults to greedy, and
non-greedy sampling costs ~2× of the Eagle3 spec speedup on this stack.

```bash
vllm bench serve \
    --backend openai-chat --base-url http://localhost:8000 \
    --endpoint /v1/chat/completions \
    --model MiniMax/MiniMax-M2.5 \
    --dataset-name random \
    --random-input-len 4096 --random-output-len 1024 \
    --num-prompts 1 --max-concurrency 1 \
    --temperature 0 \
    --save-result --result-dir /tmp/mm25_perf --result-filename run.json
```