### PR TITLE
Enable ccache for MUSA native builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.ccache/
 build/
 develop-eggs/
 dist/

--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ The plugin leverages the following key components:
 | `VLLM_WORKER_MULTIPROC_METHOD=spawn` | Recommended for multi-process workers |
 | `VLLM_MUSA_CUSTOM_OP_USE_NATIVE` | Use vLLM custom ops native implementation (default: `False`) |
 | `VLLM_MUSA_WORKER_TERMINATION_TIMEOUT_S` | Control vLLM v1 worker shutdown timeout (default: `4s`) |
+| `VLLM_MUSA_USE_CCACHE` | Enable ccache for native extension builds when `ccache` is installed (default: `1`) |
+| `VLLM_MUSA_CCACHE` | Override the ccache executable used by `setup.py` (default: first `ccache` in `PATH`) |
+| `VLLM_MUSA_CCACHE_DIR` | Override the ccache directory used by `setup.py` (default: `<repo>/.ccache`) |
+| `VLLM_MUSA_CCACHE_MAXSIZE` | Optional ccache max-size value passed through as `CCACHE_MAXSIZE` |
+| `VLLM_MUSA_REAL_MCC` | Override the real MUSA compiler wrapped by ccache (default: detected `mcc`) |
+
+### ccache for native rebuilds
+
+When `ccache` is available in `PATH`, source installs automatically route the
+host C++ compiler and MUSA `mcc` through ccache. The generated `mcc` wrapper
+normalizes MUSA-only inputs such as `.mu` sources to cacheable `.cu` copies and
+hides `-x musa` from ccache while still passing it to `mcc`. The default cache
+lives in `<repo>/.ccache`, so a second
+`pip install -e . --no-build-isolation -v` from the same checkout can reuse
+cached `.cu`, `.mu`, and C++ object compilation.
+
+Useful commands:
+
+```bash
+ccache --zero-stats
+pip install -e . --no-build-isolation -v
+ccache --show-stats
+```
 
 ## Usage
 

--- a/build_utils/__init__.py
+++ b/build_utils/__init__.py
@@ -1,0 +1,1 @@
+"""Build-time helpers for vllm-musa setup.py."""

--- a/build_utils/ccache.py
+++ b/build_utils/ccache.py
@@ -135,14 +135,34 @@ def _find_real_compiler(name: str) -> str | None:
     return shutil.which(name)
 
 
-def _resolve_executable(executable: str, *, follow_symlinks: bool = True) -> str:
+def _resolve_path(path: Path) -> Path:
+    try:
+        return path.resolve()
+    except OSError:
+        return path.absolute()
+
+
+def _resolve_executable(
+    executable: str,
+    *,
+    follow_symlinks: bool = True,
+    excluded_dirs: tuple[Path, ...] = (),
+) -> str:
     path = Path(executable)
     if path.parent != Path("."):
         if follow_symlinks:
             return str(path.resolve())
         return str(path.absolute())
 
-    found = shutil.which(executable)
+    excluded = {_resolve_path(excluded_dir) for excluded_dir in excluded_dirs}
+    path_entries = []
+    for path_entry in os.environ.get("PATH", "").split(os.pathsep):
+        search_dir = Path(path_entry or os.curdir)
+        if _resolve_path(search_dir) not in excluded:
+            path_entries.append(path_entry)
+
+    search_path = os.pathsep.join(path_entries)
+    found = shutil.which(executable, path=search_path)
     if not found:
         return executable
     if follow_symlinks:
@@ -179,9 +199,12 @@ def _link_ccache_wrapper(wrapper_dir: Path, compiler_name: str, ccache_bin: str)
         wrapper.symlink_to(ccache_bin)
     except OSError:
         # Some filesystems disallow symlinks; a tiny exec wrapper is good enough.
+        real_compiler = _resolve_executable(
+            compiler_name, excluded_dirs=(wrapper_dir,)
+        )
         wrapper.write_text(
             "#!/usr/bin/env bash\n"
-            f"exec {ccache_bin!r} {compiler_name!r} \"$@\"\n",
+            f"exec {shlex.quote(ccache_bin)} {shlex.quote(real_compiler)} \"$@\"\n",
             encoding="utf-8",
         )
         wrapper.chmod(0o755)

--- a/build_utils/ccache.py
+++ b/build_utils/ccache.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ccache integration for vllm-musa native extension builds."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shlex
+import shutil
+from pathlib import Path
+
+
+FALSE_VALUES = {"0", "false", "off", "no"}
+WRAPPER_SCRIPT = r"""#!/usr/bin/env bash
+set -euo pipefail
+
+ccache_bin="${VLLM_MUSA_REAL_CCACHE:-ccache}"
+real_mcc="${VLLM_MUSA_REAL_MCC:-mcc}"
+musa_compiler="${VLLM_MUSA_CCACHE_MUSA_COMPILER:-}"
+source_dir="${VLLM_MUSA_CCACHE_SOURCE_DIR:-${CCACHE_DIR:-/tmp}/vllm-musa-sources}"
+mkdir -p "${source_dir}"
+
+raw_args=("$@")
+force_musa=0
+for ((i = 0; i < ${#raw_args[@]}; i++)); do
+  arg="${raw_args[$i]}"
+  if [[ "${arg}" == "-x" ]]; then
+    next_arg=""
+    if ((i + 1 < ${#raw_args[@]})); then
+      next_arg="${raw_args[$((i + 1))]}"
+    fi
+    if [[ "${next_arg}" == "musa" ]]; then
+      force_musa=1
+    fi
+  elif [[ "${arg}" == "-xmusa" || "${arg}" == "-x=musa" ]]; then
+    force_musa=1
+  elif [[ "${arg}" == *.mu || "${arg}" == *.muh ]]; then
+    force_musa=1
+  fi
+done
+
+args=()
+source_include_args=()
+for ((i = 0; i < ${#raw_args[@]}; i++)); do
+  arg="${raw_args[$i]}"
+  if [[ "${arg}" == "-x" ]]; then
+    next_arg=""
+    if ((i + 1 < ${#raw_args[@]})); then
+      next_arg="${raw_args[$((i + 1))]}"
+    fi
+    if [[ "${next_arg}" == "musa" ]]; then
+      i=$((i + 1))
+      continue
+    fi
+  elif [[ "${arg}" == "-xmusa" || "${arg}" == "-x=musa" ]]; then
+    continue
+  fi
+
+  case "${arg}" in
+    *.mu|*.muh|*.cu|*.cuh)
+      source_path="$(realpath -m "${arg}")"
+      source_include_args+=("-I$(dirname "${source_path}")")
+      source_hash="$(printf '%s' "${source_path}" | sha256sum | awk '{print $1}')"
+      source_base="$(basename "${source_path}")"
+      source_stem="${source_base%.*}"
+      ccache_source="${source_dir}/${source_hash}_${source_stem}.cu"
+      if [[ ! -e "${ccache_source}" ]] || ! cmp -s "${source_path}" "${ccache_source}"; then
+        tmp_source="${ccache_source}.$$"
+        cp "${source_path}" "${tmp_source}"
+        mv "${tmp_source}" "${ccache_source}"
+      fi
+      args+=("${ccache_source}")
+      ;;
+    *.cc|*.cpp|*.cxx)
+      if [[ "${force_musa}" == "1" ]]; then
+        source_path="$(realpath -m "${arg}")"
+        source_include_args+=("-I$(dirname "${source_path}")")
+        source_hash="$(printf '%s' "${source_path}" | sha256sum | awk '{print $1}')"
+        source_base="$(basename "${source_path}")"
+        source_stem="${source_base%.*}"
+        ccache_source="${source_dir}/${source_hash}_${source_stem}.cu"
+        if [[ ! -e "${ccache_source}" ]] || ! cmp -s "${source_path}" "${ccache_source}"; then
+          tmp_source="${ccache_source}.$$"
+          cp "${source_path}" "${tmp_source}"
+          mv "${tmp_source}" "${ccache_source}"
+        fi
+        args+=("${ccache_source}")
+      else
+        args+=("${arg}")
+      fi
+      ;;
+    *)
+      args+=("${arg}")
+      ;;
+  esac
+done
+
+compiler="${real_mcc}"
+if [[ "${force_musa}" == "1" ]]; then
+  if [[ -z "${musa_compiler}" ]]; then
+    echo "vllm-musa: missing VLLM_MUSA_CCACHE_MUSA_COMPILER for MUSA ccache compile" >&2
+    exit 1
+  fi
+  compiler="${musa_compiler}"
+fi
+
+exec "${ccache_bin}" "${compiler}" "${source_include_args[@]}" "${args[@]}"
+"""
+
+
+def _compiler_digest(path: str) -> str:
+    try:
+        return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+    except OSError:
+        return "unavailable"
+
+
+def _env_enabled(name: str, default: str = "1") -> bool:
+    return os.environ.get(name, default).strip().lower() not in FALSE_VALUES
+
+
+def _find_real_compiler(name: str) -> str | None:
+    if name == "mcc":
+        musa_home = os.environ.get("MUSA_HOME") or os.environ.get("MUSA_PATH")
+        if musa_home:
+            candidate = Path(musa_home) / "bin" / "mcc"
+            if candidate.exists():
+                return str(candidate)
+
+        default_mcc = Path("/usr/local/musa/bin/mcc")
+        if default_mcc.exists():
+            return str(default_mcc)
+
+    return shutil.which(name)
+
+
+def _resolve_executable(executable: str, *, follow_symlinks: bool = True) -> str:
+    path = Path(executable)
+    if path.parent != Path("."):
+        if follow_symlinks:
+            return str(path.resolve())
+        return str(path.absolute())
+
+    found = shutil.which(executable)
+    if not found:
+        return executable
+    if follow_symlinks:
+        return str(Path(found).resolve())
+    return found
+
+
+def _write_mcc_wrapper(wrapper_dir: Path) -> Path:
+    wrapper = wrapper_dir / "mcc"
+    wrapper.write_text(WRAPPER_SCRIPT, encoding="utf-8")
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def _write_musa_compiler_wrapper(wrapper_dir: Path, real_mcc: str) -> Path:
+    wrapper = wrapper_dir / "mcc-musa-compiler"
+    script = (
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"# real_mcc_sha256: {_compiler_digest(real_mcc)}\n"
+        f"real_mcc={shlex.quote(real_mcc)}\n"
+        'exec "${real_mcc}" -x musa "$@"\n'
+    )
+    wrapper.write_text(script, encoding="utf-8")
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def _link_ccache_wrapper(wrapper_dir: Path, compiler_name: str, ccache_bin: str) -> None:
+    wrapper = wrapper_dir / compiler_name
+    try:
+        if wrapper.exists() or wrapper.is_symlink():
+            wrapper.unlink()
+        wrapper.symlink_to(ccache_bin)
+    except OSError:
+        # Some filesystems disallow symlinks; a tiny exec wrapper is good enough.
+        wrapper.write_text(
+            "#!/usr/bin/env bash\n"
+            f"exec {ccache_bin!r} {compiler_name!r} \"$@\"\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+
+
+def configure_compiler_cache(root: Path) -> bool:
+    """Configure ccache for torch_musa/torch extension compilation.
+
+    torch_musa honors ``PYTORCH_MCC`` for MUSA compilation and PyTorch honors
+    ``CXX`` for host C++ compilation. The MUSA compiler emits/consumes `.mu`
+    files and sometimes uses `-x musa`; ccache 4.x treats those as unsupported
+    inputs. The generated `mcc` wrapper creates stable `.cu` copies of those
+    sources before invoking ccache, so the real compile becomes cacheable while
+    preserving the original source files and mcc invocation semantics.
+    """
+
+    if not _env_enabled("VLLM_MUSA_USE_CCACHE", "1"):
+        print("vllm-musa: ccache disabled by VLLM_MUSA_USE_CCACHE")
+        return False
+
+    ccache_bin = os.environ.get("VLLM_MUSA_CCACHE") or shutil.which("ccache")
+    if not ccache_bin:
+        print(
+            "vllm-musa: ccache not found; native extension builds will not use ccache"
+        )
+        return False
+    ccache_bin = _resolve_executable(ccache_bin)
+
+    real_mcc = os.environ.get("VLLM_MUSA_REAL_MCC") or _find_real_compiler("mcc")
+    if not real_mcc:
+        print("vllm-musa: mcc not found; cannot configure ccache for MUSA sources")
+        return False
+    real_mcc = _resolve_executable(real_mcc, follow_symlinks=False)
+
+    cache_dir = Path(
+        os.environ.get("VLLM_MUSA_CCACHE_DIR")
+        or os.environ.get("CCACHE_DIR")
+        or root / ".ccache"
+    ).resolve()
+    wrapper_dir = cache_dir / "wrappers"
+    source_dir = cache_dir / "musa-sources"
+    wrapper_dir.mkdir(parents=True, exist_ok=True)
+    source_dir.mkdir(parents=True, exist_ok=True)
+
+    musa_compiler_wrapper = _write_musa_compiler_wrapper(wrapper_dir, real_mcc)
+    mcc_wrapper = _write_mcc_wrapper(wrapper_dir)
+    for compiler_name in ("cc", "c++", "gcc", "g++"):
+        _link_ccache_wrapper(wrapper_dir, compiler_name, ccache_bin)
+
+    path_entries = os.environ.get("PATH", "").split(os.pathsep)
+    if str(wrapper_dir) not in path_entries:
+        os.environ["PATH"] = str(wrapper_dir) + os.pathsep + os.environ.get("PATH", "")
+
+    os.environ.setdefault("CCACHE_DIR", str(cache_dir))
+    os.environ.setdefault("CCACHE_BASEDIR", str(root))
+    os.environ.setdefault("CCACHE_COMPILERCHECK", "content")
+    os.environ.setdefault("CCACHE_NOHASHDIR", "true")
+    os.environ.setdefault(
+        "CCACHE_SLOPPINESS", "include_file_ctime,include_file_mtime,time_macros"
+    )
+    os.environ["VLLM_MUSA_REAL_CCACHE"] = ccache_bin
+    os.environ["VLLM_MUSA_REAL_MCC"] = real_mcc
+    os.environ["VLLM_MUSA_CCACHE_MUSA_COMPILER"] = str(musa_compiler_wrapper)
+    os.environ.setdefault("VLLM_MUSA_CCACHE_SOURCE_DIR", str(source_dir))
+    os.environ.setdefault("PYTORCH_MCC", str(mcc_wrapper))
+
+    if "CXX" not in os.environ:
+        os.environ["CXX"] = str(wrapper_dir / "c++")
+
+    max_size = os.environ.get("VLLM_MUSA_CCACHE_MAXSIZE")
+    if max_size:
+        os.environ.setdefault("CCACHE_MAXSIZE", max_size)
+
+    print(
+        "vllm-musa: ccache enabled for native builds "
+        f"(cache_dir={cache_dir}, mcc={mcc_wrapper}, cxx={os.environ.get('CXX')})"
+    )
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "vllm-musa"
 version = "0.1.1"
 description = "vLLM platform plugin for Moore Threads (MUSA) GPUs"
 readme = "README.md"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.9"
 authors = [
     {name = "vLLM Community"},

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,14 @@ from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 root = Path(__file__).parent.resolve()
+sys.path.insert(0, str(root))
+
+from build_utils.ccache import configure_compiler_cache
+
 third_party = Path("third_party")
 arch = platform.machine().lower()
+
+configure_compiler_cache(root)
 
 # Detect editable install (pip install -e .) or develop mode
 _is_editable_install = (
@@ -338,7 +344,7 @@ CSRC_TEXT_PATCHES = {
 # =============================================================================
 
 CXX_FLAGS = ["force_mcc"]
-LINK_LIBRARIES = ["c10", "torch", "torch_python"]
+LINK_LIBRARIES = ["c10", "torch", "torch_python", "musart"]
 EXTRA_LINK_ARGS = [
     "-Wl,-rpath,$ORIGIN/../../torch/lib",
     f"-L/usr/lib/{arch}-linux-gnu",
@@ -347,15 +353,20 @@ EXTRA_LINK_ARGS = [
 
 # Detect MTGPU target architecture
 DEFAULT_MTGPU_TARGET = "mp_31"
-MTGPU_TARGET = os.environ.get("MTGPU_TARGET", DEFAULT_MTGPU_TARGET)
+MTGPU_TARGET = os.environ.get("MTGPU_TARGET")
 
-if torch.musa.is_available():
+if MTGPU_TARGET:
+    print(f"Using MTGPU_TARGET from environment: {MTGPU_TARGET}")
+else:
+    MTGPU_TARGET = DEFAULT_MTGPU_TARGET
+
+if "MTGPU_TARGET" not in os.environ and torch.musa.is_available():
     try:
         device_props = torch.musa.get_device_properties(0)
         MTGPU_TARGET = f"mp_{device_props.major}{device_props.minor}"
     except Exception as e:
         print(f"Warning: Failed to detect GPU properties: {e}")
-else:
+elif "MTGPU_TARGET" not in os.environ:
     print(f"Warning: torch.musa not available. Using default target: {MTGPU_TARGET}")
 
 SUPPORTED_MTGPU_TARGETS = ["mp_22", "mp_31"]

--- a/tests/test_build_ccache.py
+++ b/tests/test_build_ccache.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for vllm-musa ccache build wiring."""
+
+import os
+import subprocess
+from pathlib import Path
+
+from build_utils.ccache import configure_compiler_cache
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_configure_compiler_cache_sets_torch_musa_env(monkeypatch, tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    ccache = bin_dir / "ccache"
+    mcc = bin_dir / "mcc"
+    _write_executable(ccache, "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(mcc, "#!/usr/bin/env bash\nexit 0\n")
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.setenv("VLLM_MUSA_CCACHE", "ccache")
+    monkeypatch.setenv("VLLM_MUSA_REAL_MCC", "mcc")
+    monkeypatch.delenv("CXX", raising=False)
+    monkeypatch.delenv("PYTORCH_MCC", raising=False)
+    monkeypatch.delenv("CCACHE_DIR", raising=False)
+
+    assert configure_compiler_cache(root) is True
+
+    cache_dir = root / ".ccache"
+    assert os.environ["CCACHE_DIR"] == str(cache_dir.resolve())
+    assert os.environ["PYTORCH_MCC"] == str(cache_dir / "wrappers" / "mcc")
+    assert os.environ["CXX"] == str(cache_dir / "wrappers" / "c++")
+    assert os.environ["VLLM_MUSA_REAL_CCACHE"] == str(ccache)
+    assert os.environ["VLLM_MUSA_REAL_MCC"] == str(mcc)
+    assert os.environ["VLLM_MUSA_CCACHE_MUSA_COMPILER"] == str(
+        cache_dir / "wrappers" / "mcc-musa-compiler"
+    )
+    assert str(cache_dir / "wrappers") in os.environ["PATH"].split(os.pathsep)
+
+
+def test_mcc_wrapper_presents_musa_sources_as_cu_to_ccache(monkeypatch, tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    arg_log = tmp_path / "ccache-args.txt"
+    ccache = bin_dir / "ccache"
+    mcc = bin_dir / "mcc"
+    _write_executable(
+        ccache,
+        "#!/usr/bin/env bash\n"
+        f"printf '%s\\n' \"$@\" > {arg_log}\n"
+        "exit 0\n",
+    )
+    _write_executable(mcc, "#!/usr/bin/env bash\nexit 0\n")
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    source = root / "kernel.mu"
+    source.write_text("__global__ void kernel() {}\n", encoding="utf-8")
+
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ["PATH"])
+    monkeypatch.setenv("VLLM_MUSA_CCACHE", str(ccache))
+    monkeypatch.setenv("VLLM_MUSA_REAL_MCC", str(mcc))
+    monkeypatch.delenv("CXX", raising=False)
+    monkeypatch.delenv("PYTORCH_MCC", raising=False)
+    monkeypatch.delenv("CCACHE_DIR", raising=False)
+    monkeypatch.delenv("VLLM_MUSA_REAL_CCACHE", raising=False)
+    monkeypatch.delenv("VLLM_MUSA_CCACHE_SOURCE_DIR", raising=False)
+
+    assert configure_compiler_cache(root) is True
+
+    subprocess.check_call(
+        [
+            os.environ["PYTORCH_MCC"],
+            "-x",
+            "musa",
+            "-c",
+            str(source),
+            "-o",
+            str(root / "kernel.o"),
+        ]
+    )
+
+    args = arg_log.read_text(encoding="utf-8").splitlines()
+    musa_compiler = Path(args[0])
+    assert musa_compiler == Path(os.environ["VLLM_MUSA_CCACHE_MUSA_COMPILER"])
+    assert str(mcc) in musa_compiler.read_text(encoding="utf-8")
+    assert "-x musa" in musa_compiler.read_text(encoding="utf-8")
+    assert f"-I{source.parent}" in args
+    assert "-x" not in args
+    assert "musa" not in args
+    cu_sources = [arg for arg in args if arg.endswith(".cu")]
+    assert len(cu_sources) == 1
+    assert Path(cu_sources[0]).read_text(encoding="utf-8") == source.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_mcc_wrapper_only_strips_musa_language_flag(monkeypatch, tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    arg_log = tmp_path / "ccache-args.txt"
+    ccache = bin_dir / "ccache"
+    mcc = bin_dir / "mcc"
+    _write_executable(
+        ccache,
+        "#!/usr/bin/env bash\n"
+        f"printf '%s\\n' \"$@\" > {arg_log}\n"
+        "exit 0\n",
+    )
+    _write_executable(mcc, "#!/usr/bin/env bash\nexit 0\n")
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    source = root / "host.cpp"
+    source.write_text("int f() { return 0; }\n", encoding="utf-8")
+
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ["PATH"])
+    monkeypatch.setenv("VLLM_MUSA_CCACHE", str(ccache))
+    monkeypatch.setenv("VLLM_MUSA_REAL_MCC", str(mcc))
+    monkeypatch.delenv("CXX", raising=False)
+    monkeypatch.delenv("PYTORCH_MCC", raising=False)
+    monkeypatch.delenv("CCACHE_DIR", raising=False)
+    monkeypatch.delenv("VLLM_MUSA_REAL_CCACHE", raising=False)
+    monkeypatch.delenv("VLLM_MUSA_CCACHE_SOURCE_DIR", raising=False)
+
+    assert configure_compiler_cache(root) is True
+
+    subprocess.check_call(
+        [
+            os.environ["PYTORCH_MCC"],
+            "-x",
+            "c++",
+            "-c",
+            str(source),
+            "-o",
+            str(root / "host.o"),
+        ]
+    )
+
+    args = arg_log.read_text(encoding="utf-8").splitlines()
+    assert "-x" in args
+    assert "c++" in args
+    assert str(source) in args

--- a/tests/test_build_ccache.py
+++ b/tests/test_build_ccache.py
@@ -24,7 +24,7 @@ def test_configure_compiler_cache_sets_torch_musa_env(monkeypatch, tmp_path):
 
     root = tmp_path / "repo"
     root.mkdir()
-    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ["PATH"])
     monkeypatch.setenv("VLLM_MUSA_CCACHE", "ccache")
     monkeypatch.setenv("VLLM_MUSA_REAL_MCC", "mcc")
     monkeypatch.delenv("CXX", raising=False)
@@ -43,6 +43,45 @@ def test_configure_compiler_cache_sets_torch_musa_env(monkeypatch, tmp_path):
         cache_dir / "wrappers" / "mcc-musa-compiler"
     )
     assert str(cache_dir / "wrappers") in os.environ["PATH"].split(os.pathsep)
+
+
+def test_host_compiler_fallback_uses_real_compiler_path(monkeypatch, tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    arg_log = tmp_path / "ccache-args.txt"
+    ccache = bin_dir / "ccache"
+    mcc = bin_dir / "mcc"
+    _write_executable(
+        ccache,
+        "#!/usr/bin/env bash\n"
+        f"printf '%s\\n' \"$@\" > {arg_log}\n"
+        "exit 0\n",
+    )
+    for compiler_name in ("cc", "c++", "gcc", "g++", "mcc"):
+        _write_executable(bin_dir / compiler_name, "#!/usr/bin/env bash\nexit 0\n")
+
+    def fail_symlink(*_args, **_kwargs):
+        raise OSError("symlinks disabled")
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.setattr(Path, "symlink_to", fail_symlink)
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ["PATH"])
+    monkeypatch.setenv("VLLM_MUSA_CCACHE", str(ccache))
+    monkeypatch.setenv("VLLM_MUSA_REAL_MCC", str(mcc))
+    monkeypatch.delenv("CXX", raising=False)
+    monkeypatch.delenv("PYTORCH_MCC", raising=False)
+    monkeypatch.delenv("CCACHE_DIR", raising=False)
+
+    assert configure_compiler_cache(root) is True
+
+    cache_dir = root / ".ccache"
+    gcc_wrapper = cache_dir / "wrappers" / "gcc"
+    subprocess.check_call([str(gcc_wrapper), "-c", "source.cpp"])
+
+    args = arg_log.read_text(encoding="utf-8").splitlines()
+    assert args[0] == str((bin_dir / "gcc").resolve())
+    assert args[0] != str(gcc_wrapper)
 
 
 def test_mcc_wrapper_presents_musa_sources_as_cu_to_ccache(monkeypatch, tmp_path):


### PR DESCRIPTION
```bash
Run                            Elapsed    ccache result           Time saved vs fresh    Reduction vs fresh     Speedup
━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━
Fresh install           2385s / 39m45s    0/40 hits, 40 misses               baseline              baseline    baseline
──────────────────────  ────────────────  ──────────────────────  ─────────────────────  ────────────────────  ──────────
2nd editable install      119s / 1m59s    40/40 hits, 0 misses         2266s / 37m46s                 95.0%       20.0x
──────────────────────  ────────────────  ──────────────────────  ─────────────────────  ────────────────────  ──────────
3rd editable install      118s / 1m58s    40/40 hits, 0 misses         2267s / 37m47s                 95.1%       20.2x
```