### PR TITLE
Enable fp8 e4m3 KV cache on the MUSA FlashAttention backend (needs torchada#90)

### DIFF
--- a/vllm_musa/v1/attention/backends/fa_utils.py
+++ b/vllm_musa/v1/attention/backends/fa_utils.py
@@ -112,8 +112,9 @@ def get_flash_attn_version(
 
 
 def flash_attn_supports_fp8() -> bool:
-    logger.info_once("Cannot use FLASH_ATTN with FP8 on MUSA platform")
-    return False
+    # mate's FMHA takes fp8 e4m3 q/k/v with per-(batch, kv-head) descale, which is
+    # the shape vllm builds for an fp8 KV cache. e5m2 has no mate kernel.
+    return True
 
 
 def flash_attn_supports_sinks() -> bool:

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -197,12 +197,9 @@ class MUSAFlashAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_per_head_quant_scales(cls) -> bool:
-        # mate flash_attn_varlen_func rejects fp8 Q/K inputs
-        # ("inputs must be float16 or bfloat16"), so per-head FP8 quant-scale
-        # attention is NOT supported on MUSA — consistent with
-        # flash_attn_supports_fp8()=False and get_fp8_dtype_for_flashattn raising
-        # NotImplementedError. Probe: generated/musa0400/probe_fa_caps.py.
-        return False
+        # mate applies q/k/v descale per (batch, kv-head), so distinct per-head
+        # scales are honoured rather than broadcast from head 0.
+        return True
 
     @staticmethod
     def get_impl_cls() -> type["FlashAttentionImpl"]:
@@ -247,8 +244,11 @@ class MUSAFlashAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_fp8_dtype_for_flashattn(kv_cache_dtype: str) -> torch.dtype:
+        if kv_cache_dtype in ("fp8", "fp8_e4m3"):
+            return torch.float8_e4m3fn
         raise NotImplementedError(
-            "FP8 dtype is not supported for FlashAttention on MUSA."
+            f"kv_cache_dtype {kv_cache_dtype!r} is not supported for "
+            "FlashAttention on MUSA; mate provides an e4m3 FMHA kernel only."
         )
 
     @classmethod
@@ -259,7 +259,8 @@ class MUSAFlashAttentionBackend(AttentionBackend):
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype is None:
             return True
-        if kv_cache_dtype.startswith("fp8"):
+        # MUSA: e4m3 only — mate has no e5m2 FMHA kernel.
+        if kv_cache_dtype in ("fp8", "fp8_e4m3"):
             return flash_attn_supports_fp8()
         return kv_cache_dtype in ["auto", "float16", "bfloat16"]
 

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -862,7 +862,10 @@ class FlashAttentionImpl(AttentionImpl):
             and not self.kv_cache_dtype.startswith("fp8")
         )
 
-        self.supports_quant_query_input = False
+        # mate's FMHA requires q, k and v to share a dtype, so an fp8 KV cache needs an
+        # fp8 query. Letting the layer quantize Q keeps the two in step; on a non-fp8
+        # cache the layer leaves the query untouched.
+        self.supports_quant_query_input = True
 
         vllm_config = get_current_vllm_config_or_none()
         dcp_a2a = (
@@ -1020,6 +1023,7 @@ class FlashAttentionImpl(AttentionImpl):
                         causal=attn_metadata.causal,
                         window_size=sliding_window_size,
                         softcap=self.logits_soft_cap,
+                        q_descale=layer._q_scale.expand(decode_descale_shape),
                         k_descale=layer._k_scale.expand(decode_descale_shape),
                         v_descale=layer._v_scale.expand(decode_descale_shape),
                         scheduler_metadata=attn_metadata.scheduler_metadata,


### PR DESCRIPTION
## What

Enables `--kv-cache-dtype fp8` on the MUSA `FLASH_ATTN` backend: opens the gates that
rejected an fp8 KV cache, narrows the accepted dtype to **e4m3** (the only fp8 FMHA kernel
mate provides), and makes the query dtype match the cache.

## Merge gate

- [ ] MooreThreads/torchada#90 merged and released
- [ ] `pyproject.toml`: bump `torchada>=0.1.70` to the release carrying torchada#90

Without that fix the fp8 cache is written by a conversion that was compiled out, so it fills
with **zeros** — silently, with no error. The pin is what governs it: `setup.py` calls
`ensure_torchada_installed()` and imports `torchada.utils.cpp_extension` at build time, and
vllm-musa installs from source with `--no-build-isolation`, so the pinned torchada is the one
that ports the device code. (A *runtime* torchada version check would not cover this — it
inspects the installed torchada, not the one that compiled `_C`; the two diverge exactly when
someone upgrades torchada without rebuilding.)

| # | Change | Before | After |
|---|---|---|---|
| 1 | `fa_utils.flash_attn_supports_fp8()` | `False` | `True` |
| 2 | `get_fp8_dtype_for_flashattn()` | always raised `NotImplementedError` | returns `torch.float8_e4m3fn` for `fp8`/`fp8_e4m3`, raises otherwise |
| 3 | `supports_per_head_quant_scales()` | `False` | `True` |
| 4 | `supports_kv_cache_dtype()` | `startswith("fp8")` | `in ("fp8", "fp8_e4m3")` — e5m2 stays rejected |
| 5 | `FlashAttentionImpl.supports_quant_query_input` | `False` | `True` — see "Q dtype" below |
| 6 | decode fast path `flash_attn_with_kvcache(...)` | `k_descale`/`v_descale` only | also passes `q_descale` |

### Q dtype — why (5) and (6) are needed, not just the gates

mate's FMHA asserts `q.dtype == k.dtype == v.dtype`. Under an fp8 KV cache the caches are
`.view(fp8)`, so Q must be fp8 too. The attention layer only quantizes Q when
`impl.supports_quant_query_input` is set — with it `False`, Q stays bf16 and the kernel
asserts. Setting it `True` lets the layer emit an e4m3 Q (MUSA inherits
`fp8_dtype() -> torch.float8_e4m3fn`), matching cache and kernel.

This is safe for bf16: the layer builds `query_quant` only when
`supports_quant_query_input and kv_cache_dtype.startswith("fp8")`, so on `auto`/bf16 it stays
`None` and that path is byte-for-byte unchanged. It also retires a latent divergence — upstream
gates `q_descale` on `supports_quant_query_input` while this backend passes it unconditionally;
with (5) the two agree.

(6) follows from (5): once Q is quantized, the pure-decode fast path must descale it, or every
decode step attends on unscaled query codes. The other MUSA branches are unaffected — the mubin
prefill branches are already gated by `_mubin_prefill_ok`, which excludes fp8.

## Why now

The gates' rationale was that mate's FMHA rejects fp8 Q/K inputs
(`"inputs must be float16 or bfloat16"`). That is no longer true, and the string
no longer exists in mate's FMHA path. Tracing the mate releases:

| mate | `float8_e4m3fn` in `mate/jit/attention/fmha/fmha_fwd.py` |
|---|---|
| v0.2.0 / v0.2.1 / v0.2.2 | absent — fp8 genuinely rejected |
| **v0.2.3** | **present — fp8 e4m3 + q/k/v descale added** |
| v0.2.4 | present (+ `has_*_descale` AOT specs) |

`pyproject.toml` already pins `mate>=0.2.3`, so the capability is guaranteed by
the existing pin — **no dependency change is needed in this PR**.

## No change needed on the cache-write path

`_can_use_musa_reshape_and_cache_flash_nhd()` already requires
`kv_cache_dtype in ("auto","float16","bfloat16")` and otherwise falls back to
upstream `ops.reshape_and_cache_flash`, whose fp8 kernel (`Fp8KVCacheDataType`,
`fp8::scaled_convert`) is in the MUSA build list (`setup.py` ->
`csrc/libtorch_stable/cache_kernels.cu`). The descale plumbing is likewise
already present and correct: vllm builds
`descale_shape = (cu_seqlens_q.shape[0] - 1, self.num_kv_heads)`, which is
exactly the `(batch_size, num_head_kv)` shape mate asserts.

## Evidence

All on 1x MTT S5000 (`worker35093`), driver `3.3.5-server`, image
`vllm:v0.22.0-ph1-4.3.5-torch2.9-20260605-mtcc51-mate023`, `mate 0.2.3`,
`torch 2.9.0`, `torch.version.musa=40305`.

### Kernel probe — mate fp8 e4m3 FMHA + descale

Mirrors the real call path (paged KV, descale `(batch, num_kv_heads)`):

```
PASS bf16_varlen_baseline  max_rel=0.0026   <- harness sanity
PASS fp8_varlen_descale    max_rel=0.0420
PASS fp8_paged_descale     max_rel=0.0178   <- the path vllm actually takes
```

fp8 *without* descale does not match a raw-code reference. That is expected
(vllm always passes descale for an fp8 cache) and is useful evidence: descale-off
and descale-on give opposite verdicts, so the descale values are demonstrably
applied rather than ignored.

### Kernel probe — distinct per-(batch, kv-head) descale

Each kv-head given a different scale, with a control that reconstructs the
reference the *wrong* way (head-0's scale broadcast to all heads):

```
PASS fp8_paged_PER_HEAD_descale max_rel=0.0214
INFO control (head0-scale-everywhere)  max_rel=0.8268
```

2.1% vs 82.7% is what makes the PASS meaningful, and is what justifies
`supports_per_head_quant_scales() -> True`.

> ## Requires https://github.com/MooreThreads/torchada/pull/90
>
> These six changes are necessary but **not sufficient on their own**: a torchada porting bug
> made vLLM's bf16 -> fp8 conversion a silent no-op, so the fp8 KV cache filled with **zeros**
> and the model emitted garbage. That is fixed in torchada#90; with both in place the E2E is
> correct (below). `pyproject.toml` already pins `torchada>=0.1.70`; the pin needs the version
> that carries torchada#90.

### End-to-end — **PASS** (with torchada#90)

`Qwen3-8B`, TP=1, eager, `gpu_memory_utilization=0.55`, prompt `"The capital of China is"`,
on the v0.24 image `vllm-musa-v024-sampler-v4:20260703` (tree `069511a`; both files this PR
touches are byte-identical there to `de3ee7b05`, so the overlay is exactly this diff).

| kv_cache_dtype | mode | num_gpu_blocks | output | verdict |
|---|---|---|---|---|
| `auto` (bf16) | eager | 3089 | `" Beijing. The capital of China is Beijing."` | **PASS** — no regression |
| **`fp8`** | eager | **5993 (1.94x)** | `" Beijing. The capital of China is Beijing."` | **PASS** |
| **`fp8`** | **compiled + CUDAGraph** | **6022** | `" Beijing. The capital of China is Beijing."` | **PASS** |
| `fp8_e5m2` | eager | — | rejected at init | **PASS** (intended) |

The compiled run captured 51 graphs (PIECEWISE + FULL) and generated correctly, which is the
check change (5) most needed: it newly activates `QuantFP8` on the query path, and `QuantFP8`
has MUSA history of emitting garbage under capture. It does not here.

Two things make this meaningful rather than a fallback in disguise:

- **fp8 is genuinely in effect**: `num_gpu_blocks` is ~2x the bf16 run at equal
  `gpu_memory_utilization`, because each block is half the bytes. It is not silently
  reverting to bf16.
- **Stage-split**: the *first* generated token is a pure product of prefill.
  `auto -> 26549` (`" Beijing"`), `fp8 -> 26549` — and at 8 tokens fp8 is **token-identical**
  to bf16: `[26549, 13, 576, 6722, 315, 5616, 374, 26549]`.

Before this patch the same fp8 run is refused with `Cannot use FLASH_ATTN with FP8 on MUSA
platform`, so the gates are what open the path.

<details><summary>How the underlying bug was localised (pre-torchada#90)</summary>

With this patch but stock torchada, fp8 produced `" tánicodeặ/pubEUR…"`. The chain:

1. **Stage split** — fp8's *first* token was already wrong (`141873` = `" tán"`), so prefill
   corrupted, not decode.
2. **Code-path control** — with fp8, `_mubin_prefill_ok` is False, so prefill silently moves to
   generic branch 4/4. Forcing *bf16* down branch 4/4 gave byte-identical output to the mubin
   path, exonerating the branch. So: fp8-specific, inside prefill.
3. **Cache-write round-trip** (real `reshape_and_cache_flash`): bf16 write exact; **fp8 write
   `all_zero=True`** — nothing written at any scale. That is why `calculate_kv_scales` changed
   nothing.
4. **Dtype asymmetry** — only the bf16 source was dead (bf16 **0/32768**; fp16 32768/32768;
   fp32 32751/32768, `max_rel=0.0319`), pointing at the one guarded specialization.
5. **Arch probe** — `__MUSA_ARCH__=310`; the ported guard `(310 < 800)` = TAKEN vs the intended
   `(310 < 220)` = not taken. `assert(false)` + `-DNDEBUG` = silent no-op returning 0.

After torchada#90 the same round-trip gives bf16 **32758/32768, `max_rel=0.0519`** — fp8 e4m3
rounding, as expected.

Note the kernel probes at the top all **passed** throughout: mate's kernel was never at fault.
Probing a kernel in isolation could not see this — the bug was upstream of it, in the cache
write.

</details>

## Scope / limits

- **e4m3 only.** `fp8_e5m2` is explicitly rejected — mate has no e5m2 FMHA kernel.
  The previous `startswith("fp8")` would have admitted it.
- First call with descale JIT-compiles the descale kernel variant (mate's AOT sweep
  declares `has_*_descale` with domain `[False]`), so expect a one-off warm-up on the
  first fp8 request. Steady-state is unaffected.
- This PR is correctness-scoped; it does not claim a throughput win. FP8 KV cache's
  benefit here is cache capacity.
