### PR TITLE
fix: register apply_repetition_penalties_ for the MUSA PrivateUse1 backend

### DIFF
--- a/vllm_musa/patches/series/0044-MUSA-csrc-libtorch_stable-torch_bindings-PrivateUse1.patch
+++ b/vllm_musa/patches/series/0044-MUSA-csrc-libtorch_stable-torch_bindings-PrivateUse1.patch
@@ -55,7 +55,7 @@ index 1be7217ce..3133243c4 100644
  STABLE_TORCH_LIBRARY_IMPL(_C, CompositeExplicitAutograd, ops) {
  #ifndef USE_ROCM
    ops.impl("cutlass_scaled_mm_supports_fp8",
-@@ -946,5 +949,37 @@ STABLE_TORCH_LIBRARY_IMPL(_C_cache_ops, CUDA, ops) {
+@@ -946,5 +949,39 @@ STABLE_TORCH_LIBRARY_IMPL(_C_cache_ops, CUDA, ops) {
    ops.impl("cp_gather_indexer_k_quant_cache",
             TORCH_BOX(&cp_gather_indexer_k_quant_cache));
  }
@@ -90,6 +90,8 @@ index 1be7217ce..3133243c4 100644
 +  ops.impl("per_token_group_fp8_quant_packed",
 +           TORCH_BOX(&per_token_group_quant_8bit_packed));
 +  ops.impl("per_token_group_quant_int8", TORCH_BOX(&per_token_group_quant_int8));
++  // sampler penalty (sampler.cu); its upstream CUDA impl block is USE_MUSA-excluded.
++  ops.impl("apply_repetition_penalties_", TORCH_BOX(&apply_repetition_penalties_));
 +}
 +#endif
  REGISTER_EXTENSION(_C_stable_libtorch)


### PR DESCRIPTION
## Problem

Any request with a repetition / frequency / presence penalty crashes the V1
engine on MUSA:

```
NotImplementedError: Could not run '_C::apply_repetition_penalties_' with
arguments from the 'musa' backend
```

## Root cause

The kernel `apply_repetition_penalties_` (`csrc/libtorch_stable/sampler.cu`) **is**
built for MUSA and its schema is registered, but no MUSA compute impl is:

- the upstream `STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ...)` block that impls it is
  `#if !defined(USE_MUSA)`-excluded, and
- the MUSA-only `STABLE_TORCH_LIBRARY_IMPL(_C, PrivateUse1, ...)` impl allowlist
  (added by `0044-MUSA-csrc-libtorch_stable-torch_bindings-PrivateUse1.patch`)
  omitted it.

So the schema `def` registers but the `musa` (PrivateUse1) backend has no impl.

## Fix

Add the op to the PrivateUse1 allowlist in patch `0044` — one line; the symbol is
already forward-declared and compiled from `sampler.cu`. Requires the normal
`_C_stable_libtorch` rebuild (no `setup.py` or Python change).

## Validation (S5000 mp_31, torch_musa 2.9.1.post1+musa5.2.0)

- Registers on the `musa` backend after the fix; the full dispatcher path
  (`apply_repetition_penalties` → `is_cuda` → native kernel) runs with no crash.
- Byte-exact vs the torch reference: `max_abs_diff = 0.0` across `bs in {1,2,4}`,
  `rep in {1.0, 1.5, 2.0, 5.0}`.
- CUDAGraph-capture safe (plain in-place kernel); FULL-decode capture completes.
- The native kernel is ~8x faster than the torch fallback at the `[1, 151936]`
  sampling shape (5.5 us vs 41 us).

## Test plan

- [ ] `_C_stable_libtorch` rebuilds with the added impl.
- [ ] A request with `repetition_penalty` / `frequency_penalty` /
      `presence_penalty` no longer crashes on MUSA, in eager and with CUDAGraph
      capture enabled.
