### PR TITLE
Drop FP8 fused MoE override; wrap rope JIT as Dynamo-safe op

### DIFF
--- a/vllm_musa/jit_kernel/csrc/rope.py
+++ b/vllm_musa/jit_kernel/csrc/rope.py
@@ -214,7 +214,7 @@ def _rotary_embedding_impl(
 def _rotary_embedding_custom(
     positions: torch.Tensor,
     query: torch.Tensor,
-    key: torch.Tensor | None,
+    key: torch.Tensor,
     head_size: int,
     cos_sin_cache: torch.Tensor,
     is_neox: bool,
@@ -232,7 +232,7 @@ def _rotary_embedding_custom(
 def _rotary_embedding_custom_fake(
     positions: torch.Tensor,
     query: torch.Tensor,
-    key: torch.Tensor | None,
+    key: torch.Tensor,
     head_size: int,
     cos_sin_cache: torch.Tensor,
     is_neox: bool,
@@ -240,12 +240,14 @@ def _rotary_embedding_custom_fake(
     return
 
 
-# MUSA-0202: register as a vLLM custom op so Dynamo sees a single opaque
-# call instead of trying to inline `load_musa_jit` (which the JIT-compile
+# Register as a vLLM custom op so Dynamo sees a single opaque call
+# instead of trying to inline `load_musa_jit` (which the JIT-compile
 # + tvm_ffi.load_module machinery makes untraceable). Without this,
 # every model using MusaRotaryEmbedding fails compile-mode boot with
-# `SKIPPED INLINING <load_musa_jit>`. The mutates_args contract matches
-# the upstream `flashinfer_rotary_embedding` custom op shape.
+# `SKIPPED INLINING <load_musa_jit>`. Schema matches the upstream
+# `flashinfer_rotary_embedding` custom op shape (key is a required
+# Tensor; the key=None caller path bypasses the custom op — see
+# `rotary_embedding` below).
 direct_register_custom_op(
     op_name="musa_rotary_embedding",
     op_func=_rotary_embedding_custom,
@@ -262,6 +264,17 @@ def rotary_embedding(
     cos_sin_cache: torch.Tensor,
     is_neox: bool,
 ) -> None:
+    if key is None:
+        # The custom op declares `mutates_args=["query", "key"]` with a
+        # required Tensor schema for key; combining Optional[Tensor]
+        # with mutates_args is not a well-defined torch.library
+        # contract. For the rare query-only caller, run the eager impl
+        # directly — it is non-mutating for key, so no custom-op
+        # registration is needed.
+        _rotary_embedding_impl(
+            positions, query, None, head_size, cos_sin_cache, is_neox
+        )
+        return
     torch.ops.vllm.musa_rotary_embedding(
         positions,
         query,

--- a/vllm_musa/jit_kernel/csrc/rope.py
+++ b/vllm_musa/jit_kernel/csrc/rope.py
@@ -4,6 +4,8 @@ import os
 
 import torch
 
+from vllm.utils.torch_utils import direct_register_custom_op
+
 from vllm_musa.jit_kernel.csrc.jit import load_musa_jit
 from vllm_musa.jit_kernel.utils import cache_once
 
@@ -209,10 +211,6 @@ def _rotary_embedding_impl(
     )
 
 
-# @register_custom_op(
-#     op_name="musa_rotary_embedding",
-#     mutates_args=["query", "key"],
-# )
 def _rotary_embedding_custom(
     positions: torch.Tensor,
     query: torch.Tensor,
@@ -231,6 +229,31 @@ def _rotary_embedding_custom(
     )
 
 
+def _rotary_embedding_custom_fake(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor | None,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> None:
+    return
+
+
+# MUSA-0202: register as a vLLM custom op so Dynamo sees a single opaque
+# call instead of trying to inline `load_musa_jit` (which the JIT-compile
+# + tvm_ffi.load_module machinery makes untraceable). Without this,
+# every model using MusaRotaryEmbedding fails compile-mode boot with
+# `SKIPPED INLINING <load_musa_jit>`. The mutates_args contract matches
+# the upstream `flashinfer_rotary_embedding` custom op shape.
+direct_register_custom_op(
+    op_name="musa_rotary_embedding",
+    op_func=_rotary_embedding_custom,
+    mutates_args=["query", "key"],
+    fake_impl=_rotary_embedding_custom_fake,
+)
+
+
 def rotary_embedding(
     positions: torch.Tensor,
     query: torch.Tensor,
@@ -239,7 +262,7 @@ def rotary_embedding(
     cos_sin_cache: torch.Tensor,
     is_neox: bool,
 ) -> None:
-    _rotary_embedding_custom(
+    torch.ops.vllm.musa_rotary_embedding(
         positions,
         query,
         key,

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -308,9 +308,9 @@ import vllm.model_executor.layers.fused_moe.fused_moe
 #   - 1024/256 cookbook: override 59.5 tok/s vs upstream 75.3 tok/s (-26.5%)
 #   - 256/2048 decode:   override 86.2 tok/s vs upstream 80.9 tok/s (+6.6%)
 # The decode advantage is real but the prefill cost is 10x. The right shape
-# is a hybrid dispatcher (per-expert token-count threshold) — tracked as
-# MUSA-0202 follow-up. For now, let vllm upstream fused_experts_impl run
-# unhijacked so prefill scales normally.
+# is a hybrid dispatcher (per-expert token-count threshold), to be tracked
+# as a separate follow-up ticket. For now, let vllm upstream
+# fused_experts_impl run unhijacked so prefill scales normally.
 #
 # The TritonExperts._supports_quant_scheme patch is independent (it expands
 # MUSA's supported FP8 quant key list) and stays in place.

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -302,7 +302,18 @@ def fused_experts_impl(
 
 import vllm.model_executor.layers.fused_moe.fused_moe
 
-vllm.model_executor.layers.fused_moe.fused_moe.fused_experts_impl = fused_experts_impl
+# MUSA-0201: PR #34's v0.18.0-style fused_experts_impl override hijacked
+# vllm v0.20.0's modular_kernel dispatch with a blanket BS=1 GEMV fast path.
+# A/B on DeepSeek-V2-Lite-FP8 (audit 2026-05-27) showed:
+#   - 1024/256 cookbook: override 59.5 tok/s vs upstream 75.3 tok/s (-26.5%)
+#   - 256/2048 decode:   override 86.2 tok/s vs upstream 80.9 tok/s (+6.6%)
+# The decode advantage is real but the prefill cost is 10x. The right shape
+# is a hybrid dispatcher (per-expert token-count threshold) — tracked as
+# MUSA-0202 follow-up. For now, let vllm upstream fused_experts_impl run
+# unhijacked so prefill scales normally.
+#
+# The TritonExperts._supports_quant_scheme patch is independent (it expands
+# MUSA's supported FP8 quant key list) and stays in place.
 vllm.model_executor.layers.fused_moe.fused_moe.TritonExperts._supports_quant_scheme = (
     _supports_quant_scheme
 )

--- a/vllm_musa/model_executor/layers/rotary_embedding/base.py
+++ b/vllm_musa/model_executor/layers/rotary_embedding/base.py
@@ -12,14 +12,20 @@ class MusaRotaryEmbedding(RotaryEmbedding):
         query: torch.Tensor,
         key: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        self.cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
+        # MUSA-0202: do NOT reassign self.cos_sin_cache inside forward.
+        # CUDAGraph-aware Dynamo flags `self.cos_sin_cache = ...` as a
+        # buffer mutation and refuses to compile (RuntimeError: Assigning
+        # / modifying buffers of nn.Module during forward pass is not
+        # allowed when using cudagraph). Use a local variable instead;
+        # .to() is a no-op when device/dtype already match.
+        cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
 
         rotary_embedding(
             positions,
             query,
             key,
             self.head_size,
-            self.cos_sin_cache,
+            cos_sin_cache,
             self.is_neox_style,
         )
         return query, key


### PR DESCRIPTION
## Summary

- **MUSA-0201 (461504238)**: remove a single-line override in
  `vllm_musa/.../fused_moe.py` that hijacked vLLM v0.20's modular_kernel
  FP8 MoE dispatch with PR #34's v0.18.0-style chunked GEMV workaround.
  +31.2% cookbook tok/s on DeepSeek-V2-Lite-FP8, 10.7× faster prefill.
- **MUSA-0202 (d08679160)**: wrap PR #47's csrc-JIT rope as a vLLM
  custom op so torch.compile + CUDAGraph can replace the captured
  forward path. Unblocks compile-mode boot for every model using
  `MusaRotaryEmbedding` (previously failed with
  `SKIPPED INLINING <load_musa_jit>`).

Together: every FP8 path I could exercise across TP=1, 2, 4, 8 now
runs end-to-end in compile mode, including 5/5 functional smokes and
cookbook benches.

## Commit 1 — `461504238` "MUSA-0201: remove PR #34 fused_experts_impl override"

### Why

PR #34 ("Support fp8 on musa") shipped three things:

1. The required FP8 enablement: `MUSADeepGemmFp8BlockScaledMMKernel` +
   `per_token_group_quant.cu` + the `kernels__linear` patch (without
   this, vLLM raises `KeyError: <PlatformEnum.OOT: 6>` at
   `choose_scaled_mm_linear_kernel` — bare v0.20.0-dev has no MUSA FP8
   path).
2. The right path through vLLM's modular_kernel
   (`Fp8MoeBackend.DEEPGEMM` → `DeepGemmExperts.apply` → mate's
   `m_grouped_fp8_gemm_nt_contiguous`).
3. A blanket override that **bypasses (2)** for every fused-MoE call:
   ```python
   vllm.model_executor.layers.fused_moe.fused_moe.fused_experts_impl = fused_experts_impl
   ```
   The override body is a v0.18.0-style direct
   `musa_fused_gemv_moe` loop that pre-dates per-token-group quant and
   `moe_align_block_size`. The PR comment even says "version used here
   is 0.18.0".

### Evidence

Audit on DeepSeek-V2-Lite-Chat-FP8 (tp=1, BS=1, greedy):

| workload          | BASELINE (override) | upstream (no override) | Δ          |
|-------------------|---------------------|------------------------|------------|
| 1024/256 cookbook | 59.498 tok/s        | **75.250 tok/s**       | **+26.5%** |
| 256/2048 decode   | **86.207 tok/s**    | 80.879 tok/s           | -6.2%      |
| TPOT (decode)     | **11.40 ms** (87.7 tps) | 12.33 ms (81.1 tps) | -7.5%   |
| TTFT (1024 in)    | 1395 ms             | **130 ms**             | -90.7%    |

The override has a real per-decode-token advantage for BS=1
(`musa_fused_gemv_moe` beats mate's SQMMA grouped GEMM when each
expert sees 1 token) but pays a 10.7× prefill cost because it skips
`moe_kernel_quantize_input` + `moe_align_block_size`. For
production / mixed-prefill workloads it's net negative; for pure-decode
microbench it's a 7% win.

After deeper validation (TP-coverage matrix below), this commit lands
**only the override removal**. The +6% decode advantage will return as
a per-expert token-count hybrid dispatcher (tracked as follow-up).

### Diff

```
vllm_musa/model_executor/layers/fused_moe/fused_moe.py | 13 ++++++++++++-
1 file changed, 12 insertions(+), 1 deletion(-)
```

Deletes one line:

```python
vllm.model_executor.layers.fused_moe.fused_moe.fused_experts_impl = fused_experts_impl
```

Replaces with a comment block documenting the A/B numbers and pointing
at the follow-up. The `TritonExperts._supports_quant_scheme` patch
stays — it's independent (expands MUSA's supported FP8 quant key list,
not related to dispatch).

## Commit 2 — `d08679160` "MUSA-0202: wrap PR #47 rope JIT as a vllm custom op (Dynamo-safe)"

### Why

PR #47 ("opt rope jit") replaced the old TileLang rope with a new
csrc-compiled-at-runtime JIT path
(`vllm_musa/jit_kernel/csrc/rope.py` + `csrc/rope/rotary_embedding.mu`).
The new code calls `load_musa_jit` (ninja subprocess + tvm_ffi
`load_module` + `FileLock`) on first use, which Dynamo cannot inline.
Any model using `MusaRotaryEmbedding` failed compile-mode boot:

```
torch._dynamo.exc.Unsupported: SKIPPED INLINING <code object load_musa_jit
at "/ws/vllm_musa/jit_kernel/csrc/jit.py", line 163>
```

Affected: Qwen3-8B-FP8, Qwen3-30B-A3B-FP8, M2.5+Eagle3, every model
using standard rotary embedding. The PR-author tested the JIT with
`torch.compile` disabled, so this interaction was never exercised
upstream.

Confirmed by re-running PR #43 (MiniMax-M2.5+Eagle3, the 107 tok/s SOTA
ticket): boot fails before reaching `Application startup complete`.

### Fix

1. **Register the rope as a custom op** so Dynamo emits a single
   opaque call instead of tracing into `load_musa_jit`:

   ```python
   from vllm.utils.torch_utils import direct_register_custom_op

   def _rotary_embedding_custom_fake(...): return
   direct_register_custom_op(
       op_name="musa_rotary_embedding",
       op_func=_rotary_embedding_custom,
       mutates_args=["query", "key"],
       fake_impl=_rotary_embedding_custom_fake,
   )
   def rotary_embedding(...):
       torch.ops.vllm.musa_rotary_embedding(...)
   ```

   PR #47 had already left a commented-out
   `@register_custom_op(op_name="musa_rotary_embedding",
   mutates_args=["query", "key"])` decorator at this exact location —
   this commit wires it up properly. Shape matches upstream's
   `flashinfer_rotary_embedding` custom op.

2. **Stop reassigning `self.cos_sin_cache` inside forward.** The
   wrapper at
   `vllm_musa/model_executor/layers/rotary_embedding/base.py` did:

   ```python
   self.cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
   ```

   CUDAGraph-aware Dynamo flags this as a buffer mutation:

   ```
   RuntimeError: Assigning / modifying buffers of nn.Module during
   forward pass is not allowed when using cudagraph inside the compiler
   because it will cause silent errors.
   ```

   Use a local variable instead — `.to()` is a no-op when device/dtype
   already match.

### Diff

```
vllm_musa/jit_kernel/csrc/rope.py                  | 33 ++++++++++++++++++----
vllm_musa/model_executor/layers/rotary_embedding/base.py | 10 +++++--
2 files changed, 36 insertions(+), 7 deletions(-)
```

## Combined acceptance evidence

Host: yeahdongcn70 (10.18.32.18, MTT S5000 ×8)
Branch: `xd/musa-0201-fp8-fused-moe-workaround-audit @ d08679160`

### Functional smokes (eager + compile mode)

4 single-turn + 1 multi-turn per model. Pass criterion: each prompt's
expected token appears in the reply.

| Model                       | Mode           | TP | Result        |
|-----------------------------|----------------|----|---------------|
| Qwen3-8B-FP8 (dense)        | eager / compile| 1  | 5/5 PASS      |
| Qwen3-8B-FP8 (dense)        | compile        | 4  | 5/5 PASS      |
| Qwen3-8B-FP8 (dense)        | compile        | 8  | 5/5 PASS      |
| Qwen3-30B-A3B-FP8 (MoE)     | eager / compile| 1  | 5/5 PASS      |
| Qwen3-30B-A3B-FP8 (MoE)     | compile        | 2  | 5/5 PASS      |
| DeepSeek-V2-Lite-Chat-FP8 (MoE+MLA) | eager + compile | 1 | 5/5 PASS  |

### Cookbook 1024/256 BS=1 greedy, 4 warm runs warm-median

| Model                       | TP | tok/s    | TPOT (ms) |
|-----------------------------|----|----------|-----------|
| DeepSeek-V2-Lite-Chat-FP8   | 1  | 78.089   | 12.33     |
| Qwen3-30B-A3B-FP8           | 2  | 67.181   | 14.53     |
| Qwen3-8B-FP8                | 4  | 93.152   | 10.47     |
| Qwen3-8B-FP8                | 8  | **99.495** | **9.87**  |

### TP=8 hardware sanity

The Qwen3-8B-FP8 TP=8 run uses all 8 GPUs including 0xaa (GPU 4) and
0xca (GPU 6) — the two GPUs that experienced firmware reboot during an
earlier M2.5+Eagle3 attempt. In this run they served 67GB allocated +
full bench with no dmesg `reboot fw` event. Confirms those GPUs are
healthy and the M2.5+Eagle3 reboot was workload-specific, not
hardware.

### Decomposition vs baseline (DSv2-Lite-Chat-FP8, MUSA-0201 only)

| metric                  | BASELINE (override) | FINAL (override removed) | Δ          |
|-------------------------|---------------------|--------------------------|------------|
| 1024/256 cookbook tok/s | 59.498              | 78.089                   | **+31.2%** |
| 256/2048 decode tok/s   | 86.207              | 80.600                   | -6.5%      |
| TTFT 1024-input (ms)    | 1395                | 130                      | **-90.7%** |

## Known limitations / follow-ups

- **MiniMax-M2.5 + Eagle3 narrow-d5 SOTA** (the 107 tok/s ticket from
  PR #43) **still hangs at TP=8 compile mode** — but for a reason
  *separate* from the two commits in this PR:
  - boot now succeeds (MUSA-0202 unblocks rope inlining)
  - first inference triggers `illegal memory access` on the captured
    forward, leading to firmware reboot of two specific GPUs and shm
    broadcast timeout. Independent of MUSA-0201 (override removal) and
    of MUSA-0202 (Dynamo-side fix) — confirmed because Qwen3-8B-FP8
    at TP=8 on the *same* 8 GPUs works.
  - Hypothesis: a kernel-level bug in PR #47's `rotary_embedding.mu`
    triggered by M2.5's specific compile config (PIECEWISE +
    fuse_attn_quant) + Eagle3 spec decoding path + sphere SilU FP8
    fast path. Tracked as MUSA-0203 candidate.

- **Per-expert token-count hybrid dispatcher** to recover the -6.5%
  decode loss on DSv2-Lite-Chat-FP8 (and presumably M2.5 BS=1 decode):
  route to `musa_fused_gemv_moe` when per-expert tokens ≤ threshold,
  to mate's grouped FP8 GEMM otherwise. Tracked as a separate
  follow-up; not required for this PR.

## Test plan

- [x] Boot DeepSeek-V2-Lite-Chat-FP8 in compile mode, run cookbook
      1024/256 and 256/2048; confirm `>= 75 tok/s` and `>= 80 tok/s`
      respectively
- [x] Boot Qwen3-8B-FP8 in compile mode at TP=1, 4, 8; confirm 5/5
      smoke + cookbook tok/s
- [x] Boot Qwen3-30B-A3B-FP8 in compile mode at TP=1 and TP=2;
      confirm 5/5 smoke + cookbook tok/s
- [x] Verify GPUs 4 and 6 participate cleanly in TP=8 with no
      `reboot fw` in dmesg