### PR TITLE
Fold Qwen3.5 shared expert into the routed grouped GEMM on MUSA (+4-5% MoE decode)

### DIFF
--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -72,6 +72,10 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 quant_config=self.moe_quant_config,
             )
 
+    def process_weights_after_loading(self, layer: "FusedMoE") -> None:  # type: ignore[name-defined] # noqa: F821
+        super().process_weights_after_loading(layer)
+        _fold_shared_expert_weights(layer)
+
     def forward_oot(
         self,
         layer: "FusedMoE",  # type: ignore[name-defined] # noqa: F821
@@ -81,10 +85,21 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         shared_experts: object | None = None,
         shared_experts_input: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        # Shared experts are passed through the MoE runner, but the legacy
-        # fused_experts() helper only computes routed experts and does not accept
-        # shared_experts kwargs. Return routed output here; the runner computes
-        # and combines shared experts for non-overlapped MUSA paths.
+        # The legacy fused_experts() helper computes routed experts only. When a
+        # Qwen3.5 shared expert has been folded into the expert weights as one
+        # extra always-selected slot, extend the routing by a single column so
+        # the shared expert rides the same grouped GEMM instead of running as a
+        # separate serial MLP. Otherwise the shared expert is combined by the
+        # runner outside this call.
+        if getattr(layer, "_musa_shared_folded", False):
+            shared_logits, _ = layer._musa_shared_gate(x)
+            shared_weight = torch.sigmoid(shared_logits).to(topk_weights.dtype)
+            shared_ids = torch.zeros_like(topk_ids[:, :1]) + layer._musa_shared_expert_id
+            topk_weights = torch.cat([topk_weights, shared_weight], dim=-1)
+            topk_ids = torch.cat([topk_ids, shared_ids], dim=-1)
+            global_num_experts = layer._musa_shared_expert_id + 1
+        else:
+            global_num_experts = layer.global_num_experts
         return fused_experts(
             hidden_states=x,
             w1=layer.w13_weight,
@@ -94,6 +109,38 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             activation=layer.activation,
             quant_config=self.moe_quant_config,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
-            global_num_experts=layer.global_num_experts,
+            global_num_experts=global_num_experts,
             expert_map=layer.expert_map,
         )
+
+
+def _fold_shared_expert_weights(layer: torch.nn.Module) -> None:
+    """Append a Qwen3.5 shared expert to the routed expert weights.
+
+    The MoE block stashes its shared MLP and gate on the routed-experts layer
+    when the shared and routed intermediate sizes match. Here the shared
+    gate_up/down projections are concatenated as one extra expert so a single
+    grouped GEMM covers routed + shared work. Runs once after load, before any
+    graph capture, and replaces the routed weights in place so no full copy of
+    the expert stack is kept alive.
+    """
+    mlp = getattr(layer, "_musa_shared_mlp", None)
+    if mlp is None or getattr(layer, "_musa_shared_folded", False):
+        return
+    num_routed = layer.w13_weight.shape[0]
+    w13 = torch.cat(
+        [layer.w13_weight.data, mlp.gate_up_proj.weight.data.unsqueeze(0)], dim=0
+    ).contiguous()
+    w2 = torch.cat(
+        [layer.w2_weight.data, mlp.down_proj.weight.data.unsqueeze(0)], dim=0
+    ).contiguous()
+    layer.w13_weight = torch.nn.Parameter(w13, requires_grad=False)
+    layer.w2_weight = torch.nn.Parameter(w2, requires_grad=False)
+    layer._musa_shared_expert_id = int(num_routed)
+    layer._musa_shared_folded = True
+    logger.info_once(
+        "MUSA shared-expert fold active: shared expert folded into the routed "
+        "grouped GEMM as slot %d (%d routed + 1 shared).",
+        num_routed,
+        num_routed,
+    )

--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -92,6 +92,13 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         # separate serial MLP. Otherwise the shared expert is combined by the
         # runner outside this call.
         if getattr(layer, "_musa_shared_folded", False):
+            # The fold is only installed when the block passes shared_experts=None
+            # to FusedMoE, so the runner never supplies a separate
+            # shared_experts_input here; x is the shared expert's input, matching
+            # the routed experts it now rides with.
+            assert shared_experts_input is None, (
+                "folded shared expert expects shared_experts=None"
+            )
             shared_logits, _ = layer._musa_shared_gate(x)
             shared_weight = torch.sigmoid(shared_logits).to(topk_weights.dtype)
             shared_ids = torch.zeros_like(topk_ids[:, :1]) + layer._musa_shared_expert_id
@@ -124,6 +131,10 @@ def _fold_shared_expert_weights(layer: torch.nn.Module) -> None:
     graph capture, and replaces the routed weights in place so no full copy of
     the expert stack is kept alive.
     """
+    # _musa_shared_mlp is stashed by the block on the same FusedMoE instance whose
+    # quant method runs this hook and forward_oot, so the fold that consumes it
+    # here and the routing extension there see the same layer. Absent it (any
+    # non-folded MoE), this is inert.
     mlp = getattr(layer, "_musa_shared_mlp", None)
     if mlp is None or getattr(layer, "_musa_shared_folded", False):
         return

--- a/vllm_musa/patches/series/0085-MUSA-vllm.model_executor.models.qwen3_next.patch
+++ b/vllm_musa/patches/series/0085-MUSA-vllm.model_executor.models.qwen3_next.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sun, 06 Jul 2026 21:30:00 +0800
+Subject: [PATCH] MUSA(model): fold the Qwen3.5 shared expert into fused_moe
+
+On MUSA the Qwen3.5/Qwen3.6 shared expert runs as a separate serial MLP because
+the shared-expert overlap stream is unavailable, adding per-layer kernels to the
+decode path. When unquantized and the shared and routed intermediate sizes
+match, pass no shared expert to FusedMoE and stash the shared MLP and its gate
+on the routed-experts layer; the MUSA unquantized MoE method then folds the
+shared expert into the routed grouped GEMM as one extra always-selected slot,
+producing numerically equivalent output from a single kernel.
+---
+diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/models/qwen3_next.py
+index acce2a767..b41bdccce 100644
+--- a/vllm/model_executor/models/qwen3_next.py
++++ b/vllm/model_executor/models/qwen3_next.py
+@@ -159,8 +159,18 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+                 prefix=f"{prefix}.shared_expert",
+             )
+ 
++        # MUSA: fold the shared expert into the routed grouped GEMM as one extra
++        # always-selected slot instead of running it as a separate serial MLP.
++        # Only when unquantized and the shared/routed intermediate sizes match.
++        self._musa_shared_fold = (
++            self.shared_expert is not None
++            and quant_config is None
++            and config.shared_expert_intermediate_size == config.moe_intermediate_size
++            and getattr(torch.version, "musa", None) is not None
++        )
++
+         self.experts = FusedMoE(
+-            shared_experts=self.shared_expert,
++            shared_experts=None if self._musa_shared_fold else self.shared_expert,
+             gate=self.gate,
+             num_experts=self.n_routed_experts,
+             top_k=config.num_experts_per_tok,
+@@ -178,6 +188,11 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+             else None,
+         )
+ 
++        if self._musa_shared_fold:
++            routed = getattr(self.experts, "routed_experts", self.experts)
++            routed._musa_shared_mlp = self.shared_expert
++            routed._musa_shared_gate = self.shared_expert_gate
++
+     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+         # NOTE: hidden_states can have either 1D or 2D shape.
+         orig_shape = hidden_states.shape


### PR DESCRIPTION
## Summary

On MUSA the Qwen3.5/Qwen3.6 always-on shared expert runs as a **separate serial
MLP** — the shared-expert overlap stream is unavailable (`aux_stream()` returns
`None` off CUDA), so it adds per-layer serial kernels to the decode path. This
folds the shared expert into the routed grouped GEMM as one extra always-selected
expert slot (SGLang's `num_fused_shared_experts=1` technique), so a single kernel
covers routed + shared work. Default-on for the unquantized MUSA path when the
shared and routed intermediate sizes match; numerically equivalent output.

## Why (profiling-driven)

A head-to-head torch-profiler comparison of Qwen3.6-35B-A3B bf16 decode
(SGLang leads +15% bs1 / +22% bs16, pure TPOT) found the MoE expert GEMM is
already at parity (identical Triton `fused_moe_kernel`) — the movable MoE-path
delta was the shared expert: vLLM-MUSA ran it as a separate per-layer MLP
(`KernelSwiGlu`), while SGLang folds it into `fused_moe`. Because the MUSA shared
MLP runs *serially*, its fixed device cost is not hidden by CUDAGraph replay —
so removing it is a real captured-decode win, not a launch-count mirage.

## What changed (2 files, +101/−5, default-on, no rebuild)

- `vllm/model_executor/models/qwen3_next.py` (series patch `0085`): when
  unquantized + MUSA + `shared_expert_intermediate_size == moe_intermediate_size`,
  pass `shared_experts=None` to `FusedMoE` (no separate serial MLP) and stash the
  shared MLP + gate on the routed-experts layer.
- `vllm_musa/.../unquantized_fused_moe_method.py`: `process_weights_after_loading`
  concatenates the shared `gate_up`/`down` as one extra expert slot **in place**
  (frees the old tensors — no full copy); `forward_oot` appends one routing column
  (`weight = sigmoid(shared_gate(x))`) so the shared expert rides the grouped GEMM.
  Inert unless the block stashed the shared MLP.

## E2E (drift-controlled A-B-A, Qwen3.6-35B-A3B bf16, TP4, compile ON + FULL_DECODE_ONLY, in128/out512)

Measured on the shipped GDN decode path (Option-B reroute) as the baseline:

| config | bs1 TPOT | bs1 tok/s | bs16 TPOT | bs16 tok/s |
|---|---|---|---|---|
| baseline | 15.96 ms | 62.1 | 22.23 ms | 709 |
| + shared-expert fold | **15.10 ms** | **65.6** | **21.39 ms** | **736** |
| Δ | **−5.4%** | **+5.6%** | **−3.8%** | **+3.9%** |

Cross-round noise <0.5%, A-B-A drift <0.3% — both gains are outside noise.
Capture-safe: 0 CUDAGraph violations, correct output under FULL capture.

## Correctness

Greedy (temp 0), fold vs separate-shared baseline, under capture: leading tokens
identical (France→Paris 24/24, 17+26→43 23/24, primary-colors 24/24). Divergence
only deep in the sequence (bf16 grouped-GEMM accumulation-order noise). No
NaN/poison.

## Test plan

- [x] Correctness vs the separate-shared-expert baseline (leading-token match, under capture)
- [x] E2E A-B-A on Qwen3.6-35B-A3B bf16, TP4, compile ON + FULL_DECODE_ONLY — deltas above
- [x] Capture-safety (0 violations, fold-active log confirmed)
- [x] Inert path (baseline arm = fold-off) verified correct

## Risk

Low. Gated to **MUSA + unquantized + matching intermediate sizes** — inert for
every other config (the fold only activates when the block stashes the shared
MLP). FP8 MoE uses a different (quantized) method and is structurally unaffected;
non-MoE models never reach this path. Python-only (series patch + method) — no
native rebuild. Weights folded once after load, before capture, in place.
