### PR TITLE
perf: fuse SiLU and FP8 group quant before DeepGEMM

### DIFF
--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -49,6 +49,13 @@ class TestMUSAPlatformBase:
 
         assert MUSAPlatformBase.ray_device_key == "GPU"
 
+    def test_uses_musa_post_grad_pass_manager(self):
+        from vllm_musa.platform import MUSAPlatformBase
+
+        assert MUSAPlatformBase.get_pass_manager_cls() == (
+            "vllm_musa.compilation.passes.MusaPostGradPassManager"
+        )
+
     def test_is_cuda_alike_returns_true(self):
         """Test that is_cuda_alike returns True for MUSA."""
         from vllm_musa.platform import MUSAPlatformBase

--- a/tests/test_musa_sync.py
+++ b/tests/test_musa_sync.py
@@ -58,9 +58,9 @@ def test_report(ms, capsys):
     rc = ms.main(["report"])
     out = capsys.readouterr().out
     assert rc == 0
-    assert "115 divergences" in out
-    assert "'1': 60" in out and "'2': 19" in out and "'3': 1" in out
-    assert "'4a': 2" in out and "'5': 25" in out and "'6': 8" in out
+    assert "118 divergences" in out
+    assert "'1': 61" in out and "'2': 19" in out and "'3': 1" in out
+    assert "'4a': 2" in out and "'5': 27" in out and "'6': 8" in out
 
 
 def test_report_doc(ms, capsys):

--- a/tests/test_silu_deepgemm_fusion.py
+++ b/tests/test_silu_deepgemm_fusion.py
@@ -24,10 +24,12 @@ def _musa_device() -> Iterator[None]:
     from vllm.platforms import current_platform
 
     import vllm_musa
+    from vllm_musa.model_executor.kernels.linear.scaled_mm import deep_gemm
 
     if not current_platform.is_device_capability((3, 1)):
         pytest.skip("the fused SiLU group-quant kernel requires S5000/mp31")
     vllm_musa.register_custom_ops()
+    assert deep_gemm is not None  # Import registers the two DeepGEMM custom ops.
     yield
 
 
@@ -106,15 +108,32 @@ def test_custom_op_schema_fake_and_aot_dynamic() -> None:
     x, weight, weight_scale = _small_deepgemm_inputs()
     op = torch.ops.vllm.musa_silu_deepgemm_fp8_op.default
 
+    schema = str(op._schema)
+    assert "!" not in schema
+    assert schema.endswith("-> Tensor")
+    output = op(x, weight, weight_scale, 128, False)
+    assert output.shape == (x.shape[0], weight.shape[0])
+    assert output.dtype == torch.bfloat16
+    assert output.device == x.device
+    assert output.untyped_storage().data_ptr() not in {
+        tensor.untyped_storage().data_ptr() for tensor in (x, weight, weight_scale)
+    }
+
+    # MUSA's muDNN cannot compare FP8 tensors, so opcheck's schema checker
+    # fails while trying to prove that the FP8 weight was not mutated. The
+    # functional schema and storage checks above cover that contract without
+    # invoking unsupported FP8 EQ; keep the FakeTensor and AOT-dynamic checks.
     torch.library.opcheck(
         op,
         (x, weight, weight_scale, 128, False),
-        test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
+        test_utils=("test_faketensor", "test_aot_dispatch_dynamic"),
     )
 
 
 def test_rewrites_the_native_production_graph() -> None:
-    from torch.fx.experimental.proxy_tensor import make_fx
+    from copy import deepcopy
+
+    from torch._inductor.compile_fx import compile_fx
     from vllm.config import (
         CompilationConfig,
         CompilationMode,
@@ -122,6 +141,7 @@ def test_rewrites_the_native_production_graph() -> None:
         VllmConfig,
         set_current_vllm_config,
     )
+    from vllm.model_executor.layers.activation import SiluAndMul
 
     from vllm_musa.compilation.passes.silu_deepgemm_fusion import (
         MusaSiluDeepGemmFusionPass,
@@ -130,8 +150,7 @@ def test_rewrites_the_native_production_graph() -> None:
     x, weight, weight_scale = _small_deepgemm_inputs()
 
     def model(x, weight, weight_scale):
-        d = x.shape[-1] // 2
-        activated = F.silu(x[..., :d]) * x[..., d:]
+        activated = SiluAndMul.forward_native(x)
         return torch.ops.vllm.musa_deepgemm_fp8_op(
             activated, weight, weight_scale, 128, False
         )
@@ -139,25 +158,58 @@ def test_rewrites_the_native_production_graph() -> None:
     config = VllmConfig(
         compilation_config=CompilationConfig(
             mode=CompilationMode.VLLM_COMPILE,
-            backend="eager",
+            backend="inductor",
             custom_ops=["all"],
             pass_config=PassConfig(fuse_act_quant=True, eliminate_noops=True),
         )
     )
-    expected = model(x, weight, weight_scale)
-    with set_current_vllm_config(config, check_compile=False):
-        graph_module = make_fx(model, tracing_mode="fake")(x, weight, weight_scale)
-        fusion = MusaSiluDeepGemmFusionPass(config)
-        targets_before = {node.target for node in graph_module.graph.nodes}
-        fusion(graph_module.graph)
-        graph_module.recompile()
 
-    targets_after = {node.target for node in graph_module.graph.nodes}
-    assert torch.ops.vllm.musa_deepgemm_fp8_op.default in targets_before
-    assert torch.ops.vllm.musa_silu_deepgemm_fp8_op.default not in targets_before
-    assert torch.ops.vllm.musa_deepgemm_fp8_op.default not in targets_after
-    assert torch.ops.vllm.musa_silu_deepgemm_fp8_op.default in targets_after
+    class FusionBackend:
+        def __init__(self, fusion=None):
+            self.fusion = fusion
+            self.targets_before = set()
+            self.targets_after = set()
+            self.inductor_config = deepcopy(
+                config.compilation_config.inductor_compile_config
+            )
+            self.inductor_config["force_disable_caches"] = True
+            self.inductor_config["post_grad_custom_post_pass"] = self.post_pass
+
+        def post_pass(self, graph):
+            self.targets_before = {node.target for node in graph.nodes}
+            if self.fusion is not None:
+                self.fusion(graph)
+            self.targets_after = {node.target for node in graph.nodes}
+
+        def __call__(self, graph_module, example_inputs):
+            return compile_fx(
+                graph_module,
+                example_inputs,
+                config_patches=self.inductor_config,
+            )
+
+    with set_current_vllm_config(config, check_compile=False):
+        control_backend = FusionBackend()
+        compiled_control = torch.compile(model, backend=control_backend, fullgraph=True)
+        expected = compiled_control(x, weight, weight_scale)
+
+        torch._dynamo.reset()
+        fusion = MusaSiluDeepGemmFusionPass(config)
+        backend = FusionBackend(fusion)
+        compiled = torch.compile(model, backend=backend, fullgraph=True)
+        actual = compiled(x, weight, weight_scale)
+
+    assert torch.ops.vllm.musa_deepgemm_fp8_op.default in control_backend.targets_after
+    assert (
+        torch.ops.vllm.musa_silu_deepgemm_fp8_op.default
+        not in control_backend.targets_after
+    )
+    assert torch.ops.vllm.musa_deepgemm_fp8_op.default in backend.targets_before
+    assert (
+        torch.ops.vllm.musa_silu_deepgemm_fp8_op.default not in backend.targets_before
+    )
+    assert torch.ops.vllm.musa_deepgemm_fp8_op.default not in backend.targets_after
+    assert torch.ops.vllm.musa_silu_deepgemm_fp8_op.default in backend.targets_after
     assert fusion.matched_count == 1
 
-    actual = graph_module(x, weight, weight_scale)
     torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)

--- a/tests/test_silu_deepgemm_fusion.py
+++ b/tests/test_silu_deepgemm_fusion.py
@@ -153,6 +153,32 @@ def test_validated_qwen3_8b_auto_scope(overrides) -> None:
     )
 
 
+def test_default_auto_scope_is_evaluated_per_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_musa.compilation.passes.pass_manager import (
+        _silu_deepgemm_fusion_requested,
+    )
+    from vllm_musa.utils.environ import envs
+
+    setting = envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION
+    monkeypatch.delenv(setting.name, raising=False)
+    assert not setting.is_set()
+    validated = _validated_qwen3_config()
+    other = _validated_qwen3_config(
+        model_config__architectures=["Qwen3ForSequenceClassification"]
+    )
+
+    assert _silu_deepgemm_fusion_requested(validated)
+    assert not _silu_deepgemm_fusion_requested(other)
+    assert not setting.is_set()
+
+    with setting.override(False):
+        assert not _silu_deepgemm_fusion_requested(validated)
+    with setting.override(True):
+        assert _silu_deepgemm_fusion_requested(other)
+
+
 def test_custom_op_schema_fake_and_aot_dynamic() -> None:
     x, weight, weight_scale = _small_deepgemm_inputs()
     op = torch.ops.vllm.musa_silu_deepgemm_fp8_op.default

--- a/tests/test_silu_deepgemm_fusion.py
+++ b/tests/test_silu_deepgemm_fusion.py
@@ -153,17 +153,11 @@ def test_validated_qwen3_8b_auto_scope(overrides) -> None:
     )
 
 
-def test_default_auto_scope_is_evaluated_per_config(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_default_auto_scope_is_evaluated_per_config() -> None:
     from vllm_musa.compilation.passes.pass_manager import (
         _silu_deepgemm_fusion_requested,
     )
-    from vllm_musa.utils.environ import envs
 
-    setting = envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION
-    monkeypatch.delenv(setting.name, raising=False)
-    assert not setting.is_set()
     validated = _validated_qwen3_config()
     other = _validated_qwen3_config(
         model_config__architectures=["Qwen3ForSequenceClassification"]
@@ -171,12 +165,6 @@ def test_default_auto_scope_is_evaluated_per_config(
 
     assert _silu_deepgemm_fusion_requested(validated)
     assert not _silu_deepgemm_fusion_requested(other)
-    assert not setting.is_set()
-
-    with setting.override(False):
-        assert not _silu_deepgemm_fusion_requested(validated)
-    with setting.override(True):
-        assert _silu_deepgemm_fusion_requested(other)
 
 
 def test_custom_op_schema_fake_and_aot_dynamic() -> None:

--- a/tests/test_silu_deepgemm_fusion.py
+++ b/tests/test_silu_deepgemm_fusion.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""S5000 validation for dense SwiGLU plus FP8 DeepGEMM fusion."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("torchada")
+torch = pytest.importorskip("torch")
+F = pytest.importorskip("torch.nn.functional")
+pytest.importorskip("torch_musa")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _musa_device() -> Iterator[None]:
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+    torch.musa.set_device(0)
+
+    from vllm.platforms import current_platform
+
+    import vllm_musa
+
+    if not current_platform.is_device_capability((3, 1)):
+        pytest.skip("the fused SiLU group-quant kernel requires S5000/mp31")
+    vllm_musa.register_custom_ops()
+    yield
+
+
+def _quant_outputs(m: int, hidden: int):
+    q = torch.empty((m, hidden), device="musa", dtype=torch.float8_e4m3fn)
+    s = torch.empty((m, hidden // 128), device="musa", dtype=torch.float32)
+    return q, s
+
+
+@pytest.mark.parametrize("m", [1, 4, 4104])
+def test_fused_quant_is_bit_exact_for_qwen_shapes(m: int) -> None:
+    hidden = 12288
+    torch.manual_seed(759000 + m)
+    x = torch.randn((m, hidden * 2), device="musa", dtype=torch.bfloat16)
+    reference_q, reference_s = _quant_outputs(m, hidden)
+    fused_q, fused_s = _quant_outputs(m, hidden)
+
+    activated = F.swish_glu(x)
+    torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+        activated,
+        reference_q,
+        reference_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+    )
+    torch.ops._C_musa_ops.silu_and_mul_per_token_group_fp8_quant(
+        x,
+        fused_q,
+        fused_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+    )
+    torch.musa.synchronize()
+
+    assert torch.equal(
+        reference_q.view(torch.uint8).cpu(), fused_q.view(torch.uint8).cpu()
+    )
+    assert torch.equal(
+        reference_s.view(torch.int32).cpu(), fused_s.view(torch.int32).cpu()
+    )
+
+
+def _small_deepgemm_inputs():
+    torch.manual_seed(759100)
+    x = torch.randn((4, 512), device="musa", dtype=torch.bfloat16)
+    weight = torch.randn((256, 256), device="musa", dtype=torch.bfloat16).to(
+        torch.float8_e4m3fn
+    )
+    weight_scale = torch.ones((2, 2), device="musa", dtype=torch.float32)
+    return x, weight, weight_scale
+
+
+def test_pass_manager_qualname_resolves() -> None:
+    from vllm.utils.import_utils import resolve_obj_by_qualname
+
+    from vllm_musa.compilation.passes import MusaPostGradPassManager
+    from vllm_musa.platform import MUSAPlatformBase
+
+    resolved = resolve_obj_by_qualname(MUSAPlatformBase.get_pass_manager_cls())
+    assert resolved is MusaPostGradPassManager
+
+
+@pytest.mark.parametrize("is_moe, expected", [(False, True), (True, False)])
+def test_dense_model_gate_uses_model_config_api(is_moe: bool, expected: bool) -> None:
+    from vllm_musa.compilation.passes.pass_manager import _is_dense_model
+
+    config = SimpleNamespace(model_config=SimpleNamespace(is_model_moe=lambda: is_moe))
+    assert _is_dense_model(config) is expected
+
+
+def test_custom_op_schema_fake_and_aot_dynamic() -> None:
+    x, weight, weight_scale = _small_deepgemm_inputs()
+    op = torch.ops.vllm.musa_silu_deepgemm_fp8_op.default
+
+    torch.library.opcheck(
+        op,
+        (x, weight, weight_scale, 128, False),
+        test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
+    )
+
+
+def test_rewrites_the_native_production_graph() -> None:
+    from torch.fx.experimental.proxy_tensor import make_fx
+    from vllm.config import (
+        CompilationConfig,
+        CompilationMode,
+        PassConfig,
+        VllmConfig,
+        set_current_vllm_config,
+    )
+
+    from vllm_musa.compilation.passes.silu_deepgemm_fusion import (
+        MusaSiluDeepGemmFusionPass,
+    )
+
+    x, weight, weight_scale = _small_deepgemm_inputs()
+
+    def model(x, weight, weight_scale):
+        d = x.shape[-1] // 2
+        activated = F.silu(x[..., :d]) * x[..., d:]
+        return torch.ops.vllm.musa_deepgemm_fp8_op(
+            activated, weight, weight_scale, 128, False
+        )
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            backend="eager",
+            custom_ops=["all"],
+            pass_config=PassConfig(fuse_act_quant=True, eliminate_noops=True),
+        )
+    )
+    expected = model(x, weight, weight_scale)
+    with set_current_vllm_config(config, check_compile=False):
+        graph_module = make_fx(model, tracing_mode="fake")(x, weight, weight_scale)
+        fusion = MusaSiluDeepGemmFusionPass(config)
+        targets_before = {node.target for node in graph_module.graph.nodes}
+        fusion(graph_module.graph)
+        graph_module.recompile()
+
+    targets_after = {node.target for node in graph_module.graph.nodes}
+    assert torch.ops.vllm.musa_deepgemm_fp8_op.default in targets_before
+    assert torch.ops.vllm.musa_silu_deepgemm_fp8_op.default not in targets_before
+    assert torch.ops.vllm.musa_deepgemm_fp8_op.default not in targets_after
+    assert torch.ops.vllm.musa_silu_deepgemm_fp8_op.default in targets_after
+    assert fusion.matched_count == 1
+
+    actual = graph_module(x, weight, weight_scale)
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)

--- a/tests/test_silu_deepgemm_fusion.py
+++ b/tests/test_silu_deepgemm_fusion.py
@@ -104,9 +104,62 @@ def test_dense_model_gate_uses_model_config_api(is_moe: bool, expected: bool) ->
     assert _is_dense_model(config) is expected
 
 
+def _validated_qwen3_config(**overrides):
+    hf_config = SimpleNamespace(
+        architectures=["Qwen3ForCausalLM"],
+        model_type="qwen3",
+        hidden_size=4096,
+        intermediate_size=12288,
+        num_hidden_layers=36,
+    )
+    model_config = SimpleNamespace(
+        architectures=["Qwen3ForCausalLM"],
+        hf_text_config=hf_config,
+        quantization="fp8",
+        dtype=torch.bfloat16,
+    )
+    parallel_config = SimpleNamespace(
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+        data_parallel_size=1,
+    )
+    config = SimpleNamespace(
+        model_config=model_config,
+        parallel_config=parallel_config,
+        speculative_config=None,
+    )
+    for dotted_name, value in overrides.items():
+        owner_name, attribute = dotted_name.split("__", maxsplit=1)
+        setattr(getattr(config, owner_name), attribute, value)
+    return config
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"model_config__architectures": ["Qwen3MoeForCausalLM"]},
+        {"model_config__quantization": None},
+        {"model_config__dtype": torch.float16},
+        {"parallel_config__tensor_parallel_size": 2},
+        {"parallel_config__pipeline_parallel_size": 2},
+    ],
+)
+def test_validated_qwen3_8b_auto_scope(overrides) -> None:
+    from vllm_musa.platform import _is_validated_qwen3_8b_fp8_single_gpu
+
+    assert _is_validated_qwen3_8b_fp8_single_gpu(_validated_qwen3_config())
+    assert not _is_validated_qwen3_8b_fp8_single_gpu(
+        _validated_qwen3_config(**overrides)
+    )
+
+
 def test_custom_op_schema_fake_and_aot_dynamic() -> None:
     x, weight, weight_scale = _small_deepgemm_inputs()
     op = torch.ops.vllm.musa_silu_deepgemm_fp8_op.default
+
+    input_bits = x.view(torch.uint16).cpu().clone()
+    weight_bits = weight.view(torch.uint8).cpu().clone()
+    weight_scale_bits = weight_scale.view(torch.int32).cpu().clone()
 
     schema = str(op._schema)
     assert "!" not in schema
@@ -118,11 +171,14 @@ def test_custom_op_schema_fake_and_aot_dynamic() -> None:
     assert output.untyped_storage().data_ptr() not in {
         tensor.untyped_storage().data_ptr() for tensor in (x, weight, weight_scale)
     }
+    assert torch.equal(input_bits, x.view(torch.uint16).cpu())
+    assert torch.equal(weight_bits, weight.view(torch.uint8).cpu())
+    assert torch.equal(weight_scale_bits, weight_scale.view(torch.int32).cpu())
 
     # MUSA's muDNN cannot compare FP8 tensors, so opcheck's schema checker
     # fails while trying to prove that the FP8 weight was not mutated. The
-    # functional schema and storage checks above cover that contract without
-    # invoking unsupported FP8 EQ; keep the FakeTensor and AOT-dynamic checks.
+    # raw-byte checks above cover that contract without invoking unsupported
+    # FP8 EQ; keep the FakeTensor and AOT-dynamic checks.
     torch.library.opcheck(
         op,
         (x, weight, weight_scale, 128, False),

--- a/tests/test_silu_deepgemm_fusion_source.py
+++ b/tests/test_silu_deepgemm_fusion_source.py
@@ -68,4 +68,7 @@ def test_platform_auto_enablement_is_limited_to_the_validated_scope():
     assert "def _silu_deepgemm_fusion_requested(" in pass_manager_source
     assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION" not in pass_manager_source
     assert "_is_validated_qwen3_8b_fp8_single_gpu(config)" in pass_manager_source
-    assert "current_platform.is_device_capability((3, 1))" in pass_manager_source
+    assert "_has_validated_musa_device_capability()" in pass_manager_source
+    assert "torch.musa.current_device()" in pass_manager_source
+    assert "torch.musa.get_device_capability(device_id)" in pass_manager_source
+    assert "current_platform.is_device_capability" not in pass_manager_source

--- a/tests/test_silu_deepgemm_fusion_source.py
+++ b/tests/test_silu_deepgemm_fusion_source.py
@@ -43,7 +43,7 @@ def test_pass_manager_keeps_the_experimental_scope_narrow():
     ).read_text()
 
     assert "_silu_deepgemm_fusion_requested(config)" in source
-    assert "VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()" in source
+    assert "VLLM_MUSA_CUSTOM_OP_USE_NATIVE" not in source
     assert "_is_dense_model(config)" in source
     assert "_use_row_major_activation_scales(False)" in source
     assert "self.pass_config.fuse_act_quant" in source
@@ -67,6 +67,7 @@ def test_platform_auto_enablement_is_limited_to_the_validated_scope():
     ).read_text()
     assert "def _silu_deepgemm_fusion_requested(" in pass_manager_source
     assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION" not in pass_manager_source
+    assert "VLLM_MUSA_CUSTOM_OP_USE_NATIVE" not in pass_manager_source
     assert "_is_validated_qwen3_8b_fp8_single_gpu(config)" in pass_manager_source
     assert "_has_validated_musa_device_capability()" in pass_manager_source
     assert "torch.musa.current_device()" in pass_manager_source

--- a/tests/test_silu_deepgemm_fusion_source.py
+++ b/tests/test_silu_deepgemm_fusion_source.py
@@ -48,3 +48,27 @@ def test_pass_manager_keeps_the_experimental_scope_narrow():
     assert "_use_row_major_activation_scales(False)" in source
     assert "self.pass_config.fuse_act_quant" in source
     assert "self.passes.append(MusaSiluDeepGemmFusionPass(config))" in source
+
+
+def test_platform_auto_enablement_is_limited_to_the_validated_scope():
+    source = (ROOT / "vllm_musa" / "platform.py").read_text()
+
+    assert "def _is_validated_qwen3_8b_fp8_single_gpu(" in source
+    assert 'tuple(architectures or ()) == ("Qwen3ForCausalLM",)' in source
+    assert 'getattr(hf_text_config, "hidden_size", None) == 4096' in source
+    assert 'getattr(hf_text_config, "intermediate_size", None) == 12288' in source
+    assert "cls.is_device_capability(" in source
+    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.is_set()" in source
+    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.set(True)" in source
+
+    deepgemm_source = (
+        ROOT
+        / "vllm_musa"
+        / "model_executor"
+        / "kernels"
+        / "linear"
+        / "scaled_mm"
+        / "deep_gemm.py"
+    ).read_text()
+    assert "def _supports_silu_group_quant_kernel()" in deepgemm_source
+    assert "current_platform.is_device_capability(" in deepgemm_source

--- a/tests/test_silu_deepgemm_fusion_source.py
+++ b/tests/test_silu_deepgemm_fusion_source.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Source-contract checks for dense MUSA SwiGLU plus DeepGEMM fusion."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_fused_deepgemm_op_uses_shipped_silu_group_quant_kernel():
+    source = (
+        ROOT
+        / "vllm_musa"
+        / "model_executor"
+        / "kernels"
+        / "linear"
+        / "scaled_mm"
+        / "deep_gemm.py"
+    ).read_text()
+
+    assert "def _musa_silu_deepgemm_fp8_op(" in source
+    assert "silu_and_mul_per_token_group_fp8_quant(" in source
+    assert "fp8_gemm_nt(" in source
+    assert '"musa_silu_deepgemm_fp8_op"' in source
+    assert "fake_impl=_musa_silu_deepgemm_fp8_op_fake" in source
+
+
+def test_fusion_matches_the_production_native_swiglu_deepgemm_pair():
+    source = (
+        ROOT / "vllm_musa" / "compilation" / "passes" / "silu_deepgemm_fusion.py"
+    ).read_text()
+
+    assert "MatcherSiluAndMul(enabled=False)" in source
+    assert "torch.ops.vllm.musa_deepgemm_fp8_op(" in source
+    assert "torch.ops.vllm.musa_silu_deepgemm_fp8_op(" in source
+    assert source.count("\n                128,") == 2
+    assert source.count("\n                False,") == 2
+
+
+def test_pass_manager_keeps_the_experimental_scope_narrow():
+    source = (
+        ROOT / "vllm_musa" / "compilation" / "passes" / "pass_manager.py"
+    ).read_text()
+
+    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.get()" in source
+    assert "VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()" in source
+    assert "_is_dense_model(config)" in source
+    assert "_use_row_major_activation_scales(False)" in source
+    assert "self.pass_config.fuse_act_quant" in source
+    assert "self.passes.append(MusaSiluDeepGemmFusionPass(config))" in source

--- a/tests/test_silu_deepgemm_fusion_source.py
+++ b/tests/test_silu_deepgemm_fusion_source.py
@@ -57,12 +57,15 @@ def test_platform_auto_enablement_is_limited_to_the_validated_scope():
     assert 'tuple(architectures or ()) == ("Qwen3ForCausalLM",)' in source
     assert 'getattr(hf_text_config, "hidden_size", None) == 4096' in source
     assert 'getattr(hf_text_config, "intermediate_size", None) == 12288' in source
-    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.set(True)" not in source
+    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION" not in source
+
+    environ_source = (ROOT / "vllm_musa" / "utils" / "environ.py").read_text()
+    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION" not in environ_source
 
     pass_manager_source = (
         ROOT / "vllm_musa" / "compilation" / "passes" / "pass_manager.py"
     ).read_text()
     assert "def _silu_deepgemm_fusion_requested(" in pass_manager_source
-    assert "setting.is_set()" in pass_manager_source
+    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION" not in pass_manager_source
     assert "_is_validated_qwen3_8b_fp8_single_gpu(config)" in pass_manager_source
     assert "current_platform.is_device_capability((3, 1))" in pass_manager_source

--- a/tests/test_silu_deepgemm_fusion_source.py
+++ b/tests/test_silu_deepgemm_fusion_source.py
@@ -61,14 +61,7 @@ def test_platform_auto_enablement_is_limited_to_the_validated_scope():
     assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.is_set()" in source
     assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.set(True)" in source
 
-    deepgemm_source = (
-        ROOT
-        / "vllm_musa"
-        / "model_executor"
-        / "kernels"
-        / "linear"
-        / "scaled_mm"
-        / "deep_gemm.py"
+    pass_manager_source = (
+        ROOT / "vllm_musa" / "compilation" / "passes" / "pass_manager.py"
     ).read_text()
-    assert "def _supports_silu_group_quant_kernel()" in deepgemm_source
-    assert "current_platform.is_device_capability(" in deepgemm_source
+    assert "current_platform.is_device_capability((3, 1))" in pass_manager_source

--- a/tests/test_silu_deepgemm_fusion_source.py
+++ b/tests/test_silu_deepgemm_fusion_source.py
@@ -42,7 +42,7 @@ def test_pass_manager_keeps_the_experimental_scope_narrow():
         ROOT / "vllm_musa" / "compilation" / "passes" / "pass_manager.py"
     ).read_text()
 
-    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.get()" in source
+    assert "_silu_deepgemm_fusion_requested(config)" in source
     assert "VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()" in source
     assert "_is_dense_model(config)" in source
     assert "_use_row_major_activation_scales(False)" in source
@@ -57,11 +57,12 @@ def test_platform_auto_enablement_is_limited_to_the_validated_scope():
     assert 'tuple(architectures or ()) == ("Qwen3ForCausalLM",)' in source
     assert 'getattr(hf_text_config, "hidden_size", None) == 4096' in source
     assert 'getattr(hf_text_config, "intermediate_size", None) == 12288' in source
-    assert "cls.is_device_capability(" in source
-    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.is_set()" in source
-    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.set(True)" in source
+    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION.set(True)" not in source
 
     pass_manager_source = (
         ROOT / "vllm_musa" / "compilation" / "passes" / "pass_manager.py"
     ).read_text()
+    assert "def _silu_deepgemm_fusion_requested(" in pass_manager_source
+    assert "setting.is_set()" in pass_manager_source
+    assert "_is_validated_qwen3_8b_fp8_single_gpu(config)" in pass_manager_source
     assert "current_platform.is_device_capability((3, 1))" in pass_manager_source

--- a/vllm_musa/compilation/__init__.py
+++ b/vllm_musa/compilation/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_musa/compilation/passes/__init__.py
+++ b/vllm_musa/compilation/passes/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from .pass_manager import MusaPostGradPassManager
+
+__all__ = ["MusaPostGradPassManager"]

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -11,7 +11,6 @@ from vllm.logger import init_logger
 from vllm_musa.model_executor.kernels.linear.scaled_mm.deep_gemm import (
     _use_row_major_activation_scales,
 )
-from vllm_musa.utils.environ import envs
 
 from .silu_deepgemm_fusion import MusaSiluDeepGemmFusionPass
 
@@ -51,7 +50,6 @@ class MusaPostGradPassManager(PostGradPassManager):
         super().configure(config)
         if (
             _silu_deepgemm_fusion_requested(config)
-            and envs.VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()
             and _is_dense_model(config)
             and _has_validated_musa_device_capability()
             and _use_row_major_activation_scales(False)

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from functools import cache
+
+import torch
 from vllm.compilation.passes.pass_manager import PostGradPassManager
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 
 from vllm_musa.model_executor.kernels.linear.scaled_mm.deep_gemm import (
     _use_row_major_activation_scales,
@@ -14,6 +16,16 @@ from vllm_musa.utils.environ import envs
 from .silu_deepgemm_fusion import MusaSiluDeepGemmFusionPass
 
 logger = init_logger(__name__)
+
+
+@cache
+def _has_validated_musa_device_capability() -> bool:
+    """Query the current logical device; MTML capability IDs are physical."""
+    try:
+        device_id = torch.musa.current_device()
+        return tuple(torch.musa.get_device_capability(device_id)) == (3, 1)
+    except Exception:
+        return False
 
 
 def _is_dense_model(config: VllmConfig) -> bool:
@@ -41,7 +53,7 @@ class MusaPostGradPassManager(PostGradPassManager):
             _silu_deepgemm_fusion_requested(config)
             and envs.VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()
             and _is_dense_model(config)
-            and current_platform.is_device_capability((3, 1))
+            and _has_validated_musa_device_capability()
             and _use_row_major_activation_scales(False)
             and self.pass_config.fuse_act_quant
         ):

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -4,6 +4,7 @@
 from vllm.compilation.passes.pass_manager import PostGradPassManager
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 
 from vllm_musa.model_executor.kernels.linear.scaled_mm.deep_gemm import (
     _use_row_major_activation_scales,
@@ -34,6 +35,7 @@ class MusaPostGradPassManager(PostGradPassManager):
             envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION.get()
             and envs.VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()
             and _is_dense_model(config)
+            and current_platform.is_device_capability((3, 1))
             and _use_row_major_activation_scales(False)
             and self.pass_config.fuse_act_quant
         ):

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.compilation.passes.pass_manager import PostGradPassManager
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.logger import init_logger
+
+from vllm_musa.model_executor.kernels.linear.scaled_mm.deep_gemm import (
+    _use_row_major_activation_scales,
+)
+from vllm_musa.utils.environ import envs
+
+from .silu_deepgemm_fusion import MusaSiluDeepGemmFusionPass
+
+logger = init_logger(__name__)
+
+
+def _is_dense_model(config: VllmConfig) -> bool:
+    model_config = config.model_config
+    if model_config is None:
+        return False
+    is_model_moe = getattr(model_config, "is_model_moe", None)
+    if callable(is_model_moe):
+        return not is_model_moe()
+    return not bool(getattr(model_config, "is_moe", False))
+
+
+class MusaPostGradPassManager(PostGradPassManager):
+    """Add MUSA-only graph fusions to vLLM's standard post-grad pipeline."""
+
+    def configure(self, config: VllmConfig) -> None:
+        super().configure(config)
+        if (
+            envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION.get()
+            and envs.VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()
+            and _is_dense_model(config)
+            and _use_row_major_activation_scales(False)
+            and self.pass_config.fuse_act_quant
+        ):
+            with set_current_vllm_config(config, check_compile=False):
+                self.passes.append(MusaSiluDeepGemmFusionPass(config))
+            logger.info("Enabled MUSA dense SwiGLU+DeepGEMM fusion pass")

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -26,13 +26,23 @@ def _is_dense_model(config: VllmConfig) -> bool:
     return not bool(getattr(model_config, "is_moe", False))
 
 
+def _silu_deepgemm_fusion_requested(config: VllmConfig) -> bool:
+    setting = envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION
+    if setting.is_set():
+        return setting.get()
+
+    from vllm_musa.platform import _is_validated_qwen3_8b_fp8_single_gpu
+
+    return _is_validated_qwen3_8b_fp8_single_gpu(config)
+
+
 class MusaPostGradPassManager(PostGradPassManager):
     """Add MUSA-only graph fusions to vLLM's standard post-grad pipeline."""
 
     def configure(self, config: VllmConfig) -> None:
         super().configure(config)
         if (
-            envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION.get()
+            _silu_deepgemm_fusion_requested(config)
             and envs.VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()
             and _is_dense_model(config)
             and current_platform.is_device_capability((3, 1))

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -27,10 +27,6 @@ def _is_dense_model(config: VllmConfig) -> bool:
 
 
 def _silu_deepgemm_fusion_requested(config: VllmConfig) -> bool:
-    setting = envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION
-    if setting.is_set():
-        return setting.get()
-
     from vllm_musa.platform import _is_validated_qwen3_8b_fp8_single_gpu
 
     return _is_validated_qwen3_8b_fp8_single_gpu(config)

--- a/vllm_musa/compilation/passes/silu_deepgemm_fusion.py
+++ b/vllm_musa/compilation/passes/silu_deepgemm_fusion.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from torch import fx
+from vllm.compilation.passes.fusion.matcher_utils import MatcherSiluAndMul
+from vllm.compilation.passes.vllm_inductor_pass import (
+    VllmFusionPatternMatcherPass,
+    VllmPatternReplacement,
+)
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
+
+
+class MusaSiluDeepGemmPattern(VllmPatternReplacement):
+    """Fuse native SwiGLU with the opaque MUSA FP8 DeepGEMM wrapper."""
+
+    def __init__(self) -> None:
+        # Quantized FULL_AND_PIECEWISE serving routes MUSA custom ops through
+        # their native graph forms, so match the production SwiGLU nodes.
+        self.silu_and_mul_matcher = MatcherSiluAndMul(enabled=False)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        device = current_platform.device_type
+        return [
+            torch.empty((5, 256), dtype=torch.bfloat16, device=device),
+            torch.empty((64, 128), dtype=current_platform.fp8_dtype(), device=device),
+            torch.empty((1, 1), dtype=torch.float32, device=device),
+        ]
+
+    @property
+    def pattern(self):
+        def _pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            weight_scale: torch.Tensor,
+        ) -> torch.Tensor:
+            activated = self.silu_and_mul_matcher(input)
+            return torch.ops.vllm.musa_deepgemm_fp8_op(
+                activated,
+                weight,
+                weight_scale,
+                128,
+                False,
+            )
+
+        return _pattern
+
+    @property
+    def replacement(self):
+        def _replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            weight_scale: torch.Tensor,
+        ) -> torch.Tensor:
+            return torch.ops.vllm.musa_silu_deepgemm_fp8_op(
+                input,
+                weight,
+                weight_scale,
+                128,
+                False,
+            )
+
+        return _replacement
+
+
+class MusaSiluDeepGemmFusionPass(VllmFusionPatternMatcherPass):
+    def __init__(self, config: VllmConfig) -> None:
+        super().__init__(config, "musa_silu_deepgemm_fusion_pass")
+        self.register(MusaSiluDeepGemmPattern())
+        self.dump_patterns(config, self.pm_pass)
+
+    def __call__(self, graph: fx.Graph) -> None:
+        super().__call__(graph)
+        if self.matched_count:
+            logger.info(
+                "MUSA dense SwiGLU+DeepGEMM fusion matched %d pattern(s)",
+                self.matched_count,
+            )

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -1,5 +1,4 @@
 import os
-from functools import lru_cache
 from typing import ClassVar
 
 import torch
@@ -33,11 +32,6 @@ def _use_row_major_activation_scales(use_deep_gemm_e8m0: bool) -> bool:
         return False
     value = os.getenv("VLLM_MUSA_DEEPGEMM_ROW_MAJOR_ACT_SCALES", "1").lower()
     return value not in ("0", "false", "no", "off")
-
-
-@lru_cache(maxsize=1)
-def _supports_silu_group_quant_kernel() -> bool:
-    return current_platform.is_musa() and current_platform.is_device_capability((3, 1))
 
 
 def _read_int_env(name: str, default: int) -> int:
@@ -239,8 +233,7 @@ def _musa_silu_deepgemm_fp8_op(
     """
     hidden_size = input.shape[-1] // 2 if input.dim() == 2 else 0
     if (
-        not _supports_silu_group_quant_kernel()
-        or group_size != 128
+        group_size != 128
         or use_deep_gemm_e8m0
         or not _use_row_major_activation_scales(use_deep_gemm_e8m0)
         or input.dim() != 2

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -2,6 +2,7 @@ import os
 from typing import ClassVar
 
 import torch
+import torch.nn.functional as F
 import vllm.envs as envs
 from vllm.model_executor.kernels.linear import (
     Fp8BlockScaledMMLinearKernel,
@@ -13,6 +14,9 @@ from vllm.model_executor.kernels.linear.scaled_mm.deep_gemm import (
     should_use_deepgemm_for_fp8_linear,
 )
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    get_fp8_min_max,
+)
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -212,6 +216,77 @@ def _musa_deepgemm_fp8_op(
     return output
 
 
+def _musa_silu_deepgemm_fp8_op(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    use_deep_gemm_e8m0: bool,
+) -> torch.Tensor:
+    """Fuse dense SwiGLU activation with DeepGEMM input quantization.
+
+    The existing dense path materializes a BF16 SwiGLU tensor and then reads it
+    again in ``per_token_group_quant_8bit_vec``.  For the supported Qwen FP8
+    path, use the shipped SiLU+mul+group-quant kernel and feed its outputs to
+    the unchanged DeepGEMM call.  Keep a semantic fallback so direct callers do
+    not inherit the compiler pattern's narrower preconditions.
+    """
+    hidden_size = input.shape[-1] // 2 if input.dim() == 2 else 0
+    if (
+        group_size != 128
+        or use_deep_gemm_e8m0
+        or not _use_row_major_activation_scales(use_deep_gemm_e8m0)
+        or input.dim() != 2
+        or input.shape[-1] % (2 * group_size) != 0
+        or hidden_size != weight.shape[-1]
+        or input.dtype not in (torch.bfloat16, torch.float16)
+        or not input.is_contiguous()
+    ):
+        d = input.shape[-1] // 2
+        activated = F.silu(input[..., :d]) * input[..., d:]
+        return _musa_deepgemm_fp8_op(
+            activated,
+            weight,
+            weight_scale,
+            group_size,
+            use_deep_gemm_e8m0,
+        )
+
+    q_input = torch.empty(
+        (input.shape[0], hidden_size),
+        dtype=current_platform.fp8_dtype(),
+        device=input.device,
+    )
+    input_scale = torch.empty(
+        (input.shape[0], hidden_size // group_size),
+        dtype=torch.float32,
+        device=input.device,
+    )
+    fp8_min, fp8_max = get_fp8_min_max()
+    torch.ops._C_musa_ops.silu_and_mul_per_token_group_fp8_quant(
+        input,
+        q_input,
+        input_scale,
+        group_size,
+        1e-10,
+        fp8_min,
+        fp8_max,
+    )
+
+    output = torch.empty(
+        (q_input.shape[0], weight.shape[0]),
+        dtype=torch.bfloat16,
+        device=q_input.device,
+    )
+    fp8_gemm_nt(
+        (q_input, input_scale),
+        (weight, weight_scale),
+        output,
+        is_deep_gemm_e8m0_used=use_deep_gemm_e8m0,
+    )
+    return output
+
+
 def _musa_fp8_small_m_gemv_op(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -264,6 +339,21 @@ def _musa_deepgemm_fp8_op_fake(
     )
 
 
+def _musa_silu_deepgemm_fp8_op_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    use_deep_gemm_e8m0: bool,
+) -> torch.Tensor:
+    del weight_scale, group_size, use_deep_gemm_e8m0
+    return torch.empty(
+        (input.shape[0], weight.shape[0]),
+        dtype=torch.bfloat16,
+        device=input.device,
+    )
+
+
 direct_register_custom_op(
     "musa_fp8_small_m_gemv_op",
     _musa_fp8_small_m_gemv_op,
@@ -274,4 +364,10 @@ direct_register_custom_op(
     "musa_deepgemm_fp8_op",
     _musa_deepgemm_fp8_op,
     fake_impl=_musa_deepgemm_fp8_op_fake,
+)
+
+direct_register_custom_op(
+    "musa_silu_deepgemm_fp8_op",
+    _musa_silu_deepgemm_fp8_op,
+    fake_impl=_musa_silu_deepgemm_fp8_op_fake,
 )

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 from typing import ClassVar
 
 import torch
@@ -32,6 +33,11 @@ def _use_row_major_activation_scales(use_deep_gemm_e8m0: bool) -> bool:
         return False
     value = os.getenv("VLLM_MUSA_DEEPGEMM_ROW_MAJOR_ACT_SCALES", "1").lower()
     return value not in ("0", "false", "no", "off")
+
+
+@lru_cache(maxsize=1)
+def _supports_silu_group_quant_kernel() -> bool:
+    return current_platform.is_musa() and current_platform.is_device_capability((3, 1))
 
 
 def _read_int_env(name: str, default: int) -> int:
@@ -233,7 +239,8 @@ def _musa_silu_deepgemm_fp8_op(
     """
     hidden_size = input.shape[-1] // 2 if input.dim() == 2 else 0
     if (
-        group_size != 128
+        not _supports_silu_group_quant_kernel()
+        or group_size != 128
         or use_deep_gemm_e8m0
         or not _use_row_major_activation_scales(use_deep_gemm_e8m0)
         or input.dim() != 2

--- a/vllm_musa/patches/manifest.py
+++ b/vllm_musa/patches/manifest.py
@@ -221,6 +221,18 @@ _CAT6: list[DivSpec] = [
 # `musa_sync census` (difflib needs an upstream clone, so this is frozen data).
 _SHADOW_MODULES = [
     (
+        "5",
+        "vllm_musa/compilation/passes/pass_manager.py",
+        "vllm/compilation/passes/pass_manager.py",
+        "OOT post-grad pass manager with MUSA-only fusion registration",
+    ),
+    (
+        "5",
+        "vllm_musa/compilation/passes/silu_deepgemm_fusion.py",
+        "vllm/compilation/passes/fusion/act_quant_fusion.py",
+        "MUSA dense SwiGLU plus FP8 DeepGEMM fusion pattern",
+    ),
+    (
         "4a",
         "vllm_musa/v1/attention/backends/flash_attn.py",
         "vllm/v1/attention/backends/flash_attn.py",

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -157,6 +157,48 @@ def _has_routed_experts(model_config: Any | None) -> bool:
     )
 
 
+def _is_validated_qwen3_8b_fp8_single_gpu(vllm_config: Any) -> bool:
+    """Return whether the exact MUSA-0759 serving scope is selected."""
+    model_config = getattr(vllm_config, "model_config", None)
+    if model_config is None or _has_routed_experts(model_config):
+        return False
+
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    if hf_text_config is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        hf_text_config = getattr(hf_config, "text_config", hf_config)
+    architectures = getattr(model_config, "architectures", None)
+    if architectures is None:
+        architectures = getattr(hf_text_config, "architectures", None)
+
+    quantization = getattr(model_config, "quantization", None)
+    if quantization is None:
+        quantization_config = getattr(hf_text_config, "quantization_config", {})
+        if isinstance(quantization_config, dict):
+            quantization = quantization_config.get("quant_method")
+
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    single_gpu = all(
+        getattr(parallel_config, name, 1) == 1
+        for name in (
+            "tensor_parallel_size",
+            "pipeline_parallel_size",
+            "data_parallel_size",
+        )
+    )
+    return (
+        tuple(architectures or ()) == ("Qwen3ForCausalLM",)
+        and getattr(hf_text_config, "model_type", None) == "qwen3"
+        and getattr(hf_text_config, "hidden_size", None) == 4096
+        and getattr(hf_text_config, "intermediate_size", None) == 12288
+        and getattr(hf_text_config, "num_hidden_layers", None) == 36
+        and quantization == "fp8"
+        and getattr(model_config, "dtype", None) == torch.bfloat16
+        and single_gpu
+        and getattr(vllm_config, "speculative_config", None) is None
+    )
+
+
 def _deepseek_v4_flashmla_sparse_block_size(model_config: Any | None) -> int:
     value = os.getenv(_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_ENV)
     if value is None or not _is_deepseek_v4_model(model_config):
@@ -654,6 +696,17 @@ class MUSAPlatformBase(Platform):
                 "(Inductor-fused) path: the custom-op kernels corrupt FP8 output "
                 "under piecewise CUDAGraph capture. Set "
                 "VLLM_MUSA_CUSTOM_OP_USE_NATIVE=0 to force the kernels."
+            )
+
+        auto_silu_deepgemm = cls.is_device_capability(
+            (3, 1)
+        ) and _is_validated_qwen3_8b_fp8_single_gpu(vllm_config)
+        if auto_silu_deepgemm and not musa_envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION.is_set():
+            musa_envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION.set(True)
+            logger.info(
+                "Auto-enabling the validated S5000 Qwen3-8B-FP8 "
+                "SwiGLU+DeepGEMM fusion. Set "
+                "VLLM_MUSA_SILU_DEEPGEMM_FUSION=0 to disable it."
             )
 
         parallel_config = vllm_config.parallel_config

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -158,7 +158,7 @@ def _has_routed_experts(model_config: Any | None) -> bool:
 
 
 def _is_validated_qwen3_8b_fp8_single_gpu(vllm_config: Any) -> bool:
-    """Return whether the exact MUSA-0759 serving scope is selected."""
+    """Return whether the validated Qwen3-8B FP8 single-GPU scope is selected."""
     model_config = getattr(vllm_config, "model_config", None)
     if model_config is None or _has_routed_experts(model_config):
         return False

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -698,17 +698,6 @@ class MUSAPlatformBase(Platform):
                 "VLLM_MUSA_CUSTOM_OP_USE_NATIVE=0 to force the kernels."
             )
 
-        auto_silu_deepgemm = cls.is_device_capability(
-            (3, 1)
-        ) and _is_validated_qwen3_8b_fp8_single_gpu(vllm_config)
-        if auto_silu_deepgemm and not musa_envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION.is_set():
-            musa_envs.VLLM_MUSA_SILU_DEEPGEMM_FUSION.set(True)
-            logger.info(
-                "Auto-enabling the validated S5000 Qwen3-8B-FP8 "
-                "SwiGLU+DeepGEMM fusion. Set "
-                "VLLM_MUSA_SILU_DEEPGEMM_FUSION=0 to disable it."
-            )
-
         parallel_config = vllm_config.parallel_config
         model_config = vllm_config.model_config
 

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -378,6 +378,10 @@ class MUSAPlatformBase(Platform):
         "RAY_EXPERIMENTAL_NOSET_MUSA_VISIBLE_DEVICES",
     ]
 
+    @classmethod
+    def get_pass_manager_cls(cls) -> str:
+        return "vllm_musa.compilation.passes.MusaPostGradPassManager"
+
     @property
     def supported_dtypes(self) -> list[torch.dtype]:
         # MUSA GPUs support BF16 and FP16

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -88,7 +88,6 @@ class EnvBool(EnvField):
 
 class Envs:
     VLLM_MUSA_CUSTOM_OP_USE_NATIVE = EnvBool(False)
-    VLLM_MUSA_SILU_DEEPGEMM_FUSION = EnvBool(False)
     VLLM_MUSA_FUSED_ADD_RMSNORM = EnvBool(True)
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SAMPLER_FAST_PATH = EnvBool(True)

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -88,6 +88,7 @@ class EnvBool(EnvField):
 
 class Envs:
     VLLM_MUSA_CUSTOM_OP_USE_NATIVE = EnvBool(False)
+    VLLM_MUSA_SILU_DEEPGEMM_FUSION = EnvBool(False)
     VLLM_MUSA_FUSED_ADD_RMSNORM = EnvBool(True)
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SAMPLER_FAST_PATH = EnvBool(True)


### PR DESCRIPTION
## Summary

This is the first PR in a four-PR MUSA kernel stack:

1. **MUSA-0759 (this PR):** fuse SiLU and row-major group-128 FP8 activation quantization before MATE DeepGEMM.
2. MUSA-0760: fuse residual-add RMSNorm and row-major group-128 FP8 activation quantization.
3. MUSA-0763: add guarded chunked min-p sampling.
4. MUSA-0765: add guarded uniform top-k=50 renormalization.

Review/merge order: [#109](https://github.com/MooreThreads/vllm-musa/pull/109) -> [#110](https://github.com/MooreThreads/vllm-musa/pull/110) -> [#111](https://github.com/MooreThreads/vllm-musa/pull/111) -> [#112](https://github.com/MooreThreads/vllm-musa/pull/112).

The compiler pass is selected automatically for the validated Qwen3-8B-FP8,
single-S5000 contract. Unsupported model, parallelism, shape, dtype, device,
or quantization contracts keep the existing path. No campaign- or
fusion-specific environment control is introduced or read to select this
path; guarded automatic dispatch is the selection mechanism.

Exact source:

- base: `v0.24.0-dev` at `68b5ef7a7eac9959dd71f600f7df2ebd756de1f8`
- head: `7d6dd02c4b6a45e00d0131fd42b885030d7891c2`
- head ref: `xd/musa-0759-silu-deepgemm`
- pinned vLLM: `ee0da84ab9e04ac7610e28580af62c365e898389`

## Validation

### Historical per-ticket performance evidence

The figures below are retained from the earlier MUSA-0759-only serving
campaign. They predate the current environment-independent and logical-device
follow-ups, so they are directional historical evidence, not a result from the
current exact head and not the final combined four-PR A/B. The run used
Qwen3-8B-FP8, TP1, S5000, normal Inductor,
`FULL_AND_PIECEWISE` graph capture, greedy decoding, no MTP/speculative
decoding, and separate candidate/native-control source trees. `openai-chat`
adds eight Qwen template tokens, so `--random-input-len 4096` measures 4104
input tokens; every request generated exactly 1024 output tokens.

| concurrency | mean TTFT change | mean TPOT reduction |
|---:|---:|---:|
| 1 | +1.89% | +0.38% |
| 4 | -4.49% | +0.80% |
| 16 | +2.39% | +0.77% |
| 64 | +0.84% | +0.32% |

TPOT improved in all four historical cells. TTFT was noisy, especially at
concurrency 4, and is not presented as a general win.

### Superseded descendant-stack evidence

The former descendant head `f53cf6cbbd7f4d85e82270a86db1938c713d948a`
passed dense, MoE, and MLA functional serving checks. That SHA is no longer the
final stack, and the same host-81 campaign had a foreign ExecBench workload,
so its combined latency rows are rejected and none of this evidence is used as
an exact-head readiness claim.

### Exact-final MUSA-0767 gate

<!-- MUSA0767_FINAL_EVIDENCE_START -->

Status: **EXACT-HEAD FUNCTIONAL REGRESSION COMPLETE; PERFORMANCE GATES
PENDING -- keep this PR in draft.**

- final stacked head: `95c3661c8658a861a1891f981c81dcadabea0654`
- final source tree: `a766855ed712d61f81acb6b11d456ea5a128cac5`
- source archive SHA-256:
  `03dbe0526f72d4dcba6b743c500d4d5eaaf9676e263f9bd91cbfd265db140feb`
- source manifest SHA-256:
  `3ab55a222ea7fc8324c611bda9d3d842bc94850bbc7ccf4d869d0692132768a7`
- exact environment and build: 8x MTT S5000, driver `3.3.5-server`,
  MUSA runtime `50200`, `torch==2.9.1.post1`,
  `torch_musa==2.9.1.post1+4c646b6`, `torchada==0.1.75`,
  MATE/FlashAttention3 `0.2.4`, candidate extension SHA-256
  `d0baaa8ba11981438a549115d50e89c10ec566dfac1ba27c0ccdc8364c5c2bd7`
- focused native correctness and graph-capture tests: **60 passed in 44.72s**
- non-identity logical-device sampling smoke: **PASS** with
  `MUSA_VISIBLE_DEVICES=4,5`; physical devices 4 and 5 were exposed as
  logical devices 0 and 1, and the smoke selected both optimized samplers on
  logical device 0
- compiled/captured Qwen dense, Qwen MoE, and DeepSeek MLA regression:
  **PASS, 3/3 rows and 10/10 semantic requests** (Qwen3-8B-FP8 TP1
  FLASH_ATTN, Qwen3.5-35B-A3B-FP8 TP4 FLASH_ATTN, and
  DeepSeek-V2-Lite-Chat-FP8 TP1 FLASHMLA; Inductor,
  FULL_AND_PIECEWISE, MTP off)
- clean-node combined Qwen3-8B-FP8 candidate/control result at exact
  4104/1024 and concurrency 1/4/16/64, without MTP:
  `PENDING -- not present in this regression-only bundle`
  - the first control-only attempt is rejected because default prefix caching
    plus repeated deterministic prompts invalidated cold-prefill TTFT; every
    A/B leg will restart with prefix caching disabled
- Qwen3.5-2B and Qwen3.6-27B exact-token widening A/B evidence:
  `PENDING -- not present in this regression-only bundle`
- regression evidence bundle SHA-256:
  `ea1b38559be0458343b85f3cd6bba275d320d2b1c729071f455e2dccb04c5272`;
  its focused monitor verdict was **FAIL** because foreign ExecBench GPU work
  was present, so the clean performance-monitor gate remains `PENDING`

<!-- MUSA0767_FINAL_EVIDENCE_END -->

## Remaining gate

The exact-head functional regression is complete. This PR remains draft until
the combined and widening A/B plus clean performance-monitor gates are
complete and accepted. The stacked PRs must be reviewed and merged in order.
