### PR TITLE
perf: fuse residual RMSNorm and FP8 group quant

### DIFF
--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -50,6 +50,11 @@ void silu_and_mul_per_token_group_fp8_quant(
     int64_t group_size, double eps, double fp8_min,
     double fp8_max);
 
+void fused_add_rms_norm_per_token_group_fp8_quant(
+    const torch::Tensor& input, const torch::Tensor& residual,
+    const torch::Tensor& weight, torch::Tensor& residual_out,
+    torch::Tensor& output_q, torch::Tensor& output_scale, double epsilon);
+
 void per_token_group_quant_8bit_vec(
     const torch::Tensor& input,
     torch::Tensor& output_q, torch::Tensor& output_s,

--- a/csrc/musa/quantization/fused_add_rms_norm_per_token_group_fp8_quant.cu
+++ b/csrc/musa/quantization/fused_add_rms_norm_per_token_group_fp8_quant.cu
@@ -1,0 +1,275 @@
+#include <ATen/cuda/CUDAContext.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cuda_fp8.h>
+#include <torch/all.h>
+
+#include "torch_musa/csrc/core/MUSAGuard.h"
+
+namespace {
+
+constexpr int kHidden = 4096;
+constexpr int kHalfHidden = kHidden / 2;
+constexpr int kGroupSize = 128;
+constexpr int kThreads = 512;
+constexpr int kValuesPerHalf = 4;
+constexpr float kQuantEpsilon = 1.0e-10f;
+constexpr float kFp8Max = 448.0f;
+constexpr float kFp8Min = -448.0f;
+
+template <int BLOCK_SIZE>
+__device__ __forceinline__ float BlockReduceSum(float value) {
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_xor_sync(0xffffffff, value, offset);
+  }
+  if constexpr (BLOCK_SIZE <= 32) {
+    return value;
+  }
+
+  __shared__ float warp_sums[BLOCK_SIZE / 32];
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  if (lane == 0) {
+    warp_sums[warp] = value;
+  }
+  __syncthreads();
+
+  value = threadIdx.x < BLOCK_SIZE / 32 ? warp_sums[threadIdx.x] : 0.0f;
+  if (warp == 0) {
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      value += __shfl_xor_sync(0xffffffff, value, offset);
+    }
+    if (lane == 0) {
+      warp_sums[0] = value;
+    }
+  }
+  __syncthreads();
+  return warp_sums[0];
+}
+
+__device__ __forceinline__ float WarpReduceMax(float value) {
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value = fmaxf(value, __shfl_xor_sync(0xffffffff, value, offset));
+  }
+  return value;
+}
+
+template <typename T>
+__global__ void __launch_bounds__(kThreads, 1)
+    fused_add_rms_norm_per_token_group_fp8_quant_kernel(
+        const T* __restrict__ input, const T* __restrict__ residual,
+        const T* __restrict__ weight, T* __restrict__ residual_out,
+        __nv_fp8_e4m3* __restrict__ output_q,
+        float* __restrict__ output_scale, float epsilon) {
+  static_assert(sizeof(T) == 2, "the fused kernel expects a 2-byte input");
+  static_assert(kThreads * kValuesPerHalf == kHalfHidden,
+                "one block must cover each half-row exactly once");
+
+  const int row = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int first_offset = row * kHidden + tid * kValuesPerHalf;
+  const int second_offset = first_offset + kHalfHidden;
+
+  alignas(8) T input_first[kValuesPerHalf];
+  alignas(8) T input_second[kValuesPerHalf];
+  alignas(8) T residual_first[kValuesPerHalf];
+  alignas(8) T residual_second[kValuesPerHalf];
+  *reinterpret_cast<uint2*>(input_first) =
+      *reinterpret_cast<const uint2*>(input + first_offset);
+  *reinterpret_cast<uint2*>(input_second) =
+      *reinterpret_cast<const uint2*>(input + second_offset);
+  *reinterpret_cast<uint2*>(residual_first) =
+      *reinterpret_cast<const uint2*>(residual + first_offset);
+  *reinterpret_cast<uint2*>(residual_second) =
+      *reinterpret_cast<const uint2*>(residual + second_offset);
+
+  float sums_first[kValuesPerHalf];
+  float sums_second[kValuesPerHalf];
+  float square_pairs[kValuesPerHalf];
+  alignas(8) T rounded_first[kValuesPerHalf];
+  alignas(8) T rounded_second[kValuesPerHalf];
+#pragma unroll
+  for (int index = 0; index < kValuesPerHalf; ++index) {
+    const float first = static_cast<float>(input_first[index]) +
+                        static_cast<float>(residual_first[index]);
+    const float second = static_cast<float>(input_second[index]) +
+                         static_cast<float>(residual_second[index]);
+    sums_first[index] = first;
+    sums_second[index] = second;
+    rounded_first[index] = static_cast<T>(first);
+    rounded_second[index] = static_cast<T>(second);
+    // Match the current Inductor R0_BLOCK=2048 loop: corresponding squares
+    // from the two half-rows are accumulated before the 2048-element reduce.
+    square_pairs[index] = first * first + second * second;
+  }
+  *reinterpret_cast<uint2*>(residual_out + first_offset) =
+      *reinterpret_cast<uint2*>(rounded_first);
+  *reinterpret_cast<uint2*>(residual_out + second_offset) =
+      *reinterpret_cast<uint2*>(rounded_second);
+
+  // Match the generated sizePerThread=4 reduction order.
+  float local_square_sum = square_pairs[0] + square_pairs[1];
+  local_square_sum = square_pairs[2] + local_square_sum;
+  local_square_sum = square_pairs[3] + local_square_sum;
+
+  const float total_square_sum = BlockReduceSum<kThreads>(local_square_sum);
+  const float inv_rms = rsqrtf(total_square_sum * (1.0f / 4096.0f) + epsilon);
+
+  alignas(8) T weight_first[kValuesPerHalf];
+  alignas(8) T weight_second[kValuesPerHalf];
+  *reinterpret_cast<uint2*>(weight_first) =
+      *reinterpret_cast<const uint2*>(weight + tid * kValuesPerHalf);
+  *reinterpret_cast<uint2*>(weight_second) =
+      *reinterpret_cast<const uint2*>(weight + kHalfHidden +
+                                     tid * kValuesPerHalf);
+
+  alignas(8) T weighted_first[kValuesPerHalf];
+  alignas(8) T weighted_second[kValuesPerHalf];
+  float first_absmax = kQuantEpsilon;
+  float second_absmax = kQuantEpsilon;
+#pragma unroll
+  for (int index = 0; index < kValuesPerHalf; ++index) {
+    // The pinned MUSA Inductor lowering folds the nominal intermediate cast
+    // through the gain multiply. Keep normalized values in FP32 and round
+    // only the weighted result, matching the compiled serving graph.
+    const float first_normalized = sums_first[index] * inv_rms;
+    const float second_normalized = sums_second[index] * inv_rms;
+    weighted_first[index] = static_cast<T>(
+        first_normalized * static_cast<float>(weight_first[index]));
+    weighted_second[index] = static_cast<T>(
+        second_normalized * static_cast<float>(weight_second[index]));
+    first_absmax = fmaxf(
+        first_absmax, fabsf(static_cast<float>(weighted_first[index])));
+    second_absmax = fmaxf(
+        second_absmax, fabsf(static_cast<float>(weighted_second[index])));
+  }
+
+  const float first_group_absmax = WarpReduceMax(first_absmax);
+  const float second_group_absmax = WarpReduceMax(second_absmax);
+  const float first_scale = first_group_absmax / kFp8Max;
+  const float second_scale = second_group_absmax / kFp8Max;
+  const int lane = tid & 31;
+  const int first_group = tid >> 5;
+  const int second_group = first_group + kHalfHidden / kGroupSize;
+  if (lane == 0) {
+    output_scale[row * (kHidden / kGroupSize) + first_group] = first_scale;
+    output_scale[row * (kHidden / kGroupSize) + second_group] = second_scale;
+  }
+
+  union {
+    uint8_t bytes[kValuesPerHalf];
+    uint32_t packed;
+  } quantized_first, quantized_second;
+#pragma unroll
+  for (int index = 0; index < kValuesPerHalf; ++index) {
+    const float first_value = static_cast<float>(weighted_first[index]);
+    const float second_value = static_cast<float>(weighted_second[index]);
+    const float first_clamped =
+        fminf(fmaxf(first_value / first_scale, kFp8Min), kFp8Max);
+    const float second_clamped =
+        fminf(fmaxf(second_value / second_scale, kFp8Min), kFp8Max);
+    const __nv_fp8_e4m3 first_fp8 = __nv_fp8_e4m3(first_clamped);
+    const __nv_fp8_e4m3 second_fp8 = __nv_fp8_e4m3(second_clamped);
+    quantized_first.bytes[index] =
+        *reinterpret_cast<const uint8_t*>(&first_fp8);
+    quantized_second.bytes[index] =
+        *reinterpret_cast<const uint8_t*>(&second_fp8);
+  }
+  *reinterpret_cast<uint32_t*>(output_q + first_offset) =
+      quantized_first.packed;
+  *reinterpret_cast<uint32_t*>(output_q + second_offset) =
+      quantized_second.packed;
+}
+
+inline bool IsAligned16(const void* pointer) {
+  return reinterpret_cast<uintptr_t>(pointer) % 16 == 0;
+}
+
+struct TensorRange {
+  uintptr_t begin;
+  uintptr_t end;
+};
+
+TensorRange GetTensorRange(const torch::Tensor& tensor) {
+  const auto begin = reinterpret_cast<uintptr_t>(tensor.data_ptr());
+  return {begin, begin + tensor.nbytes()};
+}
+
+bool RangesOverlap(const TensorRange& left, const TensorRange& right) {
+  return left.begin < right.end && right.begin < left.end;
+}
+
+}  // namespace
+
+void fused_add_rms_norm_per_token_group_fp8_quant(
+    const torch::Tensor& input, const torch::Tensor& residual,
+    const torch::Tensor& weight, torch::Tensor& residual_out,
+    torch::Tensor& output_q, torch::Tensor& output_scale, double epsilon) {
+  TORCH_CHECK(input.is_contiguous() && residual.is_contiguous() &&
+                  weight.is_contiguous() && residual_out.is_contiguous() &&
+                  output_q.is_contiguous() && output_scale.is_contiguous(),
+              "fused RMSNorm quant requires contiguous tensors");
+  TORCH_CHECK(input.device() == residual.device() &&
+                  input.device() == weight.device() &&
+                  input.device() == residual_out.device() &&
+                  input.device() == output_q.device() &&
+                  input.device() == output_scale.device(),
+              "all fused RMSNorm quant tensors must share one device");
+  TORCH_CHECK(input.dim() == 2 && input.size(1) == kHidden,
+              "fused RMSNorm quant requires input shape [M, 4096]");
+  TORCH_CHECK(residual.sizes() == input.sizes(),
+              "residual shape must equal input shape");
+  TORCH_CHECK(residual_out.sizes() == input.sizes(),
+              "residual_out shape must equal input shape");
+  TORCH_CHECK(weight.dim() == 1 && weight.numel() == kHidden,
+              "weight shape must be [4096]");
+  TORCH_CHECK(output_q.sizes() == input.sizes(),
+              "output_q shape must equal input shape");
+  TORCH_CHECK(output_scale.dim() == 2 &&
+                  output_scale.size(0) == input.size(0) &&
+                  output_scale.size(1) == kHidden / kGroupSize,
+              "output_scale shape must be [M, 32]");
+  TORCH_CHECK(input.scalar_type() == at::ScalarType::BFloat16,
+              "fused RMSNorm quant initially supports BF16 only");
+  TORCH_CHECK(residual.scalar_type() == input.scalar_type() &&
+                  weight.scalar_type() == input.scalar_type() &&
+                  residual_out.scalar_type() == input.scalar_type(),
+              "input, residual, weight, and residual_out dtypes must match");
+  TORCH_CHECK(output_q.scalar_type() == at::ScalarType::Float8_e4m3fn,
+              "output_q must be float8_e4m3fn");
+  TORCH_CHECK(output_scale.scalar_type() == at::ScalarType::Float,
+              "output_scale must be float32");
+  TORCH_CHECK(IsAligned16(input.data_ptr()) &&
+                  IsAligned16(residual.data_ptr()) &&
+                  IsAligned16(weight.data_ptr()) &&
+                  IsAligned16(residual_out.data_ptr()) &&
+                  IsAligned16(output_q.data_ptr()) &&
+                  IsAligned16(output_scale.data_ptr()),
+              "fused RMSNorm quant requires 16-byte aligned tensor bases");
+
+  const torch::Tensor tensors[] = {input, residual, weight, residual_out,
+                                   output_q, output_scale};
+  for (int left = 0; left < 6; ++left) {
+    for (int right = left + 1; right < 6; ++right) {
+      TORCH_CHECK(!RangesOverlap(GetTensorRange(tensors[left]),
+                                 GetTensorRange(tensors[right])),
+                  "fused RMSNorm quant does not support overlapping tensors");
+    }
+  }
+
+  if (input.size(0) == 0) {
+    return;
+  }
+  const c10::musa::OptionalMUSAGuard guard(device_of(input));
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  fused_add_rms_norm_per_token_group_fp8_quant_kernel<c10::BFloat16>
+      <<<input.size(0), kThreads, 0, stream>>>(
+          static_cast<const c10::BFloat16*>(input.data_ptr()),
+          static_cast<const c10::BFloat16*>(residual.data_ptr()),
+          static_cast<const c10::BFloat16*>(weight.data_ptr()),
+          static_cast<c10::BFloat16*>(residual_out.data_ptr()),
+          static_cast<__nv_fp8_e4m3*>(output_q.data_ptr()),
+          static_cast<float*>(output_scale.data_ptr()),
+          static_cast<float>(epsilon));
+}

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -42,6 +42,13 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
                 &silu_and_mul_per_token_group_fp8_quant);
 
   musa_ops.def(
+      "fused_add_rms_norm_per_token_group_fp8_quant(Tensor input, "
+      "Tensor residual, Tensor weight, Tensor! residual_out, "
+      "Tensor! output_q, Tensor! output_scale, float epsilon) -> ()");
+  musa_ops.impl("fused_add_rms_norm_per_token_group_fp8_quant", torch::kMUSA,
+                &fused_add_rms_norm_per_token_group_fp8_quant);
+
+  musa_ops.def(
       "per_token_group_quant_8bit_vec(Tensor input, Tensor! output_q, "
       "Tensor! output_s, int group_size, float eps, float min_8bit, "
       "float max_8bit) -> ()");

--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,7 @@ VLLM_MUSA_CSRC_SOURCES = [
     "csrc/musa/mhc/deepseek_v4_mhc_pre.mu",
     "csrc/musa/moe/deepseek_v4_topk_softplus_sqrt.mu",
     "csrc/musa/quantization/silu_and_mul_per_token_group_fp8_quant.cu",
+    "csrc/musa/quantization/fused_add_rms_norm_per_token_group_fp8_quant.cu",
     "csrc/musa/quantization/per_token_group_quant_8bit_vec.cu",
     "csrc/musa/sampler.mu",
     str(_FLASHINFER_REPO.source_dir / "csrc/norm.cu"),

--- a/tests/test_musa_sync.py
+++ b/tests/test_musa_sync.py
@@ -58,9 +58,9 @@ def test_report(ms, capsys):
     rc = ms.main(["report"])
     out = capsys.readouterr().out
     assert rc == 0
-    assert "118 divergences" in out
+    assert "119 divergences" in out
     assert "'1': 61" in out and "'2': 19" in out and "'3': 1" in out
-    assert "'4a': 2" in out and "'5': 27" in out and "'6': 8" in out
+    assert "'4a': 2" in out and "'5': 28" in out and "'6': 8" in out
 
 
 def test_report_doc(ms, capsys):

--- a/tests/test_rms_deepgemm_fusion.py
+++ b/tests/test_rms_deepgemm_fusion.py
@@ -24,12 +24,10 @@ def _musa_device() -> Iterator[None]:
         pytest.skip("MUSA device is not available")
     torch.musa.set_device(0)
 
-    from vllm.platforms import current_platform
-
     import vllm_musa
     from vllm_musa.model_executor.kernels.linear.scaled_mm import deep_gemm
 
-    if not current_platform.is_device_capability((3, 1)):
+    if tuple(torch.musa.get_device_capability(0)) != (3, 1):
         pytest.skip("the fused RMSNorm group-quant kernel requires S5000/mp31")
     vllm_musa.register_custom_ops()
     assert deep_gemm is not None

--- a/tests/test_rms_deepgemm_fusion.py
+++ b/tests/test_rms_deepgemm_fusion.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""S5000 validation for residual RMSNorm plus FP8 DeepGEMM fusion."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from copy import deepcopy
+
+import pytest
+
+pytest.importorskip("torchada")
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_musa")
+
+HIDDEN = 4096
+GROUP_SIZE = 128
+EPSILON = 1e-6
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _musa_device() -> Iterator[None]:
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+    torch.musa.set_device(0)
+
+    from vllm.platforms import current_platform
+
+    import vllm_musa
+    from vllm_musa.model_executor.kernels.linear.scaled_mm import deep_gemm
+
+    if not current_platform.is_device_capability((3, 1)):
+        pytest.skip("the fused RMSNorm group-quant kernel requires S5000/mp31")
+    vllm_musa.register_custom_ops()
+    assert deep_gemm is not None
+    yield
+
+
+def _inputs(m: int = 4, n: int = 128):
+    torch.manual_seed(760400 + m + n)
+    x = torch.randn((m, HIDDEN), device="musa", dtype=torch.bfloat16)
+    residual = torch.randn_like(x)
+    norm_weight = torch.randn(HIDDEN, device="musa", dtype=torch.bfloat16)
+    weight = torch.randn((n, HIDDEN), device="musa", dtype=torch.bfloat16).to(
+        torch.float8_e4m3fn
+    )
+    weight_scale = torch.full(
+        (n // GROUP_SIZE, HIDDEN // GROUP_SIZE),
+        0.02,
+        device="musa",
+        dtype=torch.float32,
+    )
+    return x, residual, norm_weight, weight, weight_scale
+
+
+def _reference_quant(x, residual, norm_weight):
+    summed = x.float() + residual.float()
+    residual_out = summed.to(torch.bfloat16)
+    inv_rms = torch.rsqrt(summed.square().mean(dim=-1, keepdim=True) + EPSILON)
+    # This is the exact captured-Inductor lowering, not eager IR execution.
+    normalized = (summed * inv_rms * norm_weight.float()).to(x.dtype)
+    q = torch.empty_like(normalized, dtype=torch.float8_e4m3fn)
+    scale = torch.empty(
+        (x.shape[0], HIDDEN // GROUP_SIZE), device="musa", dtype=torch.float32
+    )
+    torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+        normalized, q, scale, GROUP_SIZE, 1e-10, -448.0, 448.0
+    )
+    return q, scale, residual_out
+
+
+@pytest.mark.parametrize("m", [1, 4, 16])
+def test_native_fused_quant_is_bit_exact(m: int) -> None:
+    x, residual, norm_weight, _, _ = _inputs(m=m)
+    reference_q, reference_scale, reference_residual = _reference_quant(
+        x, residual, norm_weight
+    )
+    actual_q = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    actual_scale = torch.empty_like(reference_scale)
+    actual_residual = torch.empty_like(x)
+
+    torch.ops._C_musa_ops.fused_add_rms_norm_per_token_group_fp8_quant(
+        x,
+        residual,
+        norm_weight,
+        actual_residual,
+        actual_q,
+        actual_scale,
+        EPSILON,
+    )
+    torch.musa.synchronize()
+
+    assert torch.equal(
+        reference_q.view(torch.uint8).cpu(), actual_q.view(torch.uint8).cpu()
+    )
+    assert torch.equal(
+        reference_scale.view(torch.int32).cpu(), actual_scale.view(torch.int32).cpu()
+    )
+    assert torch.equal(
+        reference_residual.view(torch.uint16).cpu(),
+        actual_residual.view(torch.uint16).cpu(),
+    )
+
+
+def test_custom_op_schema_fake_and_aot_dynamic() -> None:
+    x, residual, norm_weight, weight, weight_scale = _inputs()
+    op = torch.ops.vllm.musa_fused_add_rms_deepgemm_fp8_op.default
+
+    schema = str(op._schema)
+    assert "!" not in schema
+    assert schema.endswith("-> (Tensor, Tensor)")
+    output, residual_out = op(
+        x, residual, norm_weight, weight, weight_scale, GROUP_SIZE, False, EPSILON
+    )
+    assert output.shape == (x.shape[0], weight.shape[0])
+    assert output.dtype == torch.bfloat16
+    assert residual_out.shape == x.shape
+    assert residual_out.dtype == torch.bfloat16
+    assert output.untyped_storage().data_ptr() not in {
+        tensor.untyped_storage().data_ptr()
+        for tensor in (x, residual, norm_weight, weight, weight_scale)
+    }
+    assert residual_out.untyped_storage().data_ptr() not in {
+        tensor.untyped_storage().data_ptr()
+        for tensor in (x, residual, norm_weight, weight, weight_scale)
+    }
+
+    torch.library.opcheck(
+        op,
+        (
+            x,
+            residual,
+            norm_weight,
+            weight,
+            weight_scale,
+            GROUP_SIZE,
+            False,
+            EPSILON,
+        ),
+        test_utils=("test_faketensor", "test_aot_dispatch_dynamic"),
+    )
+
+
+def test_default_auto_scope_is_evaluated_per_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_musa.compilation.passes.pass_manager import (
+        _rms_deepgemm_fusion_requested,
+    )
+
+    validated = object()
+    other = object()
+    monkeypatch.setattr(
+        "vllm_musa.platform._is_validated_qwen3_8b_fp8_single_gpu",
+        lambda config: config is validated,
+    )
+
+    assert _rms_deepgemm_fusion_requested(validated)
+    assert not _rms_deepgemm_fusion_requested(other)
+
+
+def test_rms_fusion_has_no_kernel_environment_control() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    pass_manager = (
+        root / "vllm_musa" / "compilation" / "passes" / "pass_manager.py"
+    ).read_text()
+    environ = (root / "vllm_musa" / "utils" / "environ.py").read_text()
+
+    assert "VLLM_MUSA_RMS_DEEPGEMM_FUSION" not in pass_manager
+    assert "VLLM_MUSA_RMS_DEEPGEMM_FUSION" not in environ
+
+
+@pytest.mark.parametrize("misaligned_input", [False, True])
+def test_unsupported_inputs_preserve_ir_fallback(misaligned_input: bool) -> None:
+    hidden = 5120
+    n = 128
+    m = 4
+    torch.manual_seed(7605120 + int(misaligned_input))
+    if misaligned_input:
+        storage = torch.randn(m * hidden + 1, device="musa", dtype=torch.bfloat16)
+        x = storage[1:].view(m, hidden)
+        assert x.is_contiguous() and x.data_ptr() % 16 != 0
+    else:
+        x = torch.randn((m, hidden), device="musa", dtype=torch.bfloat16)
+    residual = torch.randn_like(x)
+    # Gemma/Qwen3.5 passes an effective FP32 gain (learned weight + 1).
+    norm_weight = torch.randn(hidden, device="musa", dtype=torch.float32)
+    weight = torch.randn((n, hidden), device="musa", dtype=torch.bfloat16).to(
+        torch.float8_e4m3fn
+    )
+    weight_scale = torch.full(
+        (n // GROUP_SIZE, hidden // GROUP_SIZE),
+        0.02,
+        device="musa",
+        dtype=torch.float32,
+    )
+
+    summed = x.float() + residual.float()
+    normalized = summed * torch.rsqrt(summed.square().mean(-1, keepdim=True) + EPSILON)
+    normalized = (normalized * norm_weight.float()).to(x.dtype)
+    expected_residual = summed.to(x.dtype)
+    expected_output = torch.ops.vllm.musa_deepgemm_fp8_op(
+        normalized, weight, weight_scale, GROUP_SIZE, False
+    )
+    actual_output, actual_residual = torch.ops.vllm.musa_fused_add_rms_deepgemm_fp8_op(
+        x,
+        residual,
+        norm_weight,
+        weight,
+        weight_scale,
+        GROUP_SIZE,
+        False,
+        EPSILON,
+    )
+    torch.musa.synchronize()
+
+    assert actual_output.dtype == x.dtype
+    assert actual_residual.dtype == x.dtype
+    assert torch.equal(
+        actual_output.view(torch.uint16).cpu(),
+        expected_output.view(torch.uint16).cpu(),
+    )
+    assert torch.equal(
+        actual_residual.view(torch.uint16).cpu(),
+        expected_residual.view(torch.uint16).cpu(),
+    )
+
+
+def test_rewrites_the_native_production_graph() -> None:
+    from torch._inductor.compile_fx import compile_fx
+    from vllm.config import (
+        CompilationConfig,
+        CompilationMode,
+        PassConfig,
+        VllmConfig,
+        set_current_vllm_config,
+    )
+
+    from vllm_musa.compilation.passes.rms_deepgemm_fusion import (
+        MusaRMSDeepGemmFusionPass,
+    )
+
+    x, residual, norm_weight, weight, weight_scale = _inputs()
+
+    def model(x, residual, norm_weight, weight, weight_scale):
+        normalized, residual_out = torch.ops.vllm_ir.fused_add_rms_norm(
+            x, residual, norm_weight, EPSILON, None
+        )
+        output = torch.ops.vllm.musa_deepgemm_fp8_op(
+            normalized, weight, weight_scale, GROUP_SIZE, False
+        )
+        return output, residual_out
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            backend="inductor",
+            custom_ops=["all"],
+            pass_config=PassConfig(fuse_act_quant=True, eliminate_noops=True),
+        )
+    )
+
+    class FusionBackend:
+        def __init__(self, fusion=None):
+            self.fusion = fusion
+            self.targets_before = set()
+            self.targets_after = set()
+            self.inductor_config = deepcopy(
+                config.compilation_config.inductor_compile_config
+            )
+            self.inductor_config["force_disable_caches"] = True
+            self.inductor_config["post_grad_custom_post_pass"] = self.post_pass
+
+        def post_pass(self, graph):
+            self.targets_before = {node.target for node in graph.nodes}
+            if self.fusion is not None:
+                self.fusion(graph)
+            self.targets_after = {node.target for node in graph.nodes}
+
+        def __call__(self, graph_module, example_inputs):
+            return compile_fx(
+                graph_module,
+                example_inputs,
+                config_patches=self.inductor_config,
+            )
+
+    with set_current_vllm_config(config, check_compile=False):
+        control_backend = FusionBackend()
+        compiled_control = torch.compile(model, backend=control_backend, fullgraph=True)
+        expected = compiled_control(x, residual, norm_weight, weight, weight_scale)
+
+        torch._dynamo.reset()
+        fusion = MusaRMSDeepGemmFusionPass(config)
+        backend = FusionBackend(fusion)
+        compiled = torch.compile(model, backend=backend, fullgraph=True)
+        actual = compiled(x, residual, norm_weight, weight, weight_scale)
+
+    control_op = torch.ops.vllm.musa_deepgemm_fp8_op.default
+    fused_op = torch.ops.vllm.musa_fused_add_rms_deepgemm_fp8_op.default
+    assert control_op in control_backend.targets_after
+    assert fused_op not in control_backend.targets_after
+    assert control_op in backend.targets_before
+    assert fused_op not in backend.targets_before
+    assert control_op not in backend.targets_after
+    assert fused_op in backend.targets_after
+    assert fusion.matched_count == 1
+
+    # DeepGEMM may choose a different but numerically equivalent launch when
+    # called behind the opaque fused op. The fused quantizer itself is checked
+    # bit-for-bit above; use the FP8 GEMM's bounded BF16 tolerance here.
+    torch.testing.assert_close(actual[0], expected[0], atol=0.125, rtol=0.1)
+    assert torch.equal(
+        actual[1].view(torch.uint16).cpu(), expected[1].view(torch.uint16).cpu()
+    )

--- a/tests/test_rms_deepgemm_fusion.py
+++ b/tests/test_rms_deepgemm_fusion.py
@@ -168,6 +168,7 @@ def test_rms_fusion_has_no_kernel_environment_control() -> None:
 
     assert "VLLM_MUSA_RMS_DEEPGEMM_FUSION" not in pass_manager
     assert "VLLM_MUSA_RMS_DEEPGEMM_FUSION" not in environ
+    assert "VLLM_MUSA_CUSTOM_OP_USE_NATIVE" not in pass_manager
 
 
 @pytest.mark.parametrize("misaligned_input", [False, True])

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -71,7 +71,7 @@ class MusaPostGradPassManager(PostGradPassManager):
             _rms_deepgemm_fusion_requested(config)
             and envs.VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()
             and _is_dense_model(config)
-            and current_platform.is_device_capability((3, 1))
+            and _has_validated_musa_device_capability()
             and _use_row_major_activation_scales(False)
             and self.pass_config.fuse_act_quant
         ):

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -11,6 +11,7 @@ from vllm_musa.model_executor.kernels.linear.scaled_mm.deep_gemm import (
 )
 from vllm_musa.utils.environ import envs
 
+from .rms_deepgemm_fusion import MusaRMSDeepGemmFusionPass
 from .silu_deepgemm_fusion import MusaSiluDeepGemmFusionPass
 
 logger = init_logger(__name__)
@@ -32,6 +33,12 @@ def _silu_deepgemm_fusion_requested(config: VllmConfig) -> bool:
     return _is_validated_qwen3_8b_fp8_single_gpu(config)
 
 
+def _rms_deepgemm_fusion_requested(config: VllmConfig) -> bool:
+    from vllm_musa.platform import _is_validated_qwen3_8b_fp8_single_gpu
+
+    return _is_validated_qwen3_8b_fp8_single_gpu(config)
+
+
 class MusaPostGradPassManager(PostGradPassManager):
     """Add MUSA-only graph fusions to vLLM's standard post-grad pipeline."""
 
@@ -48,3 +55,14 @@ class MusaPostGradPassManager(PostGradPassManager):
             with set_current_vllm_config(config, check_compile=False):
                 self.passes.append(MusaSiluDeepGemmFusionPass(config))
             logger.info("Enabled MUSA dense SwiGLU+DeepGEMM fusion pass")
+        if (
+            _rms_deepgemm_fusion_requested(config)
+            and envs.VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()
+            and _is_dense_model(config)
+            and current_platform.is_device_capability((3, 1))
+            and _use_row_major_activation_scales(False)
+            and self.pass_config.fuse_act_quant
+        ):
+            with set_current_vllm_config(config, check_compile=False):
+                self.passes.append(MusaRMSDeepGemmFusionPass(config))
+            logger.info("Enabled MUSA dense residual RMSNorm+DeepGEMM fusion pass")

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -67,7 +67,6 @@ class MusaPostGradPassManager(PostGradPassManager):
             logger.info("Enabled MUSA dense SwiGLU+DeepGEMM fusion pass")
         if (
             _rms_deepgemm_fusion_requested(config)
-            and envs.VLLM_MUSA_CUSTOM_OP_USE_NATIVE.get()
             and _is_dense_model(config)
             and _has_validated_musa_device_capability()
             and _use_row_major_activation_scales(False)

--- a/vllm_musa/compilation/passes/rms_deepgemm_fusion.py
+++ b/vllm_musa/compilation/passes/rms_deepgemm_fusion.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from torch import fx
+from vllm.compilation.passes.vllm_inductor_pass import (
+    VllmFusionPatternMatcherPass,
+    VllmPatternReplacement,
+)
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
+
+
+class MusaRMSDeepGemmPattern(VllmPatternReplacement):
+    """Fuse residual RMSNorm with the following opaque MUSA DeepGEMM call."""
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        device = current_platform.device_type
+        return [
+            torch.empty((5, 256), dtype=torch.bfloat16, device=device),
+            torch.empty((5, 256), dtype=torch.bfloat16, device=device),
+            torch.empty((256,), dtype=torch.bfloat16, device=device),
+            torch.empty((64, 256), dtype=current_platform.fp8_dtype(), device=device),
+            torch.empty((2, 2), dtype=torch.float32, device=device),
+        ]
+
+    @property
+    def pattern(self):
+        def _pattern(
+            input: torch.Tensor,
+            residual: torch.Tensor,
+            norm_weight: torch.Tensor,
+            weight: torch.Tensor,
+            weight_scale: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            normalized, residual_out = torch.ops.vllm_ir.fused_add_rms_norm(
+                input, residual, norm_weight, 1e-6, None
+            )
+            output = torch.ops.vllm.musa_deepgemm_fp8_op(
+                normalized,
+                weight,
+                weight_scale,
+                128,
+                False,
+            )
+            return output, residual_out
+
+        return _pattern
+
+    @property
+    def replacement(self):
+        def _replacement(
+            input: torch.Tensor,
+            residual: torch.Tensor,
+            norm_weight: torch.Tensor,
+            weight: torch.Tensor,
+            weight_scale: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return torch.ops.vllm.musa_fused_add_rms_deepgemm_fp8_op(
+                input,
+                residual,
+                norm_weight,
+                weight,
+                weight_scale,
+                128,
+                False,
+                1e-6,
+            )
+
+        return _replacement
+
+
+class MusaRMSDeepGemmFusionPass(VllmFusionPatternMatcherPass):
+    def __init__(self, config: VllmConfig) -> None:
+        super().__init__(config, "musa_rms_deepgemm_fusion_pass")
+        self.register(MusaRMSDeepGemmPattern())
+        self.dump_patterns(config, self.pm_pass)
+
+    def __call__(self, graph: fx.Graph) -> None:
+        super().__call__(graph)
+        if self.matched_count:
+            logger.info(
+                "MUSA residual RMSNorm+DeepGEMM fusion matched %d pattern(s)",
+                self.matched_count,
+            )

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -287,6 +287,106 @@ def _musa_silu_deepgemm_fp8_op(
     return output
 
 
+def _musa_fused_add_rms_deepgemm_fp8_op(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    use_deep_gemm_e8m0: bool,
+    epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fuse Qwen residual RMSNorm, group-128 quantization, and DeepGEMM.
+
+    The fused MUSA kernel is deliberately narrow: it mirrors the current
+    compiled Qwen dense path (BF16, hidden 4096, E4M3 group-128, row-major
+    activation scales). Unsupported direct callers retain the ordinary
+    residual RMSNorm plus DeepGEMM sequence.
+    """
+    input_ranges = tuple(
+        (tensor.data_ptr(), tensor.data_ptr() + tensor.numel() * tensor.element_size())
+        for tensor in (input, residual, norm_weight)
+    )
+    inputs_nonoverlapping = all(
+        left_end <= right_begin or right_end <= left_begin
+        for index, (left_begin, left_end) in enumerate(input_ranges)
+        for right_begin, right_end in input_ranges[index + 1 :]
+    )
+    supported = (
+        group_size == 128
+        and not use_deep_gemm_e8m0
+        and _use_row_major_activation_scales(use_deep_gemm_e8m0)
+        and input.dim() == 2
+        and input.shape[-1] == 4096
+        and residual.shape == input.shape
+        and norm_weight.dim() == 1
+        and norm_weight.shape[0] == input.shape[-1]
+        and input.dtype == torch.bfloat16
+        and residual.dtype == input.dtype
+        and norm_weight.dtype == input.dtype
+        and input.is_contiguous()
+        and residual.is_contiguous()
+        and norm_weight.is_contiguous()
+        and all(
+            tensor.data_ptr() % 16 == 0 for tensor in (input, residual, norm_weight)
+        )
+        and inputs_nonoverlapping
+    )
+    if not supported:
+        summed = input.float() + residual.float()
+        residual_out = summed.to(input.dtype)
+        variance = summed.square().mean(dim=-1, keepdim=True)
+        # Match the captured MUSA Inductor lowering used by the serving path:
+        # the nominal intermediate cast is folded through the gain multiply.
+        normalized = summed * torch.rsqrt(variance + epsilon)
+        normalized = (normalized * norm_weight.float()).to(input.dtype)
+        return (
+            _musa_deepgemm_fp8_op(
+                normalized,
+                weight,
+                weight_scale,
+                group_size,
+                use_deep_gemm_e8m0,
+            ),
+            residual_out,
+        )
+
+    q_input = torch.empty(
+        input.shape,
+        dtype=current_platform.fp8_dtype(),
+        device=input.device,
+    )
+    input_scale = torch.empty(
+        (input.shape[0], input.shape[1] // group_size),
+        dtype=torch.float32,
+        device=input.device,
+    )
+    residual_out = torch.empty_like(input)
+    torch.ops._C_musa_ops.fused_add_rms_norm_per_token_group_fp8_quant(
+        input,
+        residual,
+        norm_weight,
+        residual_out,
+        q_input,
+        input_scale,
+        epsilon,
+    )
+
+    output = torch.empty(
+        (q_input.shape[0], weight.shape[0]),
+        dtype=torch.bfloat16,
+        device=q_input.device,
+    )
+    fp8_gemm_nt(
+        (q_input, input_scale),
+        (weight, weight_scale),
+        output,
+        is_deep_gemm_e8m0_used=use_deep_gemm_e8m0,
+    )
+    return output, residual_out
+
+
 def _musa_fp8_small_m_gemv_op(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -354,6 +454,27 @@ def _musa_silu_deepgemm_fp8_op_fake(
     )
 
 
+def _musa_fused_add_rms_deepgemm_fp8_op_fake(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    use_deep_gemm_e8m0: bool,
+    epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del residual, norm_weight, weight_scale, group_size, use_deep_gemm_e8m0, epsilon
+    return (
+        torch.empty(
+            (input.shape[0], weight.shape[0]),
+            dtype=torch.bfloat16,
+            device=input.device,
+        ),
+        torch.empty_like(input),
+    )
+
+
 direct_register_custom_op(
     "musa_fp8_small_m_gemv_op",
     _musa_fp8_small_m_gemv_op,
@@ -370,4 +491,10 @@ direct_register_custom_op(
     "musa_silu_deepgemm_fp8_op",
     _musa_silu_deepgemm_fp8_op,
     fake_impl=_musa_silu_deepgemm_fp8_op_fake,
+)
+
+direct_register_custom_op(
+    "musa_fused_add_rms_deepgemm_fp8_op",
+    _musa_fused_add_rms_deepgemm_fp8_op,
+    fake_impl=_musa_fused_add_rms_deepgemm_fp8_op_fake,
 )

--- a/vllm_musa/patches/manifest.py
+++ b/vllm_musa/patches/manifest.py
@@ -233,6 +233,12 @@ _SHADOW_MODULES = [
         "MUSA dense SwiGLU plus FP8 DeepGEMM fusion pattern",
     ),
     (
+        "5",
+        "vllm_musa/compilation/passes/rms_deepgemm_fusion.py",
+        None,
+        "MUSA residual RMSNorm plus FP8 DeepGEMM fusion pattern",
+    ),
+    (
         "4a",
         "vllm_musa/v1/attention/backends/flash_attn.py",
         "vllm/v1/attention/backends/flash_attn.py",

--- a/vllm_musa/patches/manifest.py
+++ b/vllm_musa/patches/manifest.py
@@ -235,7 +235,7 @@ _SHADOW_MODULES = [
     (
         "5",
         "vllm_musa/compilation/passes/rms_deepgemm_fusion.py",
-        None,
+        "vllm/compilation/passes/fusion/rms_quant_fusion.py",
         "MUSA residual RMSNorm plus FP8 DeepGEMM fusion pattern",
     ),
     (


### PR DESCRIPTION
## Summary

This is PR 2/4 in the MUSA dense-Qwen kernel stack and is based on the
MUSA-0759 SiLU/DeepGEMM PR.

Review/merge order: [#109](https://github.com/MooreThreads/vllm-musa/pull/109) -> [#110](https://github.com/MooreThreads/vllm-musa/pull/110) -> [#111](https://github.com/MooreThreads/vllm-musa/pull/111) -> [#112](https://github.com/MooreThreads/vllm-musa/pull/112).

It adds a native fused residual-add RMSNorm plus row-major group-128 FP8
activation-quantization kernel and a compiler pass that feeds its result into
the unchanged MATE DeepGEMM path. Automatic selection is restricted to the
validated Qwen3-8B-FP8, hidden-size 4096, single-GPU S5000 contract;
unsupported configurations keep the existing RMSNorm and quantization path.
No campaign- or fusion-specific environment control is introduced or read to
select this path.

Exact source:

- base: `xd/musa-0759-silu-deepgemm` at
  `7d6dd02c4b6a45e00d0131fd42b885030d7891c2`
- head: `ee367bc5a3b6e2704e1a177a0bc214f8d511f003`
- head ref: `xd/musa-0760-rms-deepgemm`
- pinned vLLM: `ee0da84ab9e04ac7610e28580af62c365e898389`

## Validation

### Historical per-ticket performance evidence

The figures below are retained from the earlier MUSA-0760 incremental
campaign. They predate the current environment-independent and logical-device
follow-ups, so they are directional historical evidence, not a result from the
current exact head and not the final combined four-PR A/B. The run used
Qwen3-8B-FP8, TP1, S5000, normal Inductor,
`FULL_AND_PIECEWISE` graph capture, greedy decoding, no MTP/speculative
decoding, and separate candidate/control vLLM and Inductor cache roots. Every
request completed at 4104 input and 1024 output tokens.

| concurrency | mean TTFT change | mean TPOT reduction |
|---:|---:|---:|
| 1 | +3.30% | +3.06% |
| 4 | -1.20% | +0.02% |
| 16 | -2.47% | +0.63% |
| 64 | +1.11% | +1.24% |

TPOT had no aggregate regression; concurrency 4 was neutral. TTFT was
mixed/noisy and is not presented as a general win. Per the requested sequence,
MUSA-0760 must be reverified after the other ticket gates; the table above does
not satisfy that final revalidation.

### Superseded descendant-stack evidence

The former descendant head `f53cf6cbbd7f4d85e82270a86db1938c713d948a`
passed dense, MoE, and MLA functional serving checks. That SHA is no longer the
final stack, and the same host-81 campaign had a foreign ExecBench workload,
so its combined latency rows are rejected and none of this evidence is used as
an exact-head readiness claim.

### Exact-final MUSA-0767 gate

<!-- MUSA0767_FINAL_EVIDENCE_START -->

Status: **EXACT-HEAD FUNCTIONAL REGRESSION COMPLETE; PERFORMANCE GATES
PENDING -- keep this PR in draft.**

- PR-specific head: `ee367bc5a3b6e2704e1a177a0bc214f8d511f003`
- final stacked head: `95c3661c8658a861a1891f981c81dcadabea0654`
- final source tree: `a766855ed712d61f81acb6b11d456ea5a128cac5`
- source archive SHA-256:
  `03dbe0526f72d4dcba6b743c500d4d5eaaf9676e263f9bd91cbfd265db140feb`
- exact environment and build: 8x MTT S5000, driver `3.3.5-server`,
  MUSA runtime `50200`, `torch==2.9.1.post1`,
  `torch_musa==2.9.1.post1+4c646b6`, `torchada==0.1.75`,
  MATE/FlashAttention3 `0.2.4`, candidate extension SHA-256
  `d0baaa8ba11981438a549115d50e89c10ec566dfac1ba27c0ccdc8364c5c2bd7`
- focused final-stack native correctness and graph-capture tests:
  **60 passed in 44.72s**, including the exact RMS + DeepGEMM fusion tests
- compiled/captured Qwen dense, Qwen MoE, and DeepSeek MLA regression:
  **PASS, 3/3 rows and 10/10 semantic requests** (Qwen3-8B-FP8 TP1
  FLASH_ATTN, Qwen3.5-35B-A3B-FP8 TP4 FLASH_ATTN, and
  DeepSeek-V2-Lite-Chat-FP8 TP1 FLASHMLA; Inductor,
  FULL_AND_PIECEWISE, MTP off)
- clean-node combined Qwen3-8B-FP8 candidate/control result at exact
  4104/1024 and concurrency 1/4/16/64, without MTP:
  `PENDING -- not present in this regression-only bundle`
  - the first control-only attempt is rejected because default prefix caching
    plus repeated deterministic prompts invalidated cold-prefill TTFT; every
    A/B leg will restart with prefix caching disabled
- Qwen3.5-2B and Qwen3.6-27B exact-token widening A/B evidence:
  `PENDING -- not present in this regression-only bundle`
- regression evidence bundle SHA-256:
  `ea1b38559be0458343b85f3cd6bba275d320d2b1c729071f455e2dccb04c5272`;
  its focused monitor verdict was **FAIL** because foreign ExecBench GPU work
  was present, so the clean performance-monitor gate remains `PENDING`

<!-- MUSA0767_FINAL_EVIDENCE_END -->

## Remaining gate

The exact-head MUSA-0760 functional revalidation and the full functional
regression are complete. The requested post-stack Qwen3 performance
revalidation is still pending and will be supplied by the clean combined A/B.
This PR remains draft until that run, the widening A/B, and the clean
performance-monitor gates are complete and accepted.
