### PR TITLE
build: require torchada 0.1.73

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,5 @@
 # Runtime Python dependencies that are portable across MUSA images.
-torchada>=0.1.72
+torchada>=0.1.73
 mthreads-ml-py>=2.2.11
 numpy==1.26
 openai>=2.24.0

--- a/tests/test_inplace_porting_contract.py
+++ b/tests/test_inplace_porting_contract.py
@@ -8,7 +8,7 @@ ROOT = Path(__file__).resolve().parent.parent
 
 def test_torchada_floor_is_consistent():
     assert "dynamic = [\"dependencies\"]" in (ROOT / "pyproject.toml").read_text()
-    assert "torchada>=0.1.72" in (
+    assert "torchada>=0.1.73" in (
         ROOT / "requirements" / "common.txt"
     ).read_text()
 


### PR DESCRIPTION
## What

Bumps the `torchada` floor in `requirements/common.txt` from `>=0.1.72` to `>=0.1.73`.

## Why

torchada ports each extension's include roots to MUSA **in place**. Through 0.1.72 that substitution also rewrote the *defined name* of a vendor header's own CUDA->MUSA mapping, collapsing

```c
#define cudaEventDisableTiming musaEventDisableTiming
```

into `#define musaEventDisableTiming musaEventDisableTiming` — a self-reference that shadows the runtime's real `driver_types.h` value, so the symbol expands to an undeclared identifier and every translation unit using it fails to compile. 0.1.73 keeps such lines verbatim.

Fixed by MooreThreads/torchada#92 (merged), released as [torchada 0.1.73](https://pypi.org/project/torchada/0.1.73/).

## Merge gate: waiting on the PyPI mirror, not on review

The image build resolves `requirements/common.txt` through `PYPI_INDEX_URL`, which `docker/build_image.sh` defaults to the Tsinghua mirror. That mirror lags upstream PyPI by a few hours:

```
pypi.org:                     torchada (0.1.73)   available
mirrors.tuna.tsinghua.edu.cn: torchada (0.1.72)   not yet mirrored
```

So **merging before the mirror syncs breaks `docker/build_image.sh`** for anyone on the default index — pip cannot resolve `>=0.1.73`. This has bitten us before (0.1.58 was on PyPI but not on the mirror for a while). Re-check with:

```bash
pip index versions torchada --index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
```

Ready for review now; please hold the merge button until that reports 0.1.73.

## Impact on this repo

No behavior change for vllm-musa's own extensions — no in-tree vendor header defines a CUDA->MUSA mapping that the old substitution would collapse. The floor matters for downstreams that build torch extensions through torchada against this image's stack (e.g. Mooncake's EP/PG extensions with `-DWITH_EP=ON`, which do not compile on 0.1.72).

## Test plan

- [x] `torchada 0.1.73` resolves and installs from pypi.org
- [x] Image rebuilt with the bumped pin; `torchada.__version__` reports 0.1.73 (see comment below)
- [ ] Same build on the default (Tsinghua) index, once 0.1.73 is mirrored

🤖 Generated with [Claude Code](https://claude.com/claude-code)