### PR TITLE
Contiguous segregated mamba cache layout (~2× GDN decode)

### DIFF
--- a/vllm_musa/patches/series/0085-MUSA-vllm.v1.worker.gpu_model_runner.patch
+++ b/vllm_musa/patches/series/0085-MUSA-vllm.v1.worker.gpu_model_runner.patch
@@ -1,0 +1,62 @@
+From d20ed7b5a4be7d48c8ab45c3bc6d817a79bae90d Mon Sep 17 00:00:00 2001
+From: Xiaodong Ye <Squirrelbes@salesperson.net>
+Date: Wed, 8 Jul 2026 16:37:47 +0800
+Subject: [PATCH] MUSA: vllm.v1.worker.gpu_model_runner
+
+Lay mamba conv and ssm cache states out in contiguous, segregated regions
+(all conv slots, then all ssm slots) instead of interleaving conv+ssm per
+page. The temporal (ssm) state is then is_contiguous(), restoring coalesced
+access on the gated-delta-net decode path and letting state-pool kernels that
+require a contiguous tensor read it in place. The block manager copies each
+state independently by slot index (and the fused copy kernel reads the state
+stride dynamically), so the layout is transparent to it; the per-page byte
+budget is unchanged. Assert the segregated regions fit the backing raw tensor,
+since as_strided does not bounds-check.
+---
+ vllm/v1/worker/gpu_model_runner.py | 21 +++++++++++++++------
+ 1 file changed, 15 insertions(+), 6 deletions(-)
+
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index 74938a823..e4e22cf34 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -7164,12 +7164,15 @@ class GPUModelRunner(
+                     storage_offset_bytes = 0
+                     for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
+                         dtype_size = get_dtype_size(dtype)
+-                        num_element_per_page = (
+-                            kv_cache_spec.page_size_bytes // dtype_size
+-                        )
+                         target_shape = (num_blocks, *shape)
+                         stride = torch.empty(target_shape).stride()
+-                        target_stride = (num_element_per_page, *stride[1:])
++                        # MUSA: lay each mamba state out contiguously in its
++                        # own segregated region (all conv slots, then all ssm
++                        # slots) instead of interleaving conv+ssm per page, so
++                        # the ssm state is is_contiguous() and decode reads it
++                        # coalesced. Block manager copies per-state by slot, so
++                        # the layout is transparent; per-page bytes unchanged.
++                        target_stride = stride
+                         assert storage_offset_bytes % dtype_size == 0
+                         tensor = torch.as_strided(
+                             raw_tensor.view(dtype),
+@@ -7178,8 +7181,14 @@ class GPUModelRunner(
+                             storage_offset=storage_offset_bytes // dtype_size,
+                         )
+                         state_tensors.append(tensor)
+-                        storage_offset_bytes += stride[0] * dtype_size
+-
++                        storage_offset_bytes += stride[0] * num_blocks * dtype_size
++
++                    # MUSA: as_strided does not bounds-check the views; ensure the
++                    # segregated per-state regions fit within the backing raw tensor.
++                    assert (
++                        storage_offset_bytes
++                        <= raw_tensor.numel() * raw_tensor.element_size()
++                    ), "mamba state layout exceeds the backing raw tensor allocation"
+                     kv_caches[layer_name] = state_tensors
+                 else:
+                     raise NotImplementedError
+-- 
+2.34.1
+

--- a/vllm_musa/patches/series/0085-MUSA-vllm.v1.worker.gpu_model_runner.patch
+++ b/vllm_musa/patches/series/0085-MUSA-vllm.v1.worker.gpu_model_runner.patch
@@ -1,5 +1,5 @@
 From d20ed7b5a4be7d48c8ab45c3bc6d817a79bae90d Mon Sep 17 00:00:00 2001
-From: Xiaodong Ye <Squirrelbes@salesperson.net>
+From: musa <musa@local>
 Date: Wed, 8 Jul 2026 16:37:47 +0800
 Subject: [PATCH] MUSA: vllm.v1.worker.gpu_model_runner
 


### PR DESCRIPTION
## Problem

vLLM lays the mamba cache states out **interleaved per page** — `gpu_model_runner.py`
allocates each state (conv, ssm) with `dim-0 stride = num_element_per_page` (the full
conv+ssm page size) via `torch.as_strided`. As a result the temporal (ssm) state is
**not `is_contiguous()`** (e.g. Qwen3.6 GDN: `shape=(9720, 8, 128, 128)`,
`stride=(135168, 16384, 128, 1)` — the `+4096`/slot is the interleaved conv region).

That strided layout leaves the gated-delta-net (Qwen3.5/3.6) **decode path
memory-access non-coalesced**, costing ~2× throughput, and it blocks state-pool kernels
that require a contiguous tensor.

## Fix

Lay each mamba state out in its **own contiguous, segregated region** (all conv slots,
then all ssm slots) instead of interleaving conv+ssm per page. After the change the ssm
state is `is_contiguous()` (`stride=(131072, 16384, 128, 1)`). Total per-page bytes are
unchanged, so the block budget is identical, and the block manager already copies each
state independently **by slot index** (`collect_mamba_copy_meta` → `state[block_id]`), so
the layout is transparent to it.

## Results (Qwen3.6-35B-A3B, bf16, TP4, in2048/out512, captured, S5000)

Single variable = the pool layout (same fla decode kernel, same bf16 dtype):

| bs | interleaved (before) | segregated (after) | speedup | TPOT before→after |
|---|---|---|---|---|
| 1  | 44.21  | 61.66  | 1.39× | 16.0 → 16.0 ms |
| 4  | 126.21 | 207.62 | 1.65× | 22.0 → 18.8 ms |
| 16 | 330.64 | 668.01 | 2.02× | 35.5 → 23.0 ms |
| 64 | 1050.17| 2233.65| **2.13×** | 52.1 → **25.9 ms** |

Output verified coherent (`"The capital of France is Paris, …"`) before and after.

## Scope / safety

- Affects **only** the `MambaSpec` allocation branch (attention KV cache untouched).
- Validated on Qwen3.6-35B-A3B GDN (correctness + perf, eager and CUDAGraph-captured).
  A full mamba-family smoke is recommended in CI before merge.
- Also makes the pool `is_contiguous()`, which **enables** (but does not require) mate's
  fp32-VK GDN decode kernel. Wiring mate itself is a separate follow-up; on the contiguous
  pool fla already matches mate, so this layout fix is the standalone win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
