### PR TITLE
perf(gdn): run Qwen3.5 GDN decode via the fused recurrent update

### DIFF
--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -135,21 +135,30 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
 
         # MUSA: the mate fp32-VK decode kernel is unavailable in this toolchain,
         # so pure decode runs the fused recurrent update directly on the paged
-        # state pool (leaner than the upstream general prefill/decode path).
-        core_attn_out_non_spec, _ = fused_sigmoid_gating_delta_rule_update(
-            A_log=self.A_log,
-            a=a,
-            b=b,
-            dt_bias=self.dt_bias,
-            q=query,
-            k=key,
-            v=value,
-            initial_state=ssm_state,
-            inplace_final_state=True,
-            cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
-            ssm_state_indices=state_indices,
-            use_qk_l2norm_in_kernel=True,
-        )
+        # state pool (leaner than the upstream general prefill/decode path). Fall
+        # back to the general decode path if this kernel ever fails at runtime.
+        try:
+            core_attn_out_non_spec, _ = fused_sigmoid_gating_delta_rule_update(
+                A_log=self.A_log,
+                a=a,
+                b=b,
+                dt_bias=self.dt_bias,
+                q=query,
+                k=key,
+                v=value,
+                initial_state=ssm_state,
+                inplace_final_state=True,
+                cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
+                ssm_state_indices=state_indices,
+                use_qk_l2norm_in_kernel=True,
+            )
+        except Exception as exc:
+            _log_once(
+                "warning",
+                "fused decode update failed (%s); using the general decode path",
+                exc,
+            )
+            return False
         core_attn_out[:num_decode_tokens] = core_attn_out_non_spec.squeeze(0)
 
         return True

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import inspect
 
 import torch
-from mate.gdn_decode import gated_delta_rule_decode
 from mate.gdn_prefill import chunk_gated_delta_rule
 from vllm.logger import init_logger
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
@@ -116,22 +115,6 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
         )
         ssm_state = self_kv_cache[1]
 
-        if ssm_state.dtype != torch.float32:
-            _log_once(
-                "warning",
-                "MATE GDN decode requires FP32 recurrent state pool, got %s; "
-                "using upstream decode.",
-                ssm_state.dtype,
-            )
-            return False
-        if not ssm_state.is_contiguous():
-            _log_once(
-                "warning",
-                "MATE GDN decode requires a contiguous recurrent state pool. "
-                "vLLM page-padded Mamba cache is strided; using upstream decode.",
-            )
-            return False
-
         state_indices = non_spec_state_indices_tensor[:num_decode_tokens]
 
         conv_weights = self.conv1d.weight.view(
@@ -150,48 +133,24 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
 
         query, key, value = self.rearrange_mixed_qkv(mixed_qkv)
 
-        try:
-            output, _ = gated_delta_rule_decode(
-                q=query.view(num_decode_tokens, 1, *query.shape[2:]),
-                k=key.view(num_decode_tokens, 1, *key.shape[2:]),
-                v=value.view(num_decode_tokens, 1, *value.shape[2:]),
-                state=ssm_state,
-                state_layout="VK",
-                state_indices=state_indices,
-                scale=self.head_k_dim**-0.5,
-                A_log=self.A_log.detach().float(),
-                a=a.view(num_decode_tokens, 1, -1),
-                dt_bias=self.dt_bias.detach().float(),
-                b=b.view(num_decode_tokens, 1, -1),
-                disable_state_update=False,
-                use_qk_l2norm=True,
-            )
-            core_attn_out[:num_decode_tokens] = output.view(
-                num_decode_tokens,
-                self.num_v_heads // self.tp_size,
-                self.head_v_dim,
-            )
-        except Exception as e:
-            _log_once(
-                "warning",
-                "MATE GDN decode failed; using recurrent fallback: %s",
-                e,
-            )
-            core_attn_out_non_spec, _ = fused_sigmoid_gating_delta_rule_update(
-                A_log=self.A_log,
-                a=a,
-                b=b,
-                dt_bias=self.dt_bias,
-                q=query,
-                k=key,
-                v=value,
-                initial_state=ssm_state,
-                inplace_final_state=True,
-                cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
-                ssm_state_indices=state_indices,
-                use_qk_l2norm_in_kernel=True,
-            )
-            core_attn_out[:num_decode_tokens] = core_attn_out_non_spec.squeeze(0)
+        # MUSA: the mate fp32-VK decode kernel is unavailable in this toolchain,
+        # so pure decode runs the fused recurrent update directly on the paged
+        # state pool (leaner than the upstream general prefill/decode path).
+        core_attn_out_non_spec, _ = fused_sigmoid_gating_delta_rule_update(
+            A_log=self.A_log,
+            a=a,
+            b=b,
+            dt_bias=self.dt_bias,
+            q=query,
+            k=key,
+            v=value,
+            initial_state=ssm_state,
+            inplace_final_state=True,
+            cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
+            ssm_state_indices=state_indices,
+            use_qk_l2norm_in_kernel=True,
+        )
+        core_attn_out[:num_decode_tokens] = core_attn_out_non_spec.squeeze(0)
 
         return True
 


### PR DESCRIPTION
## Summary

`MusaQwenGatedDeltaNetAttention._try_mate_decode` attempted the mate fp32-VK decode kernel
(`gated_delta_rule_decode`), which requires a contiguous fp32 recurrent-state pool. vLLM's
paged Mamba state pool is page-padded (strided) and non-fp32, so the attempt hit two guards
and returned `False`, and GDN decode fell through to the upstream general path
(`super()._forward_core`). That mate decode kernel also fails to JIT-build in the current
toolchain (a mate↔TileLang `inner_cache_policy` incompat), so the fast path never ran.

Route pure non-spec decode directly through `fused_sigmoid_gating_delta_rule_update` on the
paged state pool — the leaner recurrent kernel, which already accepts the paged layout via
`ssm_state_indices` (it was previously only the exception fallback). The unusable kernel
attempt and its guards are removed (+18 / −59).

## Why

On the hybrid-GDN Qwen line (Qwen3.5/3.6 27B dense+GDN, 35B-A3B MoE+GDN), 30–48 of the
linear-attention layers ran the slower upstream decode every step. Benchmarking against
SGLang-on-MUSA (isolated S5000, in2048/out512, drift-controlled) localized the gap to this
GDN decode path.

## Benchmark

bf16 Qwen3.6-35B-A3B, TP4, in2048/out512, output tok/s; same-session, drift-controlled
(interleaved A/B for the >10% deltas):

| bs | base | this PR | SGLang | Δ vs base | vs SGLang |
|----|------|---------|--------|-----------|-----------|
| 1  | 61.4 | 62.6 | 70.9 | +1.9% | closes 12% |
| 4  | 195.4 | 214.7 | 254.8 | +9.9% | closes 33% |
| 16 | 574.2 | 678.8 | 724.2 | +18.2% | closes 70% |
| 64 | 1103 | 1581 | 1181 | +43.3% | beats SGLang +34% |

Dtype-agnostic — it applies to the FP8 GDN models too. A full re-benchmark with this change
live moves the dense+GDN Qwen3.5-27B-FP8 from SGLang-leading at every captured batch size to
vLLM leading 3 of 4, and widens the MoE+GDN Qwen3.5-35B-A3B-FP8 lead to +47–59% at bs 1/4/16.

## Correctness

15-prompt factual + reasoning grid at temperature 0: base 14/15 == patched 14/15 (identical
score; 12/15 byte-identical, the rest differ but all correct — the expected numerical
difference between two valid GDN decode kernels).

## Regression

GDN decode path plus a pure-dense control, all PASS (backend=FLASH_ATTN, FULL_DECODE_ONLY,
compile ON):

```
PASS Qwen3.5-35B-A3B-FP8 (GDN + FP8 MoE, TP4)  contains_paris=True reason_correct=True
PASS Qwen3.5-27B-FP8     (GDN dense, TP2)       contains_paris=True jupiter=True
PASS Qwen3-32B-FP8       (pure-dense CONTROL)   contains_paris=True reason_correct=True
```

The pure-dense control confirms the non-GDN path is unaffected. Python-only change — no
reinstall.

## Test plan

- [x] `python -m py_compile vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py`
- [x] Serve Qwen3.5-27B-FP8 (TP2) + Qwen3.5-35B-A3B-FP8 (TP4), compile ON, FULL_DECODE_ONLY — coherent completions
- [x] `vllm bench serve` in2048/out512 bs {1,4,16,64} vs the pre-change build — deltas above
- [x] Pure-dense control (Qwen3-32B-FP8) unaffected

## Risk

Low. One file, `_try_mate_decode` (pure non-spec decode) only; prefill and speculative/mixed
paths are untouched. It removes an always-failing kernel attempt, so decode now runs the
fused recurrent kernel instead of `super()._forward_core` — validated equivalent above.

## Follow-up

Fix the mate↔TileLang `inner_cache_policy` incompat so the mate fp32-VK decode kernel builds;
it can then replace `fused_sigmoid_gating_delta_rule_update` via a gather/scatter wrapper if
it proves faster.
