### PR TITLE
MUSA: add native vec8 MoE-glue kernels (act_and_mul, moe_sum)

### DIFF
--- a/vllm_musa/__init__.py
+++ b/vllm_musa/__init__.py
@@ -143,6 +143,9 @@ def _register_patches() -> None:
 def _register_ops() -> None:
     """Register OOT custom ops (activation, layernorm, fused_moe, etc.)."""
     import vllm_musa.model_executor  # noqa: F401
+    import vllm_musa.jit_kernel.csrc.moe as _moe  # noqa: F401
+
+    _moe.prewarm()
 
 
 def _register_modules() -> None:

--- a/vllm_musa/jit_kernel/csrc/moe.py
+++ b/vllm_musa/jit_kernel/csrc/moe.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import logging
+
+import torch
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from vllm_musa.jit_kernel.csrc.jit import load_musa_jit
+from vllm_musa.jit_kernel.utils import cache_once
+
+logger = logging.getLogger(__name__)
+
+# Native MUSA vec8 (int4-packed, 8 elems/load) MoE glue. The bf16 decode path otherwise runs
+# silu(gate)*up and the top-k reduce as several eager kernels; the vec8 kernels do each in one
+# pass and are 1:1 op replacements, so they capture into the FULL_DECODE graph unchanged. The
+# correctness guards (device / contiguity / dtype / shape) fall back to the eager kernels for
+# any input they do not support (e.g. FP8/int8 activations), so they are always safe to apply.
+
+_SILU = 0
+_FAST_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+@cache_once
+def _moe_module():
+    return load_musa_jit(
+        "vllm_musa_moe",
+        ("moe/act_and_mul.mu", "moe/moe_sum_reduce.mu"),
+        extra_musa_cflags=(
+            "-Wno-error=address-of-temporary",
+            "-fmusa-flush-denormals-to-zero",
+            "-fno-signed-zeros",
+            "-mllvm", "-mtgpu-opt-level=1",
+            "-mllvm", "-mtgpu-load-store-opt=1",
+            "-mllvm", "-mtgpu-fold-global-ldst=1",
+        ),
+    )
+
+
+@cache_once
+def _moe_available() -> bool:
+    """True once the native kernels JIT-build. Cached so the guarded callers fall back to the
+    eager kernels (rather than raise) when the build fails, and never recompile under capture."""
+    try:
+        _moe_module()
+        return True
+    except Exception:
+        logger.warning("native MUSA MoE glue unavailable; using eager kernels", exc_info=True)
+        return False
+
+
+# Single-element sentinel expert_ids per device. With expert_step = rows the kernel reads
+# expert_ids[row / rows] == expert_ids[0] == 0 for every row (0 != -1 => all rows processed)
+# and the bounds check ceil(rows / expert_step) == 1 holds. Pre-created so the captured path
+# never does a host->device scalar copy.
+_DUMMY_EIDS: dict[torch.device, torch.Tensor] = {}
+
+
+def _dummy_expert_ids(device: torch.device) -> torch.Tensor:
+    t = _DUMMY_EIDS.get(device)
+    if t is None:
+        t = torch.zeros(1, dtype=torch.int32, device=device)
+        _DUMMY_EIDS[device] = t
+    return t
+
+
+def _silu_and_mul_custom(out: torch.Tensor, x: torch.Tensor) -> None:
+    rows = x.numel() // x.shape[-1]
+    _moe_module().sgl_musa_moe_act_and_mul(
+        x.view(rows, x.shape[-1]), out.view(rows, out.shape[-1]),
+        _dummy_expert_ids(x.device), max(rows, 1), _SILU, 1,
+    )
+
+
+def _silu_and_mul_fake(out: torch.Tensor, x: torch.Tensor) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="musa_fast_silu_and_mul",
+    op_func=_silu_and_mul_custom,
+    mutates_args=["out"],
+    fake_impl=_silu_and_mul_fake,
+)
+
+
+def _moe_sum_custom(out: torch.Tensor, x: torch.Tensor) -> None:
+    _moe_module().sgl_musa_moe_sum_reduce(x, out, 1.0)
+
+
+def _moe_sum_fake(out: torch.Tensor, x: torch.Tensor) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="musa_fast_moe_sum",
+    op_func=_moe_sum_custom,
+    mutates_args=["out"],
+    fake_impl=_moe_sum_fake,
+)
+
+
+def maybe_fast_silu_and_mul(out: torch.Tensor, x: torch.Tensor) -> bool:
+    """out[..., d] = silu(x[..., :d]) * x[..., d:2d] via the native vec8 kernel; a drop-in for
+    torch.ops._C.silu_and_mul(out, x). Returns False (eager fallback) for unsupported inputs."""
+    if x.device.type != "musa":
+        return False
+    if not _moe_available():
+        return False
+    if not (x.is_contiguous() and out.is_contiguous()):
+        return False
+    if x.dtype not in _FAST_DTYPES:
+        return False
+    if out.shape[-1] * 2 != x.shape[-1]:
+        return False
+    torch.ops.vllm.musa_fast_silu_and_mul(out, x)
+    return True
+
+
+def maybe_fast_moe_sum(x: torch.Tensor, out: torch.Tensor) -> bool:
+    """out[t, h] = sum_k x[t, k, h] via the native kernel; a drop-in for ops.moe_sum(x, out).
+    Returns False (eager fallback) for unsupported inputs."""
+    if x.device.type != "musa":
+        return False
+    if not _moe_available():
+        return False
+    if not (x.is_contiguous() and out.is_contiguous()):
+        return False
+    if x.dtype not in _FAST_DTYPES:
+        return False
+    if x.dim() != 3 or out.dim() != 2 or x.shape[0] != out.shape[0] or x.shape[2] != out.shape[1]:
+        return False
+    torch.ops.vllm.musa_fast_moe_sum(out, x)
+    return True
+
+
+def prewarm() -> None:
+    """JIT-compile the module at load so the first call never compiles inside graph capture."""
+    _moe_available()

--- a/vllm_musa/jit_kernel/csrc/moe/act_and_mul.mu
+++ b/vllm_musa/jit_kernel/csrc/moe/act_and_mul.mu
@@ -1,0 +1,609 @@
+#include <cstdint>
+#include <climits>
+#include <string>
+#include <type_traits>
+
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+#include <musa_runtime.h>
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/dtype.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+#include <tvm/ffi/extra/musa/device_guard.h>
+#include <tvm/ffi/function.h>
+
+#include "../common.h"
+#include "../device_utils.h"
+
+constexpr int kThreads = 512;
+constexpr int kVecThreads = 256;
+constexpr int kFlatVecThreads = 512;
+constexpr int kFlatVecThreadsMedium = 256;
+constexpr int kFlatVecThreadsHalfMedium = 384;
+constexpr int kFlatVecChunksPerThread = 1;
+constexpr int kSiluActivation = 0;
+constexpr int kGeluActivation = 1;
+constexpr int kVecElems = 8;
+
+template <typename T>
+__device__ __forceinline__ T cast_from_float(float value) {
+  return from_float<T>(value);
+}
+
+template <>
+__device__ __forceinline__ float cast_from_float<float>(float value) {
+  return value;
+}
+
+__device__ __forceinline__ float gelu_exact(float x) {
+  return 0.5f * x * (1.0f + erff(x * 0.7071067811865475f));
+}
+
+__device__ __forceinline__ float fast_silu(float x) {
+  const float half_x = 0.5f * x;
+  return half_x * (1.0f + tanhf(half_x));
+}
+
+__device__ __forceinline__ float apply_activation(float x, int activation_type) {
+  return activation_type == kGeluActivation ? gelu_exact(x) : fast_silu(x);
+}
+
+template <int ACTIVATION_TYPE>
+__device__ __forceinline__ float apply_activation(float x) {
+  if constexpr (ACTIVATION_TYPE == kGeluActivation) {
+    return gelu_exact(x);
+  } else {
+    return fast_silu(x);
+  }
+}
+
+template <typename T>
+union Pack16B {
+  int4 v;
+  T elems[kVecElems];
+};
+
+template <typename T>
+__device__ __forceinline__ int4 load_vec8(const T* ptr) {
+  return *reinterpret_cast<const int4*>(ptr);
+}
+
+template <typename T>
+__device__ __forceinline__ void store_vec8(T* ptr, const int4& value) {
+  *reinterpret_cast<int4*>(ptr) = value;
+}
+
+template <typename T, typename IdT, int ACTIVATION_TYPE, int BLOCK_THREADS>
+__global__ __launch_bounds__(BLOCK_THREADS, 1)
+void moe_act_and_mul_flat_vec8_kernel(
+    const T* __restrict__ gateup_output,
+    T* __restrict__ down_input,
+    const IdT* __restrict__ expert_ids,
+    int rows,
+    int half_hidden_size,
+    int expert_step,
+    int chunks_per_row,
+    int total_chunks) {
+  const int base_chunk =
+      (static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x) *
+      kFlatVecChunksPerThread;
+  const int hidden_size = half_hidden_size * 2;
+#pragma unroll
+  for (int c = 0; c < kFlatVecChunksPerThread; ++c) {
+    const int chunk = base_chunk + c;
+    if (chunk < total_chunks) {
+      const int row = chunk / chunks_per_row;
+      if (row < rows) {
+        const IdT expert_id = expert_ids[row / expert_step];
+        if (expert_id != static_cast<IdT>(-1)) {
+          const int chunk_in_row = chunk - row * chunks_per_row;
+          const int col = chunk_in_row * kVecElems;
+          const T* gate_ptr =
+              gateup_output + static_cast<int64_t>(row) * hidden_size + col;
+          const T* up_ptr = gate_ptr + half_hidden_size;
+          T* out_ptr =
+              down_input + static_cast<int64_t>(row) * half_hidden_size + col;
+
+          Pack16B<T> gate_pack;
+          Pack16B<T> up_pack;
+          Pack16B<T> out_pack;
+          gate_pack.v = load_vec8(gate_ptr);
+          up_pack.v = load_vec8(up_ptr);
+
+#pragma unroll
+          for (int i = 0; i < kVecElems; ++i) {
+            const float gate = to_float(gate_pack.elems[i]);
+            const float up = to_float(up_pack.elems[i]);
+            out_pack.elems[i] =
+                cast_from_float<T>(apply_activation<ACTIVATION_TYPE>(gate) * up);
+          }
+
+          store_vec8(out_ptr, out_pack.v);
+        }
+      }
+    }
+  }
+}
+
+template <typename T, typename IdT, int ACTIVATION_TYPE, int BLOCK_THREADS>
+__global__ __launch_bounds__(BLOCK_THREADS, 1)
+void moe_act_and_mul_flat_vec8_no_filter_kernel(
+    const T* __restrict__ gateup_output,
+    T* __restrict__ down_input,
+    int rows,
+    int half_hidden_size,
+    int chunks_per_row,
+    int total_chunks) {
+  const int chunk = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (chunk >= total_chunks) {
+    return;
+  }
+
+  const int row = chunk / chunks_per_row;
+  if (row >= rows) {
+    return;
+  }
+
+  const int chunk_in_row = chunk - row * chunks_per_row;
+  const int col = chunk_in_row * kVecElems;
+  const int hidden_size = half_hidden_size * 2;
+  const T* gate_ptr = gateup_output + static_cast<int64_t>(row) * hidden_size + col;
+  const T* up_ptr = gate_ptr + half_hidden_size;
+  T* out_ptr = down_input + static_cast<int64_t>(row) * half_hidden_size + col;
+
+  Pack16B<T> gate_pack;
+  Pack16B<T> up_pack;
+  Pack16B<T> out_pack;
+  gate_pack.v = load_vec8(gate_ptr);
+  up_pack.v = load_vec8(up_ptr);
+
+#pragma unroll
+  for (int i = 0; i < kVecElems; ++i) {
+    const float gate = to_float(gate_pack.elems[i]);
+    const float up = to_float(up_pack.elems[i]);
+    out_pack.elems[i] = cast_from_float<T>(apply_activation<ACTIVATION_TYPE>(gate) * up);
+  }
+
+  store_vec8(out_ptr, out_pack.v);
+}
+
+template <typename T, typename IdT, int ACTIVATION_TYPE>
+__global__ __launch_bounds__(kVecThreads, 1)
+void moe_act_and_mul_vec8_kernel(
+    const T* __restrict__ gateup_output,
+    T* __restrict__ down_input,
+    const IdT* __restrict__ expert_ids,
+    int64_t rows,
+    int64_t half_hidden_size,
+    int expert_step) {
+  const int64_t row = static_cast<int64_t>(blockIdx.y);
+  if (row >= rows) {
+    return;
+  }
+
+  const IdT expert_id = expert_ids[row / expert_step];
+  if (expert_id == static_cast<IdT>(-1)) {
+    return;
+  }
+
+  const int64_t chunks = half_hidden_size / kVecElems;
+  const int64_t chunk = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (chunk >= chunks) {
+    return;
+  }
+
+  const int64_t col = chunk * kVecElems;
+  const int64_t hidden_size = half_hidden_size * 2;
+  const T* gate_ptr = gateup_output + row * hidden_size + col;
+  const T* up_ptr = gate_ptr + half_hidden_size;
+  T* out_ptr = down_input + row * half_hidden_size + col;
+
+  Pack16B<T> gate_pack;
+  Pack16B<T> up_pack;
+  Pack16B<T> out_pack;
+  gate_pack.v = load_vec8(gate_ptr);
+  up_pack.v = load_vec8(up_ptr);
+
+#pragma unroll
+  for (int i = 0; i < kVecElems; ++i) {
+    const float gate = to_float(gate_pack.elems[i]);
+    const float up = to_float(up_pack.elems[i]);
+    out_pack.elems[i] = cast_from_float<T>(apply_activation<ACTIVATION_TYPE>(gate) * up);
+  }
+
+  store_vec8(out_ptr, out_pack.v);
+}
+
+template <typename T, typename IdT, int ACTIVATION_TYPE>
+__global__ __launch_bounds__(kVecThreads, 1)
+void moe_act_and_mul_row_vec8_kernel(
+    const T* __restrict__ gateup_output,
+    T* __restrict__ down_input,
+    const IdT* __restrict__ expert_ids,
+    int64_t rows,
+    int64_t half_hidden_size,
+    int expert_step) {
+  const int64_t row = static_cast<int64_t>(blockIdx.x);
+  if (row >= rows) {
+    return;
+  }
+
+  const IdT expert_id = expert_ids[row / expert_step];
+  if (expert_id == static_cast<IdT>(-1)) {
+    return;
+  }
+
+  const int64_t chunks = half_hidden_size / kVecElems;
+  const int64_t hidden_size = half_hidden_size * 2;
+  const T* gate_base = gateup_output + row * hidden_size;
+  const T* up_base = gate_base + half_hidden_size;
+  T* out_base = down_input + row * half_hidden_size;
+
+  for (int64_t chunk = threadIdx.x; chunk < chunks; chunk += blockDim.x) {
+    const int64_t col = chunk * kVecElems;
+    const T* gate_ptr = gate_base + col;
+    const T* up_ptr = up_base + col;
+    T* out_ptr = out_base + col;
+
+    Pack16B<T> gate_pack;
+    Pack16B<T> up_pack;
+    Pack16B<T> out_pack;
+    gate_pack.v = load_vec8(gate_ptr);
+    up_pack.v = load_vec8(up_ptr);
+
+#pragma unroll
+    for (int i = 0; i < kVecElems; ++i) {
+      const float gate = to_float(gate_pack.elems[i]);
+      const float up = to_float(up_pack.elems[i]);
+      out_pack.elems[i] =
+          cast_from_float<T>(apply_activation<ACTIVATION_TYPE>(gate) * up);
+    }
+
+    store_vec8(out_ptr, out_pack.v);
+  }
+}
+
+template <typename T, typename IdT, int ACTIVATION_TYPE>
+__global__ __launch_bounds__(kThreads, 1)
+void moe_act_and_mul_row_kernel(
+    const T* __restrict__ gateup_output,
+    T* __restrict__ down_input,
+    const IdT* __restrict__ expert_ids,
+    int64_t rows,
+    int64_t half_hidden_size,
+    int expert_step) {
+  const int64_t row = static_cast<int64_t>(blockIdx.x);
+  if (row >= rows) {
+    return;
+  }
+
+  const IdT expert_id = expert_ids[row / expert_step];
+  if (expert_id == static_cast<IdT>(-1)) {
+    return;
+  }
+
+  const int64_t hidden_size = half_hidden_size * 2;
+  const T* gate_ptr = gateup_output + row * hidden_size;
+  const T* up_ptr = gate_ptr + half_hidden_size;
+  T* out_ptr = down_input + row * half_hidden_size;
+
+  for (int64_t col = threadIdx.x; col < half_hidden_size; col += blockDim.x) {
+    const float gate = to_float(gate_ptr[col]);
+    const float up = to_float(up_ptr[col]);
+    out_ptr[col] = cast_from_float<T>(apply_activation<ACTIVATION_TYPE>(gate) * up);
+  }
+}
+
+template <typename T, typename IdT, int ACTIVATION_TYPE>
+__global__ __launch_bounds__(kThreads, 1)
+void moe_act_and_mul_split_kernel(
+    const T* __restrict__ gateup_output,
+    T* __restrict__ down_input,
+    const IdT* __restrict__ expert_ids,
+    int64_t rows,
+    int64_t half_hidden_size,
+    int expert_step) {
+  const int64_t row = static_cast<int64_t>(blockIdx.y);
+  if (row >= rows) {
+    return;
+  }
+
+  const IdT expert_id = expert_ids[row / expert_step];
+  if (expert_id == static_cast<IdT>(-1)) {
+    return;
+  }
+
+  const int64_t col = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (col >= half_hidden_size) {
+    return;
+  }
+
+  const int64_t hidden_size = half_hidden_size * 2;
+  const T* gate_ptr = gateup_output + row * hidden_size;
+  const T* up_ptr = gate_ptr + half_hidden_size;
+  T* out_ptr = down_input + row * half_hidden_size;
+
+  const float gate = to_float(gate_ptr[col]);
+  const float up = to_float(up_ptr[col]);
+  out_ptr[col] = cast_from_float<T>(apply_activation<ACTIVATION_TYPE>(gate) * up);
+}
+
+void check_moe_act_and_mul_inputs(
+    ffi::TensorView gateup_output,
+    ffi::TensorView down_input,
+    ffi::TensorView expert_ids,
+    int64_t expert_step,
+    int64_t activation_type,
+    int64_t skip_expert_check) {
+  CHECK_INPUT(gateup_output);
+  CHECK_INPUT(down_input);
+  CHECK_INPUT(expert_ids);
+  CHECK_CONTIGUOUS_2D(gateup_output);
+  CHECK_CONTIGUOUS_2D(down_input);
+  TVM_FFI_ICHECK_EQ(gateup_output.device().device_id, down_input.device().device_id);
+  TVM_FFI_ICHECK_EQ(gateup_output.device().device_id, expert_ids.device().device_id);
+  TVM_FFI_ICHECK_EQ(gateup_output.size(0), down_input.size(0));
+  TVM_FFI_ICHECK_EQ(gateup_output.size(1), down_input.size(1) * 2);
+  TVM_FFI_ICHECK(dtype_equal(gateup_output.dtype(), down_input.dtype()));
+  TVM_FFI_ICHECK(
+      dtype_equal(gateup_output.dtype(), dl_float16) ||
+      dtype_equal(gateup_output.dtype(), dl_bfloat16) ||
+      dtype_equal(gateup_output.dtype(), dl_float32));
+  TVM_FFI_ICHECK(
+      dtype_equal(expert_ids.dtype(), dl_int64) ||
+      dtype_equal(expert_ids.dtype(), dl_int32));
+  TVM_FFI_ICHECK_GE(expert_step, 1);
+  TVM_FFI_ICHECK(skip_expert_check == 0 || skip_expert_check == 1);
+  TVM_FFI_ICHECK_GE(expert_ids.size(0), (down_input.size(0) + expert_step - 1) / expert_step);
+  TVM_FFI_ICHECK(
+      activation_type == kSiluActivation || activation_type == kGeluActivation);
+}
+
+template <typename T, typename IdT, int ACTIVATION_TYPE>
+void launch_moe_act_and_mul(
+    ffi::TensorView gateup_output,
+    ffi::TensorView down_input,
+    ffi::TensorView expert_ids,
+    int expert_step,
+    bool skip_expert_check,
+    musaStream_t stream) {
+  const int64_t rows = down_input.size(0);
+  const int64_t half_hidden_size = down_input.size(1);
+  if (rows == 0 || half_hidden_size == 0) {
+    return;
+  }
+  const int64_t tiles = (half_hidden_size + kThreads - 1) / kThreads;
+  constexpr bool can_vec8 = !std::is_same_v<T, float>;
+  const bool use_vec8 = can_vec8 && (half_hidden_size % kVecElems) == 0;
+  if (use_vec8) {
+    const int64_t chunks = half_hidden_size / kVecElems;
+    const int vec_threads = chunks <= 128 ? 128 : kVecThreads;
+    if (rows > 128) {
+      const int64_t total_chunks = rows * chunks;
+      if (rows <= static_cast<int64_t>(INT32_MAX) &&
+          half_hidden_size <= static_cast<int64_t>(INT32_MAX) &&
+          chunks <= static_cast<int64_t>(INT32_MAX) &&
+          total_chunks <= static_cast<int64_t>(INT32_MAX)) {
+        if (skip_expert_check) {
+          if constexpr (std::is_same_v<T, half>) {
+            if (rows >= 1024 && rows <= 4096) {
+              const int64_t chunk_tiles =
+                  (total_chunks + kFlatVecThreadsHalfMedium - 1) /
+                  kFlatVecThreadsHalfMedium;
+              moe_act_and_mul_flat_vec8_no_filter_kernel<
+                  T, IdT, ACTIVATION_TYPE, kFlatVecThreadsHalfMedium>
+                  <<<dim3(static_cast<unsigned>(chunk_tiles)),
+                     dim3(kFlatVecThreadsHalfMedium), 0, stream>>>(
+                      static_cast<const T*>(gateup_output.data_ptr()),
+                      static_cast<T*>(down_input.data_ptr()),
+                      static_cast<int>(rows),
+                      static_cast<int>(half_hidden_size),
+                      static_cast<int>(chunks),
+                      static_cast<int>(total_chunks));
+            } else {
+              const int64_t chunk_tiles =
+                  (total_chunks + kFlatVecThreads - 1) / kFlatVecThreads;
+              moe_act_and_mul_flat_vec8_no_filter_kernel<
+                  T, IdT, ACTIVATION_TYPE, kFlatVecThreads>
+                  <<<dim3(static_cast<unsigned>(chunk_tiles)),
+                     dim3(kFlatVecThreads), 0, stream>>>(
+                      static_cast<const T*>(gateup_output.data_ptr()),
+                      static_cast<T*>(down_input.data_ptr()),
+                      static_cast<int>(rows),
+                      static_cast<int>(half_hidden_size),
+                      static_cast<int>(chunks),
+                      static_cast<int>(total_chunks));
+            }
+          } else {
+            const int64_t chunk_tiles =
+                (total_chunks + kFlatVecThreads - 1) / kFlatVecThreads;
+            moe_act_and_mul_flat_vec8_no_filter_kernel<
+                T, IdT, ACTIVATION_TYPE, kFlatVecThreads>
+                <<<dim3(static_cast<unsigned>(chunk_tiles)),
+                   dim3(kFlatVecThreads), 0, stream>>>(
+                    static_cast<const T*>(gateup_output.data_ptr()),
+                    static_cast<T*>(down_input.data_ptr()),
+                    static_cast<int>(rows),
+                    static_cast<int>(half_hidden_size),
+                    static_cast<int>(chunks),
+                    static_cast<int>(total_chunks));
+          }
+          return;
+        }
+        const int64_t chunk_tiles =
+            (total_chunks + kFlatVecThreads * kFlatVecChunksPerThread - 1) /
+            (kFlatVecThreads * kFlatVecChunksPerThread);
+        if (rows >= 1024 && rows <= 4096) {
+          if constexpr (std::is_same_v<T, half>) {
+            const int64_t half_medium_chunk_tiles =
+                (total_chunks +
+                 kFlatVecThreadsHalfMedium * kFlatVecChunksPerThread - 1) /
+                (kFlatVecThreadsHalfMedium * kFlatVecChunksPerThread);
+            moe_act_and_mul_flat_vec8_kernel<
+                T, IdT, ACTIVATION_TYPE, kFlatVecThreadsHalfMedium>
+                <<<dim3(static_cast<unsigned>(half_medium_chunk_tiles)),
+                   dim3(kFlatVecThreadsHalfMedium), 0, stream>>>(
+                    static_cast<const T*>(gateup_output.data_ptr()),
+                    static_cast<T*>(down_input.data_ptr()),
+                    static_cast<const IdT*>(expert_ids.data_ptr()),
+                    static_cast<int>(rows),
+                    static_cast<int>(half_hidden_size),
+                    expert_step,
+                    static_cast<int>(chunks),
+                    static_cast<int>(total_chunks));
+          } else {
+            const int64_t medium_chunk_tiles =
+                (total_chunks +
+                 kFlatVecThreadsMedium * kFlatVecChunksPerThread - 1) /
+                (kFlatVecThreadsMedium * kFlatVecChunksPerThread);
+            moe_act_and_mul_flat_vec8_kernel<
+                T, IdT, ACTIVATION_TYPE, kFlatVecThreadsMedium>
+                <<<dim3(static_cast<unsigned>(medium_chunk_tiles)),
+                   dim3(kFlatVecThreadsMedium), 0, stream>>>(
+                    static_cast<const T*>(gateup_output.data_ptr()),
+                    static_cast<T*>(down_input.data_ptr()),
+                    static_cast<const IdT*>(expert_ids.data_ptr()),
+                    static_cast<int>(rows),
+                    static_cast<int>(half_hidden_size),
+                    expert_step,
+                    static_cast<int>(chunks),
+                    static_cast<int>(total_chunks));
+          }
+        } else {
+          moe_act_and_mul_flat_vec8_kernel<
+              T, IdT, ACTIVATION_TYPE, kFlatVecThreads>
+              <<<dim3(static_cast<unsigned>(chunk_tiles)),
+                 dim3(kFlatVecThreads), 0, stream>>>(
+                  static_cast<const T*>(gateup_output.data_ptr()),
+                  static_cast<T*>(down_input.data_ptr()),
+                  static_cast<const IdT*>(expert_ids.data_ptr()),
+                  static_cast<int>(rows),
+                  static_cast<int>(half_hidden_size),
+                  expert_step,
+                  static_cast<int>(chunks),
+                  static_cast<int>(total_chunks));
+        }
+      } else {
+        moe_act_and_mul_row_vec8_kernel<T, IdT, ACTIVATION_TYPE>
+            <<<dim3(static_cast<unsigned>(rows)),
+               dim3(static_cast<unsigned>(vec_threads)), 0, stream>>>(
+                static_cast<const T*>(gateup_output.data_ptr()),
+                static_cast<T*>(down_input.data_ptr()),
+                static_cast<const IdT*>(expert_ids.data_ptr()),
+                rows,
+                half_hidden_size,
+                expert_step);
+      }
+      return;
+    }
+
+    const int64_t chunk_tiles =
+        (chunks + vec_threads - 1) / vec_threads;
+    dim3 grid(static_cast<unsigned>(chunk_tiles), static_cast<unsigned>(rows));
+    moe_act_and_mul_vec8_kernel<T, IdT, ACTIVATION_TYPE>
+        <<<grid, dim3(static_cast<unsigned>(vec_threads)), 0, stream>>>(
+        static_cast<const T*>(gateup_output.data_ptr()),
+        static_cast<T*>(down_input.data_ptr()),
+        static_cast<const IdT*>(expert_ids.data_ptr()),
+        rows,
+        half_hidden_size,
+        expert_step);
+    return;
+  }
+
+  const bool use_split = rows <= 128 && half_hidden_size > kThreads;
+
+  if (use_split) {
+    dim3 grid(static_cast<unsigned>(tiles), static_cast<unsigned>(rows));
+    moe_act_and_mul_split_kernel<T, IdT, ACTIVATION_TYPE>
+        <<<grid, dim3(kThreads), 0, stream>>>(
+        static_cast<const T*>(gateup_output.data_ptr()),
+        static_cast<T*>(down_input.data_ptr()),
+        static_cast<const IdT*>(expert_ids.data_ptr()),
+        rows,
+        half_hidden_size,
+        expert_step);
+    return;
+  }
+
+  moe_act_and_mul_row_kernel<T, IdT, ACTIVATION_TYPE>
+      <<<dim3(static_cast<unsigned>(rows)), dim3(kThreads), 0, stream>>>(
+          static_cast<const T*>(gateup_output.data_ptr()),
+          static_cast<T*>(down_input.data_ptr()),
+          static_cast<const IdT*>(expert_ids.data_ptr()),
+          rows,
+          half_hidden_size,
+          expert_step);
+}
+
+template <typename T, int ACTIVATION_TYPE>
+void dispatch_moe_act_and_mul_dtype(
+    ffi::TensorView gateup_output,
+    ffi::TensorView down_input,
+    ffi::TensorView expert_ids,
+    int expert_step,
+    int activation_type,
+    bool skip_expert_check,
+    musaStream_t stream) {
+  if (dtype_equal(expert_ids.dtype(), dl_int64)) {
+    launch_moe_act_and_mul<T, int64_t, ACTIVATION_TYPE>(
+        gateup_output, down_input, expert_ids, expert_step, skip_expert_check, stream);
+  } else {
+    launch_moe_act_and_mul<T, int32_t, ACTIVATION_TYPE>(
+        gateup_output, down_input, expert_ids, expert_step, skip_expert_check, stream);
+  }
+}
+
+template <typename T>
+void dispatch_moe_act_and_mul_activation(
+    ffi::TensorView gateup_output,
+    ffi::TensorView down_input,
+    ffi::TensorView expert_ids,
+    int expert_step,
+    int activation_type,
+    bool skip_expert_check,
+    musaStream_t stream) {
+  if (activation_type == kGeluActivation) {
+    dispatch_moe_act_and_mul_dtype<T, kGeluActivation>(
+        gateup_output, down_input, expert_ids, expert_step, activation_type, skip_expert_check, stream);
+  } else {
+    dispatch_moe_act_and_mul_dtype<T, kSiluActivation>(
+        gateup_output, down_input, expert_ids, expert_step, activation_type, skip_expert_check, stream);
+  }
+}
+
+void sgl_musa_moe_act_and_mul(
+    ffi::TensorView gateup_output,
+    ffi::TensorView down_input,
+    ffi::TensorView expert_ids,
+    int64_t expert_step,
+    int64_t activation_type,
+    int64_t skip_expert_check) {
+  check_moe_act_and_mul_inputs(
+      gateup_output, down_input, expert_ids, expert_step, activation_type, skip_expert_check);
+  ffi::MUSADeviceGuard device_guard(gateup_output.device().device_id);
+  musaStream_t stream = get_stream(gateup_output.device());
+  const int step = static_cast<int>(expert_step);
+  const int act = static_cast<int>(activation_type);
+  const bool skip_check = skip_expert_check != 0;
+
+  if (dtype_equal(gateup_output.dtype(), dl_float16)) {
+    dispatch_moe_act_and_mul_activation<half>(
+        gateup_output, down_input, expert_ids, step, act, skip_check, stream);
+  } else if (dtype_equal(gateup_output.dtype(), dl_bfloat16)) {
+    dispatch_moe_act_and_mul_activation<__mt_bfloat16>(
+        gateup_output, down_input, expert_ids, step, act, skip_check, stream);
+  } else if (dtype_equal(gateup_output.dtype(), dl_float32)) {
+    dispatch_moe_act_and_mul_activation<float>(
+        gateup_output, down_input, expert_ids, step, act, skip_check, stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "Unsupported moe_act_and_mul dtype";
+  }
+
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA moe_act_and_mul kernel failed: " << musaGetErrorString(err);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_moe_act_and_mul, sgl_musa_moe_act_and_mul);

--- a/vllm_musa/jit_kernel/csrc/moe/moe_sum_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/moe/moe_sum_reduce.mu
@@ -1,0 +1,675 @@
+#include <cstdint>
+#include <type_traits>
+
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+#include <musa_runtime.h>
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/dtype.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+#include <tvm/ffi/extra/musa/device_guard.h>
+#include <tvm/ffi/function.h>
+
+#include "../common.h"
+#include "../device_utils.h"
+
+constexpr int kWarpSize = 32;
+
+template <typename T>
+__device__ __forceinline__ T convert_from_float(float value) {
+  return from_float<T>(value);
+}
+
+template <>
+__device__ __forceinline__ float convert_from_float<float>(float value) {
+  return value;
+}
+
+template <typename T>
+__device__ __forceinline__ int4 load_vec8(const T* ptr) {
+  return *reinterpret_cast<const int4*>(ptr);
+}
+
+template <typename T>
+__device__ __forceinline__ void store_vec8(T* ptr, const int4& value) {
+  *reinterpret_cast<int4*>(ptr) = value;
+}
+
+template <typename T>
+union Pack16B {
+  int4 v;
+  T elems[8];
+};
+
+template <typename T>
+union Pack4B {
+  int v;
+  T elems[2];
+};
+
+template <typename T, int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * kWarpSize, 1)
+void moe_sum_reduce_warp_token_vec8_kernel(
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int64_t token_num,
+    int64_t hidden_dim,
+    int64_t topk_num,
+    int64_t stride_token,
+    int64_t stride_topk,
+    int64_t out_stride_token,
+    float scale) {
+  constexpr int VEC = 8;
+  const int warp_id = threadIdx.x / kWarpSize;
+  const int lane = threadIdx.x & (kWarpSize - 1);
+  const int64_t token = static_cast<int64_t>(blockIdx.y) * WARPS_PER_BLOCK + warp_id;
+  if (token >= token_num) {
+    return;
+  }
+
+  const int64_t chunks = hidden_dim / VEC;
+  for (int64_t chunk = static_cast<int64_t>(blockIdx.x) * kWarpSize + lane;
+       chunk < chunks;
+       chunk += static_cast<int64_t>(gridDim.x) * kWarpSize) {
+    const int64_t d = chunk * VEC;
+    const int64_t base = token * stride_token + d;
+    float acc[VEC];
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) {
+      acc[i] = 0.0f;
+    }
+
+#pragma unroll 1
+    for (int64_t k = 0; k < topk_num; ++k) {
+      Pack16B<T> pack;
+      pack.v = load_vec8(input + base + k * stride_topk);
+#pragma unroll
+      for (int i = 0; i < VEC; ++i) {
+        acc[i] += to_float(pack.elems[i]);
+      }
+    }
+
+    Pack16B<T> out;
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) {
+      out.elems[i] = convert_from_float<T>(acc[i] * scale);
+    }
+    store_vec8(output + token * out_stride_token + d, out.v);
+  }
+}
+
+template <typename T, int TOPK, int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * kWarpSize, 1)
+void moe_sum_reduce_warp_token_vec8_topk_kernel(
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int64_t token_num,
+    int64_t hidden_dim,
+    int64_t stride_token,
+    int64_t stride_topk,
+    int64_t out_stride_token,
+    float scale) {
+  constexpr int VEC = 8;
+  const int warp_id = threadIdx.x / kWarpSize;
+  const int lane = threadIdx.x & (kWarpSize - 1);
+  const int64_t token = static_cast<int64_t>(blockIdx.y) * WARPS_PER_BLOCK + warp_id;
+  if (token >= token_num) {
+    return;
+  }
+
+  const int64_t chunks = hidden_dim / VEC;
+  for (int64_t chunk = static_cast<int64_t>(blockIdx.x) * kWarpSize + lane;
+       chunk < chunks;
+       chunk += static_cast<int64_t>(gridDim.x) * kWarpSize) {
+    const int64_t d = chunk * VEC;
+    const int64_t base = token * stride_token + d;
+    float acc[VEC];
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) {
+      acc[i] = 0.0f;
+    }
+
+#pragma unroll
+    for (int k = 0; k < TOPK; ++k) {
+      Pack16B<T> pack;
+      pack.v = load_vec8(input + base + static_cast<int64_t>(k) * stride_topk);
+#pragma unroll
+      for (int i = 0; i < VEC; ++i) {
+        acc[i] += to_float(pack.elems[i]);
+      }
+    }
+
+    Pack16B<T> out;
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) {
+      out.elems[i] = convert_from_float<T>(acc[i] * scale);
+    }
+    store_vec8(output + token * out_stride_token + d, out.v);
+  }
+}
+
+template <typename T>
+__global__ __launch_bounds__(256, 1)
+void moe_sum_reduce_small_token_vec8_kernel(
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int64_t token_num,
+    int64_t hidden_dim,
+    int64_t topk_num,
+    int64_t stride_token,
+    int64_t stride_topk,
+    int64_t out_stride_token,
+    float scale) {
+  constexpr int VEC = 8;
+  const int64_t token = blockIdx.y;
+  if (token >= token_num) {
+    return;
+  }
+
+  const int64_t chunks = hidden_dim / VEC;
+  for (int64_t chunk = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       chunk < chunks;
+       chunk += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+    const int64_t d = chunk * VEC;
+    const int64_t base = token * stride_token + d;
+    float acc[VEC];
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) {
+      acc[i] = 0.0f;
+    }
+
+#pragma unroll 1
+    for (int64_t k = 0; k < topk_num; ++k) {
+      Pack16B<T> pack;
+      pack.v = load_vec8(input + base + k * stride_topk);
+#pragma unroll
+      for (int i = 0; i < VEC; ++i) {
+        acc[i] += to_float(pack.elems[i]);
+      }
+    }
+
+    Pack16B<T> out;
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) {
+      out.elems[i] = convert_from_float<T>(acc[i] * scale);
+    }
+    store_vec8(output + token * out_stride_token + d, out.v);
+  }
+}
+
+template <typename T, int TOPK>
+__global__ __launch_bounds__(256, 1)
+void moe_sum_reduce_small_token_vec8_topk_kernel(
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int64_t token_num,
+    int64_t hidden_dim,
+    int64_t stride_token,
+    int64_t stride_topk,
+    int64_t out_stride_token,
+    float scale) {
+  constexpr int VEC = 8;
+  const int64_t token = blockIdx.y;
+  if (token >= token_num) {
+    return;
+  }
+
+  const int64_t chunks = hidden_dim / VEC;
+  for (int64_t chunk = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       chunk < chunks;
+       chunk += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+    const int64_t d = chunk * VEC;
+    const int64_t base = token * stride_token + d;
+    float acc[VEC];
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) {
+      acc[i] = 0.0f;
+    }
+
+#pragma unroll
+    for (int k = 0; k < TOPK; ++k) {
+      Pack16B<T> pack;
+      pack.v = load_vec8(input + base + static_cast<int64_t>(k) * stride_topk);
+#pragma unroll
+      for (int i = 0; i < VEC; ++i) {
+        acc[i] += to_float(pack.elems[i]);
+      }
+    }
+
+    Pack16B<T> out;
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) {
+      out.elems[i] = convert_from_float<T>(acc[i] * scale);
+    }
+    store_vec8(output + token * out_stride_token + d, out.v);
+  }
+}
+
+template <typename T, int TOPK, int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * kWarpSize, 1)
+void moe_sum_reduce_warp_token_topk_kernel(
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int64_t token_num,
+    int64_t hidden_dim,
+    int64_t stride_token,
+    int64_t stride_topk,
+    int64_t out_stride_token,
+    float scale) {
+  const int warp_id = threadIdx.x / kWarpSize;
+  const int lane = threadIdx.x & (kWarpSize - 1);
+  const int64_t token = static_cast<int64_t>(blockIdx.y) * WARPS_PER_BLOCK + warp_id;
+  if (token >= token_num) {
+    return;
+  }
+
+  for (int64_t d = static_cast<int64_t>(blockIdx.x) * kWarpSize + lane;
+       d < hidden_dim;
+       d += static_cast<int64_t>(gridDim.x) * kWarpSize) {
+    const int64_t base = token * stride_token + d;
+    float acc = 0.0f;
+#pragma unroll
+    for (int k = 0; k < TOPK; ++k) {
+      acc += to_float(input[base + static_cast<int64_t>(k) * stride_topk]);
+    }
+    output[token * out_stride_token + d] = convert_from_float<T>(acc * scale);
+  }
+}
+
+template <typename T, int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * kWarpSize, 1)
+void moe_sum_reduce_warp_token_general_kernel(
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int64_t token_num,
+    int64_t hidden_dim,
+    int64_t stride_token,
+    int64_t stride_topk,
+    int64_t out_stride_token,
+    int topk_num,
+    float scale) {
+  const int warp_id = threadIdx.x / kWarpSize;
+  const int lane = threadIdx.x & (kWarpSize - 1);
+  const int64_t token = static_cast<int64_t>(blockIdx.y) * WARPS_PER_BLOCK + warp_id;
+  if (token >= token_num) {
+    return;
+  }
+
+  for (int64_t d = static_cast<int64_t>(blockIdx.x) * kWarpSize + lane;
+       d < hidden_dim;
+       d += static_cast<int64_t>(gridDim.x) * kWarpSize) {
+    const int64_t base = token * stride_token + d;
+    float acc = 0.0f;
+#pragma unroll 1
+    for (int k = 0; k < topk_num; ++k) {
+      acc += to_float(input[base + static_cast<int64_t>(k) * stride_topk]);
+    }
+    output[token * out_stride_token + d] = convert_from_float<T>(acc * scale);
+  }
+}
+
+template <typename T, int TOPK>
+__global__ void moe_sum_reduce_scalar_topk_kernel(
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int64_t token_num,
+    int64_t hidden_dim,
+    int64_t stride_token,
+    int64_t stride_topk,
+    int64_t out_stride_token,
+    float scale) {
+  for (int64_t token = blockIdx.y; token < token_num; token += gridDim.y) {
+    for (int64_t d = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         d < hidden_dim;
+         d += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+      const int64_t base = token * stride_token + d;
+      float acc = 0.0f;
+#pragma unroll
+      for (int k = 0; k < TOPK; ++k) {
+        acc += to_float(input[base + static_cast<int64_t>(k) * stride_topk]);
+      }
+      output[token * out_stride_token + d] = convert_from_float<T>(acc * scale);
+    }
+  }
+}
+
+template <typename T, int TOPK>
+__global__ __launch_bounds__(256, 1)
+void moe_sum_reduce_scalar_vec2_topk_kernel(
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int64_t token_num,
+    int64_t hidden_dim,
+    int64_t stride_token,
+    int64_t stride_topk,
+    int64_t out_stride_token,
+    float scale) {
+  constexpr int VEC = 2;
+  for (int64_t token = blockIdx.y; token < token_num; token += gridDim.y) {
+    const int64_t chunks = hidden_dim / VEC;
+    for (int64_t chunk = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         chunk < chunks;
+         chunk += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+      const int64_t d = chunk * VEC;
+      const int64_t base = token * stride_token + d;
+      float acc0 = 0.0f;
+      float acc1 = 0.0f;
+#pragma unroll
+      for (int k = 0; k < TOPK; ++k) {
+        Pack4B<T> pack;
+        pack.v = *reinterpret_cast<const int*>(input + base + static_cast<int64_t>(k) * stride_topk);
+        acc0 += to_float(pack.elems[0]);
+        acc1 += to_float(pack.elems[1]);
+      }
+      Pack4B<T> out;
+      out.elems[0] = convert_from_float<T>(acc0 * scale);
+      out.elems[1] = convert_from_float<T>(acc1 * scale);
+      *reinterpret_cast<int*>(output + token * out_stride_token + d) = out.v;
+    }
+  }
+}
+
+template <typename T>
+__global__ void moe_sum_reduce_scalar_general_kernel(
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int64_t token_num,
+    int64_t hidden_dim,
+    int64_t stride_token,
+    int64_t stride_topk,
+    int64_t out_stride_token,
+    int topk_num,
+    float scale) {
+  for (int64_t token = blockIdx.y; token < token_num; token += gridDim.y) {
+    for (int64_t d = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         d < hidden_dim;
+         d += static_cast<int64_t>(blockDim.x) * gridDim.x) {
+      const int64_t base = token * stride_token + d;
+      float acc = 0.0f;
+#pragma unroll 1
+      for (int k = 0; k < topk_num; ++k) {
+        acc += to_float(input[base + static_cast<int64_t>(k) * stride_topk]);
+      }
+      output[token * out_stride_token + d] = convert_from_float<T>(acc * scale);
+    }
+  }
+}
+
+void check_moe_sum_reduce_inputs(ffi::TensorView input, ffi::TensorView output) {
+  CHECK_MUSA_CONTIGUOUS(input);
+  CHECK_MUSA_CONTIGUOUS(output);
+  TVM_FFI_ICHECK_EQ(input.ndim(), 3);
+  TVM_FFI_ICHECK_EQ(output.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(input.size(0), output.size(0));
+  TVM_FFI_ICHECK_EQ(input.size(2), output.size(1));
+  TVM_FFI_ICHECK_EQ(input.device().device_id, output.device().device_id);
+  TVM_FFI_ICHECK(dtype_equal(input.dtype(), output.dtype()));
+  TVM_FFI_ICHECK(dtype_equal(input.dtype(), dl_float32) ||
+                 dtype_equal(input.dtype(), dl_float16) ||
+                 dtype_equal(input.dtype(), dl_bfloat16));
+}
+
+int small_vec8_threads(int64_t hidden_dim) {
+  const int64_t chunks = hidden_dim / 8;
+  if (chunks == 352) return 32;  // hidden=2816
+  constexpr int candidates[] = {256, 224, 192, 160, 128, 96, 64, 32};
+  int best_threads = 256;
+  int64_t best_score = INT64_MAX;
+  for (int threads : candidates) {
+    const int64_t blocks = (chunks + threads - 1) / threads;
+    const int64_t padded = blocks * threads;
+    const int64_t waste = padded - chunks;
+    const int64_t score = waste + blocks * 32;
+    if (score < best_score) {
+      best_score = score;
+      best_threads = threads;
+    }
+  }
+  return best_threads;
+}
+
+template <typename T>
+void launch_moe_sum_reduce(ffi::TensorView input, ffi::TensorView output, float scale) {
+  const int64_t token_num = input.size(0);
+  const int64_t topk_num = input.size(1);
+  const int64_t hidden_dim = input.size(2);
+  const int64_t stride_token = input.stride(0);
+  const int64_t stride_topk = input.stride(1);
+  const int64_t out_stride_token = output.stride(0);
+  musaStream_t stream = get_stream(input.device());
+
+  if (token_num == 0 || hidden_dim == 0) {
+    return;
+  }
+
+  if (!std::is_same_v<T, float> &&
+      ((topk_num == 2 && token_num <= 8) ||
+       (topk_num == 4 &&
+        (token_num <= 8 || (token_num <= 32 && hidden_dim <= 4096) ||
+         (token_num >= 256 && hidden_dim >= 7168))) ||
+       ((topk_num == 8 || topk_num == 9) && token_num <= 512)) &&
+      (hidden_dim % 8) == 0) {
+    const int THREADS =
+        (topk_num == 2 && token_num <= 4) ? 128 :
+        (token_num <= 4 ? 64 : (token_num <= 8 ? 128 : 256));
+    const bool use_vec2 =
+        (topk_num == 4) ? token_num >= 256 : token_num >= 64;
+    int64_t grid_x =
+        ((use_vec2 ? hidden_dim / 2 : hidden_dim) + THREADS - 1) / THREADS;
+    grid_x = grid_x > 65535 ? 65535 : grid_x;
+    int64_t grid_y = token_num > 65535 ? 65535 : token_num;
+    dim3 grid(static_cast<unsigned>(grid_x), static_cast<unsigned>(grid_y));
+    dim3 block(THREADS);
+#define LAUNCH_TINY_TOPK(TOPK)                                                \
+  do {                                                                        \
+    if (use_vec2) {                                                           \
+      moe_sum_reduce_scalar_vec2_topk_kernel<T, TOPK>                         \
+          <<<grid, block, 0, stream>>>(                                       \
+              static_cast<const T*>(input.data_ptr()),                        \
+              static_cast<T*>(output.data_ptr()),                             \
+              token_num, hidden_dim, stride_token, stride_topk,               \
+              out_stride_token, scale);                                       \
+    } else {                                                                  \
+      moe_sum_reduce_scalar_topk_kernel<T, TOPK><<<grid, block, 0, stream>>>( \
+          static_cast<const T*>(input.data_ptr()),                            \
+          static_cast<T*>(output.data_ptr()),                                 \
+          token_num, hidden_dim, stride_token, stride_topk, out_stride_token, \
+          scale);                                                             \
+    }                                                                         \
+  } while (0)
+    switch (topk_num) {
+      case 2:
+        LAUNCH_TINY_TOPK(2);
+        break;
+      case 4:
+        LAUNCH_TINY_TOPK(4);
+        break;
+      case 8:
+        LAUNCH_TINY_TOPK(8);
+        break;
+      default:
+        LAUNCH_TINY_TOPK(9);
+        break;
+    }
+#undef LAUNCH_TINY_TOPK
+    return;
+  }
+
+  const bool small_vec8_ok =
+      !std::is_same_v<T, float> && token_num <= 96 && (hidden_dim % 8) == 0;
+  if (small_vec8_ok) {
+    const int THREADS = (token_num <= 4 && hidden_dim == 7168) ? 256 : small_vec8_threads(hidden_dim);
+    int64_t grid_x = (hidden_dim / 8 + THREADS - 1) / THREADS;
+    grid_x = grid_x > 65535 ? 65535 : grid_x;
+    int64_t grid_y = token_num > 65535 ? 65535 : token_num;
+    dim3 grid(static_cast<unsigned>(grid_x), static_cast<unsigned>(grid_y));
+    dim3 block(THREADS);
+    if (token_num <= 32) {
+#define LAUNCH_SMALL_VEC8_TOPK(TOPK)                                          \
+  moe_sum_reduce_small_token_vec8_topk_kernel<T, TOPK><<<grid, block, 0, stream>>>( \
+      static_cast<const T*>(input.data_ptr()),                                \
+      static_cast<T*>(output.data_ptr()),                                     \
+      token_num, hidden_dim, stride_token, stride_topk, out_stride_token,     \
+      scale)
+      switch (topk_num) {
+        case 2:
+          LAUNCH_SMALL_VEC8_TOPK(2);
+          break;
+        case 4:
+          LAUNCH_SMALL_VEC8_TOPK(4);
+          break;
+        case 8:
+          LAUNCH_SMALL_VEC8_TOPK(8);
+          break;
+        case 9:
+          LAUNCH_SMALL_VEC8_TOPK(9);
+          break;
+        default:
+          moe_sum_reduce_small_token_vec8_kernel<T><<<grid, block, 0, stream>>>(
+              static_cast<const T*>(input.data_ptr()),
+              static_cast<T*>(output.data_ptr()),
+              token_num,
+              hidden_dim,
+              topk_num,
+              stride_token,
+              stride_topk,
+              out_stride_token,
+              scale);
+      }
+#undef LAUNCH_SMALL_VEC8_TOPK
+    } else {
+      moe_sum_reduce_small_token_vec8_kernel<T><<<grid, block, 0, stream>>>(
+          static_cast<const T*>(input.data_ptr()),
+          static_cast<T*>(output.data_ptr()),
+          token_num,
+          hidden_dim,
+          topk_num,
+          stride_token,
+          stride_topk,
+          out_stride_token,
+          scale);
+    }
+    return;
+  }
+
+  const bool vec8_ok =
+      !std::is_same_v<T, float> && token_num >= 128 && (hidden_dim % 8) == 0;
+  if (vec8_ok) {
+    constexpr int WARPS_PER_BLOCK = 8;
+    constexpr int THREADS = WARPS_PER_BLOCK * kWarpSize;
+    int64_t grid_x = (hidden_dim / 8 + kWarpSize - 1) / kWarpSize;
+    grid_x = grid_x > 65535 ? 65535 : grid_x;
+    int64_t grid_y = (token_num + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    grid_y = grid_y > 65535 ? 65535 : grid_y;
+    moe_sum_reduce_warp_token_vec8_kernel<T, WARPS_PER_BLOCK>
+        <<<dim3(static_cast<unsigned>(grid_x), static_cast<unsigned>(grid_y)),
+           dim3(THREADS), 0, stream>>>(
+            static_cast<const T*>(input.data_ptr()),
+            static_cast<T*>(output.data_ptr()),
+            token_num,
+            hidden_dim,
+            topk_num,
+            stride_token,
+            stride_topk,
+            out_stride_token,
+            scale);
+    return;
+  }
+
+  const bool warp_per_token = token_num > 128;
+  if (warp_per_token) {
+    constexpr int WARPS_PER_BLOCK = 4;
+    constexpr int THREADS = WARPS_PER_BLOCK * kWarpSize;
+    int64_t grid_x = (hidden_dim + kWarpSize - 1) / kWarpSize;
+    grid_x = grid_x > 65535 ? 65535 : grid_x;
+    int64_t grid_y = (token_num + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    grid_y = grid_y > 65535 ? 65535 : grid_y;
+    dim3 grid(static_cast<unsigned>(grid_x), static_cast<unsigned>(grid_y));
+    dim3 block(THREADS);
+#define LAUNCH_WARP_TOPK(TOPK)                                                \
+  moe_sum_reduce_warp_token_topk_kernel<T, TOPK, WARPS_PER_BLOCK>             \
+      <<<grid, block, 0, stream>>>(                                           \
+          static_cast<const T*>(input.data_ptr()),                            \
+          static_cast<T*>(output.data_ptr()),                                 \
+          token_num, hidden_dim, stride_token, stride_topk, out_stride_token, \
+          scale)
+    switch (topk_num) {
+      case 2:
+        LAUNCH_WARP_TOPK(2);
+        break;
+      case 4:
+        LAUNCH_WARP_TOPK(4);
+        break;
+      case 8:
+        LAUNCH_WARP_TOPK(8);
+        break;
+      case 9:
+        LAUNCH_WARP_TOPK(9);
+        break;
+      default:
+        moe_sum_reduce_warp_token_general_kernel<T, WARPS_PER_BLOCK>
+            <<<grid, block, 0, stream>>>(
+                static_cast<const T*>(input.data_ptr()),
+                static_cast<T*>(output.data_ptr()),
+                token_num, hidden_dim, stride_token, stride_topk,
+                out_stride_token, static_cast<int>(topk_num), scale);
+    }
+#undef LAUNCH_WARP_TOPK
+  } else {
+    constexpr int THREADS = 256;
+    int64_t grid_x = (hidden_dim + THREADS - 1) / THREADS;
+    grid_x = grid_x > 65535 ? 65535 : grid_x;
+    int64_t grid_y = token_num > 65535 ? 65535 : token_num;
+    dim3 grid(static_cast<unsigned>(grid_x), static_cast<unsigned>(grid_y));
+    dim3 block(THREADS);
+#define LAUNCH_SCALAR_TOPK(TOPK)                                              \
+  moe_sum_reduce_scalar_topk_kernel<T, TOPK><<<grid, block, 0, stream>>>(     \
+      static_cast<const T*>(input.data_ptr()),                                \
+      static_cast<T*>(output.data_ptr()),                                     \
+      token_num, hidden_dim, stride_token, stride_topk, out_stride_token,     \
+      scale)
+    switch (topk_num) {
+      case 2:
+        LAUNCH_SCALAR_TOPK(2);
+        break;
+      case 4:
+        LAUNCH_SCALAR_TOPK(4);
+        break;
+      case 8:
+        LAUNCH_SCALAR_TOPK(8);
+        break;
+      case 9:
+        LAUNCH_SCALAR_TOPK(9);
+        break;
+      default:
+        moe_sum_reduce_scalar_general_kernel<T><<<grid, block, 0, stream>>>(
+            static_cast<const T*>(input.data_ptr()),
+            static_cast<T*>(output.data_ptr()),
+            token_num, hidden_dim, stride_token, stride_topk, out_stride_token,
+            static_cast<int>(topk_num), scale);
+    }
+#undef LAUNCH_SCALAR_TOPK
+  }
+}
+
+void sgl_musa_moe_sum_reduce(ffi::TensorView input, ffi::TensorView output,
+                             double routed_scaling_factor) {
+  check_moe_sum_reduce_inputs(input, output);
+  ffi::MUSADeviceGuard device_guard(input.device().device_id);
+  const float scale = static_cast<float>(routed_scaling_factor);
+  if (dtype_equal(input.dtype(), dl_float32)) {
+    launch_moe_sum_reduce<float>(input, output, scale);
+  } else if (dtype_equal(input.dtype(), dl_float16)) {
+    launch_moe_sum_reduce<half>(input, output, scale);
+  } else if (dtype_equal(input.dtype(), dl_bfloat16)) {
+    launch_moe_sum_reduce<__mt_bfloat16>(input, output, scale);
+  } else {
+    TVM_FFI_THROW(ValueError) << "Unsupported moe_sum_reduce dtype";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA moe_sum_reduce kernel failed: " << musaGetErrorString(err);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_moe_sum_reduce, sgl_musa_moe_sum_reduce);

--- a/vllm_musa/patches/series/0008-MUSA-vllm.model_executor.layers.fused_moe.activation.patch
+++ b/vllm_musa/patches/series/0008-MUSA-vllm.model_executor.layers.fused_moe.activation.patch
@@ -4,21 +4,23 @@ Date: Wed, 3 Jun 2026 11:47:35 +0000
 Subject: [PATCH] MUSA: vllm.model_executor.layers.fused_moe.activation
 
 ---
- vllm/model_executor/layers/fused_moe/activation.py | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
+ vllm/model_executor/layers/fused_moe/activation.py | 8 ++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/vllm/model_executor/layers/fused_moe/activation.py b/vllm/model_executor/layers/fused_moe/activation.py
 index b2e67e622..441ffca34 100644
 --- a/vllm/model_executor/layers/fused_moe/activation.py
 +++ b/vllm/model_executor/layers/fused_moe/activation.py
-@@ -122,7 +122,11 @@ def apply_moe_activation(
- 
+@@ -122,7 +122,13 @@ def apply_moe_activation(
+
      # Activations with gated multiplication (gate × activation(up))
      if activation == MoEActivation.SILU:
 -        torch.ops._C.silu_and_mul(output, input)
 +        if input.device.type == "musa":
-+            d = input.shape[-1] // 2
-+            output.copy_(F.silu(input[..., :d]) * input[..., d:])
++            from vllm_musa.jit_kernel.csrc.moe import maybe_fast_silu_and_mul
++            if not maybe_fast_silu_and_mul(output, input):
++                d = input.shape[-1] // 2
++                output.copy_(F.silu(input[..., :d]) * input[..., d:])
 +        else:
 +            torch.ops._C.silu_and_mul(output, input)
      elif activation == MoEActivation.GELU:

--- a/vllm_musa/patches/series/0066-MUSA-vllm.model_executor.layers.fused_moe.fused_moe.patch
+++ b/vllm_musa/patches/series/0066-MUSA-vllm.model_executor.layers.fused_moe.fused_moe.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sun, 22 Jun 2026 00:00:00 +0000
+Subject: [PATCH] MUSA: vllm.model_executor.layers.fused_moe.fused_moe
+
+---
+diff --git a/vllm/model_executor/layers/fused_moe/fused_moe.py b/vllm/model_executor/layers/fused_moe/fused_moe.py
+index 8d974ea56..1374855f5 100644
+--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
++++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
+@@ -1861,9 +1861,9 @@ def fused_experts_impl(
+         B_bias=w2_bias,
+     )
+ 
+-    ops.moe_sum(
+-        intermediate_cache3.view(*intermediate_cache3.size()),
+-        out_hidden_states,
+-    )
++    _ic3 = intermediate_cache3.view(*intermediate_cache3.size())
++    from vllm_musa.jit_kernel.csrc.moe import maybe_fast_moe_sum
++    if not maybe_fast_moe_sum(_ic3, out_hidden_states):
++        ops.moe_sum(_ic3, out_hidden_states)
+ 
+     return out_hidden_states


### PR DESCRIPTION
Route the bf16 fused-MoE SiLU activation and moe_sum reduction through native vec8 (int4-packed) MUSA kernels, prewarmed at load and captured into the decode CUDA graph. Guarded by device/contiguity/dtype/shape checks that fall back to the eager kernels for unsupported inputs (FP8/int8 and the dense non-MoE paths), so the fast paths apply only to contiguous float16/bfloat16/float32 MoE tensors.