### PR TITLE
MUSA: dense FMHA block_size=64 default + qwen3_moe _custom_ops boot fix

### DIFF
--- a/vllm_musa/patches/series/0063-MUSA-vllm.model_executor.models.qwen3_moe.patch
+++ b/vllm_musa/patches/series/0063-MUSA-vllm.model_executor.models.qwen3_moe.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sat, 21 Jun 2026 00:00:00 +0000
+Subject: [PATCH] MUSA: vllm.model_executor.models.qwen3_moe
+
+---
+ vllm/model_executor/models/qwen3_moe.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/vllm/model_executor/models/qwen3_moe.py b/vllm/model_executor/models/qwen3_moe.py
+index 4ec1be336..bbe696e3b 100644
+--- a/vllm/model_executor/models/qwen3_moe.py
++++ b/vllm/model_executor/models/qwen3_moe.py
+@@ -57,6 +57,14 @@ from vllm.model_executor.layers.linear import (
+ from vllm.model_executor.layers.logits_processor import LogitsProcessor
+ from vllm.model_executor.layers.quantization import QuantizationConfig
+ from vllm.model_executor.layers.rotary_embedding import get_rope
++
++# MUSA: the FP8 act-quant fusion matcher resolves
++# torch.ops._C.rotary_embedding.default at import; on MUSA the classic _C op
++# stubs only register as a side effect of importing vllm._custom_ops. Force that
++# import here so the stub exists before the compile backend's matcher reads it,
++# letting the MoE/VL decoder boot non-eager without the inductor-heuristics flag.
++import vllm._custom_ops  # noqa: F401,E402
++
+ from vllm.model_executor.layers.vocab_parallel_embedding import (
+     ParallelLMHead,
+     VocabParallelEmbedding,

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -603,6 +603,26 @@ class MUSAPlatformBase(Platform):
                         sparse_block_size,
                     )
 
+        # Dense FMHA (FLASH_ATTN) decode reads paged KV through mate's Fmha
+        # kernel, which has a fast TME (bulk tensor-engine) gather path that the
+        # kernel only selects when page_size == 64; any other page size forces a
+        # slower load-store-unit per-page gather (force_lsu_kv). Default the dense
+        # KV block size to 64 to take the TME path (parity with the FlashMLA branch
+        # above, which forces 64 for the same hardware reason). Opt out with
+        # VLLM_MUSA_FA_BLOCK_SIZE_64=0.
+        import os as _fa_os
+
+        if (
+            model_config is not None
+            and not model_config.use_mla
+            and cache_config is not None
+            and cache_config.block_size is not None
+            and cache_config.block_size % 64 != 0
+            and _fa_os.environ.get("VLLM_MUSA_FA_BLOCK_SIZE_64", "1") != "0"
+        ):
+            cache_config.block_size = 64
+            logger.info("Forcing kv cache block size to 64 for FMHA TME decode path.")
+
         scheduler_config = vllm_config.scheduler_config
         # Note: model_config may be None during testing
         if (


### PR DESCRIPTION
Default the non-MLA dense KV cache block size to 64 so mate's Fmha decode takes the TME bulk-gather path (opt out with VLLM_MUSA_FA_BLOCK_SIZE_64=0).

Add a build-time series patch forcing `import vllm._custom_ops` in vLLM's qwen3_moe.py so the classic _C op stubs register before the FP8 act-quant fusion matcher resolves torch.ops._C.rotary_embedding.default, letting the MoE/VL decoder boot non-eager without the inductor-heuristics flag.