### PR TITLE
fix: stop baking MUSA_VISIBLE_DEVICES=all into the image

### DIFF
--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -419,8 +419,7 @@ FROM mooncake AS final
 
 ARG BUILD_VLLM_RS=1
 
-ENV MTHREADS_VISIBLE_DEVICES=all \
-    MUSA_VISIBLE_DEVICES=all
+ENV MTHREADS_VISIBLE_DEVICES=all
 
 COPY --from=vllm_rs_build /tmp/vllm-rs-artifacts/ /tmp/vllm-rs-artifacts/
 

--- a/tests/jit_kernel/test_csrc_jit_kernels.py
+++ b/tests/jit_kernel/test_csrc_jit_kernels.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 import pytest
 import torch
 
-os.environ.setdefault("TORCHDYNAMO_DISABLE", "1")
 os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 os.environ.setdefault("PYTHONUNBUFFERED", "1")
 os.environ.setdefault("VLLM_MUSA_JIT_CACHE_DIR", "/tmp/vllm_musa_pytest_jit_cache")
@@ -24,6 +23,17 @@ def _require_musa() -> None:
 @pytest.fixture(scope="module", autouse=True)
 def _musa_device():
     _require_musa()
+
+
+@pytest.fixture(autouse=True)
+def _eager_only(monkeypatch):
+    """Keep these kernel tests off the compiled path.
+
+    torch.compile reads TORCHDYNAMO_DISABLE when it is called, not when torch is
+    imported, so setting it at module scope would follow pytest's import of this
+    file into sibling modules whose tests must actually compile.
+    """
+    monkeypatch.setenv("TORCHDYNAMO_DISABLE", "1")
 
 
 def _sync() -> None:

--- a/tests/test_inplace_porting_contract.py
+++ b/tests/test_inplace_porting_contract.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Cross-repository contract checks for torchada's in-place source porter."""
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -112,6 +113,29 @@ def test_vllm_rs_uses_rsproxy_for_cargo_without_overriding_upstream_toolchain():
     assert "COPY docker/cargo-config.toml /root/.cargo/config.toml" in dockerfile
     assert 'replace-with = "rsproxy-sparse"' in cargo_config
     assert 'registry = "sparse+https://rsproxy.cn/index/"' in cargo_config
+
+
+def test_musa_image_does_not_bake_a_device_id_list():
+    """The image selects GPUs through the container runtime, not the driver.
+
+    MUSA_VISIBLE_DEVICES is a device-id list for both the MUSA driver and vLLM.
+    Baking "all" leaves the driver on every device (it ignores what it cannot
+    parse) but makes vLLM fail engine start on int("all"), so the image must
+    leave the variable alone and let the caller set it.
+    """
+    dockerfile = (ROOT / "docker" / "musa.Dockerfile").read_text()
+    # Drop comments, then fold backslash continuations so that a multi-line
+    # `ENV A=1 \ <newline> B=2` block reads as the single instruction it is.
+    body = "\n".join(
+        line for line in dockerfile.splitlines() if not line.lstrip().startswith("#")
+    )
+    env_instructions = [
+        line
+        for line in re.sub(r"\\\s*\n\s*", " ", body).splitlines()
+        if line.lstrip().startswith(("ENV", "ARG"))
+    ]
+    assert not any("MUSA_VISIBLE_DEVICES" in line for line in env_instructions)
+    assert any("MTHREADS_VISIBLE_DEVICES=all" in line for line in env_instructions)
 
 
 def test_setup_finds_local_build_helpers_before_importing_them():

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -372,6 +372,7 @@ class TestMUSAPlatformBase:
             use_mla=False,
             has_sink=False,
             use_sparse=False,
+            use_mm_prefix=False,
             device_capability=DeviceCapability(3, 1),
         )
 

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -435,15 +435,18 @@ class TestMUSAPlatformDefaults:
         assert vllm_config.compilation_config.max_cudagraph_capture_size is None
         assert vllm_config.compilation_config.cudagraph_capture_sizes == [1, 2, 4, 8]
 
-    @pytest.mark.xfail(
-        reason="v0.22 platform.py apply_config_platform_defaults no "
-        "longer forces cudagraph_mode=NONE at tp=4 (no such code path remains). "
-        "Open behavioral question: does large-TP cudagraph capture need disabling "
-        "on MUSA v0.22? Potential dropped-safety regression -- flagged, not "
-        "resolved here.",
-        strict=False,
-    )
-    def test_tp4_disables_musa_cudagraph_capture(self):
+    def test_tp4_keeps_musa_cudagraph_capture(self):
+        """Tensor parallelism alone must not turn cudagraph capture off.
+
+        An earlier platform default forced ``cudagraph_mode=NONE`` above TP=2,
+        on the reading that MCCL collectives could not run under stream
+        capture. That reading was wrong: capture broke because collectives fell
+        back to ``torch.distributed.all_reduce``, whose MCCL ProcessGroup
+        watchdog called into the driver inside the capture window. Routing them
+        through the captureable, stream-bound custom all-reduce fixed the cause
+        and the TP guard came out with it. Capture stays on at TP=4, so a
+        reintroduced TP gate fails here.
+        """
         from vllm.config import CUDAGraphMode
 
         from vllm_musa.platform import MUSAPlatformBase
@@ -457,9 +460,9 @@ class TestMUSAPlatformDefaults:
 
         MUSAPlatformBase.check_and_update_config(vllm_config)
 
-        assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
-        assert vllm_config.compilation_config.max_cudagraph_capture_size == 0
-        assert vllm_config.compilation_config.cudagraph_capture_sizes == []
+        assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.PIECEWISE
+        assert vllm_config.compilation_config.max_cudagraph_capture_size == 512
+        assert vllm_config.compilation_config.cudagraph_capture_sizes == [1, 2, 4, 8]
 
     def test_tp2_keeps_musa_cudagraph_capture(self):
         from vllm.config import CUDAGraphMode
@@ -1349,9 +1352,11 @@ class TestMUSAFP8ActivationQuant:
                 dispatch_key="MUSA",
             ),
         )
+        # float32 input takes the fallback branch, which calls the op out of
+        # the _C namespace rather than _C_musa_ops.
         monkeypatch.setattr(
             torch.ops,
-            "_C_musa_ops",
+            "_C",
             SimpleNamespace(per_token_group_fp8_quant=fake_quant),
             raising=False,
         )


### PR DESCRIPTION
## Purpose

`docker run <image>` + `vllm serve` fails on the v0.24.0-ph1-5.2.0 image unless the caller
overrides `MUSA_VISIBLE_DEVICES`:

```
ValueError: invalid literal for int() with base 10: 'all'
ValueError: Non-integer device ID 'all' is not supported by musa.
-> RuntimeError: Engine core initialization failed. Failed core proc(s): {}
```

Two independently reasonable changes collided:

1. Upstream vLLM `ebfbcfe46a` ("Stop setting CUDA_VISIBLE_DEVICES internally in vLLM, add
   device_ids arg", #45026) inverted the contract for the device-control variable. vLLM used
   to **write** it for workers, overwriting whatever was there — so a baked `all` never
   survived to be parsed. It now **reads** it as the authoritative logical-to-physical map and
   requires integer ids.
2. `e76ebea1f` ("build: add vllm-musa Docker image flow", #100) added
   `ENV MUSA_VISIBLE_DEVICES=all` to the new Dockerfile. The v0.20/v0.22 images set only
   `MTHREADS_VISIBLE_DEVICES=all`.

It went unnoticed because a run that sets `MUSA_VISIBLE_DEVICES` explicitly (`gpu run`, `-e`)
overwrites the baked value. A container scoped only through `MTHREADS_VISIBLE_DEVICES` keeps
`all` and hits it.

## Changes

- **`docker/musa.Dockerfile`** — stop baking `MUSA_VISIBLE_DEVICES`, and a contract test so it
  cannot come back. `MTHREADS_VISIBLE_DEVICES=all` is unchanged: that one is the container
  runtime's, and it does take `all`.
- **tests** — three repairs that bring the suite back to green.

## Why unset rather than teaching the platform to accept `all`

`all` is not a value the MUSA driver knows; it works only by being unparseable. Measured on
2 GPUs, one fresh process per value:

| `MUSA_VISIBLE_DEVICES` | `torch.musa.device_count()` |
|---|---|
| unset | 2 |
| `all` | 2 |
| `zzz` | 2 — indistinguishable from `all` |
| `0` | 1 |
| `1` | 1 |
| `0,1` | 2 |

The driver selects on an integer list and ignores what it cannot parse. So unset is exactly
equivalent to `all` at the driver layer, and dropping the ENV changes nothing there while fixing
vLLM. `""` is not an alternative — it yields `device_count()=0`.

Accepting `all` in the platform was considered and rejected: `CUDA_VISIBLE_DEVICES=all` fails the
same way upstream, so accepting it would make MUSA diverge. Normalizing the variable from Python
was also rejected — torch_musa warns that changing it after program start yields
`musaErrorUnknown`; it belongs to the driver.

Layer ownership, for the record: `MUSA_VISIBLE_DEVICES` is parsed by the driver
(`libmusa.so.5.2.0`, described there as "Specify visible devices."), and appears **0 times** in
`mthreads-container-runtime`. `MTHREADS_VISIBLE_DEVICES` is the reverse. The runtime does not
inject `MUSA_VISIBLE_DEVICES`, so the Dockerfile was its only source.

## Test Plan / Result

Hardware: 4 x MTT S5000, driver 3.3.5-server, image
`v0.24.0-ph1-5.2.0-torch2.9.1.post1-20260715`.

**The reported failure**, plain `from vllm import LLM`, Qwen3-0.6B, TP1 — only the env differs:

| `MUSA_VISIBLE_DEVICES` | result |
|---|---|
| `all` (as the image ships) | `ValueError: invalid literal for int() with base 10: 'all'` |
| `0` | `GENERATED: ' Beijing. The capital of the United States'` |
| unset (this PR) | `GENERATED: ' Beijing. The capital of the United States'` |

**Unit tests**: `268 passed, 2 skipped` (was `4 failed, 1 xfailed`). Each repair fixes a test that
had drifted from a deliberate change; no production behaviour is altered by any of them:

- `test_turboquant_supports_k8v4_on_musa` — called `supports_combination` without `use_mm_prefix`
  and raised TypeError. Upstream takes it between `use_sparse` and `device_capability`, and the
  MUSA backend already accepts and forwards it.
- `test_per_token_group_quant_accepts_strided_2d_input` — its fp32 input takes the fallback
  branch, which calls the op through `_C`, but the test faked it on `_C_musa_ops`, so the real
  kernel ran and rejected the CPU tensor.
- `test_gated_qkv_vllm_ir_lowers_to_triton_hop` — `test_csrc_jit_kernels` set
  `TORCHDYNAMO_DISABLE` at module scope; `torch.compile` reads it when called and pytest imports
  every module at collection, so a sibling module's `torch.compile` silently became a no-op
  (`compile_count == 0`). Now set from an autouse fixture and restored afterwards.
- `test_tp4_disables_musa_cudagraph_capture` — a non-strict xfail flagging a possible dropped
  safety. It is not one: the TP>2 capture disable went in on the reading that MCCL could not be
  captured, and came out three days later once collectives moved to the captureable custom
  all-reduce (the earlier fallback to `torch.distributed.all_reduce` let the MCCL watchdog call
  into the driver mid-capture). A later rebase dropped the comment holding that rationale, which
  is what left the question looking open. Rewritten to assert the behaviour that replaced it, so
  a reintroduced TP gate fails loudly.

  Confirmed at TP=4, `enforce_eager=False`: all four ranks report
  `Graph capturing finished in 619 secs, took 9.16 GiB` over 51 FULL graphs, no illegal memory
  access, and the request answers correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
