### PR TITLE
Support torch.compile cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "torch",
     "torch_musa",
-    "torchada>=0.1.61",
+    "torchada>=0.1.62",
     "mate>=0.2.1",
     "flash_attn_3>=0.1.4",
     "mthreads-ml-py>=2.2.11",

--- a/setup.py
+++ b/setup.py
@@ -433,7 +433,7 @@ setup(
     include_package_data=False,
     # pinned here because --no-build-isolation skips pyproject.toml deps
     install_requires=[
-        "torchada>=0.1.61",
+        "torchada>=0.1.62",
         "mthreads-ml-py>=2.2.11",
         "numpy<2",
         "openai>=2.24.0",

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -1213,6 +1213,7 @@ class TestObjectPatchPhase:
         # torch/vLLM config compat shims migrated from vllm_musa/__init__.py
         "torch._functorch.config",
         "torch._inductor.config",
+        "torch._inductor.aot_cache_safelist",
         "vllm.compilation.backends",
         "vllm.compilation.compiler_interface",
         "vllm._custom_ops",

--- a/vllm_musa/patches/manifest.py
+++ b/vllm_musa/patches/manifest.py
@@ -168,6 +168,15 @@ _CAT6: list[DivSpec] = [
         intent="filter missing torch._inductor.config keys in vLLM compile contexts",
     ),
     DivSpec(
+        id="torch___inductor__aot_cache_safelist",
+        category="6",
+        path="vllm_musa/patches/torch___inductor__aot_cache_safelist.patch.py",
+        upstream_path=None,
+        apply_phase="runtime",
+        required=False,
+        intent="mark torch-wrap Tensor methods AOT-cache safe on torch 2.9 (compile cache)",
+    ),
+    DivSpec(
         id="vllm__compilation__backends",
         category="6",
         path="vllm_musa/patches/vllm__compilation__backends.patch.py",

--- a/vllm_musa/patches/torch___inductor__aot_cache_safelist.patch.py
+++ b/vllm_musa/patches/torch___inductor__aot_cache_safelist.patch.py
@@ -9,10 +9,8 @@ artifact is not serializable" unless ``VLLM_DISABLE_COMPILE_CACHE=1``.
 
 torch exposes ``unsafe_marked_cacheable_functions`` exactly for this; the dict
 value is a version salt mixed into cache keys. torch >= 2.10 safelists tensor
-methods natively, where ``setdefault`` keeps this a no-op. Verified on
-yeahdongcn70 / torch 2.9 (MUSA-0511): with the entry, default-mode boots save
-and reload compile artifacts; the only other offender was torchada's factory
-wrappers (fixed in torchada).
+methods natively, where ``setdefault`` keeps this a no-op. With the entry,
+default-mode boots save and reload compile artifacts on torch 2.9.
 """
 
 import torch
@@ -23,7 +21,7 @@ logger = init_logger(__name__)
 PATCHES: list = []
 
 _SAFE_TENSOR_METHODS = ("torch._tensor.split",)
-_CACHE_SALT = "vllm-musa-0511-v1"
+_CACHE_SALT = "vllm-musa-aot-cache-safelist-v1"
 
 
 def apply() -> None:

--- a/vllm_musa/patches/torch___inductor__aot_cache_safelist.patch.py
+++ b/vllm_musa/patches/torch___inductor__aot_cache_safelist.patch.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA cat-6 object patch: mark torch-wrap rewritten Tensor methods cache-safe.
+
+vLLM's IR torch-wrap (``ir_enable_torch_wrap``) emits unbound ``torch.Tensor.*``
+call_function nodes (e.g. ``torch.Tensor.split`` for QKV). torch 2.9's AOT
+autograd cache safelist predates these nodes, so every compiled graph bypasses
+the cache and ``InductorStandaloneAdaptor.compile`` raises "The compiled
+artifact is not serializable" unless ``VLLM_DISABLE_COMPILE_CACHE=1``.
+
+torch exposes ``unsafe_marked_cacheable_functions`` exactly for this; the dict
+value is a version salt mixed into cache keys. torch >= 2.10 safelists tensor
+methods natively, where ``setdefault`` keeps this a no-op. Verified on
+yeahdongcn70 / torch 2.9 (MUSA-0511): with the entry, default-mode boots save
+and reload compile artifacts; the only other offender was torchada's factory
+wrappers (fixed in torchada).
+"""
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+PATCHES: list = []
+
+_SAFE_TENSOR_METHODS = ("torch._tensor.split",)
+_CACHE_SALT = "vllm-musa-0511-v1"
+
+
+def apply() -> None:
+    try:
+        safelist = torch._inductor.config.unsafe_marked_cacheable_functions
+    except Exception as e:
+        logger.debug("Skipping AOT-cache safelist patch: %s", e)
+        return
+    for name in _SAFE_TENSOR_METHODS:
+        safelist.setdefault(name, _CACHE_SALT)

--- a/vllm_musa/patches/torch___inductor__aot_cache_safelist.patch.py
+++ b/vllm_musa/patches/torch___inductor__aot_cache_safelist.patch.py
@@ -13,7 +13,6 @@ methods natively, where ``setdefault`` keeps this a no-op. With the entry,
 default-mode boots save and reload compile artifacts on torch 2.9.
 """
 
-import torch
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -26,6 +25,8 @@ _CACHE_SALT = "vllm-musa-aot-cache-safelist-v1"
 
 def apply() -> None:
     try:
+        import torch
+
         safelist = torch._inductor.config.unsafe_marked_cacheable_functions
     except Exception as e:
         logger.debug("Skipping AOT-cache safelist patch: %s", e)


### PR DESCRIPTION
Related work: https://github.com/MooreThreads/torchada/pull/76

```log
2026-06-10 11:30:27 | gpu_model_runner | 139623526012736 | INFO : Model loading took 29.04 GiB memory and 28.927489 seconds
2026-06-10 11:30:42 | backends | 139623526012736 | INFO : Using cache directory: /root/.cache/vllm/torch_compile_cache/a599c65868/rank_0_0/backbone for vLLM's torch.compile
2026-06-10 11:30:42 | backends | 139623526012736 | INFO : Dynamo bytecode transform time: 14.33 s
2026-06-10 11:30:44 | backends | 139623526012736 | INFO : Directly load the compiled graph(s) for compile range (1, 8192) from the cache, took 1.803 s
```