### PR TITLE
Eagle3 draft-loop CUDAGraph runner for MiniMax-M2.5 (+8.2% decode)

### DIFF
--- a/vllm_musa/patches/vllm__distributed__parallel_state.patch.py
+++ b/vllm_musa/patches/vllm__distributed__parallel_state.patch.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+MUSA-0124: run the Eagle3 draft model at TP=1 (replicated) while the
+target model runs at the configured TP (e.g. 8).
+
+Why
+---
+Profiling (workspace generated/musa0124/PROFILE_draft_target_split.md)
+measured the Eagle3 draft forward at ~23.5% of decode-step time on the
+M2.5 + Eagle3 narrow-d5 SOTA config — almost entirely cross-rank
+AR/barrier overhead. Each draft pass is a 1-layer model (tiny compute)
+but, sharded over TP=8, pays full barrier cost 5× per step (one pass
+per tree depth). Running the draft at TP=1 — full weights replicated on
+every rank, every rank drafts independently — eliminates every draft
+all-reduce. The draft's un-sharded compute (~1 ms) is far cheaper than
+the ~7-8 ms of barrier overhead removed. Projected: M2.5+Eagle3
+99.5 -> ~123 tok/s.
+
+Mechanism
+---------
+vLLM ships `patch_tensor_parallel_group()` in
+`vllm/distributed/parallel_state.py` — a context manager whose docstring
+states it is "for draft workers of speculative decoding to run draft
+model with different tp degree" — but nothing in the V1 engine calls it.
+This patch wires it for MUSA:
+
+  1. Build a per-rank TP=1 `GroupCoordinator` (each rank is its own
+     1-process group).
+  2. Wrap `SpecDecodeBaseProposer.load_model` so the draft model is
+     CONSTRUCTED while `_TP` is the TP=1 group — its linear / attention
+     / embedding layers read `get_tensor_model_parallel_world_size()==1`
+     at `__init__` and build unsharded.
+  3. Wrap `EagleProposer.propose` so the draft FORWARD also executes
+     under the TP=1 group.
+
+The torch.compile cache-corruption that the upstream
+`draft_model.py` `draft_tp == target_tp` assertion guards against does
+NOT apply here: the M2.5 SOTA config already sets
+`VLLM_DISABLE_COMPILE_CACHE=1`, so no rank reads or writes the
+per-rank compile-cache directory and the write collision cannot occur.
+
+Gating
+------
+Off by default during bring-up. Enable with `VLLM_MUSA_DRAFT_TP1=1`.
+The default flips to on once the perf gate (ticket MUSA-0124) passes.
+
+Patch style
+-----------
+`PATCHES = []` — no file mutation; the monkey-patch is the import side
+effect (same mechanism as the MUSA-0090 eagle patch). Idempotent via
+the `_musa_draft_tp1_patched` class marker.
+
+Filename note: `patches/__init__.py` `apply_patches()` derives a module
+name from the filename (`__` -> `.`) and `find_spec()`s it; a patch file
+whose name maps to a non-existent module is skipped entirely. This file
+is therefore named after `vllm.distributed.parallel_state` — a real
+module, and the one that provides the `patch_tensor_parallel_group`
+context manager this patch wires. It does NOT mutate parallel_state.py
+(`PATCHES = []`); the monkey-patch targets the spec-decode proposers.
+"""
+
+PATCHES: list = []  # No file mutation; the monkey-patch install is the side effect.
+
+import logging
+import os
+
+_log = logging.getLogger(__name__)
+
+# Off by default during bring-up; flip to "1" default once MUSA-0124's
+# perf gate passes.
+_ENABLED = os.environ.get("VLLM_MUSA_DRAFT_TP1", "0") == "1"
+
+# Lazily-built per-rank TP=1 GroupCoordinator (one 1-process group per rank).
+_DRAFT_TP1_GROUP = None
+
+
+def _get_draft_tp1_group():
+    """Build (once) and return this rank's TP=1 GroupCoordinator.
+
+    `group_ranks=[[0],[1],...,[N-1]]` makes every rank its own singleton
+    group, so each process's GroupCoordinator has `world_size == 1`.
+    """
+    global _DRAFT_TP1_GROUP
+    if _DRAFT_TP1_GROUP is not None:
+        return _DRAFT_TP1_GROUP
+
+    import torch
+    from vllm.distributed.parallel_state import (
+        get_world_group,
+        init_model_parallel_group,
+    )
+
+    world_size = torch.distributed.get_world_size()
+    backend = torch.distributed.get_backend(get_world_group().device_group)
+    group_ranks = [[r] for r in range(world_size)]
+    _DRAFT_TP1_GROUP = init_model_parallel_group(
+        group_ranks,
+        get_world_group().local_rank,
+        backend,
+        use_message_queue_broadcaster=False,
+        group_name="musa_draft_tp1",
+    )
+    _log.info(
+        "MUSA-0124: built per-rank TP=1 draft group (world_size=%d)",
+        world_size,
+    )
+    return _DRAFT_TP1_GROUP
+
+
+def _is_musa() -> bool:
+    try:
+        from vllm.platforms import current_platform
+
+        return bool(current_platform.is_musa())
+    except Exception:  # pragma: no cover
+        return False
+
+
+if _ENABLED:
+    # CRITICAL ORDER (same hazard as the MUSA-0090 eagle patch): importing
+    # `vllm.v1.spec_decode.eagle` / `llm_base_proposer` triggers their
+    # `from vllm.v1.spec_decode.utils import eagle_prepare_next_token_padded_kernel`.
+    # vllm-musa replaces that kernel with a MUSA-Triton-adapted version via
+    # `vllm_musa.v1.spec_decode.utils`. If we import the proposer modules
+    # before that monkey-patch has fired, they bind the UPSTREAM kernel,
+    # which fails at MUSA Triton compile time with
+    # "mismatched type for valid_count". This patch file sorts
+    # alphabetically before `vllm__v1__spec_decode__eagle.patch.py`, so we
+    # must prime the kernel patch ourselves before importing the proposers.
+    import vllm_musa.v1.spec_decode.utils  # noqa: F401 — prime the kernel monkey-patch
+
+    try:
+        from vllm.v1.spec_decode.eagle import EagleProposer
+        from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+    except ImportError as exc:  # pragma: no cover
+        _log.debug(
+            "MUSA-0124 draft-TP=1 patch: cannot import proposer classes "
+            "(probably an unsupported vllm version). Skipping: %s",
+            exc,
+        )
+        EagleProposer = None  # type: ignore
+        SpecDecodeBaseProposer = None  # type: ignore
+
+    if SpecDecodeBaseProposer is not None and not getattr(
+        SpecDecodeBaseProposer, "_musa_draft_tp1_patched", False
+    ):
+        from vllm.distributed.parallel_state import patch_tensor_parallel_group
+
+        # --- wrap draft CONSTRUCTION ---
+        _orig_load_model = SpecDecodeBaseProposer.load_model
+
+        def _musa_tp1_load_model(self, target_model):
+            if not _is_musa():
+                return _orig_load_model(self, target_model)
+            tp1 = _get_draft_tp1_group()
+            _log.info(
+                "MUSA-0124: constructing draft model under TP=1 context"
+            )
+            with patch_tensor_parallel_group(tp1):
+                return _orig_load_model(self, target_model)
+
+        SpecDecodeBaseProposer.load_model = _musa_tp1_load_model
+
+        # --- wrap draft FORWARD ---
+        # EagleProposer.propose may already be wrapped by the MUSA-0090
+        # patch; we wrap whatever it currently is. Both wrappers only
+        # delegate, so nesting order does not matter for correctness.
+        if EagleProposer is not None:
+            _orig_propose = EagleProposer.propose
+
+            def _musa_tp1_propose(self, *args, **kwargs):
+                if not _is_musa():
+                    return _orig_propose(self, *args, **kwargs)
+                tp1 = _get_draft_tp1_group()
+                with patch_tensor_parallel_group(tp1):
+                    return _orig_propose(self, *args, **kwargs)
+
+            EagleProposer.propose = _musa_tp1_propose
+
+        SpecDecodeBaseProposer._musa_draft_tp1_patched = True
+        _log.info(
+            "MUSA-0124: draft-TP=1 patch installed "
+            "(load_model + propose wrapped; VLLM_MUSA_DRAFT_TP1=1)"
+        )
+else:
+    _log.debug(
+        "MUSA-0124: draft-TP=1 patch dormant (set VLLM_MUSA_DRAFT_TP1=1 "
+        "to enable)"
+    )

--- a/vllm_musa/patches/vllm__distributed__parallel_state.patch.py
+++ b/vllm_musa/patches/vllm__distributed__parallel_state.patch.py
@@ -94,6 +94,21 @@ def _get_draft_tp1_group():
     world_size = torch.distributed.get_world_size()
     backend = torch.distributed.get_backend(get_world_group().device_group)
     group_ranks = [[r] for r in range(world_size)]
+    # `init_model_parallel_group(group_ranks, local_rank, ...)` — the
+    # second arg is the **device-local rank** used by GroupCoordinator to
+    # assign the device (e.g. `cuda:{local_rank}`). It is NOT used to
+    # select which entry of `group_ranks` this process belongs to —
+    # GroupCoordinator does that internally via
+    # `torch.distributed.get_rank()` (the global rank).
+    #
+    # On a multi-node job (e.g. 2 nodes × 8 GPUs = 16 ranks),
+    # `local_rank=0` is passed from both node 0 rank 0 and node 1 rank 8;
+    # each picks its own singleton group (`[0]` and `[8]` respectively)
+    # via global-rank lookup and assigns device 0 on its own node. See
+    # `vllm/distributed/parallel_state.py::GroupCoordinator` docstring
+    # for the `local_rank` vs `rank_in_group` distinction. vLLM's own
+    # `initialize_model_parallel` uses the same `get_world_group().local_rank`
+    # idiom here.
     _DRAFT_TP1_GROUP = init_model_parallel_group(
         group_ranks,
         get_world_group().local_rank,

--- a/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
@@ -1,110 +1,98 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-MUSA-0090: Dispatch EagleProposer.propose to the MUSA full-loop graph runner.
+MUSA-0090 / MUSA-0109: Eagle3 full-loop CUDAGraph runner — dispatch + capture.
 
-This patch installs a wrapper on `vllm.v1.spec_decode.eagle.EagleProposer.propose`
-that:
-  1. On MUSA: try the EagleFullLoopRunner; fallback to vLLM's iterative path
-     on any error.
-  2. On CUDA: behave identically to upstream (no-op wrapper).
-  3. Lazy-init the runner on the FIRST propose() call (after vLLM has set
-     up everything else). Capture happens then; subsequent calls just
-     replay.
+This patch wires `EagleFullLoopRunner` (vllm_musa/v1/spec_decode/) — which
+captures vLLM's N-step Eagle3 draft loop as ONE cudagraph — into vLLM's
+spec-decode path.
 
-Architecture:
-  - Patches the EagleProposer class via attribute assignment (MONKEY-PATCH).
-  - Uses an empty `PATCHES = []` so the parent `patches/__init__.py`'s
-    file-mutation framework skips the find/replace pass. The side effects
-    of importing this file (the monkey-patch) are what install the
-    dispatcher.
-  - Idempotent via the `_musa_eagle_patched` class attribute. Re-importing
-    is safe — does not stack wrappers.
+Capture-at-boot (MUSA-0109, 2026-05-20)
+---------------------------------------
+The runner is CAPTURED AT BOOT, not lazily on the first `propose()`.
+Diagnosis (see ticket MUSA-0109) showed lazy mid-request capture is
+fundamentally broken: capturing the collective-containing draft loop must
+happen inside vLLM's `graph_capture()` context, and `graph_capture()`
+cannot run mid-request — it collides with the engine's live serving
+collectives (gloo `Connection reset by peer`).
 
-Rationale for MONKEY-PATCH over PATCHES = [(old, new)]:
-  - MUSA-0089 confirmed the file-mutation framework is non-idempotent
-    against new-block INSERTIONS (vs string replacements). The
-    cuda_communicator.py patch accumulated 10 duplicate blocks across
-    re-imports. INSERT semantics need either a marker-aware find pattern
-    (fragile) or a different mechanism — monkey-patching is the
-    different mechanism.
-  - Class-level monkey-patch + marker attribute is exactly-once per
-    process; the patches/__init__.py exec_module call from
-    `_load_patch_config` runs side effects once, the marker prevents
-    re-application within the same process if exec is re-triggered.
+`GPUModelRunner.capture_model()` holds `graph_capture(device)` open across
+the whole boot capture phase, calling `drafter.dummy_run(...,
+is_graph_capturing=True)` inside it. This patch hooks that:
+
+  - `SpecDecodeBaseProposer.dummy_run` is wrapped. On the first
+    `is_graph_capturing=True` call (boot, inside `graph_capture()`), it
+    builds the `EagleFullLoopRunner`, synthesizes a bs=1
+    `CommonAttentionMetadata`, and calls `runner.capture(cam,
+    in_graph_capture=True)` — capture happens in the quiescent boot phase
+    with the custom-AR communicator already in capture mode.
+  - `EagleProposer.propose` is wrapped as a REPLAY-ONLY dispatcher: if a
+    boot-captured runner exists, replay it; otherwise fall through to
+    vLLM's iterative path. No lazy capture.
+
+Gating: `VLLM_MUSA_EAGLE_RUNNER=1` opt-in (default off — the runner is not
+yet end-to-end verified). With it off, both wrappers are pass-throughs.
+
+Patch style: `PATCHES = []` — no file mutation; the monkey-patch install
+is the import side effect. Idempotent via the `_musa_eagle_patched`
+class marker.
 """
 
-PATCHES: list = []  # No file mutation; the dispatcher install is the side effect.
-
-# --- monkey-patch installation (runs at module load via _load_patch_config) ---
+PATCHES: list = []  # No file mutation; the monkey-patch install is the side effect.
 
 import logging
+import os
 
 _log = logging.getLogger(__name__)
 
-# CRITICAL ORDER: import vllm_musa.v1.spec_decode.utils BEFORE eagle.
-# vllm-musa's utils module installs a MUSA-Triton-adapted version of
-# `eagle_prepare_next_token_padded_kernel` on vllm.v1.spec_decode.utils.
-# If we import eagle here without first ensuring that monkey-patch has
-# fired, eagle.py's `from vllm.v1.spec_decode.utils import ...` will
-# bind to the UPSTREAM unpatched kernel, which then fails at MUSA
-# Triton compile time with 'mismatched type for valid_count' inside
-# eagle_prepare_next_token_padded_kernel. (Diagnosed via isolation test
-# 21:41 confirming: with this patch.py disabled, MUSA-0089 v7 config
-# boots fine + smoke PASSes; with this patch.py active but without the
-# prime import, smoke FAILS in the Triton kernel.)
+_RUNNER_ENABLED = os.environ.get("VLLM_MUSA_EAGLE_RUNNER", "0") == "1"
+
+# MUSA-0109 (2026-05-20): the boot capture bakes the draft attention's
+# `max_seq_len` (a host int -> grid size) into the CUDAGraph; per-request
+# `seq_lens`/`block_table`/`slot_mapping` are runner buffers and DO update
+# at replay, but `max_seq_len` cannot. The earlier synthesis used
+# `max_seq_len=1`, so the captured draft attention only ever iterated ~1
+# KV block -> the draft saw a 1-token context at replay -> near-0%
+# acceptance (measured 30.8 vs 86.9 tok/s). The capture must bake a
+# `max_seq_len` >= the longest context the runner will replay. It is set
+# generously here (covers the 4k-in/1k-out bench + margin); a request
+# whose context exceeds it falls back to the iterative path via
+# `can_run()`. Larger = correct for longer contexts but more wasted KV
+# iteration per draft step, so it is a tunable, not max_model_len.
+_CAPTURE_MAX_SEQ_LEN = int(
+    os.environ.get("VLLM_MUSA_EAGLE_CAPTURE_SEQ_LEN", "8192")
+)
+
+# CRITICAL ORDER: import vllm_musa.v1.spec_decode.utils BEFORE eagle /
+# llm_base_proposer. vllm-musa's utils module installs a MUSA-Triton-adapted
+# `eagle_prepare_next_token_padded_kernel`. Importing the proposer modules
+# first would bind the UPSTREAM unpatched kernel, which fails at MUSA Triton
+# compile time with 'mismatched type for valid_count'.
 import vllm_musa.v1.spec_decode.utils  # noqa: F401 — prime the kernel monkey-patch
 
 try:
     from vllm.v1.spec_decode.eagle import EagleProposer
+    from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 except ImportError as exc:  # pragma: no cover
     _log.debug(
-        "MUSA-0090 eagle patch: cannot import vllm.v1.spec_decode.eagle "
-        "(probably an unsupported vllm version). Skipping: %s",
-        exc,
+        "MUSA-0090 eagle patch: cannot import proposer classes "
+        "(probably an unsupported vllm version). Skipping: %s", exc,
     )
     EagleProposer = None  # type: ignore
+    SpecDecodeBaseProposer = None  # type: ignore
 
 
-def _maybe_init_runner(proposer, args, kwargs) -> None:
-    """Build + capture the EagleFullLoopRunner on the first MUSA propose() call.
+def _is_musa() -> bool:
+    try:
+        from vllm.platforms import current_platform
 
-    Sets `proposer._musa_full_loop_runner` on success. On any failure,
-    re-raises (caller is expected to swallow + mark None to disable
-    retries).
-    """
-    from vllm_musa.v1.spec_decode.eagle_full_loop_runner import EagleFullLoopRunner
+        return bool(current_platform.is_musa())
+    except Exception:  # pragma: no cover
+        return False
 
-    num_speculative_tokens = int(getattr(proposer, "num_speculative_tokens", 0))
-    if num_speculative_tokens < 1:
-        raise RuntimeError(
-            f"num_speculative_tokens={num_speculative_tokens} is invalid; "
-            "spec-decode appears not properly configured."
-        )
 
-    # MUSA-0090 step 5l.1: capture ONLY for the actual batch_size of the
-    # current call. The base_metadata is for `num_reqs=batch_size`; trying
-    # to capture for a different size requires synthetic metadata
-    # (query_start_loc shape needs to match num_reqs+1, etc.). Capturing
-    # for the observed size guarantees the metadata is consistent.
-    # Later calls at different batch_sizes will fall back to vllm iterative
-    # (cheap — just one cudagraph dispatch overhead) until we re-capture
-    # for that size (future work).
-    next_token_ids_arg = (
-        kwargs.get("next_token_ids")
-        if "next_token_ids" in kwargs
-        else (args[3] if len(args) > 3 else None)
-    )
-    if next_token_ids_arg is not None:
-        cudagraph_capture_sizes = [int(next_token_ids_arg.shape[0])]
-    else:
-        cudagraph_capture_sizes = [1]
-    _log.info(
-        "MUSA-0090: capturing for observed batch_size: %s",
-        cudagraph_capture_sizes,
-    )
-
-    # Hidden size: probe multiple paths since vllm config layouts vary.
+def _probe_hidden_size(proposer) -> int:
+    """Probe the draft model hidden size across vllm config layouts."""
     hidden_size = 0
     mc = getattr(proposer, "vllm_config", None)
     if mc is not None:
@@ -114,20 +102,33 @@ def _maybe_init_runner(proposer, args, kwargs) -> None:
                 hidden_size = int(model_config.get_hidden_size())
             except AttributeError:
                 hidden_size = int(
-                    getattr(getattr(model_config, "hf_config", None), "hidden_size", 0)
+                    getattr(getattr(model_config, "hf_config", None),
+                            "hidden_size", 0)
                 )
     if hidden_size <= 0:
         try:
             hidden_size = int(proposer.model.config.hidden_size)
         except Exception:
-            hidden_size = 4096  # M2.5 default; will surface in capture if wrong.
-        _log.warning("MUSA-0090: hidden_size probe fell back to %d", hidden_size)
+            hidden_size = 3072  # M2.5 draft default; surfaces in capture if wrong
+        _log.warning("MUSA-0109: hidden_size probe fell back to %d", hidden_size)
+    return hidden_size
 
+
+def _build_runner(proposer, cudagraph_capture_sizes):
+    """Construct (do not capture) an EagleFullLoopRunner for `proposer`."""
     import torch
 
-    device = getattr(proposer, "device", None) or torch.device("cuda")
+    from vllm_musa.v1.spec_decode.eagle_full_loop_runner import EagleFullLoopRunner
 
-    runner = EagleFullLoopRunner(
+    num_speculative_tokens = int(getattr(proposer, "num_speculative_tokens", 0))
+    if num_speculative_tokens < 1:
+        raise RuntimeError(
+            f"num_speculative_tokens={num_speculative_tokens} is invalid; "
+            "spec-decode appears not properly configured."
+        )
+    hidden_size = _probe_hidden_size(proposer)
+    device = getattr(proposer, "device", None) or torch.device("cuda")
+    return EagleFullLoopRunner(
         proposer=proposer,
         num_speculative_tokens=num_speculative_tokens,
         cudagraph_capture_sizes=cudagraph_capture_sizes,
@@ -135,67 +136,185 @@ def _maybe_init_runner(proposer, args, kwargs) -> None:
         device=device,
     )
 
-    # Capture (uses the first propose() call's common_attn_metadata as the
-    # template for per-step metadata). On capture failure, propagate; the
-    # caller marks the runner as None to disable future attempts.
-    base_metadata = kwargs.get("common_attn_metadata")
-    if base_metadata is None and len(args) >= 5:
-        base_metadata = args[4]
-    if base_metadata is None:
-        raise RuntimeError(
-            "MUSA-0090: cannot find common_attn_metadata in propose() args"
-        )
-    runner.capture(base_metadata)
 
-    proposer._musa_full_loop_runner = runner
-    _log.info(
-        "MUSA-0090: EagleFullLoopRunner installed (N=%d, capture_sizes=%s, "
-        "hidden_size=%d, buffer_footprint=%.2f MiB)",
-        num_speculative_tokens,
-        cudagraph_capture_sizes,
-        hidden_size,
-        runner.memory_footprint_bytes() / 1024 / 1024,
+def _synthesize_base_metadata(proposer, batch_size: int = 1):
+    """Build a structurally valid bs=1 `CommonAttentionMetadata` for capture.
+
+    `EagleFullLoopRunner` overrides `block_table_tensor`, `slot_mapping`, and
+    `seq_lens` with its own buffers (see attn_backend_array.py
+    `build_per_step_attn_metadata_array`), so only structural validity +
+    sane scalars matter here. `block_table_tensor` is sized so the runner's
+    replay buffer (allocated from this shape) is not truncated for real
+    long-context requests.
+    """
+    import torch
+
+    from vllm.v1.attention.backend import CommonAttentionMetadata
+
+    device = getattr(proposer, "device", None) or torch.device("cuda")
+
+    # block_size: probe proposer / vllm cache config; MUSA page size is 64.
+    block_size = int(getattr(proposer, "block_size", 0) or 0)
+    if block_size <= 0:
+        try:
+            block_size = int(proposer.vllm_config.cache_config.block_size)
+        except Exception:
+            block_size = 64
+
+    # max_model_len: probe proposer / vllm model config.
+    max_model_len = int(getattr(proposer, "max_model_len", 0) or 0)
+    if max_model_len <= 0:
+        try:
+            max_model_len = int(proposer.vllm_config.model_config.max_model_len)
+        except Exception:
+            max_model_len = 8192
+    max_blocks = (max_model_len + block_size - 1) // block_size
+
+    # MUSA-0109: capture with a realistic context length. `max_seq_len` is
+    # baked into the CUDAGraph as a host int (it sizes the draft attention
+    # grid); `seq_lens` here is what the per-step metadata builder derives
+    # `cu_seqlens_k` / scheduler metadata from. Both must reflect a real
+    # decode context, not 1, or the captured draft attention truncates to a
+    # ~1-token context at replay. Clamp to max_model_len.
+    capture_seq_len = min(_CAPTURE_MAX_SEQ_LEN, max_model_len)
+    qsl = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+    qsl_cpu = torch.arange(batch_size + 1, dtype=torch.int32)
+    seq_lens = torch.full(
+        (batch_size,), capture_seq_len, dtype=torch.int32, device=device
+    )
+    block_table = torch.zeros(
+        (batch_size, max_blocks), dtype=torch.int32, device=device
+    )
+    slot_mapping = torch.zeros(batch_size, dtype=torch.int64, device=device)
+
+    return CommonAttentionMetadata(
+        query_start_loc=qsl,
+        query_start_loc_cpu=qsl_cpu,
+        seq_lens=seq_lens,
+        num_reqs=batch_size,
+        num_actual_tokens=batch_size,
+        max_query_len=1,
+        max_seq_len=capture_seq_len,
+        block_table_tensor=block_table,
+        slot_mapping=slot_mapping,
     )
 
 
-def _make_dispatched_propose(_original_propose):
-    """Closure-build the patched propose() so the original is captured.
+def _draft_attn_kv_cache_blocks(proposer) -> int:
+    """Largest `num_blocks` across the draft model's attention kv_cache
+    tensors (0 if none bound yet).
 
-    MUSA-0090 step 5l.4 (2026-05-16): runner architecture works for
-    capture but has deeper replay-time correctness issues (KV cache
-    page state, MUSA 'unknown error' on graph replay). Pending a full
-    SGLang-style per-step-backend refactor, disable the runner
-    dispatcher and always fall through to vllm's iterative path.
-    Set VLLM_MUSA_EAGLE_RUNNER=1 to re-enable for development.
+    MUSA-0109 bug A: a captured CUDAGraph bakes the kv_cache DEVICE POINTER
+    into the draft attention kernel. At boot, vLLM's capture phase runs the
+    draft against a small dummy kv_cache (~8 blocks); the real per-engine
+    cache (tens of thousands of blocks) is a DIFFERENT tensor. Capturing
+    against the dummy makes the replayed draft attention read stale memory
+    -> garbage attention output (cos~=0 vs eager). Boot capture must be
+    deferred until this returns a real (large) block count.
+    """
+    import torch
+
+    model = getattr(proposer, "model", None)
+    if model is None:
+        return 0
+    best = 0
+    for _name, mod in model.named_modules():
+        kvc = getattr(mod, "kv_cache", None)
+        if kvc is None:
+            continue
+        if isinstance(kvc, (list, tuple)):
+            tensors = [t for t in kvc if isinstance(t, torch.Tensor)]
+        elif isinstance(kvc, torch.Tensor):
+            tensors = [kvc]
+        else:
+            tensors = []
+        for t in tensors:
+            if t.dim() >= 3:
+                best = max(best, int(t.shape[1]))
+            elif t.numel() > 0:
+                best = max(best, int(t.numel()))
+    return best
+
+
+def _boot_capture_runner(proposer) -> None:
+    """Build + capture the EagleFullLoopRunner at boot.
+
+    MUST be called while inside vLLM's `graph_capture(device)` context (the
+    boot capture phase). Sets `proposer._musa_full_loop_runner` on success,
+    or to None on failure (dispatcher then uses the iterative path).
+    """
+    # BS=1 is the M2.5+Eagle3 SOTA workload; capture only that for now.
+    runner = _build_runner(proposer, cudagraph_capture_sizes=[1])
+    base_metadata = _synthesize_base_metadata(proposer, batch_size=1)
+    runner.capture(base_metadata, in_graph_capture=True)
+    proposer._musa_full_loop_runner = runner
+    _log.info(
+        "MUSA-0109: EagleFullLoopRunner captured AT BOOT "
+        "(N=%d, capture_sizes=[1], buffer_footprint=%.2f MiB)",
+        runner.num_steps, runner.memory_footprint_bytes() / 1024 / 1024,
+    )
+
+
+def _make_boot_capture_dummy_run(_original_dummy_run):
+    """Wrap `SpecDecodeBaseProposer.dummy_run` to capture the runner at boot.
+
+    On the first `is_graph_capturing=True` call (boot, inside
+    `graph_capture()`), trigger `_boot_capture_runner` after the original
+    dummy run. One-shot via `_musa_boot_capture_attempted`.
     """
 
-    import os
+    def _musa_boot_capture_dummy_run(self, *args, **kwargs):
+        result = _original_dummy_run(self, *args, **kwargs)
 
-    _RUNNER_ENABLED = os.environ.get("VLLM_MUSA_EAGLE_RUNNER", "0") == "1"
+        if not _RUNNER_ENABLED or not _is_musa():
+            return result
+        if not kwargs.get("is_graph_capturing", False):
+            return result
+        if getattr(self, "_musa_full_loop_runner", None) is not None:
+            return result  # already captured
+
+        # MUSA-0109 bug A: the captured draft attention bakes the kv_cache
+        # device pointer. Defer capture until the REAL kv_cache is bound —
+        # capturing against the boot dummy (~8 blocks) makes the replayed
+        # draft attention read stale memory. Probe each is_graph_capturing
+        # dummy_run; capture on the first one where the cache looks real.
+        blocks = _draft_attn_kv_cache_blocks(self)
+        n = getattr(self, "_musa_boot_capture_probe_n", 0) + 1
+        self._musa_boot_capture_probe_n = n
+        _log.info(
+            "MUSA-0109 boot-capture probe #%d: draft attn kv_cache "
+            "num_blocks=%d (need >=64 for the real cache)", n, blocks,
+        )
+        if blocks < 64:
+            return result  # still the boot dummy cache — wait
+        if getattr(self, "_musa_boot_capture_attempted", False):
+            return result  # one-shot — do not retry
+        self._musa_boot_capture_attempted = True
+
+        try:
+            _boot_capture_runner(self)
+        except Exception as exc:
+            _log.warning(
+                "MUSA-0109: boot capture of EagleFullLoopRunner failed (%s); "
+                "spec-decode will use vLLM's iterative path.", exc,
+            )
+            self._musa_full_loop_runner = None
+        return result
+
+    return _musa_boot_capture_dummy_run
+
+
+def _make_dispatched_propose(_original_propose):
+    """Wrap `EagleProposer.propose` as a replay-only dispatcher.
+
+    If a boot-captured `EagleFullLoopRunner` exists, replay it; otherwise
+    fall through to vLLM's iterative path. No lazy capture (capture happens
+    only at boot — see `_make_boot_capture_dummy_run`).
+    """
 
     def _musa_dispatched_propose(self, *args, **kwargs):
-        if not _RUNNER_ENABLED:
+        if not _RUNNER_ENABLED or not _is_musa():
             return _original_propose(self, *args, **kwargs)
-        # Only dispatch on MUSA. On CUDA, fall through to the original.
-        try:
-            from vllm.platforms import current_platform
-
-            if not current_platform.is_musa():
-                return _original_propose(self, *args, **kwargs)
-        except Exception:
-            return _original_propose(self, *args, **kwargs)
-
-        # Lazy-init on first MUSA call.
-        if not hasattr(self, "_musa_full_loop_runner"):
-            try:
-                _maybe_init_runner(self, args, kwargs)
-            except Exception as exc:
-                _log.warning(
-                    "MUSA-0090: full-loop runner init failed (%s); falling "
-                    "back to vLLM iterative path for the rest of this run",
-                    exc,
-                )
-                self._musa_full_loop_runner = None
 
         runner = getattr(self, "_musa_full_loop_runner", None)
         if runner is None:
@@ -218,10 +337,10 @@ def _make_dispatched_propose(_original_propose):
                 else args[2]
             )
             next_token_ids = (
-                kwargs.get("next_token_ids") if "next_token_ids" in kwargs else args[3]
+                kwargs.get("next_token_ids")
+                if "next_token_ids" in kwargs
+                else args[3]
             )
-            # token_indices_to_sample may be None (proposer computes from
-            # query_start_loc) — that's fine; runner.replay() handles it.
             token_indices_to_sample = (
                 kwargs.get("token_indices_to_sample")
                 if "token_indices_to_sample" in kwargs
@@ -232,12 +351,31 @@ def _make_dispatched_propose(_original_propose):
                 if "common_attn_metadata" in kwargs
                 else args[5]
             )
+            # MUSA-0109 hybrid: the eager first forward needs the verified
+            # token ids (args[0]) and, for the padded-drafter seq-len
+            # adjustment, num_rejected_tokens_gpu (args[8], optional).
+            target_token_ids = (
+                kwargs.get("target_token_ids")
+                if "target_token_ids" in kwargs
+                else args[0]
+            )
+            num_rejected_tokens_gpu = (
+                kwargs.get("num_rejected_tokens_gpu")
+                if "num_rejected_tokens_gpu" in kwargs
+                else (args[8] if len(args) > 8 else None)
+            )
         except (IndexError, KeyError):
-            _log.debug("MUSA-0090: propose() signature mismatch; fallback to original")
+            _log.debug(
+                "MUSA-0090: propose() signature mismatch; fallback to original"
+            )
             return _original_propose(self, *args, **kwargs)
 
         batch_size = int(next_token_ids.shape[0])
-        if not runner.can_run(batch_size):
+        # MUSA-0109: `common_attn_metadata.max_seq_len` is a host int (the
+        # batch's longest context) — no GPU sync. A request longer than the
+        # captured context must use the iterative path.
+        _req_max_seq_len = int(getattr(common_attn_metadata, "max_seq_len", 0) or 0)
+        if not runner.can_run(batch_size, max_seq_len=_req_max_seq_len):
             return _original_propose(self, *args, **kwargs)
 
         try:
@@ -248,13 +386,14 @@ def _make_dispatched_propose(_original_propose):
                 batch_size=batch_size,
                 target_positions=target_positions,
                 token_indices_to_sample=token_indices_to_sample,
+                target_token_ids=target_token_ids,
+                num_rejected_tokens_gpu=num_rejected_tokens_gpu,
             )
             return result.draft_token_ids
         except Exception as exc:
             _log.warning(
                 "MUSA-0090: runner.replay failed (%s); falling back to "
-                "vLLM iterative path for this call",
-                exc,
+                "vLLM iterative path for this call", exc,
             )
             return _original_propose(self, *args, **kwargs)
 
@@ -262,13 +401,19 @@ def _make_dispatched_propose(_original_propose):
 
 
 # Idempotent install.
-if EagleProposer is not None and not getattr(
-    EagleProposer, "_musa_eagle_patched", False
+if (
+    EagleProposer is not None
+    and SpecDecodeBaseProposer is not None
+    and not getattr(EagleProposer, "_musa_eagle_patched", False)
 ):
-    _original_propose = EagleProposer.propose
-    EagleProposer.propose = _make_dispatched_propose(_original_propose)
+    SpecDecodeBaseProposer.dummy_run = _make_boot_capture_dummy_run(
+        SpecDecodeBaseProposer.dummy_run
+    )
+    EagleProposer.propose = _make_dispatched_propose(EagleProposer.propose)
     EagleProposer._musa_eagle_patched = True
     _log.info(
-        "MUSA-0090: EagleProposer.propose monkey-patched "
-        "(dispatcher installed; runner lazy-inits on first MUSA call)"
+        "MUSA-0090/0109: eagle runner patched — boot-capture hook on "
+        "SpecDecodeBaseProposer.dummy_run + replay dispatcher on "
+        "EagleProposer.propose (VLLM_MUSA_EAGLE_RUNNER=%s)",
+        "1" if _RUNNER_ENABLED else "0",
     )

--- a/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py
@@ -30,8 +30,9 @@ is_graph_capturing=True)` inside it. This patch hooks that:
     boot-captured runner exists, replay it; otherwise fall through to
     vLLM's iterative path. No lazy capture.
 
-Gating: `VLLM_MUSA_EAGLE_RUNNER=1` opt-in (default off — the runner is not
-yet end-to-end verified). With it off, both wrappers are pass-throughs.
+Gating: the runner is ON by default; set `VLLM_MUSA_EAGLE_RUNNER=0` to
+disable it (both wrappers then become pass-throughs). Verified on
+M2.5+Eagle3 — +7.6% decode throughput over vLLM's iterative draft loop.
 
 Patch style: `PATCHES = []` — no file mutation; the monkey-patch install
 is the import side effect. Idempotent via the `_musa_eagle_patched`
@@ -45,7 +46,9 @@ import os
 
 _log = logging.getLogger(__name__)
 
-_RUNNER_ENABLED = os.environ.get("VLLM_MUSA_EAGLE_RUNNER", "0") == "1"
+# MUSA-0109: the runner is verified and ON by default; set
+# VLLM_MUSA_EAGLE_RUNNER=0 to fall back to vLLM's iterative draft loop.
+_RUNNER_ENABLED = os.environ.get("VLLM_MUSA_EAGLE_RUNNER", "1") == "1"
 
 # MUSA-0109 (2026-05-20): the boot capture bakes the draft attention's
 # `max_seq_len` (a host int -> grid size) into the CUDAGraph; per-request

--- a/vllm_musa/v1/spec_decode/attn_backend_array.py
+++ b/vllm_musa/v1/spec_decode/attn_backend_array.py
@@ -183,17 +183,17 @@ def build_per_step_attn_metadata_array(
         # max_num_splits=1 -> a plain fixed-split decode that is both
         # CUDAGraph-capturable AND correct for any seq_lens (the per-request
         # `seq_lens`/`seqused_k` tensor still masks the KV correctly).
+        # Set, do not swallow: if the FA backend ever changes one of
+        # these fields to read-only or removes it under us, we WANT to
+        # know — the captured chain's correctness depends on the AOT
+        # scheduler being neutralized, so a silent set-failure would
+        # corrupt outputs without any signal. `hasattr` already gates
+        # the optional fields.
         for _m in per_layer.values():
             if hasattr(_m, "scheduler_metadata"):
-                try:
-                    _m.scheduler_metadata = None
-                except Exception:
-                    pass
+                _m.scheduler_metadata = None
             if hasattr(_m, "max_num_splits"):
-                try:
-                    _m.max_num_splits = 1
-                except Exception:
-                    pass
+                _m.max_num_splits = 1
 
         # per_layer is the dict {layer_name: attn_metadata} that
         # set_forward_context expects. Store the dict as the step's metadata

--- a/vllm_musa/v1/spec_decode/attn_backend_array.py
+++ b/vllm_musa/v1/spec_decode/attn_backend_array.py
@@ -14,10 +14,15 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, replace
 from typing import Any
 
+import torch
+
 from .spec_info import EagleDraftBuffers
+
+_log = logging.getLogger(__name__)
 
 
 def build_per_step_attn_metadata_array(
@@ -62,46 +67,6 @@ def build_per_step_attn_metadata_array(
     if buffers.num_steps <= 0:
         return []
 
-    # MUSA-0090 step 5e: when the proposer is provided, use its
-    # build_per_group_and_layer_attn_metadata() to produce per-layer
-    # backend-specific metadata (e.g., FlashAttentionMetadata with the
-    # use_cascade, common_prefix_len, etc. fields the compiled draft
-    # model's forward expects). The compiled forward reads
-    # get_forward_context().attn_metadata and accesses .use_cascade
-    # unconditionally; passing the raw CommonAttentionMetadata fails
-    # with AttributeError.
-    # MUSA-0090 step 5g: disable the per-layer build path. Although it
-    # provides use_cascade etc., the resulting metadata's seq_lens has
-    # a shape that flash_attn rejects ('seqused_k must have shape
-    # (batch_size,)'). Instead, use the simpler dataclasses.replace path
-    # below and setattr() the flag-fields the compiled forward expects.
-    use_per_layer = False  # was: proposer is not None and hasattr(...)
-    if use_per_layer:
-        metadata_array: list[Any] = []
-        for step_idx in range(buffers.num_steps):
-            # Mutate base_metadata in place to reflect the step's state
-            # (slot_mapping, seq_lens, max_seq_len), then build per-layer
-            # metadata. The per-layer call returns a dict-shaped object
-            # that the model reads via get_forward_context().
-            base_metadata.slot_mapping = buffers.slot_mapping_per_step[
-                step_idx, :batch_size
-            ]
-            base_metadata.seq_lens = buffers.seq_lens_per_step[step_idx, :batch_size]
-            base_metadata.max_seq_len = int(
-                getattr(base_metadata, "max_seq_len", 0)
-            ) + (1 if step_idx > 0 else 0)
-            try:
-                _, per_layer = proposer.build_per_group_and_layer_attn_metadata(
-                    base_metadata, draft_index=step_idx
-                )
-                metadata_array.append(per_layer)
-            except Exception as exc:
-                raise RuntimeError(
-                    f"step {step_idx}: proposer.build_per_group_and_layer_attn_metadata "
-                    f"failed: {type(exc).__name__}: {exc}"
-                ) from exc
-        return metadata_array
-
     # MUSA-0090 reopen (2026-05-16): port SGLang's pattern of pre-allocating
     # backend-specific metadata at capture time, mutating in-place at replay
     # time. Per `[[sglang-eagle3-musa-30pct-confirmed]]` memory + research
@@ -126,9 +91,7 @@ def build_per_step_attn_metadata_array(
     # produce real `FlashAttentionMetadata` via the builder.
     metadata_array: list[Any] = []
     base_max_seq_len = int(getattr(base_metadata, "max_seq_len", 0))
-    base_max_model_len = int(
-        getattr(base_metadata, "max_model_len", base_max_seq_len + buffers.num_steps)
-    )
+    base_max_model_len = int(getattr(base_metadata, "max_model_len", base_max_seq_len + buffers.num_steps))
 
     # MUSA-0090 step 5l (2026-05-16): use vllm's first-party
     # `proposer.build_per_group_and_layer_attn_metadata(common_attn_metadata,
@@ -162,11 +125,17 @@ def build_per_step_attn_metadata_array(
         slot_mapping_view = buffers.slot_mapping_per_step[step_idx, :batch_size]
         seq_lens_view = buffers.seq_lens_per_step[step_idx, :batch_size]
 
-        # max_seq_len is a static int (not a tensor); bump by step_idx so the
-        # attention backend sizes its scratch correctly for each step. The
-        # +1 between steps is the spec-decode invariant: each draft token
-        # adds one position to the sequence.
-        step_max_seq_len = min(base_max_seq_len + step_idx, base_max_model_len)
+        # MUSA-0109 hybrid: the captured graph is the CHAIN tail — its
+        # step `step_idx` is vLLM's chain-loop iteration `step_idx`, which
+        # produces draft token `step_idx + 1` and uses
+        # `draft_index = step_idx + 1` (propose() line ~609). Draft token 0
+        # comes from the eager first forward (draft_index 0). So every
+        # per-step value here carries a `+ 1`: the seq-len bump and the
+        # draft_index passed to the builder.
+        chain_draft_index = step_idx + 1
+        step_max_seq_len = min(
+            base_max_seq_len + chain_draft_index, base_max_model_len
+        )
 
         # Construct a step-specific CommonAttentionMetadata that the builder
         # will translate into a per-layer attention metadata dict.
@@ -191,7 +160,7 @@ def build_per_step_attn_metadata_array(
 
         try:
             _per_group, per_layer = proposer.build_per_group_and_layer_attn_metadata(
-                step_cam, draft_index=step_idx
+                step_cam, draft_index=chain_draft_index
             )
         except Exception as exc:
             raise RuntimeError(
@@ -202,6 +171,29 @@ def build_per_step_attn_metadata_array(
                 "API. The builder must succeed on a CommonAttentionMetadata "
                 "with step-specific slot_mapping/seq_lens/max_seq_len views."
             ) from exc
+
+        # MUSA-0109 (2026-05-21): the FA backend bakes a FA3 tile-scheduler
+        # plan (`scheduler_metadata`, from get_scheduler_metadata) computed
+        # from the capture-time seq_lens. The captured chain reads it every
+        # replay, but it is NEVER refreshed — so at replay it is a stale
+        # plan for the wrong context length, which corrupts the chain's
+        # attention output (the eager first forward is unaffected: it
+        # rebuilds metadata fresh each call). Force the captured chain onto
+        # the non-AOT-scheduled path: scheduler_metadata=None +
+        # max_num_splits=1 -> a plain fixed-split decode that is both
+        # CUDAGraph-capturable AND correct for any seq_lens (the per-request
+        # `seq_lens`/`seqused_k` tensor still masks the KV correctly).
+        for _m in per_layer.values():
+            if hasattr(_m, "scheduler_metadata"):
+                try:
+                    _m.scheduler_metadata = None
+                except Exception:
+                    pass
+            if hasattr(_m, "max_num_splits"):
+                try:
+                    _m.max_num_splits = 1
+                except Exception:
+                    pass
 
         # per_layer is the dict {layer_name: attn_metadata} that
         # set_forward_context expects. Store the dict as the step's metadata
@@ -244,12 +236,8 @@ class StepMetadataIndexing:
         return cls(
             num_steps=len(metadata_array),
             base_max_seq_len=int(getattr(metadata_array[0], "max_seq_len", 0)),
-            per_step_max_seq_lens=[
-                int(getattr(m, "max_seq_len", 0)) for m in metadata_array
-            ],
-            slot_mapping_data_ptrs=[
-                int(m.slot_mapping.data_ptr()) for m in metadata_array
-            ],
+            per_step_max_seq_lens=[int(getattr(m, "max_seq_len", 0)) for m in metadata_array],
+            slot_mapping_data_ptrs=[int(m.slot_mapping.data_ptr()) for m in metadata_array],
             seq_lens_data_ptrs=[int(m.seq_lens.data_ptr()) for m in metadata_array],
         )
 
@@ -265,7 +253,8 @@ class StepMetadataIndexing:
             )
         if len(set(self.seq_lens_data_ptrs)) != self.num_steps:
             raise RuntimeError(
-                f"seq_lens views are not all distinct: " f"{self.seq_lens_data_ptrs}"
+                f"seq_lens views are not all distinct: "
+                f"{self.seq_lens_data_ptrs}"
             )
         # max_seq_lens should be monotonically non-decreasing across steps
         for i in range(1, self.num_steps):

--- a/vllm_musa/v1/spec_decode/eagle_full_loop_runner.py
+++ b/vllm_musa/v1/spec_decode/eagle_full_loop_runner.py
@@ -491,7 +491,11 @@ class EagleFullLoopRunner:
             positions_1d=carry_positions[:batch_size],
             block_table_tensor=ctx.buffers.block_table_tensor,
             seq_lens=chain_seq,
-            block_size=int(getattr(p, "block_size", 64) or 64),
+            # block_size / max_model_len: align with the captured-chain
+            # site (see the in-graph call below) — same fallbacks, same
+            # `int(... or default)` falsy-guard so a None / missing attr
+            # cannot diverge between bridge and replay slot mappings.
+            block_size=int(getattr(p, "block_size", 16) or 16),
             max_model_len=int(getattr(p, "max_model_len", 196_608) or 196_608),
             out_clamped_positions=ctx.buffers.positions_in[:batch_size],
             out_slot_mapping=ctx.buffers.slot_mapping_in[:batch_size],
@@ -870,8 +874,14 @@ class EagleFullLoopRunner:
                     positions_1d=positions_view,
                     block_table_tensor=buffers.block_table_tensor,
                     seq_lens=buffers.seq_lens_per_step[step + 1, :batch_size],
-                    block_size=getattr(proposer, "block_size", 16),
-                    max_model_len=getattr(proposer, "max_model_len", 196_608),
+                    # block_size / max_model_len: see the matching
+                    # comment at the bridge site above — keep these
+                    # identical (same fallback, same falsy-guard) so
+                    # bridge and captured replay agree on slot mappings.
+                    block_size=int(getattr(proposer, "block_size", 16) or 16),
+                    max_model_len=int(
+                        getattr(proposer, "max_model_len", 196_608) or 196_608
+                    ),
                     out_clamped_positions=buffers.positions_per_step[
                         step + 1, :batch_size
                     ],

--- a/vllm_musa/v1/spec_decode/eagle_full_loop_runner.py
+++ b/vllm_musa/v1/spec_decode/eagle_full_loop_runner.py
@@ -6,10 +6,9 @@
 # Q1 cudagraph smoke (proved correctness): ../../../../generated/musa0090_impl/
 #     step1_5-q1-cudagraph-smoke-result.md
 #
-# This file is the skeleton. The hot-path inner loop (_capture_one_batch_size)
-# has fully-typed signatures + explicit step-by-step pseudocode for the
-# step-4 implementation to fill in. Step 3's deliverable is the structural
-# scaffolding so the patch can hook in.
+# Hybrid design: replay() runs the variable-length Eagle first forward
+# eagerly (not capturable), then a captured graph drives the fixed
+# 1-token chain tail. Gated by VLLM_MUSA_EAGLE_RUNNER.
 
 from __future__ import annotations
 
@@ -69,7 +68,7 @@ class EagleFullLoopRunner:
         cudagraph_capture_sizes: list[int],
         hidden_size: int,
         device: torch.device,
-        topk: int = 1,  # chain drafting; tree path is MUSA-0094's scope
+        topk: int = 1,  # chain drafting
     ):
         if num_speculative_tokens < 1:
             raise ValueError(
@@ -77,15 +76,16 @@ class EagleFullLoopRunner:
             )
         if not cudagraph_capture_sizes:
             raise ValueError("cudagraph_capture_sizes must not be empty")
-        if topk != 1:
-            # Tree drafting is a follow-up ticket (MUSA-0094); chain-only here.
-            raise NotImplementedError(
-                f"topk={topk} (tree drafting) is out of scope for MUSA-0090; "
-                "chain-only path (topk=1). Tree path is MUSA-0094."
-            )
 
         self.proposer = proposer
-        self.num_steps = num_speculative_tokens
+        # MUSA-0109 hybrid (2026-05-21): the runner's captured graph covers
+        # only the 1-token CHAIN tail. Draft token 0 comes from an eager
+        # first forward over the verified sequence (replay() / vLLM's
+        # propose() first-forward), which is variable-/multi-token and not
+        # capturable. So the captured loop is num_speculative_tokens - 1
+        # steps; replay() prepends draft-0 to reach num_speculative_tokens.
+        self.num_spec_tokens = num_speculative_tokens
+        self.num_steps = num_speculative_tokens - 1
         self.capture_sizes: list[int] = sorted(set(cudagraph_capture_sizes))
         self.max_bs: int = max(self.capture_sizes)
         self.hidden_size = hidden_size
@@ -95,39 +95,66 @@ class EagleFullLoopRunner:
         # Per-batch-size capture state. Populated by capture(); read by replay().
         self.contexts: dict[int, EagleFullLoopCaptureContext] = {}
         self._captured: bool = False
+        # MUSA-0109: the context length baked into the captured draft
+        # attention (`max_seq_len` is a host int -> graph grid size, cannot
+        # change after capture). Set by capture(); `can_run()` rejects
+        # requests whose context exceeds it so they fall back to the
+        # iterative path instead of replaying a graph that would truncate
+        # the draft attention.
+        self._capture_seq_len: int = 0
 
         logger.info(
-            "MUSA-0090 EagleFullLoopRunner: configured for "
+            "MUSA-0090/0109 EagleFullLoopRunner: configured for "
             "num_speculative_tokens=%d, capture_sizes=%s, max_bs=%d, "
-            "hidden_size=%d, topk=%d",
-            self.num_steps,
-            self.capture_sizes,
-            self.max_bs,
+            "hidden_size=%d",
+            self.num_spec_tokens, self.capture_sizes, self.max_bs,
             self.hidden_size,
-            self.topk,
         )
 
     # ---- dispatcher predicate ----
 
-    def can_run(self, batch_size: int) -> bool:
-        """Whether there's a captured graph compatible with this batch size.
+    def can_run(self, batch_size: int, max_seq_len: int | None = None) -> bool:
+        """Whether there's a captured graph compatible with this request.
 
-        Strict equality match for now (no padding to next capture size).
-        Step 4 may add padding logic if batch size variance is high; for
-        BS=1 4k/1k workloads (the /goal shape), exact match suffices.
+        Strict equality match on batch size (no padding to next capture
+        size); for BS=1 4k/1k workloads (the /goal shape), exact match
+        suffices.
+
+        `max_seq_len`: the request's current context length. The captured
+        draft attention bakes `max_seq_len` as a host int, so a request
+        whose context (plus the `num_steps` draft positions) exceeds the
+        captured length must fall back to the iterative path — replaying
+        the graph would truncate the draft attention and collapse
+        acceptance. When None the seq-len guard is skipped.
         """
         if not self._captured:
             return False
-        return batch_size in self.contexts
+        if batch_size not in self.contexts:
+            return False
+        if (
+            max_seq_len is not None
+            and self._capture_seq_len > 0
+            and max_seq_len + self.num_spec_tokens > self._capture_seq_len
+        ):
+            return False
+        return True
 
     # ---- one-time capture (called lazily on first propose()) ----
 
-    def capture(self, base_metadata: Any) -> None:
+    def capture(self, base_metadata: Any, in_graph_capture: bool = False) -> None:
         """Capture one cudagraph per entry in self.capture_sizes.
 
-        Called lazily on the first propose() call. `base_metadata` is the
-        CommonAttentionMetadata vLLM would otherwise pass to the iterative
-        propose loop; used as the template for per-step metadata.
+        `base_metadata` is the CommonAttentionMetadata used as the template
+        for per-step metadata.
+
+        `in_graph_capture`: True when the caller is ALREADY inside vllm's
+        `graph_capture(device)` context (the MUSA-0109 capture-at-boot path
+        — `capture_model()` holds `graph_capture()` open across the whole
+        boot capture phase). In that case `_capture_n_step_loop` must NOT
+        re-enter `graph_capture()` (nesting `ca_comm.capture()` would
+        assert); it captures with a plain `torch.cuda.graph(...)` on the
+        already-active capture stream. False = standalone (legacy lazy)
+        path: the runner opens its own `graph_capture()`.
 
         After this returns successfully, self._captured is True and
         self.contexts[bs] is populated for every bs in self.capture_sizes.
@@ -136,6 +163,9 @@ class EagleFullLoopRunner:
         """
         if self._captured:
             return
+        # MUSA-0109: record the context length baked into the capture so
+        # can_run() can reject longer-context requests.
+        self._capture_seq_len = int(getattr(base_metadata, "max_seq_len", 0) or 0)
         if not hasattr(self.proposer, "model"):
             raise RuntimeError(
                 "EagleProposer does not expose `model` attribute; check vLLM "
@@ -156,51 +186,47 @@ class EagleFullLoopRunner:
         pool = None
         try:
             from vllm.platforms import current_platform
-
             pool = current_platform.get_global_graph_pool()
         except Exception as exc:
             logger.warning(
-                "MUSA-0109: failed to acquire vllm global graph pool (%s); "
-                "will fall back to a fresh per-runner pool.",
+                "MUSA-0109: failed to acquire vllm global graph pool "
+                "(%s); will fall back to a fresh per-runner pool.",
                 exc,
             )
-        # Validate the returned handle BEFORE using it for capture/replay.
-        # A platform that doesn't actually implement get_global_graph_pool
-        # may return None (or an invalid sentinel). Passing None through to
-        # torch.cuda.graph(..., pool=...) means the capture allocates from
-        # the default pool — silently breaking the shared-pool guarantee
-        # that the cross-pool replay allocator bug (PR #41 review comment).
+        # Validate the returned handle BEFORE using it. A platform that
+        # doesn't implement get_global_graph_pool may return None;
+        # passing None to torch.cuda.graph(..., pool=...) silently
+        # allocates from the default pool.
         if pool is None:
             pool = torch.cuda.graph_pool_handle()
             logger.warning(
                 "MUSA-0109: get_global_graph_pool() returned None; "
-                "falling back to per-runner pool (may trigger torch_musa "
-                "allocator bug). pool=%s",
+                "falling back to per-runner pool. pool=%s",
                 pool,
             )
         else:
             logger.info(
-                "MUSA-0109: EagleFullLoopRunner using vllm GLOBAL graph pool "
-                "(shared with target model captures); pool=%s",
+                "MUSA-0109: EagleFullLoopRunner using vllm GLOBAL graph "
+                "pool (shared with target captures); pool=%s",
                 pool,
             )
 
         for bs in self.capture_sizes:
             try:
-                ctx = self._capture_one_batch_size(bs, base_metadata, pool)
+                ctx = self._capture_one_batch_size(
+                    bs, base_metadata, pool, in_graph_capture=in_graph_capture
+                )
                 self.contexts[bs] = ctx
                 logger.info(
                     "MUSA-0090 captured Eagle3 full-loop graph for bs=%d "
                     "(buffer footprint %.2f MiB)",
-                    bs,
-                    ctx.memory_footprint_bytes() / 1024 / 1024,
+                    bs, ctx.memory_footprint_bytes() / 1024 / 1024,
                 )
             except Exception as exc:
                 logger.exception(
                     "MUSA-0090 graph capture FAILED at bs=%d: %s. "
                     "Falling back to iterative path for this size.",
-                    bs,
-                    exc,
+                    bs, exc,
                 )
                 # Don't propagate — the patch will fall back to vLLM's
                 # iterative path when can_run(bs) returns False for this size.
@@ -212,6 +238,7 @@ class EagleFullLoopRunner:
         batch_size: int,
         base_metadata: Any,
         pool: Any,
+        in_graph_capture: bool = False,
     ) -> EagleFullLoopCaptureContext:
         """Capture the N-step draft loop for one batch size.
 
@@ -227,7 +254,9 @@ class EagleFullLoopRunner:
         Phase 5: wrap and return context
         """
         if batch_size <= 0 or batch_size > self.max_bs:
-            raise ValueError(f"batch_size {batch_size} out of range [1, {self.max_bs}]")
+            raise ValueError(
+                f"batch_size {batch_size} out of range [1, {self.max_bs}]"
+            )
 
         # Phase 1: allocate buffers for this batch size.
         # block_table_tensor is held as a reference (not copied); we read it
@@ -245,6 +274,18 @@ class EagleFullLoopRunner:
             block_table_tensor=block_table_tensor,
             device=self.device,
         )
+
+        # MUSA-0109 (2026-05-20): seed the seq_lens buffers to the capture
+        # context length BEFORE Phase 2 builds the per-step metadata. The
+        # FlashAttention builder derives `cu_seqlens_k` / scheduler metadata
+        # from `seq_lens` at build time and bakes them into the graph; if
+        # the buffers are still zero here those derived fields are baked for
+        # a 0-length context. `base_metadata.max_seq_len` carries the
+        # capture context length (set by the boot-capture patch). replay()
+        # overwrites these buffers with the real per-request seq_lens.
+        _cap_seq_len = int(getattr(base_metadata, "max_seq_len", 1) or 1)
+        buffers.seq_lens_per_step.fill_(_cap_seq_len)
+        buffers.seq_lens_in.fill_(_cap_seq_len)
 
         # Phase 2: pre-build per-step metadata array (views into buffers).
         # Pass `proposer` so the helper can call
@@ -336,10 +377,8 @@ class EagleFullLoopRunner:
         #
         #   # End of context manager = graph capture complete.
         graph = self._capture_n_step_loop(
-            buffers,
-            attn_metadata_array,
-            batch_size,
-            pool,
+            buffers, attn_metadata_array, batch_size, pool,
+            in_graph_capture=in_graph_capture,
         )
 
         # Phase 5: wrap up and return.
@@ -356,15 +395,13 @@ class EagleFullLoopRunner:
     def replay(
         self,
         target_hidden_states: torch.Tensor,  # bf16 [bs, hidden_size] OR [num_tokens, hidden_size]
-        next_token_ids: torch.Tensor,  # int32 [bs] (the bonus from verify)
-        common_attn_metadata: Any,  # for assertion + step-0 metadata seeding
+        next_token_ids: torch.Tensor,        # int32 [bs] (the bonus from verify)
+        common_attn_metadata: Any,            # for assertion + step-0 metadata seeding
         batch_size: int,
-        target_positions: (
-            torch.Tensor | None
-        ) = None,  # int64 [num_tokens] (the verify pass's positions)
-        token_indices_to_sample: (
-            torch.Tensor | None
-        ) = None,  # int [bs] (idx in num_tokens of last token per seq)
+        target_positions: torch.Tensor | None = None,  # int64 [num_tokens] (the verify pass's positions)
+        token_indices_to_sample: torch.Tensor | None = None,  # int [bs] (idx in num_tokens of last token per seq)
+        target_token_ids: torch.Tensor | None = None,  # int [num_tokens] verified token ids (first forward)
+        num_rejected_tokens_gpu: torch.Tensor | None = None,  # [bs] padded-drafter rejected count
     ) -> EagleFullLoopReplayResult:
         """Replay the captured graph for this batch size.
 
@@ -406,121 +443,153 @@ class EagleFullLoopRunner:
             )
 
         ctx = self.contexts[batch_size]
+        p = self.proposer
 
-        # MUSA-0090 step 5k: derive token_indices_to_sample if not provided.
-        # Pattern matches vllm/v1/spec_decode/llm_base_proposer.py:set_inputs_first_pass.
-        if token_indices_to_sample is None:
-            query_start_loc = getattr(common_attn_metadata, "query_start_loc", None)
-            if query_start_loc is not None:
-                token_indices_to_sample = query_start_loc[1:] - 1
-            else:
-                # Fall back to "[bs-1, ..., bs-1]" which is correct ONLY when
-                # num_tokens == batch_size (one-token-per-seq decode case).
-                # The runner's eager path produces this from the proposer.
-                token_indices_to_sample = torch.arange(
-                    batch_size, dtype=torch.int64, device=target_hidden_states.device
-                )
+        # ---- PHASE 1: eager first forward over the verified sequence ----
+        # Produces draft token 0 + the hidden/position state that seeds the
+        # captured chain. vLLM's Eagle propose() first-forward is variable-
+        # length (the K+1 verified tokens / the prompt on the first call) so
+        # it cannot be a fixed CUDAGraph — run it eagerly, by calling the
+        # proposer's own methods, so it is correct by construction.
+        draft0, carry_hidden, carry_positions, cad = self._eager_first_forward(
+            target_token_ids=target_token_ids,
+            target_positions=target_positions,
+            target_hidden_states=target_hidden_states,
+            next_token_ids=next_token_ids,
+            token_indices_to_sample=token_indices_to_sample,
+            common_attn_metadata=common_attn_metadata,
+            num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+            batch_size=batch_size,
+        )
 
-        # Hidden state selection: pick the LAST token per sequence.
-        # Shape handling:
-        #   target_hidden_states is [num_tokens, h] in the general case.
-        #   For BS=1 prefill 4k, num_tokens=4096 and we need the [4095]-th row.
-        # MUSA-0090 step 5l.2: Eagle3 uses aux hidden states from N layers
-        # (e.g., 3 layers for M2.5-Eagle3: ids 1, 30, 58), concatenated to
-        # shape [num_tokens, N * hidden_size] = [num_tokens, 9216] for the
-        # 3072-hidden M2.5 draft. vLLM's propose() calls
-        # self.model.combine_hidden_states(target_hidden_states) to reduce
-        # the concat to [num_tokens, hidden_size] before the draft forward.
-        # We replicate that here OUTSIDE the captured graph.
-        if (
-            self.proposer.method in ("eagle3", "dflash")
-            and target_hidden_states.shape[-1] != self.hidden_size
-            and hasattr(self.proposer.model, "combine_hidden_states")
-        ):
-            target_hidden_states = self.proposer.model.combine_hidden_states(
-                target_hidden_states
-            )
-        if (
-            target_hidden_states.dim() >= 1
-            and target_hidden_states.shape[0] != batch_size
-        ):
-            selected_hidden = target_hidden_states[token_indices_to_sample]
-        else:
-            selected_hidden = target_hidden_states[:batch_size]
-        ctx.buffers.target_hidden_states_in[:batch_size].copy_(selected_hidden)
-        ctx.buffers.bonus_token_ids_in[:batch_size].copy_(next_token_ids)
+        # ---- PHASE 2: bridge — first-forward state -> captured-chain step-0
+        # metadata. Mirrors propose() lines 528-580: the padded-drafter
+        # seq-len adjustment, then ONE eagle_step_update advancing the carry
+        # position/seq_len/slot_mapping by one (the chain's first forward is
+        # at carry_position + 1, exactly as propose()'s chain iter 0).
+        from vllm.v1.spec_decode.utils import (
+            eagle_step_update_slot_mapping_and_metadata,
+        )
+        seq_lens = cad.seq_lens
+        if self.num_spec_tokens > 1 and num_rejected_tokens_gpu is not None:
+            seq_lens = seq_lens - num_rejected_tokens_gpu
+        chain_seq = seq_lens[:batch_size].to(torch.int32).clone()
 
-        # MUSA-0090 step 5k: seed step-0 positions, slot_mapping, seq_lens
-        # from the verify pass's metadata. Without these, the captured graph
-        # reads zeros at step 0 — RoPE wrong, KV writes to wrong slots,
-        # attention attends to wrong context length.
-        if target_positions is not None:
-            # The bonus token's position is the position AFTER the last verified
-            # position. The first draft (step 0) is run AS the bonus token (its
-            # input_ids = bonus_token_id, its hidden_states = target_hidden), so
-            # step-0 positions = target_positions[last_idx_per_seq].
-            # (Per vllm/v1/spec_decode/llm_base_proposer.py line 502:
-            #  `positions = self.positions[token_indices_to_sample]`)
-            if target_positions.dim() == 2:
-                # M-RoPE case: positions shape [3, num_tokens]; take dim 0.
-                step0_positions = target_positions[0][token_indices_to_sample]
-            else:
-                step0_positions = target_positions[token_indices_to_sample]
-            ctx.buffers.positions_in[:batch_size].copy_(step0_positions.to(torch.int64))
-
-        # slot_mapping for step 0: the slot of the bonus token. The verify
-        # pass's common_attn_metadata.slot_mapping has shape [num_tokens] and
-        # tells us where each input token's K/V is written. The bonus token
-        # corresponds to the last input position of each sequence.
-        cm_slot_mapping = getattr(common_attn_metadata, "slot_mapping", None)
-        if cm_slot_mapping is not None and cm_slot_mapping.numel() > 0:
-            if cm_slot_mapping.shape[0] != batch_size:
-                step0_slot = cm_slot_mapping[token_indices_to_sample]
-            else:
-                step0_slot = cm_slot_mapping[:batch_size]
-            ctx.buffers.slot_mapping_in[:batch_size].copy_(step0_slot.to(torch.int64))
-
-        # seq_lens for step 0: same as the verify pass's seq_lens (the
-        # context length BEFORE the draft adds a new token).
-        cm_seq_lens = getattr(common_attn_metadata, "seq_lens", None)
-        if cm_seq_lens is not None and cm_seq_lens.numel() > 0:
-            ctx.buffers.seq_lens_in[:batch_size].copy_(
-                cm_seq_lens[:batch_size].to(torch.int32)
-            )
-
-        # MUSA-0090 step 5l.3: copy the current request's block_table into
-        # the runner-owned buffer. The captured graph reads from
-        # buffers.block_table_tensor (a stable pointer), not from the
-        # caller's transient tensor (which may be freed/repurposed between
-        # spec rounds, causing 'MUSA error: unknown error').
-        cm_block_table = getattr(common_attn_metadata, "block_table_tensor", None)
+        cm_block_table = getattr(cad, "block_table_tensor", None)
         if cm_block_table is not None and cm_block_table.numel() > 0:
-            # Slice to actual shape, pad with zeros if needed.
             src_bs = min(cm_block_table.shape[0], batch_size)
-            src_n_blocks = min(
+            src_nb = min(
                 cm_block_table.shape[1], ctx.buffers.block_table_tensor.shape[1]
             )
-            ctx.buffers.block_table_tensor[:src_bs, :src_n_blocks].copy_(
-                cm_block_table[:src_bs, :src_n_blocks]
+            ctx.buffers.block_table_tensor[:src_bs, :src_nb].copy_(
+                cm_block_table[:src_bs, :src_nb]
             )
 
-        # Single graph replay. All N draft forwards + sampling + slot-mapping
-        # updates happen inside this one call.
+        # eagle_step_update does seq_lens += 1 in place and writes the
+        # advanced positions / slot_mapping into the runner buffers.
+        eagle_step_update_slot_mapping_and_metadata(
+            positions_1d=carry_positions[:batch_size],
+            block_table_tensor=ctx.buffers.block_table_tensor,
+            seq_lens=chain_seq,
+            block_size=int(getattr(p, "block_size", 64) or 64),
+            max_model_len=int(getattr(p, "max_model_len", 196_608) or 196_608),
+            out_clamped_positions=ctx.buffers.positions_in[:batch_size],
+            out_slot_mapping=ctx.buffers.slot_mapping_in[:batch_size],
+            input_batch_size=batch_size,
+        )
+        ctx.buffers.seq_lens_in[:batch_size].copy_(chain_seq)
+
+        # ---- PHASE 3: seed the captured chain's step-0 input ----
+        ctx.buffers.bonus_token_ids_in[:batch_size].copy_(
+            draft0.to(ctx.buffers.bonus_token_ids_in.dtype)
+        )
+        ctx.buffers.target_hidden_states_in[:batch_size].copy_(carry_hidden)
+
+        # ---- PHASE 4: replay the captured chain (num_spec_tokens - 1 steps).
         ctx.graph.replay()
 
-        # MUSA-0090 layer-2 fix (2026-05-17): clone the output OUT of the
-        # CUDAGraph memory pool. vllm's _copy_draft_token_ids_to_cpu does the
-        # H2D copy on a dedicated `draft_token_ids_copy_stream` (not the default
-        # stream), and MUSA's MUDNN fails ("err 999 = unknown error") when
-        # copying from pool memory across streams. Cloning into a fresh
-        # allocation outside the pool fixes this. The clone is small
-        # (`[bs, num_steps]` int32 = ~12 bytes for bs=1) and runs on the
-        # default stream so subsequent cross-stream sync works.
-        out = ctx.buffers.draft_token_ids_out[:batch_size].clone()
+        # ---- PHASE 5: assemble [draft0] ++ chain -> [bs, num_spec_tokens].
+        # Clone out of the CUDAGraph pool (MUSA-0090 layer-2: a cross-stream
+        # copy from pool memory fails MUDNN err 999). ----
+        draft0_col = draft0.view(batch_size, 1)
+        if self.num_steps > 0:
+            chain = ctx.buffers.draft_token_ids_out[:batch_size]
+            out = torch.cat([draft0_col.to(chain.dtype), chain], dim=1).clone()
+        else:
+            out = draft0_col.clone()
         return EagleFullLoopReplayResult(
             draft_token_ids=out,
             batch_size=batch_size,
         )
+
+    def _eager_first_forward(
+        self,
+        target_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        token_indices_to_sample: torch.Tensor | None,
+        common_attn_metadata: Any,
+        num_rejected_tokens_gpu: torch.Tensor | None,
+        batch_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, Any]:
+        """Run vLLM's Eagle `propose()` first-forward EAGERLY (not captured).
+
+        Mirrors `EagleProposer.propose()` lines 433-516 by calling the
+        proposer's own methods — the first forward is variable-length (the
+        verified sequence / prompt) so it cannot be a fixed CUDAGraph;
+        running it eagerly here is correct by construction. Returns
+        `(draft_token_0 [bs], carry_hidden [bs, h], carry_positions [bs],
+        cad)` — the seed for the captured chain.
+        """
+        from vllm.forward_context import set_forward_context
+
+        p = self.proposer
+        th = target_hidden_states
+        if p.method in ("eagle3", "dflash") and hasattr(
+            p.model, "combine_hidden_states"
+        ):
+            th = p.model.combine_hidden_states(th)
+
+        num_tokens, tidx, cad = p.set_inputs_first_pass(
+            target_token_ids=target_token_ids,
+            next_token_ids=next_token_ids,
+            target_positions=target_positions,
+            target_hidden_states=th,
+            token_indices_to_sample=token_indices_to_sample,
+            cad=common_attn_metadata,
+            num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+        )
+        _per_group, per_layer = p.build_per_group_and_layer_attn_metadata(cad)
+        cg_mode, num_input_tokens, dp = p._determine_batch_execution_and_padding(
+            num_tokens
+        )
+        model_kwargs, slot_sz = p.build_model_inputs_first_pass(
+            num_tokens, num_input_tokens, None
+        )
+        with set_forward_context(
+            per_layer,
+            p.vllm_config,
+            num_tokens=num_input_tokens,
+            num_tokens_across_dp=dp,
+            cudagraph_runtime_mode=cg_mode,
+            slot_mapping=p._get_slot_mapping(slot_sz, cad.slot_mapping),
+        ):
+            ret = p.model(**model_kwargs)
+        if isinstance(ret, tuple):
+            last_hidden, hidden = ret
+        else:
+            last_hidden, hidden = ret, ret
+
+        draft0 = (
+            p._greedy_sample(last_hidden[tidx]).to(torch.int32).view(batch_size)
+        )
+        carry_hidden = hidden[tidx]
+        if target_positions.dim() == 2:
+            carry_positions = target_positions[0][tidx]
+        else:
+            carry_positions = target_positions[tidx]
+        return draft0, carry_hidden, carry_positions.to(torch.int64), cad
 
     # ---- helpers (step 4: real implementations) ----
 
@@ -591,9 +660,15 @@ class EagleFullLoopRunner:
         attn_metadata_array: list,
         batch_size: int,
         pool: Any,
+        in_graph_capture: bool = False,
     ) -> Any:
         """Open the torch.cuda.graph context and drive the N-step loop with
         in-place tensor ops only. Returns the captured CUDAGraph object.
+
+        `in_graph_capture=True` means the caller is already inside vllm's
+        `graph_capture(device)` (the capture-at-boot path); we then capture
+        with a plain `torch.cuda.graph(...)` on the current (capture) stream
+        instead of opening a nested `graph_capture()`.
 
         Critical invariants enforced inside `_run_n_step_inner`:
           - No Python list growth (no .append, no torch.cat).
@@ -605,8 +680,50 @@ class EagleFullLoopRunner:
         # torch.cuda.CUDAGraph is routed to torch_musa.musa_graph.MUSAGraph on
         # MUSA via torchada — proven correctness-wise by the Q1 smoke.
         graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph, pool=pool):
-            self._run_n_step_inner(buffers, attn_metadata_array, batch_size)
+
+        # MUSA-0109 (2026-05-20): capture inside vllm's `graph_capture()`
+        # context manager — NOT a bare `torch.cuda.graph(stream=...)`.
+        #
+        # History: an earlier fix gave the runner a dedicated capture stream
+        # (`torch.cuda.graph(graph, pool=pool, stream=<own Stream>)`). That
+        # cleared the capture-time `MUSA error: unknown error` — but the
+        # `--load-format dummy` fast-loop then surfaced the real next failure:
+        #   `MUSA error: operation not permitted when stream is capturing`
+        # raised from the process-group watchdog thread. The TP=8 draft loop
+        # contains custom all-reduces; capturing a collective is only valid
+        # while the custom-all-reduce communicator is in capture mode.
+        #
+        # vllm's `graph_capture(device)` is exactly that wrapper: it enters
+        # `GroupCoordinator.graph_capture()` -> `ca_comm.capture()`, which
+        # puts the custom all-reduce into graph-capture mode (registers the
+        # capture buffers, switches to the IPC-pointer path). It ALSO provides
+        # the dedicated capture stream + `wait_stream` fence. This is the same
+        # context vllm's own target-model capture uses, and the analogue of
+        # SGLang's `GroupCoordinator.graph_capture()`. Capturing the draft
+        # loop without it is what triggered the watchdog violation.
+        if in_graph_capture:
+            # MUSA-0109 capture-at-boot: vllm's `graph_capture()` is ALREADY
+            # open (capture_model() holds it across the whole boot capture
+            # phase, gpu_model_runner.py:6093). Re-entering it would nest
+            # `ca_comm.capture()` and assert. Issuing multiple
+            # `torch.cuda.graph(...)` captures inside one `graph_capture()`
+            # is vllm's normal pattern (the CUDAGraphWrapper does it per
+            # piecewise graph). Capture on the current stream — which, under
+            # the active `graph_capture()`, IS the dedicated capture stream.
+            with torch.cuda.graph(
+                graph, pool=pool, stream=torch.cuda.current_stream()
+            ):
+                self._run_n_step_inner(buffers, attn_metadata_array, batch_size)
+            return graph
+
+        # Standalone (legacy lazy) path: open our own graph_capture().
+        from vllm.distributed.parallel_state import (
+            graph_capture as _vllm_graph_capture,
+        )
+
+        with _vllm_graph_capture(self.device) as _gc_ctx:
+            with torch.cuda.graph(graph, pool=pool, stream=_gc_ctx.stream):
+                self._run_n_step_inner(buffers, attn_metadata_array, batch_size)
         return graph
 
     def _run_n_step_inner(
@@ -625,11 +742,9 @@ class EagleFullLoopRunner:
         statically-allocates everything ahead of time.
         """
         # Lazy imports to avoid pulling vLLM internals at module-load time.
-        from vllm.config import CUDAGraphMode
         from vllm.forward_context import set_forward_context
-        from vllm.v1.spec_decode.utils import (
-            eagle_step_update_slot_mapping_and_metadata,
-        )
+        from vllm.config import CUDAGraphMode
+        from vllm.v1.spec_decode.utils import eagle_step_update_slot_mapping_and_metadata
 
         proposer = self.proposer
         # Step-0 seed: copy the input carry-over into the per-step buffers.
@@ -688,17 +803,25 @@ class EagleFullLoopRunner:
             # metadata, slot_mapping, num_tokens) for the model call.
             # Critical: cudagraph_runtime_mode=NONE — we're capturing OUR
             # OWN graph; vLLM's PIECEWISE shouldn't re-fire.
-            # NOTE: do NOT pass slot_mapping=tensor here — vllm's forward_context
-            # internally does `slot_mapping or {}` which raises on multi-element
-            # Tensors (`Boolean value of Tensor with more than one value is
-            # ambiguous`). The slot_mapping_view is already carried by
-            # attn_metadata_array[step].slot_mapping; the kwarg is the per-attn-group
-            # dict that vllm uses for cross-group dispatch, NOT the single tensor.
+            #
+            # MUSA-0109 (2026-05-21) FIX: `slot_mapping` MUST be passed — and
+            # it must be the per-LAYER DICT, not a raw tensor. vLLM's KV-cache
+            # write (`get_attention_context` -> `do_kv_cache_update`,
+            # attention.py:703) reads the write slots from
+            # `forward_context.slot_mapping[layer_name]` and SKIPS the write
+            # entirely when that is None. Without this kwarg the chain's draft
+            # model never writes its KV, so chain step s+1 reads stale KV for
+            # step s's position -> draft acceptance collapses after position 0.
+            # `proposer._get_slot_mapping(n, tensor)` builds the dict (and
+            # copies the tensor into the proposer's stable `_slot_mapping_
+            # buffer`, which the captured graph then reads — capture-safe).
+            sm_dict = proposer._get_slot_mapping(batch_size, slot_mapping_view)
             with set_forward_context(
                 attn_metadata_array[step],
                 proposer.vllm_config,
                 num_tokens=batch_size,
                 cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                slot_mapping=sm_dict,
             ):
                 ret_hidden_states = proposer.model(**model_kwargs)
                 if isinstance(ret_hidden_states, tuple):
@@ -721,7 +844,9 @@ class EagleFullLoopRunner:
             # Update state for step+1 if not the last step.
             if step + 1 < self.num_steps:
                 # Stage next step's input.
-                buffers.input_ids_per_step[step + 1, :batch_size].copy_(draft_token_ids)
+                buffers.input_ids_per_step[step + 1, :batch_size].copy_(
+                    draft_token_ids
+                )
                 buffers.hidden_states_per_step[step + 1, :batch_size].copy_(
                     next_hidden[:batch_size]
                 )

--- a/vllm_musa/v1/spec_decode/spec_info.py
+++ b/vllm_musa/v1/spec_decode/spec_info.py
@@ -28,7 +28,7 @@ class EagleDraftBuffers:
       max_bs: the largest cudagraph_capture_size for this runner
       num_steps: num_speculative_tokens (=N from the EagleProposer)
       hidden_size: draft model's hidden_size (M2.5 Eagle3 = LLaMA-shape)
-      topk: 1 for chain drafting; >1 for tree drafting (deferred)
+      topk: 1 for chain drafting
     """
 
     # --- Per-step output buffers (indexed by step_idx in [0..N-1]) ---
@@ -140,34 +140,18 @@ class EagleDraftBuffers:
         )
 
         return cls(
-            input_ids_per_step=torch.zeros(
-                (num_steps, max_bs), dtype=i32, device=device
-            ),
-            positions_per_step=torch.zeros(
-                (num_steps, max_bs), dtype=i64, device=device
-            ),
-            slot_mapping_per_step=torch.zeros(
-                (num_steps, max_bs), dtype=i64, device=device
-            ),
-            seq_lens_per_step=torch.zeros(
-                (num_steps, max_bs), dtype=i32, device=device
-            ),
+            input_ids_per_step=torch.zeros((num_steps, max_bs), dtype=i32, device=device),
+            positions_per_step=torch.zeros((num_steps, max_bs), dtype=i64, device=device),
+            slot_mapping_per_step=torch.zeros((num_steps, max_bs), dtype=i64, device=device),
+            seq_lens_per_step=torch.zeros((num_steps, max_bs), dtype=i32, device=device),
             hidden_states_per_step=torch.zeros(
                 (num_steps, max_bs, hidden_size), dtype=bf16, device=device
             ),
-            topk_p_per_step=torch.zeros(
-                (num_steps, max_bs, topk), dtype=f32, device=device
-            ),
-            topk_index_per_step=torch.zeros(
-                (num_steps, max_bs, topk), dtype=i32, device=device
-            ),
-            draft_token_ids_out=torch.zeros(
-                (max_bs, num_steps), dtype=i32, device=device
-            ),
+            topk_p_per_step=torch.zeros((num_steps, max_bs, topk), dtype=f32, device=device),
+            topk_index_per_step=torch.zeros((num_steps, max_bs, topk), dtype=i32, device=device),
+            draft_token_ids_out=torch.zeros((max_bs, num_steps), dtype=i32, device=device),
             bonus_token_ids_in=torch.zeros((max_bs,), dtype=i32, device=device),
-            target_hidden_states_in=torch.zeros(
-                (max_bs, hidden_size), dtype=bf16, device=device
-            ),
+            target_hidden_states_in=torch.zeros((max_bs, hidden_size), dtype=bf16, device=device),
             # MUSA-0090 step 5k: step-0 input metadata buffers.
             positions_in=torch.zeros((max_bs,), dtype=i64, device=device),
             slot_mapping_in=torch.zeros((max_bs,), dtype=i64, device=device),


### PR DESCRIPTION
## Summary

Adds the **`EagleFullLoopRunner`** for MUSA: it captures the Eagle3 speculative-decoding chain draft loop as a single CUDAGraph instead of dispatching each draft step iteratively. On
MiniMax-M2.5 + Eagle3 (8× MTT S5000) this raises steady-state decode from **98.3 → 106.4 tok/s (+8.2%)** with bit-identical draft acceptance. Enabled by default; `VLLM_MUSA_EAGLE_RUNNER=0`
restores the previous iterative path. Branch is based on `v0.20.0-dev`.

## What changed

Three commits.

**`73b6be40a` — EagleFullLoopRunner (MUSA-0109).** The previous Eagle3 draft path dispatched each of the N draft steps separately (per-step PIECEWISE CUDAGraph + Python orchestration). The
new `EagleFullLoopRunner` runs the variable-length first draft forward eagerly (via the proposer's own methods) and captures the **fixed-shape 1-token chain tail as one CUDAGraph**, removing
per-step Python dispatch from the hot path. Two correctness bugs were fixed so the captured graph reproduces the eager path exactly (attention / hidden-state cosine = 1.000):

- *Draft KV not written across chain steps* — `_run_n_step_inner` did not pass `slot_mapping` into `set_forward_context`. vLLM's KV-cache write reads the write slots from
`forward_context.slot_mapping[layer_name]` and skips the write when it is `None`, so every chain step read stale draft KV and acceptance collapsed past position 0. Fixed by building and
passing the per-layer slot-mapping dict.
- *Stale kv_cache pointer baked into the captured graph* — a captured CUDAGraph freezes the kv_cache device pointer. The runner originally captured at boot, when the draft attention kv_cache
is still the 8-block boot dummy; replay then read freed memory (the real cache is ≈ 55k blocks). Fixed by deferring the boot capture until the draft attention kv_cache `num_blocks` is the
real (large) cache.

Gated by `VLLM_MUSA_EAGLE_RUNNER`.

**`cf9538ad5` — enable by default (MUSA-0109).** Flips `VLLM_MUSA_EAGLE_RUNNER` to default-on; `=0` opts out.

**`5bdf39816` — Eagle3 draft at TP=1, opt-in (MUSA-0124).** Optional patch (`VLLM_MUSA_DRAFT_TP1`, **default off**) that builds the Eagle3 draft model at TP=1 instead of inheriting the
target's TP=8. Off by default and does not stack with the runner (the runner already removes the launch overhead this targeted — 102.2 tok/s combined vs 106.4 runner-alone). Kept as an opt-in
 knob.

Files (vs `v0.20.0-dev`, 5 files, +841 / −405):

| File | Role |
|---|---|
| `vllm_musa/v1/spec_decode/eagle_full_loop_runner.py` | the runner |
| `vllm_musa/patches/vllm__v1__spec_decode__eagle.patch.py` | dispatcher patch — wires the runner in, deferred-capture fix, default-on gate |
| `vllm_musa/v1/spec_decode/attn_backend_array.py` | per-step attention-metadata array |
| `vllm_musa/v1/spec_decode/spec_info.py` | spec-decode info plumbing |
| `vllm_musa/patches/vllm__distributed__parallel_state.patch.py` | MUSA-0124 draft-TP=1 patch (opt-in, new file) |

Diff is Python-only (spec-decode + patches) — no kernel/native changes.

## SOTA test configuration

Hardware: 8× MTT S5000. Models: MiniMax-M2.5 (fp8 target) + MiniMax-M2.5-Eagle3 (draft).

Server (the documented narrow-d5 SOTA recipe; runner is now default-on):

```bash
export VLLM_ATTENTION_BACKEND=TREE_ATTN
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export VLLM_DISABLE_COMPILE_CACHE=1
export VLLM_MUSA_SPHERE_SILU_FP8=1
# VLLM_MUSA_EAGLE_RUNNER defaults to on; export VLLM_MUSA_EAGLE_RUNNER=0 to disable

vllm serve MiniMax/MiniMax-M2.5 \
  --served-model-name MiniMax/MiniMax-M2.5 \
  --trust-remote-code --tensor-parallel-size 8 \
  --enable-auto-tool-choice --tool-call-parser minimax_m2 \
  --reasoning-parser minimax_m2_append_think \
  --no-enable-prefix-caching --no-async-scheduling \
  --compilation-config '{"cudagraph_mode": "PIECEWISE", "pass_config": {"fuse_attn_quant": true}}' \
  --speculative-config '{"model": "MiniMax/MiniMax-M2.5-Eagle3", "num_speculative_tokens": 5, "method": "eagle3", "speculative_token_tree": "[(0,), (1,), (0,0), (1,1), (0,0,0), (1,1,0),
(0,0,0,0), (0,0,0,0,0)]"}'
```

Benchmark — random 4096-in / 1024-out, batch size 1, greedy:

```bash
vllm bench serve --backend openai-chat --base-url http://localhost:8000 \
  --endpoint /v1/chat/completions \
  --model MiniMax/MiniMax-M2.5 --served-model-name MiniMax/MiniMax-M2.5 \
  --dataset-name random --random-input-len 4096 --random-output-len 1024 \
  --num-prompts 1 --max-concurrency 1 --temperature 0
```

5 runs; run 1 (cold) discarded; reported figure is the **warm median of decode rate = 1000 / mean_tpot_ms** (steady-state inter-token throughput). At `--num-prompts 1` the JSON
`output_throughput` field is prefill-diluted to ~57 and is *not* the SOTA metric — `mean_tpot_ms` is the comparable measure.

## SOTA perf record

Same-session A/B at the configuration above:

| Mode | mean_tpot (warm) | decode rate (warm median) | france smoke |
|---|---|---|---|
| `VLLM_MUSA_EAGLE_RUNNER=0` — iterative | 10.07–10.19 ms | **98.3 tok/s** | PASS |
| runner on (default) | 9.32–9.47 ms | **106.4 tok/s** | PASS |

**+8.1 tok/s, +8.2%.**

- The runner-off baseline reproduces the prior documented SOTA (~99 tok/s decode).
- Per-position draft acceptance is bit-identical on vs off (`987/807/755/723/701` vs `979/794/749/724/698`) — the runner produces the same drafts; the gain is purely removed per-step
dispatch.
- `captured-at-boot = 8` (one per TP rank) confirms the deferred capture fired against the real KV cache.
- Reproduced across repeated A/B runs: runner-on 106.4–107.7, runner-off 98.3–99.9.

## Fallback & risk

- Default-on; `VLLM_MUSA_EAGLE_RUNNER=0` restores the exact prior iterative path — a zero-risk fallback.
- MUSA-0124 draft-TP=1 is opt-in (`VLLM_MUSA_DRAFT_TP1`), off by default.