### PR TITLE
Register-resident FP8 per-token-group quant kernel (+4-5% dense decode)

### DIFF
--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -50,6 +50,12 @@ void silu_and_mul_per_token_group_fp8_quant(
     int64_t group_size, double eps, double fp8_min,
     double fp8_max);
 
+void per_token_group_quant_8bit_vec(
+    const torch::Tensor& input,
+    torch::Tensor& output_q, torch::Tensor& output_s,
+    int64_t group_size, double eps, double min_8bit,
+    double max_8bit);
+
 void musa_top_k_top_p_sampling_from_probs(
     at::Tensor probs,
     at::Tensor output,

--- a/csrc/musa/quantization/per_token_group_quant_8bit_vec.cu
+++ b/csrc/musa/quantization/per_token_group_quant_8bit_vec.cu
@@ -1,0 +1,173 @@
+#include <ATen/cuda/CUDAContext.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cuda_fp8.h>
+#include <torch/all.h>
+
+// Register-resident per-token-group 8-bit quantization.
+//
+// One 16-thread group cooperates on a 128-element quant group: each lane loads
+// its 8 source elements (16 B) with a single 128-bit load into registers,
+// reduces the group absmax with warp shuffles, then quantizes straight from
+// registers and writes the 8 output bytes with a single 64-bit store. No shared
+// memory and no __syncthreads(), unlike the shared-memory staging path.
+//
+// Scales are written row- or column-major from the output_s strides; the column
+// layout matches the block-FP8 GEMM scale expectations.
+
+namespace {
+
+constexpr int THREADS_PER_GROUP = 16;
+
+// Warp-segment max reduce within a 16-thread group.
+__device__ __forceinline__ float GroupReduceMax(float val) {
+  unsigned mask = threadIdx.x % 32 >= 16 ? 0xffff0000 : 0x0000ffff;
+
+  val = fmaxf(val, __shfl_xor_sync(mask, val, 8));
+  val = fmaxf(val, __shfl_xor_sync(mask, val, 4));
+  val = fmaxf(val, __shfl_xor_sync(mask, val, 2));
+  val = fmaxf(val, __shfl_xor_sync(mask, val, 1));
+  return val;
+}
+
+inline int GetGroupsPerBlock(int64_t num_groups) {
+  if (num_groups % 16 == 0) return 16;
+  if (num_groups % 8 == 0) return 8;
+  if (num_groups % 4 == 0) return 4;
+  if (num_groups % 2 == 0) return 2;
+  return 1;
+}
+
+template <typename T, typename DST_DTYPE, bool IS_COLUMN_MAJOR>
+__global__ void per_token_group_quant_8bit_vec_kernel(
+    const T* __restrict__ input, void* __restrict__ output_q,
+    float* __restrict__ output_s, const int group_size, const int num_groups,
+    const int groups_per_block, const float eps, const float min_8bit,
+    const float max_8bit, const int num_groups_per_row, const int scale_stride) {
+  static_assert(sizeof(T) == 2, "vec quant kernel expects a 2-byte input type");
+  constexpr int VEC_SIZE = 16 / sizeof(T);  // 8 elements = 16 B per lane
+  static_assert(sizeof(T) * VEC_SIZE == 16, "one 128-bit load per lane");
+
+  const int local_group_id = threadIdx.x / THREADS_PER_GROUP;
+  const int lane_id = threadIdx.x % THREADS_PER_GROUP;
+  const int64_t global_group_id =
+      static_cast<int64_t>(blockIdx.x) * groups_per_block + local_group_id;
+  if (global_group_id >= num_groups) return;
+
+  const int64_t group_offset = global_group_id * group_size;
+  const T* group_input = input + group_offset + lane_id * VEC_SIZE;
+  DST_DTYPE* group_output =
+      static_cast<DST_DTYPE*>(output_q) + group_offset + lane_id * VEC_SIZE;
+
+  // One 128-bit load of this lane's 8 source elements into registers.
+  alignas(16) T regs[VEC_SIZE];
+  *reinterpret_cast<uint4*>(&regs[0]) =
+      *reinterpret_cast<const uint4*>(group_input);
+
+  float local_absmax = eps;
+#pragma unroll
+  for (int i = 0; i < VEC_SIZE; ++i) {
+    local_absmax = fmaxf(local_absmax, fabsf(static_cast<float>(regs[i])));
+  }
+  local_absmax = GroupReduceMax(local_absmax);
+
+  const float y_s = local_absmax / max_8bit;
+
+  float* scale_output;
+  if constexpr (IS_COLUMN_MAJOR) {
+    const int row_idx = global_group_id / num_groups_per_row;
+    const int col_idx = global_group_id % num_groups_per_row;
+    scale_output = output_s + col_idx * scale_stride + row_idx;
+  } else {
+    scale_output = output_s + global_group_id;
+  }
+  if (lane_id == 0) *scale_output = y_s;
+
+  // Quantize from registers and pack into a single 64-bit store.
+  union {
+    uint8_t b[VEC_SIZE];
+    uint2 v;
+  } pack;
+#pragma unroll
+  for (int i = 0; i < VEC_SIZE; ++i) {
+    float q = fminf(fmaxf(static_cast<float>(regs[i]) / y_s, min_8bit), max_8bit);
+    DST_DTYPE qb = DST_DTYPE(q);
+    pack.b[i] = *reinterpret_cast<const uint8_t*>(&qb);
+  }
+  *reinterpret_cast<uint2*>(group_output) = pack.v;
+}
+
+#define VEC_DISPATCH_HALF_TYPES(TYPE, NAME, ...)          \
+  AT_DISPATCH_SWITCH(TYPE, NAME,                          \
+                     AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__) \
+                         AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__))
+
+}  // namespace
+
+// Drop-in for per_token_group_fp8_quant on the group_size==128 bf16/fp16 path.
+// Column-major scales are inferred from output_s strides.
+void per_token_group_quant_8bit_vec(const torch::Tensor& input,
+                                    torch::Tensor& output_q,
+                                    torch::Tensor& output_s, int64_t group_size,
+                                    double eps, double min_8bit,
+                                    double max_8bit) {
+  TORCH_CHECK(input.is_contiguous());
+  TORCH_CHECK(output_q.is_contiguous());
+  TORCH_CHECK(output_s.dim() == 2);
+  TORCH_CHECK(group_size == 128,
+              "per_token_group_quant_8bit_vec supports group_size==128.");
+  TORCH_CHECK(input.scalar_type() == at::ScalarType::Half ||
+                  input.scalar_type() == at::ScalarType::BFloat16,
+              "per_token_group_quant_8bit_vec supports bf16/fp16 input.");
+  TORCH_CHECK(input.numel() % group_size == 0);
+
+  const int num_groups = static_cast<int>(input.numel() / group_size);
+  if (num_groups == 0) return;
+
+  const int groups_per_block = GetGroupsPerBlock(num_groups);
+  const int num_blocks = num_groups / groups_per_block;
+  const int num_threads = groups_per_block * THREADS_PER_GROUP;
+
+  const bool is_column_major = output_s.stride(0) < output_s.stride(1);
+  const int num_groups_per_row =
+      static_cast<int>(input.size(input.dim() - 1)) / group_size;
+  const int scale_stride = static_cast<int>(output_s.stride(1));
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  auto dst_type = output_q.scalar_type();
+
+#define LAUNCH_VEC_QUANT_KERNEL(T, DST_DTYPE, IS_COL)                          \
+  per_token_group_quant_8bit_vec_kernel<T, DST_DTYPE, IS_COL>                 \
+      <<<num_blocks, num_threads, 0, stream>>>(                              \
+          static_cast<const T*>(input.data_ptr()), output_q.data_ptr(),      \
+          static_cast<float*>(output_s.data_ptr()), group_size, num_groups,  \
+          groups_per_block, static_cast<float>(eps),                         \
+          static_cast<float>(min_8bit), static_cast<float>(max_8bit),        \
+          num_groups_per_row, scale_stride)
+
+#define LAUNCH_VEC_QUANT_DST(T, DST_DTYPE)      \
+  do {                                          \
+    if (is_column_major) {                      \
+      LAUNCH_VEC_QUANT_KERNEL(T, DST_DTYPE, true);  \
+    } else {                                    \
+      LAUNCH_VEC_QUANT_KERNEL(T, DST_DTYPE, false); \
+    }                                           \
+  } while (0)
+
+  VEC_DISPATCH_HALF_TYPES(
+      input.scalar_type(), "per_token_group_quant_8bit_vec", ([&] {
+        if (dst_type == at::ScalarType::Float8_e4m3fn) {
+          LAUNCH_VEC_QUANT_DST(scalar_t, __nv_fp8_e4m3);
+        } else if (dst_type == at::ScalarType::Char) {
+          LAUNCH_VEC_QUANT_DST(scalar_t, int8_t);
+        } else {
+          TORCH_CHECK(false,
+                      "per_token_group_quant_8bit_vec only supports FP8/INT8 "
+                      "outputs.");
+        }
+      }));
+
+#undef LAUNCH_VEC_QUANT_DST
+#undef LAUNCH_VEC_QUANT_KERNEL
+}

--- a/csrc/musa/quantization/per_token_group_quant_8bit_vec.cu
+++ b/csrc/musa/quantization/per_token_group_quant_8bit_vec.cu
@@ -121,6 +121,12 @@ void per_token_group_quant_8bit_vec(const torch::Tensor& input,
                   input.scalar_type() == at::ScalarType::BFloat16,
               "per_token_group_quant_8bit_vec supports bf16/fp16 input.");
   TORCH_CHECK(input.numel() % group_size == 0);
+  TORCH_CHECK(output_s.scalar_type() == at::ScalarType::Float,
+              "per_token_group_quant_8bit_vec requires a float32 output_s.");
+  // The kernel loads each group with a 128-bit vector op, which needs a
+  // 16-byte aligned base; a contiguous view with an odd storage offset is not.
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(input.data_ptr()) % 16 == 0,
+              "per_token_group_quant_8bit_vec requires a 16-byte aligned input.");
 
   const int num_groups = static_cast<int>(input.numel() / group_size);
   if (num_groups == 0) return;

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -40,6 +40,13 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
       "float fp8_max) -> ()");
   musa_ops.impl("silu_and_mul_per_token_group_fp8_quant", torch::kMUSA,
                 &silu_and_mul_per_token_group_fp8_quant);
+
+  musa_ops.def(
+      "per_token_group_quant_8bit_vec(Tensor input, Tensor! output_q, "
+      "Tensor! output_s, int group_size, float eps, float min_8bit, "
+      "float max_8bit) -> ()");
+  musa_ops.impl("per_token_group_quant_8bit_vec", torch::kMUSA,
+                &per_token_group_quant_8bit_vec);
   musa_ops.def(
       "musa_top_k_top_p_sampling_from_probs(Tensor probs, Tensor! output, Tensor? maybe_indices, Tensor? "
       "maybe_top_k_arr, "

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ VLLM_MUSA_CSRC_SOURCES = [
     "csrc/musa/mhc/deepseek_v4_mhc_pre.mu",
     "csrc/musa/moe/deepseek_v4_topk_softplus_sqrt.mu",
     "csrc/musa/quantization/silu_and_mul_per_token_group_fp8_quant.cu",
+    "csrc/musa/quantization/per_token_group_quant_8bit_vec.cu",
     "csrc/musa/sampler.mu",
     str(_FLASHINFER_REPO.source_dir / "csrc/norm.cu"),
     str(_FLASHINFER_REPO.source_dir / "csrc/renorm.cu"),

--- a/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
@@ -111,11 +111,14 @@ def per_token_group_quant_fp8(
         # Register-resident vec kernel for the common group_size==128 bf16/fp16
         # activation-quant path (no shared-memory staging). Column-major and
         # TMA-aligned scale layouts are honored via output_s strides. Other
-        # configs (ue8m0, non-128 groups, fp32 input) use the stable kernel.
+        # configs (ue8m0, non-128 groups, fp32 input) use the stable kernel; so
+        # does a contiguous view whose base is not 16-byte aligned, which the
+        # kernel's 128-bit vector load requires.
         if (
             group_size == 128
             and not use_ue8m0
             and x_kernel.dtype in (torch.bfloat16, torch.float16)
+            and x_kernel.data_ptr() % 16 == 0
         ):
             torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
                 x_kernel,

--- a/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py
@@ -108,18 +108,37 @@ def per_token_group_quant_fp8(
             )
         x_kernel = x if x.is_contiguous() else x.contiguous()
 
-        torch.ops._C.per_token_group_fp8_quant(
-            x_kernel,
-            x_q,
-            x_s,
-            group_size,
-            eps,
-            fp8_min,
-            fp8_max,
-            use_ue8m0,
-            column_major_scales,
-            tma_aligned_scales,
-        )
+        # Register-resident vec kernel for the common group_size==128 bf16/fp16
+        # activation-quant path (no shared-memory staging). Column-major and
+        # TMA-aligned scale layouts are honored via output_s strides. Other
+        # configs (ue8m0, non-128 groups, fp32 input) use the stable kernel.
+        if (
+            group_size == 128
+            and not use_ue8m0
+            and x_kernel.dtype in (torch.bfloat16, torch.float16)
+        ):
+            torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+                x_kernel,
+                x_q,
+                x_s,
+                group_size,
+                eps,
+                fp8_min,
+                fp8_max,
+            )
+        else:
+            torch.ops._C.per_token_group_fp8_quant(
+                x_kernel,
+                x_q,
+                x_s,
+                group_size,
+                eps,
+                fp8_min,
+                fp8_max,
+                use_ue8m0,
+                column_major_scales,
+                tma_aligned_scales,
+            )
         return x_q, x_s.contiguous()
 
     # TRITON FALLBACK


### PR DESCRIPTION
## Summary

Vendor a register-resident per-token-group 8-bit quant kernel into the MUSA csrc
and route the common `group_size==128` bf16/fp16 FP8 activation-quant path to it.
Each 16-thread group loads its 128-element quant group with one 128-bit load into
registers, reduces the group absmax with warp shuffles, quantizes straight from
registers, and writes the packed bytes with one 64-bit store — **no shared-memory
staging and no barrier**, unlike the previous kernel. Ships **on by default** (no
env flag); ue8m0 scales, non-128 groups, and fp32 input keep the existing kernel.

## Why (profiling-driven)

A head-to-head torch-profiler comparison of vLLM-MUSA vs SGLang-on-MUSA on
**Qwen3-8B-FP8 dense decode** (bs1, compile ON + FULL_DECODE_ONLY, isolated S5000)
found SGLang leads by **+11.4%** and localized it to three roughly-equal,
capture-surviving device-time deltas. The largest clean, in-our-control one is the
FP8 per-token-group quant: SGLang's kernel is **2.4× faster at the same 144
calls/step**. The mechanism is *register-residency* — the previous kernel staged
the group through shared memory with a `__syncthreads()`; the SGLang technique
keeps it in registers. This is a pure kernel-efficiency win, so it survives
CUDAGraph capture (the launch-count difference collapses under capture; per-kernel
device time does not).

## What changed (5 files, +218)

- `csrc/musa/quantization/per_token_group_quant_8bit_vec.cu` — the kernel (adapted
  to MUSA's 16-thread/group + `uint4` vec pattern; SGLang's flashinfer/PDL
  machinery is CUDA-only and not ported).
- `csrc/musa/{musa_ops.h,torch_bindings.cpp}` — declare + register the op under
  `_C_musa_ops`.
- `setup.py` — add the `.cu` to the MUSA source list.
- `fp8_utils.py::per_token_group_quant_fp8` — route the common case to the new op;
  everything else falls back to the existing stable kernel. Output and
  column-major/TMA-aligned scale layouts are unchanged (drop-in).

## Cold-cache microbench (`mate.bench_kineto`, `flush_l2=True`, A/B fast-math symmetric)

| shape | baseline | vec | speedup |
|---|---|---|---|
| M=1 K=4096 (decode) | 5.80 µs | 2.85 µs | **2.04×** |
| M=1 K=12288 | 5.83 µs | 2.97 µs | 1.96× |
| M=2048 K=4096 (prefill) | 54.4 µs | 37.1 µs | 1.46× |

## E2E (drift-controlled A/B/A, Qwen3-8B-FP8, TP1, compile ON + FULL_DECODE_ONLY, in128/out512)

| metric | baseline | vec | Δ |
|---|---|---|---|
| bs1 median TPOT | 11.33 ms | **10.84 ms** | **−4.3%** |
| bs1 output tok/s | 87.7 | **91.7** | **+4.6%** |
| bs16 median TPOT | 12.96 ms | **12.31 ms** | **−4.9%** |
| bs16 output tok/s | 1212 | **1277** | **+5.6%** |
| TTFT (prefill) | — | — | improved (no regression) |

The gain is ~20× the measured run-to-run noise; both arms had identical compile
fusions, so the delta is purely the standalone quant-kernel swap.

## Correctness

Bit-exact drop-in: `q_mismatch=0`, `s_maxdiff=0.0` vs the stable kernel across
M∈{1,4,16,64,2048} × K∈{4096,12288} × {row,column}-major scales; finite,
non-poison. Same absmax and `val / y_s` arithmetic → identical FP8 bytes and FP32
scales.

## FP8 regression matrix (native change → full FP8 matrix; all PASS)

Backend + compile ON + FULL_DECODE_ONLY; new op provably exercised (runtime
call-counter), forbidden fallback strings absent:

```
PASS Qwen3-8B-FP8              (dense FP8, FLASH_ATTN, TP1)   coherent  vec_op_calls=2400
PASS Qwen3.5-MoE-A3B-FP8       (fused MoE FP8, FLASH_ATTN, TP4) coherent  vec exercised on all 4 workers
PASS DeepSeek-V2-Lite-Chat-FP8 (MLA FP8, FLASHMLA, TP1)       coherent  vec_op_calls=3000
     └─ multi-request server smoke: 5 sequential + multi-turn, all 200 OK, coherent (col-major/TMA scale gate)
PASS Qwen3-8B (bf16 control)   (dense bf16, FLASH_ATTN, TP1)  coherent  vec_op_calls=0 (correctly bypassed)
```

0 tracebacks / MUSA errors / illegal-memory-access / NaN / CUDAGraph capture
violations across all serve logs.

## Test plan

- [x] Cold-cache microbench A/B (baseline vs vec), decode + prefill shapes
- [x] Bit-exact correctness grid (M×K×{row,col}-major)
- [x] E2E drift-controlled A/B/A on Qwen3-8B-FP8 (bs1/16) — deltas above
- [x] FP8 regression matrix: dense FP8, MoE FP8, DeepSeek MLA FP8 + multi-request, bf16 control

## Risk

Low. Drop-in replacement with an identical output/scale layout; conservative
fallback to the stable kernel for ue8m0 / non-128 groups / fp32 input; non-FP8
paths never reach it (bf16 control confirms). Native csrc — needs a reinstall.
