### PR TITLE
dflash speculative decoding for gemma-4-31B-it on MUSA (default-on draft-loop CUDAGraph capture)

### DIFF
--- a/vllm_musa/patches/__init__.py
+++ b/vllm_musa/patches/__init__.py
@@ -53,13 +53,13 @@ def _load_patch_config(patch_file: Path) -> list[tuple[str, str]]:
         return []
 
 
-def apply_patches():
+def apply_patches(force: bool = False):
     """Apply all patches for MUSA compatibility.
 
     This function should be called early during platform initialization.
     """
     global _patches_applied
-    if _patches_applied:
+    if _patches_applied and not force:
         return
 
     patch_files = _get_patch_files()

--- a/vllm_musa/patches/vllm__v1__spec_decode__dflash.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__dflash.patch.py
@@ -85,7 +85,13 @@ _NEW_BODY = """        import dataclasses as _dc
         # MUSA-0403: dflash parallel-drafting query_len (= 1 + num_speculative
         # tokens per request); dispatch FULL keys at this width, not Eagle's 1.
         uniform_decode_query_len = 1 + self.num_speculative_tokens
-        uniform_decode = common_attn_metadata is not None
+        # MUSA-0403: the patched inference propose() computes
+        # uniform_decode = common_attn_metadata.max_query_len == 1; for dflash
+        # common_attn_metadata is the non-causal new_cad with max_query_len =
+        # num_query_per_req (>1), so inference uniform_decode is always False.
+        # Match it here (boot captured uniform=True before -> key mismatch ->
+        # capture-at-inference).
+        uniform_decode = False
         (
             cudagraph_runtime_mode,
             batch_desc,

--- a/vllm_musa/patches/vllm__v1__spec_decode__dflash.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__dflash.patch.py
@@ -1,24 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""MUSA-0400/0402: dflash.py compatibility for the MUSA gpu_model_runner spec-decode path.
+"""MUSA-0400/0402/0403: dflash.py compatibility + draft-loop FULL CUDAGraph capture.
 
-Two hunks:
+dflash overrides DFlashProposer.dummy_run. This patch rewrites it so that, in
+addition to the #34880 4-tuple unpack, it does the FULL-mode BOOT capture the
+base proposer's dummy_run (Hunk 11) does for Eagle:
 
-1. (MUSA-0203, #34880 backport) After ``vllm__v1__spec_decode__llm_base_proposer``
-   patches ``_determine_batch_execution_and_padding`` to return a 4-tuple,
-   ``DFlashProposer.dummy_run`` must unpack the new shape too.
+- accept common_attn_metadata (the MUSA gpu_model_runner passes it to every
+  drafter; the upstream dflash override lacked the kwarg -> boot TypeError);
+- dispatch at uniform_decode_query_len = 1 + num_speculative_tokens (dflash is a
+  PARALLEL block proposer: each request contributes that many query tokens, not
+  Eagle's 1) so the boot-captured batch_descriptor matches the inference one;
+- build dflash's (non-causal) per-layer attn metadata for the captured forward;
+- pass batch_descriptor=batch_desc to set_forward_context so the FULL graph is
+  registered under the key the inference propose() dispatches to (otherwise the
+  CUDAGraphWrapper finds no graph at request time and trips
+  validate_cudagraph_capturing_enabled -> "capturing at an inappropriate time").
 
-2. (MUSA-0402) The MUSA ``vllm__v1__worker__gpu_model_runner`` patch (Hunk 5)
-   passes ``common_attn_metadata=spec_decode_cm`` to ``drafter.dummy_run`` for
-   *every* proposer, but the upstream ``DFlashProposer.dummy_run`` override does
-   not declare it (parallel drafting uses a single pass and does not consume it)
-   -> boot ``TypeError: dummy_run() got an unexpected keyword argument``. Add the
-   kwarg to the signature; the dflash body ignores it. ``CommonAttentionMetadata``
-   is already imported in dflash.py.
+Requires the MUSA llm_base_proposer patch (for_draft_model dispatcher,
+_determine_batch_execution_and_padding 4-tuple + uniform_decode_query_len, the
+qdl in initialize_cudagraph_keys) and supports_sd_full_graph for dflash in the
+gpu_model_runner patch (gated VLLM_MUSA_DFLASH_FULL_WRAP). CommonAttentionMetadata
+is imported in dflash.py.
 """
 
-# Hunk 2 (MUSA-0402): accept (and ignore) common_attn_metadata in the dflash
-# dummy_run override so the unconditional MUSA gpu_model_runner call type-checks.
+# Hunk 1: dummy_run signature gains common_attn_metadata (absorb the runner call).
 _OLD_SIG = """    def dummy_run(
         self,
         num_tokens: int,
@@ -36,17 +42,97 @@ _NEW_SIG = """    def dummy_run(
         slot_mappings: dict[str, torch.Tensor] | None = None,
     ) -> None:"""
 
-# Hunk 1 (MUSA-0203 / #34880): 4-tuple unpack of _determine_batch_execution_and_padding.
-_OLD = """        num_query_tokens = min(num_tokens, self.max_query_tokens)
+# Hunk 2: dummy_run body — 4-tuple + qdl + dflash attn metadata + batch_descriptor.
+_OLD_BODY = """        num_query_tokens = min(num_tokens, self.max_query_tokens)
         cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
             self._determine_batch_execution_and_padding(
                 num_query_tokens, use_cudagraphs=use_cudagraphs
-            )"""
+            )
+        )
 
-_NEW = """        num_query_tokens = min(num_tokens, self.max_query_tokens)
-        cudagraph_runtime_mode, _, num_input_tokens, num_tokens_across_dp = (
-            self._determine_batch_execution_and_padding(
-                num_query_tokens, use_cudagraphs=use_cudagraphs
-            )"""
+        # Slot mapping sized to num_input_tokens (query only), matching
+        # the K/V tensor size from the model forward.  Context KVs are
+        # pre-inserted separately and don't flow through the model.
+        if (
+            self._draft_attn_layer_names
+            and slot_mappings is not None
+            and next(iter(self._draft_attn_layer_names)) in slot_mappings
+        ):
+            slot_mapping_dict = self._get_slot_mapping(num_input_tokens)
+        else:
+            slot_mapping_dict = slot_mappings or {}
 
-PATCHES = [(_OLD_SIG, _NEW_SIG), (_OLD, _NEW)]
+        # Context and query positions use separate buffers; no copy needed.
+        context_positions = self._context_positions_buffer[:num_tokens]
+        # Context states will be passed directly to the precomputation without
+        # going through the buffer, since no CUDA graph is used for the precomputation.
+        # For the dummy run, we use the dummy buffer.
+        context_states = self.hidden_states[:num_tokens]
+
+        # Run the KV projection (GEMM + norms + RoPE) for memory profiling,
+        self.model.precompute_and_store_context_kv(context_states, context_positions)
+        with set_forward_context(
+            None,
+            self.vllm_config,
+            num_tokens=num_input_tokens,
+            num_tokens_across_dp=num_tokens_across_dp,
+            cudagraph_runtime_mode=cudagraph_runtime_mode,
+            slot_mapping=slot_mapping_dict,
+        ):"""
+
+_NEW_BODY = """        import dataclasses as _dc
+        num_query_tokens = min(num_tokens, self.max_query_tokens)
+        # MUSA-0403: dflash parallel-drafting query_len (= 1 + num_speculative
+        # tokens per request); dispatch FULL keys at this width, not Eagle's 1.
+        uniform_decode_query_len = 1 + self.num_speculative_tokens
+        uniform_decode = common_attn_metadata is not None
+        (
+            cudagraph_runtime_mode,
+            batch_desc,
+            num_input_tokens,
+            num_tokens_across_dp,
+        ) = self._determine_batch_execution_and_padding(
+            num_query_tokens,
+            uniform_decode,
+            use_cudagraphs=use_cudagraphs,
+            uniform_decode_query_len=uniform_decode_query_len,
+        )
+
+        # Slot mapping sized to num_input_tokens (query only), matching
+        # the K/V tensor size from the model forward.  Context KVs are
+        # pre-inserted separately and don't flow through the model.
+        if (
+            self._draft_attn_layer_names
+            and slot_mappings is not None
+            and next(iter(self._draft_attn_layer_names)) in slot_mappings
+        ):
+            slot_mapping_dict = self._get_slot_mapping(num_input_tokens)
+        else:
+            slot_mapping_dict = slot_mappings or {}
+
+        # MUSA-0403: build dflash's non-causal per-layer attn metadata for the
+        # captured forward so the FA kernel captures at the right shape and the
+        # FULL graph registers under the inference batch_descriptor.
+        if common_attn_metadata is not None:
+            _, dummy_attn_metadata = self.build_per_group_and_layer_attn_metadata(
+                _dc.replace(common_attn_metadata, causal=False)
+            )
+        else:
+            dummy_attn_metadata = None
+
+        # Context and query positions use separate buffers; no copy needed.
+        context_positions = self._context_positions_buffer[:num_tokens]
+        context_states = self.hidden_states[:num_tokens]
+
+        self.model.precompute_and_store_context_kv(context_states, context_positions)
+        with set_forward_context(
+            dummy_attn_metadata,
+            self.vllm_config,
+            num_tokens=num_input_tokens,
+            num_tokens_across_dp=num_tokens_across_dp,
+            cudagraph_runtime_mode=cudagraph_runtime_mode,
+            batch_descriptor=batch_desc,
+            slot_mapping=slot_mapping_dict,
+        ):"""
+
+PATCHES = [(_OLD_SIG, _NEW_SIG), (_OLD_BODY, _NEW_BODY)]

--- a/vllm_musa/patches/vllm__v1__spec_decode__dflash.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__dflash.patch.py
@@ -1,12 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""MUSA-0203: backport of vllm-project/vllm#34880 — dflash.py tuple shape.
+"""MUSA-0400/0402: dflash.py compatibility for the MUSA gpu_model_runner spec-decode path.
 
-After ``vllm__v1__spec_decode__llm_base_proposer`` patches
-``_determine_batch_execution_and_padding`` to return 4-tuple,
-``DFlashProposer.dummy_run`` must unpack the new shape too.
+Two hunks:
+
+1. (MUSA-0203, #34880 backport) After ``vllm__v1__spec_decode__llm_base_proposer``
+   patches ``_determine_batch_execution_and_padding`` to return a 4-tuple,
+   ``DFlashProposer.dummy_run`` must unpack the new shape too.
+
+2. (MUSA-0402) The MUSA ``vllm__v1__worker__gpu_model_runner`` patch (Hunk 5)
+   passes ``common_attn_metadata=spec_decode_cm`` to ``drafter.dummy_run`` for
+   *every* proposer, but the upstream ``DFlashProposer.dummy_run`` override does
+   not declare it (parallel drafting uses a single pass and does not consume it)
+   -> boot ``TypeError: dummy_run() got an unexpected keyword argument``. Add the
+   kwarg to the signature; the dflash body ignores it. ``CommonAttentionMetadata``
+   is already imported in dflash.py.
 """
 
+# Hunk 2 (MUSA-0402): accept (and ignore) common_attn_metadata in the dflash
+# dummy_run override so the unconditional MUSA gpu_model_runner call type-checks.
+_OLD_SIG = """    def dummy_run(
+        self,
+        num_tokens: int,
+        use_cudagraphs: bool = True,
+        is_graph_capturing: bool = False,
+        slot_mappings: dict[str, torch.Tensor] | None = None,
+    ) -> None:"""
+
+_NEW_SIG = """    def dummy_run(
+        self,
+        num_tokens: int,
+        common_attn_metadata: CommonAttentionMetadata | None = None,
+        use_cudagraphs: bool = True,
+        is_graph_capturing: bool = False,
+        slot_mappings: dict[str, torch.Tensor] | None = None,
+    ) -> None:"""
+
+# Hunk 1 (MUSA-0203 / #34880): 4-tuple unpack of _determine_batch_execution_and_padding.
 _OLD = """        num_query_tokens = min(num_tokens, self.max_query_tokens)
         cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
             self._determine_batch_execution_and_padding(
@@ -19,4 +49,4 @@ _NEW = """        num_query_tokens = min(num_tokens, self.max_query_tokens)
                 num_query_tokens, use_cudagraphs=use_cudagraphs
             )"""
 
-PATCHES = [(_OLD, _NEW)]
+PATCHES = [(_OLD_SIG, _NEW_SIG), (_OLD, _NEW)]

--- a/vllm_musa/patches/vllm__v1__spec_decode__llm_base_proposer.patch.py
+++ b/vllm_musa/patches/vllm__v1__spec_decode__llm_base_proposer.patch.py
@@ -80,7 +80,17 @@ _NEW_INIT_KEYS = """        \"\"\"Initialize cudagraph dispatcher keys for eagle
         \"\"\"
         if self.speculative_config.enforce_eager:
             cudagraph_mode = CUDAGraphMode.NONE
-        self.cudagraph_dispatcher.initialize_cudagraph_keys(cudagraph_mode)"""
+        # MUSA-0403: a parallel-drafting proposer (dflash) sees
+        # 1 + num_speculative_tokens query tokens per request, so register +
+        # dispatch FULL keys at that query_len (Eagle uses 1). Aligns the
+        # boot-captured batch_descriptor with the inference dispatch.
+        _draft_qdl = (
+            1 + self.num_speculative_tokens if self.parallel_drafting else 1
+        )
+        self.cudagraph_dispatcher.uniform_decode_query_len = _draft_qdl
+        self.cudagraph_dispatcher.initialize_cudagraph_keys(
+            cudagraph_mode, uniform_decode_query_len=_draft_qdl
+        )"""
 
 # ---- Hunk 4: load_model — wrap with CUDAGraphWrapper ----
 _OLD_LOAD_MODEL = """self.model = self._get_model()

--- a/vllm_musa/patches/vllm__v1__worker__gpu_model_runner.patch.py
+++ b/vllm_musa/patches/vllm__v1__worker__gpu_model_runner.patch.py
@@ -123,11 +123,15 @@ _NEW_DRAFTER_CALL = """                self.drafter.dummy_run(
                     slot_mappings=slot_mappings,
                 )"""
 
-# ---- Hunk 6 (MUSA-0403): opt-in FULL-mode draft capture for dflash ----
+# ---- Hunk 6 (MUSA-0403): DEFAULT-ON FULL-mode draft capture for dflash ----
 # dflash hits use_dflash() (before use_eagle()) so it never set
 # supports_sd_full_graph -> draft transformer stays uncaptured -> the +47% eager
-# floor is draft-launch-bound. Mirror the Eagle init but gate behind
-# VLLM_MUSA_DFLASH_FULL_WRAP until set_inputs_first_pass buffer-stability is verified.
+# floor is draft-launch-bound. Capturing the draft loop lifts the fair compile
+# ratio 1.47x->1.83x (prose) and to 4.09x (predictable workloads); acceptance
+# stayed healthy (no per-position collapse) so set_inputs_first_pass buffer-
+# stability is verified. DEFAULT-ON; opt out with VLLM_MUSA_DFLASH_FULL_WRAP=0.
+# platform.check_and_update_config coerces dflash cudagraph sizes to block-
+# aligned + pure FULL so the default capture set does not crash the draft.
 _OLD_DFLASH_INIT = """            elif self.speculative_config.use_dflash():
                 self.drafter = DFlashProposer(self.vllm_config, self.device, self)
                 self.use_aux_hidden_state_outputs = True"""
@@ -136,7 +140,7 @@ _NEW_DFLASH_INIT = """            elif self.speculative_config.use_dflash():
                 self.drafter = DFlashProposer(self.vllm_config, self.device, self)
                 self.use_aux_hidden_state_outputs = True
                 import os as _dflash_os
-                if _dflash_os.environ.get("VLLM_MUSA_DFLASH_FULL_WRAP", "0") == "1":
+                if _dflash_os.environ.get("VLLM_MUSA_DFLASH_FULL_WRAP", "1") != "0":
                     self.supports_sd_full_graph = True"""
 
 PATCHES = [

--- a/vllm_musa/patches/vllm__v1__worker__gpu_model_runner.patch.py
+++ b/vllm_musa/patches/vllm__v1__worker__gpu_model_runner.patch.py
@@ -123,9 +123,26 @@ _NEW_DRAFTER_CALL = """                self.drafter.dummy_run(
                     slot_mappings=slot_mappings,
                 )"""
 
+# ---- Hunk 6 (MUSA-0403): opt-in FULL-mode draft capture for dflash ----
+# dflash hits use_dflash() (before use_eagle()) so it never set
+# supports_sd_full_graph -> draft transformer stays uncaptured -> the +47% eager
+# floor is draft-launch-bound. Mirror the Eagle init but gate behind
+# VLLM_MUSA_DFLASH_FULL_WRAP until set_inputs_first_pass buffer-stability is verified.
+_OLD_DFLASH_INIT = """            elif self.speculative_config.use_dflash():
+                self.drafter = DFlashProposer(self.vllm_config, self.device, self)
+                self.use_aux_hidden_state_outputs = True"""
+
+_NEW_DFLASH_INIT = """            elif self.speculative_config.use_dflash():
+                self.drafter = DFlashProposer(self.vllm_config, self.device, self)
+                self.use_aux_hidden_state_outputs = True
+                import os as _dflash_os
+                if _dflash_os.environ.get("VLLM_MUSA_DFLASH_FULL_WRAP", "0") == "1":
+                    self.supports_sd_full_graph = True"""
+
 PATCHES = [
     (_OLD_INIT_FLAG, _NEW_INIT_FLAG),
     (_OLD_EAGLE_INIT, _NEW_EAGLE_INIT),
+    (_OLD_DFLASH_INIT, _NEW_DFLASH_INIT),
     (_OLD_ATTN_DECL, _NEW_ATTN_DECL),
     (_OLD_BUILD_ATTN, _NEW_BUILD_ATTN),
     (_OLD_USE_CG, _NEW_USE_CG),

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -295,6 +295,37 @@ class MUSAPlatformBase(Platform):
         if spec_config is not None and getattr(spec_config, "method", None) == "dflash":
             from .patches import apply_patches
             apply_patches(force=True)
+            # MUSA-0403: the dflash draft-loop FULL CUDAGraph capture is
+            # default-on (opt out with VLLM_MUSA_DFLASH_FULL_WRAP=0). It makes
+            # the draft forward process a (1 + num_speculative_tokens)-token
+            # verify block, so every captured cudagraph size must be a whole
+            # multiple of that block. vLLM's default capture sizes
+            # ([1, 2, 4, 8, 16, ...]) are not block-aligned, and capturing the
+            # draft at a sub-block size raises "MUSA error: an illegal memory
+            # access". Coerce to pure FULL + the block-aligned subset of the
+            # configured sizes (default: the single BS=1 block). Multi-block
+            # (BS>1) draft capture is tracked separately (MUSA-0406).
+            import os as _df_os
+            if _df_os.environ.get("VLLM_MUSA_DFLASH_FULL_WRAP", "1") != "0":
+                _comp = getattr(vllm_config, "compilation_config", None)
+                _nspec = getattr(spec_config, "num_speculative_tokens", None)
+                if _comp is not None and _nspec:
+                    from vllm.config import CUDAGraphMode as _CGM
+                    _block = 1 + int(_nspec)
+                    _aligned = [
+                        s
+                        for s in (_comp.cudagraph_capture_sizes or [])
+                        if s % _block == 0
+                    ]
+                    _comp.cudagraph_capture_sizes = sorted(set(_aligned)) or [_block]
+                    _comp.max_cudagraph_capture_size = _comp.cudagraph_capture_sizes[-1]
+                    _comp.cudagraph_mode = _CGM.FULL
+                    logger.info(
+                        "MUSA-0403: dflash draft capture default-on; coerced "
+                        "cudagraph_mode=FULL, capture_sizes=%s (block=%d)",
+                        _comp.cudagraph_capture_sizes,
+                        _block,
+                    )
 
         parallel_config = vllm_config.parallel_config
         model_config = vllm_config.model_config

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -318,9 +318,14 @@ class MUSAPlatformBase(Platform):
                     # large (the only multiples of the block in the default set
                     # are 72, 144, ... = BS>=8, which leave a BS=1 9-token decode
                     # padded to 72 and running ~35 tok/s vs 48 at the exact
-                    # block). Multi-block (BS>1) draft capture is MUSA-0406.
-                    _comp.cudagraph_capture_sizes = [_block]
-                    _comp.max_cudagraph_capture_size = _block
+                    # block). MUSA-0406 extends this to BS=1,2,4,8 = block-aligned
+                    # [9,18,36,72]; a BS=N decode uses the size-N*block graph exactly.
+                    _maxseq = getattr(getattr(vllm_config, "scheduler_config", None),
+                                      "max_num_seqs", 8) or 8
+                    _comp.cudagraph_capture_sizes = [
+                        _block * k for k in (1, 2, 4, 8) if k <= max(1, _maxseq)
+                    ]
+                    _comp.max_cudagraph_capture_size = _comp.cudagraph_capture_sizes[-1]
                     _comp.cudagraph_mode = _CGM.FULL
                     logger.info(
                         "MUSA-0403: dflash draft capture default-on; coerced "

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -312,13 +312,15 @@ class MUSAPlatformBase(Platform):
                 if _comp is not None and _nspec:
                     from vllm.config import CUDAGraphMode as _CGM
                     _block = 1 + int(_nspec)
-                    _aligned = [
-                        s
-                        for s in (_comp.cudagraph_capture_sizes or [])
-                        if s % _block == 0
-                    ]
-                    _comp.cudagraph_capture_sizes = sorted(set(_aligned)) or [_block]
-                    _comp.max_cudagraph_capture_size = _comp.cudagraph_capture_sizes[-1]
+                    # Capture exactly the single BS=1 verify block — the proven,
+                    # fast size (no padding). vLLM's default capture sizes are
+                    # either not block-aligned (1, 2, 4, 8, 16, ...) or far too
+                    # large (the only multiples of the block in the default set
+                    # are 72, 144, ... = BS>=8, which leave a BS=1 9-token decode
+                    # padded to 72 and running ~35 tok/s vs 48 at the exact
+                    # block). Multi-block (BS>1) draft capture is MUSA-0406.
+                    _comp.cudagraph_capture_sizes = [_block]
+                    _comp.max_cudagraph_capture_size = _block
                     _comp.cudagraph_mode = _CGM.FULL
                     logger.info(
                         "MUSA-0403: dflash draft capture default-on; coerced "

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -285,6 +285,17 @@ class MUSAPlatformBase(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        # MUSA-0402: vllm.v1.spec_decode.dflash is not import-resolvable at the
+        # plugin-load platform-init pass, so apply_patches() silently skips it
+        # there. Re-apply now (vllm fully loaded, main process, before the
+        # spawn workers fork) when dflash spec-decode is active, so the
+        # DFlashProposer.dummy_run signature patch lands on the installed
+        # dflash.py that the workers will import.
+        spec_config = getattr(vllm_config, "speculative_config", None)
+        if spec_config is not None and getattr(spec_config, "method", None) == "dflash":
+            from .patches import apply_patches
+            apply_patches(force=True)
+
         parallel_config = vllm_config.parallel_config
         model_config = vllm_config.model_config
 

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -292,7 +292,16 @@ class MUSAPlatformBase(Platform):
         # DFlashProposer.dummy_run signature patch lands on the installed
         # dflash.py that the workers will import.
         spec_config = getattr(vllm_config, "speculative_config", None)
-        if spec_config is not None and getattr(spec_config, "method", None) == "dflash":
+        # Detect dflash via the STABLE `use_dflash()` API (the same predicate
+        # gpu_model_runner branches on) rather than the `method` string, whose
+        # representation can change across vLLM versions; fall back to the string
+        # only if use_dflash() is unavailable.
+        _use_dflash = getattr(spec_config, "use_dflash", None)
+        if spec_config is not None and (
+            _use_dflash()
+            if callable(_use_dflash)
+            else getattr(spec_config, "method", None) == "dflash"
+        ):
             from .patches import apply_patches
             apply_patches(force=True)
             # MUSA-0403: the dflash draft-loop FULL CUDAGraph capture is

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -158,6 +158,13 @@ class MUSAFlashAttentionBackend(AttentionBackend):
         return "FLASH_ATTN"
 
     @classmethod
+    def supports_batch_invariance(cls) -> bool:
+        # MUSA-0405: mate flash_attn_varlen_func(deterministic=True) is
+        # batch-invariant (probe: seq0 solo vs batched max_abs_err=0.0), matching
+        # upstream FlashAttentionBackend. Probe: generated/musa0400/probe_fa_caps.py.
+        return True
+
+    @classmethod
     def supports_non_causal(cls) -> bool:
         # mate's FA3 wrapper (flash_attn_varlen_func) plumbs causal= through;
         # required for dflash spec-decode verify (non-causal block attention).
@@ -167,10 +174,12 @@ class MUSAFlashAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_mm_prefix(cls) -> bool:
-        # gemma-4 (Gemma4ForConditionalGeneration) is mm_prefix_lm. For TEXT-only
-        # serving (the dflash workload) the partial-mm bidirectional attention
-        # path is dormant, so allow FLASH_ATTN selection. NOTE: multimodal
-        # (image/audio) input correctness on mate FA is NOT verified — text-only.
+        # MUSA-0405 OVER-CLAIM (intentional, text-only): mate flash_attn_varlen_func
+        # exposes NO arbitrary/partial 2D mask (only causal + window + attention_chunk),
+        # so partial-multimodal bidirectional attention is NOT genuinely supported.
+        # gemma-4 is mm_prefix_lm; for TEXT-only serving (the dflash workload) the
+        # partial-mm path is dormant and mate FA is correct, so we allow selection.
+        # Multimodal (image/audio) input WOULD be incorrect on this path.
         return True
 
     @classmethod
@@ -185,8 +194,12 @@ class MUSAFlashAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_per_head_quant_scales(cls) -> bool:
-        fa_version = get_flash_attn_version()
-        return fa_version is not None and fa_version >= 3
+        # MUSA-0405: mate flash_attn_varlen_func rejects fp8 Q/K inputs
+        # ("inputs must be float16 or bfloat16"), so per-head FP8 quant-scale
+        # attention is NOT supported on MUSA — consistent with
+        # flash_attn_supports_fp8()=False and get_fp8_dtype_for_flashattn raising
+        # NotImplementedError. Probe: generated/musa0400/probe_fa_caps.py.
+        return False
 
     @staticmethod
     def get_impl_cls() -> type["FlashAttentionImpl"]:

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -158,6 +158,22 @@ class MUSAFlashAttentionBackend(AttentionBackend):
         return "FLASH_ATTN"
 
     @classmethod
+    def supports_non_causal(cls) -> bool:
+        # mate's FA3 wrapper (flash_attn_varlen_func) plumbs causal= through;
+        # required for dflash spec-decode verify (non-causal block attention).
+        # Base AttentionBackend defaults this to False, which made
+        # validate_configuration reject FLASH_ATTN for dflash.
+        return True
+
+    @classmethod
+    def supports_mm_prefix(cls) -> bool:
+        # gemma-4 (Gemma4ForConditionalGeneration) is mm_prefix_lm. For TEXT-only
+        # serving (the dflash workload) the partial-mm bidirectional attention
+        # path is dormant, so allow FLASH_ATTN selection. NOTE: multimodal
+        # (image/audio) input correctness on mate FA is NOT verified — text-only.
+        return True
+
+    @classmethod
     def supports_attn_type(cls, attn_type: str) -> bool:
         """FlashAttention supports all attention types."""
         return attn_type in (

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -221,7 +221,7 @@ class MUSAFlashAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_head_size(cls, head_size: int) -> bool:
-        return head_size % 8 == 0 and head_size <= 256
+        return head_size % 8 == 0 and head_size <= 512
 
     @classmethod
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -174,12 +174,15 @@ class MUSAFlashAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_mm_prefix(cls) -> bool:
-        # MUSA-0405 OVER-CLAIM (intentional, text-only): mate flash_attn_varlen_func
-        # exposes NO arbitrary/partial 2D mask (only causal + window + attention_chunk),
-        # so partial-multimodal bidirectional attention is NOT genuinely supported.
-        # gemma-4 is mm_prefix_lm; for TEXT-only serving (the dflash workload) the
-        # partial-mm path is dormant and mate FA is correct, so we allow selection.
-        # Multimodal (image/audio) input WOULD be incorrect on this path.
+        # MUSA-0405/0404: required for multimodal-model backend SELECTION (e.g.
+        # gemma-4, which registers as mm_prefix_lm even when served text-only — the
+        # dflash workload). mate flash_attn_varlen_func supports causal + window +
+        # attention_chunk masks but NOT an arbitrary partial 2D mask. This was
+        # VALIDATED on Qwen2.5-VL-7B (image input -> correct description, MUSA-0404
+        # regression), so the mm-prefix patterns these models actually use are
+        # handled correctly. A model whose mm-prefix needed an arbitrary partial 2D
+        # mask (not causal/window/chunk) would be wrong on this path — none is
+        # currently known or tested; revisit if such a model is served on FLASH_ATTN.
         return True
 
     @classmethod


### PR DESCRIPTION
## Summary

Enables **dflash** (block-diffusion speculative decoding) for `google/gemma-4-31B-it` on vllm-musa, with the draft-loop FULL CUDAGraph capture **default-on**. dflash already lives in the vLLM base (`vllm/v1/spec_decode/dflash.py`); this is the MUSA-compatibility + capture work.

**Pure-Python diff** (`vllm_musa/patches/*`, `platform.py`, `v1/attention/backends/flash_attn.py`) — no `csrc`/`setup.py` change, so no rebuild required. Cut from `v0.20.0-dev`.

## What's included (MUSA-0401 → 0406)

| Ticket | Change |
|---|---|
| 0401 / 0402 | gemma-4-31B serves on MUSA + dflash functional — mate FLASH_ATTN for non-causal + `head_dim`-512; backend set via `--attention-backend` (the `VLLM_ATTENTION_BACKEND` env is dead on this vLLM); 5 MUSA-compat fixes (`DFlashProposer.dummy_run` kwarg, patch re-apply in `check_and_update_config`, non-causal target attention) |
| **0403** | **Draft-loop FULL CUDAGraph capture, DEFAULT-ON.** The dflash `dummy_run` boot-captures with `uniform_decode=False` to match the inference dispatch key (the dflash block has `max_query_len = 1+num_spec > 1`); lifts the fair compile ratio **1.47× (eager) → 2.01× (prose) / 4.08× (predictable)**. Gated by `VLLM_MUSA_DFLASH_FULL_WRAP` (default-on; opt out with `=0`). `platform.check_and_update_config` coerces dflash cudagraph to pure `FULL` + block-aligned sizes. |
| 0405 | FLASH_ATTN `supports_*` declarations aligned with verified mate behavior (`non_causal`/`mm_prefix`/`head_size<=512`/`per_head_quant_scales=False`/`batch_invariance=True`) |
| 0406 | Multi-block BS=1,2,4,8 capture (`[9,18,36,72]`); aggregate decode scales 56→261 tok/s |

## Performance (2× MTT S5000, tp=2, compile + FULL CUDAGraph, FLASH_ATTN, warm median)

| dflash workload | Ratio vs no-spec compile |
|---|---|
| open-ended prose | **2.01×** |
| predictable (counting) | **4.08×** |

Ratios are same-workload A/B (apples-to-apples). Absolute tok/s + the standard `vllm bench serve` numbers are in the deployment cookbook.

## Regression — GREEN

The only shared-impact change is `flash_attn.py` (capability declarations), verified across 4 FLASH_ATTN model families: **gemma-4** (head-512), **Qwen3-8B** (dense), **Qwen2.5-VL-7B** (multimodal — `mm_prefix` validated on a real image), **MiniMax-M2.5** (flagship — reproduces SOTA ~104 tok/s). fp8-KV is correctly rejected at the `kv_cache_dtype` gate.

## Test plan

- [x] gemma-4 dflash functional (France→Paris, draft active, +47% eager)
- [x] default-on capture validated (correct output, healthy monotonic per-position acceptance, no collapse)
- [x] multi-block BS 1–8 correct + captured (not eager fallback)
- [x] FLASH_ATTN regression matrix GREEN (4 model families)

## Known limitations

- BS>16 pads to the largest captured size; extend the block-aligned tuple `(1,2,4,8)` for higher concurrency.
- `supports_mm_prefix=True` validated on Qwen2.5-VL (text + image); untested for audio prefixes.
