### PR TITLE
MUSA: add calibrated FP8 MoE backend selection on S5000

### DIFF
--- a/benchmarks/fused_moe/benchmark_dispatch_crossover.py
+++ b/benchmarks/fused_moe/benchmark_dispatch_crossover.py
@@ -1,0 +1,1252 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Cold-cache crossover sweep for MUSA FP8 fused-MoE backends.
+
+All dimensions are the actual per-rank kernel dimensions. A coarse sweep only
+produces a candidate interval; rerun densely around both crossings and confirm
+the result with serving A/B before adding a policy entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import inspect
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+# isort: off
+import torchada  # noqa: F401  # must patch before torch ecosystem imports
+import torch
+import torch.nn.functional as F
+# isort: on
+
+from mate.testing.utils import bench_gpu_time_with_musa_event
+
+from vllm_musa.model_executor.layers.fused_moe import fused_moe
+from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (
+    MusaFusedMoeBackend,
+    MusaFusedMoeShape,
+)
+
+
+@dataclass(frozen=True)
+class Shape:
+    name: str
+    experts: int
+    hidden_size: int
+    intermediate_size: int
+    top_k: int
+    block_size: int
+
+
+@dataclass
+class Result:
+    shape: dict[str, Any]
+    tokens: int
+    backend: str
+    samples_ms: list[float]
+    median_ms: float | None
+    p20_ms: float | None
+    p95_ms: float | None
+    iqr_ms: float | None
+    min_ms: float | None
+    max_ms: float | None
+    max_abs_diff: float | None
+    mean_abs_diff: float | None
+    relative_l2_error: float | None
+    cosine_similarity: float | None
+    max_row_relative_l2: float | None
+    min_row_cosine: float | None
+    max_abs_diff_over_reference_absmax: float | None
+    output_absmax: float | None
+    output_std: float | None
+    finite: bool | None
+    non_poison: bool | None
+    correctness_pass: bool | None
+    correctness_basis: str
+    reference_backend: str
+    error: str | None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--experts", type=int, required=True)
+    parser.add_argument("--hidden-size", type=int, required=True)
+    parser.add_argument("--intermediate-size", type=int, required=True)
+    parser.add_argument("--top-k", type=int, required=True)
+    parser.add_argument("--block-size", type=int, choices=(128,), default=128)
+    parser.add_argument(
+        "--tokens",
+        default=(
+            "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,24,32,48,64,"
+            "96,128,192,256,384,512,"
+            "768,1024,1536,2048,3072,4096,6144,8192,12288,16384"
+        ),
+    )
+    parser.add_argument(
+        "--backends",
+        default="gemv,grouped_gemm,upstream",
+        help=(
+            "Comma-separated subset of gemv, grouped_gemm, "
+            "deepgemm_prefill, and upstream; upstream is mandatory for "
+            "qualification"
+        ),
+    )
+    parser.add_argument(
+        "--route-mode",
+        choices=("balanced", "unique_random", "hot"),
+        default="balanced",
+    )
+    parser.add_argument(
+        "--folded-shared-expert",
+        action="store_true",
+        help=(
+            "Treat the final expert and final routing slot as an always-selected "
+            "folded shared expert"
+        ),
+    )
+    parser.add_argument("--sweep-kind", choices=("coarse", "dense"), default="coarse")
+    parser.add_argument(
+        "--dense-prefix-max",
+        type=int,
+        default=16,
+        help=(
+            "For dense sweeps, materialize every token count from 1 through "
+            "this bound so a <= GEMV threshold never spans unmeasured holes."
+        ),
+    )
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--repeats-per-round", type=int, default=10)
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--l2-flush-mb", type=int, default=8192)
+    parser.add_argument("--seed", type=int, default=20260720)
+    parser.add_argument("--atol", type=float, default=0.02)
+    parser.add_argument("--rtol", type=float, default=0.08)
+    parser.add_argument("--gemv-max-relative-l2", type=float, default=0.06)
+    parser.add_argument("--gemv-min-cosine", type=float, default=0.998)
+    parser.add_argument("--gemv-max-row-relative-l2", type=float, default=0.08)
+    parser.add_argument("--gemv-min-row-cosine", type=float, default=0.995)
+    parser.add_argument("--gemv-max-normalized-abs-diff", type=float, default=0.10)
+    parser.add_argument("--gemv-oracle-max-relative-l2", type=float, default=0.01)
+    parser.add_argument("--gemv-oracle-min-cosine", type=float, default=0.9999)
+    parser.add_argument("--gemv-oracle-max-row-relative-l2", type=float, default=0.02)
+    parser.add_argument("--gemv-oracle-min-row-cosine", type=float, default=0.9998)
+    parser.add_argument(
+        "--gemv-oracle-max-normalized-abs-diff", type=float, default=0.05
+    )
+    parser.add_argument("--oracle-probe-tokens", type=int, default=4)
+    parser.add_argument("--grouped-max-relative-l2", type=float, default=0.01)
+    parser.add_argument("--grouped-min-cosine", type=float, default=0.9999)
+    parser.add_argument("--grouped-max-row-relative-l2", type=float, default=0.02)
+    parser.add_argument("--grouped-min-row-cosine", type=float, default=0.999)
+    parser.add_argument("--grouped-max-normalized-abs-diff", type=float, default=0.05)
+    parser.add_argument("--regression-margin", type=float, default=0.03)
+    parser.add_argument("--max-iqr-ratio", type=float, default=0.10)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def synchronize() -> None:
+    torch.musa.synchronize()
+
+
+def command_output(command: list[str]) -> str | None:
+    try:
+        return subprocess.check_output(
+            command,
+            text=True,
+            stderr=subprocess.STDOUT,
+            timeout=15,
+        ).strip()[:4000]
+    except Exception:
+        return None
+
+
+def repo_provenance() -> dict[str, Any]:
+    module_path = Path(inspect.getfile(fused_moe)).resolve()
+    repo = next(
+        (
+            parent
+            for parent in (module_path.parent, *module_path.parents)
+            if (parent / ".git").exists()
+        ),
+        None,
+    )
+    if repo is None:
+        return {"module_path": str(module_path), "repo": None}
+    head = command_output(["git", "-C", str(repo), "rev-parse", "HEAD"])
+    status = command_output(["git", "-C", str(repo), "status", "--short"])
+    try:
+        diff = subprocess.check_output(
+            ["git", "-C", str(repo), "diff", "--binary"],
+            stderr=subprocess.DEVNULL,
+        )
+        diff_sha256 = hashlib.sha256(diff).hexdigest()
+    except Exception:
+        diff_sha256 = None
+    return {
+        "module_path": str(module_path),
+        "repo": str(repo),
+        "head": head,
+        "status": status,
+        "dirty_patch_sha256": diff_sha256,
+        "custom_ops_module": str(Path(inspect.getfile(fused_moe.musa_ops)).resolve()),
+    }
+
+
+def package_versions() -> dict[str, str | None]:
+    versions: dict[str, str | None] = {}
+    for package in ("torch", "torch_musa", "torchada", "mate", "vllm", "vllm-musa"):
+        try:
+            versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            versions[package] = None
+    return versions
+
+
+def quantized_weight(shape: tuple[int, ...], seed: int) -> torch.Tensor:
+    generator = torch.Generator(device="musa")
+    generator.manual_seed(seed)
+    output = torch.empty(shape, device="musa", dtype=torch.float8_e4m3fn)
+    chunk_experts = max(1, min(shape[0], 8))
+    for start in range(0, shape[0], chunk_experts):
+        end = min(start + chunk_experts, shape[0])
+        source = torch.randn(
+            (end - start, *shape[1:]),
+            device="musa",
+            dtype=torch.bfloat16,
+            generator=generator,
+        ).mul_(8.0)
+        output[start:end].copy_(source.to(torch.float8_e4m3fn))
+    return output
+
+
+def block_scale_shape(weight: torch.Tensor, block_size: int) -> tuple[int, int, int]:
+    experts, output_size, input_size = weight.shape
+    if input_size % block_size != 0 or output_size % block_size != 0:
+        raise ValueError(
+            f"weight shape {tuple(weight.shape)} is not aligned to block {block_size}"
+        )
+    return experts, output_size // block_size, input_size // block_size
+
+
+def block_scales(weight: torch.Tensor, block_size: int, seed: int) -> torch.Tensor:
+    generator = torch.Generator(device="musa")
+    generator.manual_seed(seed)
+    scales = torch.rand(
+        block_scale_shape(weight, block_size),
+        device="musa",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    return scales.mul_(0.0045).add_(0.0005).contiguous()
+
+
+def routes(
+    tokens: int,
+    experts: int,
+    top_k: int,
+    mode: str,
+    seed: int,
+    folded_shared_expert: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device="musa")
+    generator.manual_seed(seed)
+    routed_experts = experts - 1 if folded_shared_expert else experts
+    routed_top_k = top_k - 1 if folded_shared_expert else top_k
+    if mode == "balanced":
+        rows = torch.arange(tokens, device="musa", dtype=torch.int32)[:, None]
+        offsets = torch.arange(routed_top_k, device="musa", dtype=torch.int32)[None, :]
+        ids = (rows * routed_top_k + offsets).remainder(routed_experts)
+    elif mode == "hot":
+        ids = torch.arange(routed_top_k, device="musa", dtype=torch.int32)[None, :]
+        ids = ids.expand(tokens, routed_top_k).contiguous().remainder(routed_experts)
+    else:
+        scores = torch.rand(
+            (tokens, routed_experts),
+            device="musa",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        ids = scores.topk(routed_top_k, dim=-1, sorted=False).indices.to(torch.int32)
+    weights = torch.rand(
+        (tokens, routed_top_k),
+        device="musa",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    weights.div_(weights.sum(dim=-1, keepdim=True))
+    if folded_shared_expert:
+        shared_ids = torch.full(
+            (tokens, 1), experts - 1, device="musa", dtype=torch.int32
+        )
+        shared_logits = torch.randn(
+            (tokens, 1),
+            device="musa",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        ids = torch.cat((ids, shared_ids), dim=1)
+        weights = torch.cat((weights, shared_logits.sigmoid()), dim=1)
+    return ids.contiguous(), weights.contiguous()
+
+
+def oracle_coverage_routes(
+    tokens: int,
+    experts: int,
+    top_k: int,
+    folded_shared_expert: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build a tiny deterministic probe covering first, middle, and tail experts."""
+
+    routed_experts = experts - 1 if folded_shared_expert else experts
+    routed_top_k = top_k - 1 if folded_shared_expert else top_k
+    requested = tokens * routed_top_k
+    stride = max(1, routed_experts // max(1, requested))
+    ordered_candidates = [0, routed_experts // 2, routed_experts - 1]
+    ordered_candidates.extend(
+        (index * stride) % routed_experts for index in range(routed_experts)
+    )
+    ordered_candidates.extend(range(routed_experts))
+    candidates = list(dict.fromkeys(ordered_candidates))
+
+    rows: list[list[int]] = []
+    cursor = 0
+    for _ in range(tokens):
+        row: list[int] = []
+        while len(row) < routed_top_k:
+            candidate = candidates[cursor % len(candidates)]
+            cursor += 1
+            if candidate not in row:
+                row.append(candidate)
+        if folded_shared_expert:
+            row.append(experts - 1)
+        rows.append(row)
+
+    topk_ids = torch.tensor(rows, device="musa", dtype=torch.int32)
+    routed_weights = torch.full(
+        (tokens, routed_top_k),
+        1.0 / routed_top_k,
+        device="musa",
+        dtype=torch.float32,
+    )
+    if folded_shared_expert:
+        shared_weights = torch.full(
+            (tokens, 1), 0.5, device="musa", dtype=torch.float32
+        )
+        topk_weights = torch.cat((routed_weights, shared_weights), dim=1)
+    else:
+        topk_weights = routed_weights
+    return topk_ids.contiguous(), topk_weights.contiguous()
+
+
+def backend_kwargs(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    block_size: int,
+) -> dict[str, Any]:
+    return {
+        "hidden_states": hidden_states,
+        "w1": w1,
+        "w2": w2,
+        "topk_weights": topk_weights,
+        "topk_ids": topk_ids,
+        "activation": "silu",
+        "apply_router_weight_on_input": False,
+        "use_fp8_w8a8": True,
+        "use_int8_w8a8": False,
+        "use_int8_w8a16": False,
+        "use_int4_w4a16": False,
+        "ocp_mx_scheme": None,
+        "per_channel_quant": False,
+        "global_num_experts": w1.shape[0],
+        "expert_map": None,
+        "w1_scale": w1_scale,
+        "w2_scale": w2_scale,
+        "w1_zp": None,
+        "w2_zp": None,
+        "a1_scale": None,
+        "a2_scale": None,
+        "block_shape": [block_size, block_size],
+        "w1_bias": None,
+        "w2_bias": None,
+    }
+
+
+def build_backends(kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, bool]]:
+    gemv_gate = {
+        key: value
+        for key, value in kwargs.items()
+        if key not in {"apply_router_weight_on_input", "block_shape"}
+    }
+    grouped_gate = dict(kwargs)
+    deepgemm_prefill_gate = {
+        key: value
+        for key, value in kwargs.items()
+        if key not in {"topk_weights", "global_num_experts", "w1_zp", "w2_zp"}
+    }
+    capabilities = {
+        "gemv": fused_moe._can_use_musa_native_fp8_moe_gemv(**gemv_gate),
+        "grouped_gemm": fused_moe._can_use_musa_fp8_moe_grouped_gemm(**grouped_gate),
+        "deepgemm_prefill": fused_moe._can_use_moe_deepgemm_prefill(
+            **deepgemm_prefill_gate
+        ),
+        "upstream": True,
+    }
+
+    def gemv() -> torch.Tensor:
+        return fused_moe.fused_experts_impl(
+            **kwargs,
+            inplace=False,
+            _allow_deepgemm_prefill=False,
+        )
+
+    def grouped_gemm() -> torch.Tensor:
+        return fused_moe._musa_fp8_moe_grouped_gemm_impl(
+            hidden_states=kwargs["hidden_states"],
+            w1=kwargs["w1"],
+            w2=kwargs["w2"],
+            topk_weights=kwargs["topk_weights"],
+            topk_ids=kwargs["topk_ids"],
+            w1_scale=kwargs["w1_scale"],
+            w2_scale=kwargs["w2_scale"],
+            expert_map=None,
+            inplace=False,
+        )
+
+    def deepgemm_prefill() -> torch.Tensor:
+        return fused_moe._musa_fp8_moe_deepgemm_prefill_impl(
+            hidden_states=kwargs["hidden_states"],
+            w1=kwargs["w1"],
+            w2=kwargs["w2"],
+            topk_weights=kwargs["topk_weights"],
+            topk_ids=kwargs["topk_ids"],
+            w1_scale=kwargs["w1_scale"],
+            w2_scale=kwargs["w2_scale"],
+            inplace=False,
+        )
+
+    def upstream() -> torch.Tensor:
+        return fused_moe._upstream_fused_moe._musa_original_fused_experts_impl(**kwargs)
+
+    return {
+        "gemv": gemv,
+        "grouped_gemm": grouped_gemm,
+        "deepgemm_prefill": deepgemm_prefill,
+        "upstream": upstream,
+    }, capabilities
+
+
+def dispatcher_smoke(
+    kwargs: dict[str, Any],
+    requested_backends: list[str],
+    direct_outputs: dict[str, torch.Tensor],
+) -> dict[str, Any]:
+    dispatchable_backends = [
+        backend
+        for backend in requested_backends
+        if backend in {"gemv", "grouped_gemm", "upstream"}
+    ]
+    old_backend = fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND
+    original_gemv = fused_moe.fused_experts_impl
+    original_grouped = fused_moe._maybe_musa_fp8_moe_grouped_gemm
+    original_upstream = fused_moe._upstream_fused_moe._musa_original_fused_experts_impl
+    outputs: dict[str, torch.Tensor] = {}
+    errors: dict[str, str] = {}
+    identities: dict[str, Any] = {}
+    call_counts = {"gemv": 0, "grouped_gemm": 0, "upstream": 0}
+
+    def counted_gemv(*args: Any, **inner_kwargs: Any) -> torch.Tensor:
+        call_counts["gemv"] += 1
+        return original_gemv(*args, **inner_kwargs)
+
+    def counted_grouped(*args: Any, **inner_kwargs: Any) -> torch.Tensor | None:
+        call_counts["grouped_gemm"] += 1
+        return original_grouped(*args, **inner_kwargs)
+
+    def counted_upstream(*args: Any, **inner_kwargs: Any) -> torch.Tensor:
+        call_counts["upstream"] += 1
+        return original_upstream(*args, **inner_kwargs)
+
+    try:
+        fused_moe.fused_experts_impl = counted_gemv
+        fused_moe._maybe_musa_fp8_moe_grouped_gemm = counted_grouped
+        fused_moe._upstream_fused_moe._musa_original_fused_experts_impl = (
+            counted_upstream
+        )
+        for backend in dispatchable_backends:
+            for name in call_counts:
+                call_counts[name] = 0
+            fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND = MusaFusedMoeBackend(backend)
+            try:
+                outputs[backend] = fused_moe._musa_fused_experts_impl_dispatch(
+                    **kwargs
+                ).detach()
+                synchronize()
+                identities[backend] = {
+                    "call_counts": dict(call_counts),
+                    "passed": call_counts[backend] == 1
+                    and sum(call_counts.values()) == 1,
+                }
+            except Exception as exc:
+                errors[backend] = f"{type(exc).__name__}: {exc}"
+    finally:
+        fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND = old_backend
+        fused_moe.fused_experts_impl = original_gemv
+        fused_moe._maybe_musa_fp8_moe_grouped_gemm = original_grouped
+        fused_moe._upstream_fused_moe._musa_original_fused_experts_impl = (
+            original_upstream
+        )
+
+    comparisons: dict[str, Any] = {}
+    for backend, output in outputs.items():
+        direct_output = direct_outputs.get(backend)
+        if direct_output is None:
+            comparisons[backend] = {"passed": False, "error": "direct output missing"}
+            continue
+        diff = (output.float() - direct_output.float()).abs()
+        comparisons[backend] = {
+            "passed": bool(torch.equal(output, direct_output)),
+            "max_abs_diff": float(diff.max().item()),
+            "mean_abs_diff": float(diff.mean().item()),
+            **comparison_metrics(output, direct_output),
+        }
+    passed = bool(
+        not errors
+        and all(
+            identities.get(name, {}).get("passed") for name in dispatchable_backends
+        )
+        and all(
+            comparisons.get(name, {}).get("passed") for name in dispatchable_backends
+        )
+    )
+    return {
+        "passed": passed,
+        "not_dispatchable": sorted(
+            set(requested_backends) - set(dispatchable_backends)
+        ),
+        "errors": errors,
+        "identities": identities,
+        "comparisons": comparisons,
+    }
+
+
+def deepgemm_prefill_dispatch_smoke(
+    kwargs: dict[str, Any], direct_output: torch.Tensor
+) -> dict[str, Any]:
+    """Prove that the default eager path reaches production DeepGEMM."""
+
+    old_backend = fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND
+    original_deepgemm = fused_moe._maybe_moe_deepgemm_prefill
+    original_upstream = fused_moe._upstream_fused_moe._musa_original_fused_experts_impl
+    calls = {"deepgemm_prefill": 0, "upstream": 0}
+
+    def counted_deepgemm(**inner_kwargs: Any) -> torch.Tensor | None:
+        calls["deepgemm_prefill"] += 1
+        return original_deepgemm(**inner_kwargs)
+
+    def counted_upstream(*args: Any, **inner_kwargs: Any) -> torch.Tensor:
+        calls["upstream"] += 1
+        return original_upstream(*args, **inner_kwargs)
+
+    try:
+        fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND = MusaFusedMoeBackend.AUTO
+        fused_moe._maybe_moe_deepgemm_prefill = counted_deepgemm
+        fused_moe._upstream_fused_moe._musa_original_fused_experts_impl = (
+            counted_upstream
+        )
+        output = fused_moe._musa_fused_experts_impl_dispatch(**kwargs).detach()
+        synchronize()
+        difference = (output.float() - direct_output.float()).abs()
+        comparison = {
+            "bitwise_equal": bool(torch.equal(output, direct_output)),
+            "max_abs_diff": float(difference.max().item()),
+            "mean_abs_diff": float(difference.mean().item()),
+            **comparison_metrics(output, direct_output),
+        }
+        expected_calls = {"deepgemm_prefill": 1, "upstream": 0}
+        return {
+            "passed": calls == expected_calls and comparison["bitwise_equal"],
+            "calls": calls,
+            "expected_calls": expected_calls,
+            "comparison": comparison,
+        }
+    except Exception as exc:
+        return {
+            "passed": False,
+            "calls": calls,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    finally:
+        fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND = old_backend
+        fused_moe._maybe_moe_deepgemm_prefill = original_deepgemm
+        fused_moe._upstream_fused_moe._musa_original_fused_experts_impl = (
+            original_upstream
+        )
+
+
+def deepgemm_prefill_implementation(kwargs: dict[str, Any]) -> str:
+    try:
+        from vllm_musa.jit_kernel.tilelang.deep_gemm_contig_preprocess import (
+            can_use_fp8_tilelang,
+        )
+
+        use_fused_glue = can_use_fp8_tilelang(
+            kwargs["hidden_states"],
+            kwargs["topk_ids"],
+            kwargs["w1"].shape[0],
+            True,
+        )
+        return "fused_glue" if use_fused_glue else "grouped_glue_fallback"
+    except Exception as exc:
+        return f"probe_error:{type(exc).__name__}:{exc}"
+
+
+def quantile(samples: list[float], q: float) -> float:
+    ordered = sorted(samples)
+    index = min(len(ordered) - 1, max(0, round((len(ordered) - 1) * q)))
+    return ordered[index]
+
+
+def comparison_metrics(
+    output: torch.Tensor, reference: torch.Tensor
+) -> dict[str, float]:
+    output_flat = output.float().flatten()
+    reference_flat = reference.float().flatten()
+    difference = output_flat - reference_flat
+    reference_norm = reference_flat.norm().clamp_min(torch.finfo(torch.float32).eps)
+    relative_l2 = float((difference.norm() / reference_norm).item())
+    cosine = float(F.cosine_similarity(output_flat, reference_flat, dim=0).item())
+    output_rows = output.float().reshape(-1, output.shape[-1])
+    reference_rows = reference.float().reshape(-1, reference.shape[-1])
+    difference_rows = output_rows - reference_rows
+    row_reference_norms = reference_rows.norm(dim=1).clamp_min(
+        torch.finfo(torch.float32).eps
+    )
+    row_relative_l2 = difference_rows.norm(dim=1) / row_reference_norms
+    row_cosine = F.cosine_similarity(output_rows, reference_rows, dim=1)
+    reference_absmax = (
+        reference_flat.abs().max().clamp_min(torch.finfo(torch.float32).eps)
+    )
+    return {
+        "relative_l2_error": relative_l2,
+        "cosine_similarity": cosine,
+        "max_row_relative_l2": float(row_relative_l2.max().item()),
+        "min_row_cosine": float(row_cosine.min().item()),
+        "max_abs_diff_over_reference_absmax": float(
+            (difference.abs().max() / reference_absmax).item()
+        ),
+    }
+
+
+def dequantized_fp32_reference(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    block_size: int,
+) -> torch.Tensor:
+    """Compute a bounded correctness oracle without activation quantization.
+
+    This is intentionally used only for a small, fixed-size coverage
+    probe. Native GEMV consumes BF16 activations directly, while the
+    established Triton and grouped paths dynamically quantize activations to
+    FP8. Comparing GEMV to those paths with elementwise allclose can therefore
+    reject the more accurate result.
+    """
+
+    tokens, hidden_size = hidden_states.shape
+    intermediate_size = w2.shape[2]
+    output = torch.zeros(
+        (tokens, hidden_size), device=hidden_states.device, dtype=torch.float32
+    )
+
+    def dequantize(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+        expanded_scale = scale.repeat_interleave(block_size, dim=0)
+        expanded_scale = expanded_scale.repeat_interleave(block_size, dim=1)
+        return weight.float() * expanded_scale
+
+    for token_index in range(tokens):
+        activation = hidden_states[token_index].float()
+        for slot in range(topk_ids.shape[1]):
+            expert = int(topk_ids[token_index, slot].item())
+            w1_dequantized = dequantize(w1[expert], w1_scale[expert])
+            projected = F.linear(activation, w1_dequantized)
+            del w1_dequantized
+            activated = F.silu(projected[:intermediate_size])
+            activated.mul_(projected[intermediate_size:])
+            w2_dequantized = dequantize(w2[expert], w2_scale[expert])
+            expert_output = F.linear(activated, w2_dequantized)
+            del w2_dequantized
+            output[token_index].add_(
+                expert_output, alpha=float(topk_weights[token_index, slot].item())
+            )
+    return output
+
+
+def recommend_thresholds(
+    results: list[Result], tokens: list[int], margin: float, max_iqr_ratio: float
+) -> dict[str, int | None]:
+    points: dict[int, dict[str, Result]] = {}
+    for result in results:
+        if (
+            result.error is None
+            and result.correctness_pass is True
+            and result.median_ms is not None
+            and result.p95_ms is not None
+            and result.iqr_ms is not None
+        ):
+            points.setdefault(result.tokens, {})[result.backend] = result
+
+    def safely_faster(token_count: int, backend: str) -> bool:
+        point = points.get(token_count, {})
+        candidate = point.get(backend)
+        alternatives = [result for name, result in point.items() if name != backend]
+        if candidate is None or not alternatives:
+            return False
+        best_median = min(result.median_ms for result in alternatives)
+        best_p95 = min(result.p95_ms for result in alternatives)
+        best_alternative = min(alternatives, key=lambda result: result.median_ms)
+        stable = (
+            candidate.iqr_ms / candidate.median_ms <= max_iqr_ratio
+            and best_alternative.iqr_ms / best_alternative.median_ms <= max_iqr_ratio
+        )
+        return bool(
+            stable
+            and candidate.median_ms <= best_median * (1 - margin)
+            and candidate.p95_ms <= best_p95 * (1 + margin)
+        )
+
+    # A production ``<= threshold`` rule covers every integer token count.
+    # Never extrapolate a continuous GEMV prefix across holes in a sparse
+    # sweep: stop at the first unmeasured integer even if a later anchor wins.
+    gemv_max = None
+    expected_token = 1
+    for token_count in tokens:
+        if token_count != expected_token:
+            break
+        if not safely_faster(token_count, "gemv"):
+            break
+        gemv_max = token_count
+        expected_token += 1
+
+    grouped_min = None
+    for index, token_count in enumerate(tokens):
+        # A production ``>= threshold`` rule covers every integer above the
+        # threshold.  Require the measured suffix itself to be contiguous;
+        # otherwise a sparse sweep could silently skip an unsafe interval.
+        suffix = tokens[index:]
+        if suffix != list(range(token_count, suffix[-1] + 1)):
+            continue
+        stable = True
+        for suffix_token in suffix:
+            if not safely_faster(suffix_token, "grouped_gemm"):
+                stable = False
+                break
+        if stable:
+            grouped_min = token_count
+            break
+    return {
+        "gemv_max_tokens": gemv_max,
+        "grouped_gemm_min_tokens": grouped_min,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    shape = Shape(
+        name=args.name,
+        experts=args.experts,
+        hidden_size=args.hidden_size,
+        intermediate_size=args.intermediate_size,
+        top_k=args.top_k,
+        block_size=args.block_size,
+    )
+    tokens = sorted({int(value) for value in args.tokens.split(",") if value})
+    if args.sweep_kind == "dense" and tokens:
+        dense_prefix_max = min(max(tokens), args.dense_prefix_max)
+        tokens = sorted(set(tokens).union(range(1, dense_prefix_max + 1)))
+    requested_backends = [value for value in args.backends.split(",") if value]
+    unknown = set(requested_backends) - {
+        "gemv",
+        "grouped_gemm",
+        "deepgemm_prefill",
+        "upstream",
+    }
+    if unknown:
+        raise ValueError(f"unsupported backends: {sorted(unknown)}")
+    if "upstream" not in requested_backends:
+        raise ValueError("upstream is mandatory as the correctness reference")
+    if not tokens or min(tokens) <= 0:
+        raise ValueError("tokens must contain positive integers")
+    if args.dense_prefix_max <= 0:
+        raise ValueError("dense-prefix-max must be positive")
+    if args.oracle_probe_tokens <= 0:
+        raise ValueError("oracle-probe-tokens must be positive")
+    if not 0 < args.regression_margin < 1:
+        raise ValueError("regression-margin must be between zero and one")
+    if args.max_iqr_ratio <= 0:
+        raise ValueError("max-iqr-ratio must be positive")
+    if shape.top_k <= 0 or shape.top_k > shape.experts:
+        raise ValueError("top-k must be in [1, experts]")
+    if args.folded_shared_expert and (shape.experts < 2 or shape.top_k < 2):
+        raise ValueError("folded shared expert requires experts >= 2 and top-k >= 2")
+    if args.rounds <= 0 or args.rounds % len(requested_backends) != 0:
+        raise ValueError("rounds must be a positive multiple of backend count")
+
+    w1 = quantized_weight(
+        (shape.experts, 2 * shape.intermediate_size, shape.hidden_size), args.seed
+    )
+    w2 = quantized_weight(
+        (shape.experts, shape.hidden_size, shape.intermediate_size), args.seed + 1
+    )
+    w1_scale = block_scales(w1, shape.block_size, args.seed + 2)
+    w2_scale = block_scales(w2, shape.block_size, args.seed + 3)
+    capability = tuple(int(value) for value in torch.musa.get_device_capability())
+    device_name = torch.musa.get_device_name(0)
+    multiprocessor_count = int(
+        torch.musa.get_device_properties(0).multi_processor_count
+    )
+    if capability != (3, 1) or "S5000" not in device_name.upper():
+        raise RuntimeError(
+            "this policy sweep is valid only on MTT S5000/MP31, got "
+            f"device={device_name!r} capability={capability}"
+        )
+    policy_key = MusaFusedMoeShape(
+        device_capability=capability,
+        multiprocessor_count=multiprocessor_count,
+        local_experts=shape.experts,
+        w1_output_size=2 * shape.intermediate_size,
+        w2_input_size=shape.intermediate_size,
+        hidden_size=shape.hidden_size,
+        top_k=shape.top_k,
+        block_n=shape.block_size,
+        block_k=shape.block_size,
+        activation="silu",
+        expert_parallel=False,
+        hidden_dtype=str(torch.bfloat16),
+        weight_dtype=str(torch.float8_e4m3fn),
+        scale_dtype=str(torch.float32),
+        w1_scale_shape=tuple(w1_scale.shape),
+        w2_scale_shape=tuple(w2_scale.shape),
+        gemv_block=os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK", "auto"),
+        graph_mode="eager",
+    )
+    metadata = {
+        "schema": "musa-fused-moe-crossover.v6",
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "argv": sys.argv,
+        "shape": asdict(shape),
+        "shape_dimensions_are_per_rank": True,
+        "policy_key": asdict(policy_key),
+        "route_mode": args.route_mode,
+        "folded_shared_expert": args.folded_shared_expert,
+        "sweep_kind": args.sweep_kind,
+        "dense_prefix_max": args.dense_prefix_max,
+        "seed": args.seed,
+        "tokens": tokens,
+        "gemv_recommendation_requires_contiguous_prefix": True,
+        "grouped_recommendation_requires_contiguous_suffix": True,
+        "backends": requested_backends,
+        "warmup": args.warmup,
+        "repeats_per_round": args.repeats_per_round,
+        "rounds": args.rounds,
+        "l2_flush_mb": args.l2_flush_mb,
+        "cold_cache": True,
+        "atol": args.atol,
+        "rtol": args.rtol,
+        "gemv_max_relative_l2": args.gemv_max_relative_l2,
+        "gemv_min_cosine": args.gemv_min_cosine,
+        "gemv_max_row_relative_l2": args.gemv_max_row_relative_l2,
+        "gemv_min_row_cosine": args.gemv_min_row_cosine,
+        "gemv_max_normalized_abs_diff": args.gemv_max_normalized_abs_diff,
+        "gemv_oracle_max_relative_l2": args.gemv_oracle_max_relative_l2,
+        "gemv_oracle_min_cosine": args.gemv_oracle_min_cosine,
+        "gemv_oracle_max_row_relative_l2": (args.gemv_oracle_max_row_relative_l2),
+        "gemv_oracle_min_row_cosine": args.gemv_oracle_min_row_cosine,
+        "gemv_oracle_max_normalized_abs_diff": (
+            args.gemv_oracle_max_normalized_abs_diff
+        ),
+        "oracle_probe_tokens": args.oracle_probe_tokens,
+        "grouped_max_relative_l2": args.grouped_max_relative_l2,
+        "grouped_min_cosine": args.grouped_min_cosine,
+        "grouped_max_row_relative_l2": args.grouped_max_row_relative_l2,
+        "grouped_min_row_cosine": args.grouped_min_row_cosine,
+        "grouped_max_normalized_abs_diff": args.grouped_max_normalized_abs_diff,
+        "regression_margin": args.regression_margin,
+        "max_iqr_ratio": args.max_iqr_ratio,
+        "gemv_block": os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK", "auto"),
+        "deepgemm_prefill_env": os.environ.get(
+            "VLLM_MUSA_MOE_DEEPGEMM_PREFILL", "default-on"
+        ),
+        "deepgemm_prefill_min_tokens": os.environ.get(
+            "VLLM_MUSA_MOE_DEEPGEMM_PREFILL_MIN_TOKENS", "2500"
+        ),
+        "device_name": device_name,
+        "device_capability": capability,
+        "multiprocessor_count": multiprocessor_count,
+        "torch_musa_runtime": getattr(torch.version, "musa", None),
+        "packages": package_versions(),
+        "repo": repo_provenance(),
+        "mthreads_gmi": command_output(["mthreads-gmi", "-q"]),
+        "mcc_version": command_output(["mcc", "--version"]),
+        "estimated_static_bytes": (
+            w1.numel() * w1.element_size()
+            + w2.numel() * w2.element_size()
+            + w1_scale.numel() * w1_scale.element_size()
+            + w2_scale.numel() * w2_scale.element_size()
+        ),
+    }
+    results: list[Result] = []
+    dispatcher_evidence: dict[str, Any] = {}
+    deepgemm_dispatch_evidence: dict[str, Any] = {}
+    deepgemm_implementation: dict[str, str] = {}
+    oracle_evidence: dict[str, Any] | None = None
+    gemv_oracle_pass = "gemv" not in requested_backends
+
+    if "gemv" in requested_backends:
+        oracle_seed = args.seed + 104729
+        oracle_generator = torch.Generator(device="musa")
+        oracle_generator.manual_seed(oracle_seed)
+        oracle_hidden_states = torch.randn(
+            (args.oracle_probe_tokens, shape.hidden_size),
+            device="musa",
+            dtype=torch.bfloat16,
+            generator=oracle_generator,
+        )
+        oracle_topk_ids, oracle_topk_weights = oracle_coverage_routes(
+            args.oracle_probe_tokens,
+            shape.experts,
+            shape.top_k,
+            args.folded_shared_expert,
+        )
+        oracle_kwargs = backend_kwargs(
+            hidden_states=oracle_hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=oracle_topk_weights,
+            topk_ids=oracle_topk_ids,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            block_size=shape.block_size,
+        )
+        oracle_backends, oracle_capabilities = build_backends(oracle_kwargs)
+        oracle_outputs: dict[str, torch.Tensor] = {}
+        oracle_errors: dict[str, str] = {}
+        for backend in requested_backends:
+            if not oracle_capabilities[backend]:
+                oracle_errors[backend] = "production capability gate rejected"
+                continue
+            try:
+                oracle_outputs[backend] = oracle_backends[backend]().detach().clone()
+                synchronize()
+            except Exception as exc:
+                oracle_errors[backend] = f"{type(exc).__name__}: {exc}"
+        try:
+            oracle = dequantized_fp32_reference(
+                hidden_states=oracle_hidden_states,
+                w1=w1,
+                w2=w2,
+                topk_weights=oracle_topk_weights,
+                topk_ids=oracle_topk_ids,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                block_size=shape.block_size,
+            )
+            comparisons: dict[str, Any] = {}
+            for backend, output in oracle_outputs.items():
+                difference = (output.float() - oracle).abs()
+                comparisons[backend] = {
+                    "max_abs_diff": float(difference.max().item()),
+                    "mean_abs_diff": float(difference.mean().item()),
+                    **comparison_metrics(output, oracle),
+                }
+            gemv_comparison = comparisons.get("gemv")
+            gemv_oracle_pass = bool(
+                gemv_comparison is not None
+                and not oracle_errors
+                and gemv_comparison["relative_l2_error"]
+                <= args.gemv_oracle_max_relative_l2
+                and gemv_comparison["cosine_similarity"] >= args.gemv_oracle_min_cosine
+                and gemv_comparison["max_row_relative_l2"]
+                <= args.gemv_oracle_max_row_relative_l2
+                and gemv_comparison["min_row_cosine"] >= args.gemv_oracle_min_row_cosine
+                and gemv_comparison["max_abs_diff_over_reference_absmax"]
+                <= args.gemv_oracle_max_normalized_abs_diff
+            )
+            oracle_evidence = {
+                "tokens": args.oracle_probe_tokens,
+                "route_mode": "deterministic_coverage",
+                "seed": oracle_seed,
+                "selected_experts": sorted(
+                    int(value) for value in oracle_topk_ids.unique().cpu().tolist()
+                ),
+                "reference": "dequantized-fp32-no-activation-quantization",
+                "gemv_passed": gemv_oracle_pass,
+                "comparisons": comparisons,
+                "errors": oracle_errors,
+            }
+            del oracle
+        except Exception as exc:
+            gemv_oracle_pass = False
+            oracle_evidence = {
+                "tokens": args.oracle_probe_tokens,
+                "route_mode": "deterministic_coverage",
+                "seed": oracle_seed,
+                "reference": "dequantized-fp32-no-activation-quantization",
+                "gemv_passed": False,
+                "errors": {
+                    **oracle_errors,
+                    "oracle": f"{type(exc).__name__}: {exc}",
+                },
+            }
+        del (
+            oracle_hidden_states,
+            oracle_topk_ids,
+            oracle_topk_weights,
+            oracle_outputs,
+        )
+        torch.musa.empty_cache()
+
+    for token_count in tokens:
+        generator = torch.Generator(device="musa")
+        generator.manual_seed(args.seed + token_count)
+        hidden_states = torch.randn(
+            (token_count, shape.hidden_size),
+            device="musa",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        topk_ids, topk_weights = routes(
+            token_count,
+            shape.experts,
+            shape.top_k,
+            args.route_mode,
+            args.seed + token_count,
+            args.folded_shared_expert,
+        )
+        kwargs = backend_kwargs(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            block_size=shape.block_size,
+        )
+        backends, capabilities = build_backends(kwargs)
+        unsupported = [name for name in requested_backends if not capabilities[name]]
+        if unsupported:
+            raise RuntimeError(f"production capability gate rejected: {unsupported}")
+        outputs: dict[str, torch.Tensor] = {}
+        errors: dict[str, str] = {}
+        for backend in requested_backends:
+            try:
+                outputs[backend] = backends[backend]().detach().clone()
+                synchronize()
+            except Exception as exc:
+                errors[backend] = f"{type(exc).__name__}: {exc}"
+
+        dispatcher_evidence[str(token_count)] = dispatcher_smoke(
+            kwargs, requested_backends, outputs
+        )
+        if "deepgemm_prefill" in requested_backends:
+            deepgemm_implementation[str(token_count)] = deepgemm_prefill_implementation(
+                kwargs
+            )
+            if "deepgemm_prefill" in outputs:
+                deepgemm_dispatch_evidence[str(token_count)] = (
+                    deepgemm_prefill_dispatch_smoke(kwargs, outputs["deepgemm_prefill"])
+                )
+            else:
+                deepgemm_dispatch_evidence[str(token_count)] = {
+                    "passed": False,
+                    "error": errors.get("deepgemm_prefill", "direct output missing"),
+                }
+
+        reference = outputs.get("upstream")
+        samples: dict[str, list[float]] = {name: [] for name in requested_backends}
+        for round_index in range(args.rounds):
+            offset = round_index % len(requested_backends)
+            order = requested_backends[offset:] + requested_backends[:offset]
+            for backend in order:
+                if backend in errors:
+                    continue
+                try:
+                    measurements = bench_gpu_time_with_musa_event(
+                        backends[backend],
+                        dry_run_iters=args.warmup,
+                        repeat_iters=args.repeats_per_round,
+                        l2_flush=True,
+                        l2_flush_size_mb=args.l2_flush_mb,
+                    )
+                    samples[backend].extend(float(value) for value in measurements)
+                except Exception as exc:
+                    errors[backend] = f"{type(exc).__name__}: {exc}"
+                finally:
+                    torch.musa.empty_cache()
+
+        for backend in requested_backends:
+            diff_max = None
+            diff_mean = None
+            relative_l2 = None
+            cosine = None
+            max_row_relative_l2 = None
+            min_row_cosine = None
+            normalized_abs_diff = None
+            output_absmax = None
+            output_std = None
+            finite = None
+            non_poison = None
+            correct = None
+            correctness_basis = "unavailable"
+            output = outputs.get(backend)
+            if reference is not None and output is not None:
+                output_float = output.float()
+                diff = (output_float - reference.float()).abs()
+                diff_max = float(diff.max().item())
+                diff_mean = float(diff.mean().item())
+                metrics = comparison_metrics(output, reference)
+                relative_l2 = metrics["relative_l2_error"]
+                cosine = metrics["cosine_similarity"]
+                max_row_relative_l2 = metrics["max_row_relative_l2"]
+                min_row_cosine = metrics["min_row_cosine"]
+                normalized_abs_diff = metrics["max_abs_diff_over_reference_absmax"]
+                output_absmax = float(output_float.abs().max().item())
+                output_std = float(output_float.std().item())
+                finite = bool(torch.isfinite(output_float).all().item())
+                non_poison = finite and output_absmax > 1e-6 and output_std > 1e-7
+                if backend == "gemv":
+                    correctness_basis = (
+                        "sampled-fp32-oracle-and-rowwise-normalized-envelope"
+                    )
+                    correct = bool(
+                        non_poison
+                        and gemv_oracle_pass
+                        and relative_l2 <= args.gemv_max_relative_l2
+                        and cosine >= args.gemv_min_cosine
+                        and max_row_relative_l2 <= args.gemv_max_row_relative_l2
+                        and min_row_cosine >= args.gemv_min_row_cosine
+                        and normalized_abs_diff <= args.gemv_max_normalized_abs_diff
+                    )
+                elif backend == "upstream":
+                    correctness_basis = "established-reference"
+                    correct = bool(non_poison)
+                else:
+                    correctness_basis = "upstream-normalized-envelope"
+                    correct = bool(
+                        non_poison
+                        and relative_l2 <= args.grouped_max_relative_l2
+                        and cosine >= args.grouped_min_cosine
+                        and max_row_relative_l2 <= args.grouped_max_row_relative_l2
+                        and min_row_cosine >= args.grouped_min_row_cosine
+                        and normalized_abs_diff <= args.grouped_max_normalized_abs_diff
+                    )
+            timings = samples[backend]
+            q25 = quantile(timings, 0.25) if timings else None
+            q75 = quantile(timings, 0.75) if timings else None
+            results.append(
+                Result(
+                    shape=asdict(shape),
+                    tokens=token_count,
+                    backend=backend,
+                    samples_ms=timings,
+                    median_ms=statistics.median(timings) if timings else None,
+                    p20_ms=quantile(timings, 0.2) if timings else None,
+                    p95_ms=quantile(timings, 0.95) if timings else None,
+                    iqr_ms=(q75 - q25) if q25 is not None and q75 is not None else None,
+                    min_ms=min(timings) if timings else None,
+                    max_ms=max(timings) if timings else None,
+                    max_abs_diff=diff_max,
+                    mean_abs_diff=diff_mean,
+                    relative_l2_error=relative_l2,
+                    cosine_similarity=cosine,
+                    max_row_relative_l2=max_row_relative_l2,
+                    min_row_cosine=min_row_cosine,
+                    max_abs_diff_over_reference_absmax=normalized_abs_diff,
+                    output_absmax=output_absmax,
+                    output_std=output_std,
+                    finite=finite,
+                    non_poison=non_poison,
+                    correctness_pass=correct,
+                    correctness_basis=correctness_basis,
+                    reference_backend="upstream",
+                    error=errors.get(backend),
+                )
+            )
+        del hidden_states, topk_ids, topk_weights, outputs, reference
+        torch.musa.empty_cache()
+
+    qualified = bool(
+        dispatcher_evidence
+        and all(item["passed"] for item in dispatcher_evidence.values())
+        and (
+            not deepgemm_dispatch_evidence
+            or all(item["passed"] for item in deepgemm_dispatch_evidence.values())
+        )
+        and all(
+            result.error is None and result.correctness_pass is True
+            for result in results
+        )
+    )
+    candidate = (
+        recommend_thresholds(
+            results, tokens, args.regression_margin, args.max_iqr_ratio
+        )
+        if qualified
+        else {"gemv_max_tokens": None, "grouped_gemm_min_tokens": None}
+    )
+    payload = {
+        "metadata": metadata,
+        "qualification": {
+            "passed": qualified,
+            "reference_backend": {
+                "gemv": "sampled-fp32-oracle-and-rowwise-normalized-envelope",
+                "grouped_gemm": "upstream-normalized-envelope",
+                "deepgemm_prefill": "upstream-normalized-envelope",
+                "upstream": "established-reference",
+            },
+            "note": (
+                "candidate only; dense crossover, route-mode, independent-seed, "
+                "CUDAGraph, and serving A/B gates remain"
+            ),
+        },
+        "oracle_evidence": oracle_evidence,
+        "dispatcher_smoke_by_tokens": dispatcher_evidence,
+        "deepgemm_dispatch_smoke_by_tokens": deepgemm_dispatch_evidence,
+        "deepgemm_implementation_by_tokens": deepgemm_implementation,
+        "candidate_recommendation": candidate,
+        "results": [asdict(result) for result in results],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0 if qualified else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/fused_moe/benchmark_dispatch_graph.py
+++ b/benchmarks/fused_moe/benchmark_dispatch_graph.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Validate the native FP8 MoE GEMV dispatcher under CUDAGraph replay."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+# isort: off
+import torchada  # noqa: F401  # must patch before torch ecosystem imports
+import torch
+# isort: on
+
+from benchmark_dispatch_crossover import (
+    backend_kwargs,
+    block_scales,
+    package_versions,
+    quantized_weight,
+    repo_provenance,
+    routes,
+    synchronize,
+)
+
+from vllm_musa.model_executor.layers.fused_moe import fused_moe
+from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (
+    MusaFusedMoeBackend,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--experts", type=int, required=True)
+    parser.add_argument("--hidden-size", type=int, required=True)
+    parser.add_argument("--intermediate-size", type=int, required=True)
+    parser.add_argument("--top-k", type=int, required=True)
+    parser.add_argument("--tokens", type=int, required=True)
+    parser.add_argument("--seed", type=int, default=20260720)
+    parser.add_argument("--replays", type=int, default=8)
+    parser.add_argument("--folded-shared-expert", action="store_true")
+    parser.add_argument(
+        "--requested",
+        choices=("auto", "gemv"),
+        default="auto",
+        help="Use auto to validate the calibrated production policy.",
+    )
+    parser.add_argument(
+        "--expected-backend",
+        choices=("gemv", "upstream"),
+        default="gemv",
+        help="Backend identity expected during graph capture.",
+    )
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.folded_shared_expert and (args.experts < 2 or args.top_k < 2):
+        raise ValueError("folded shared expert requires experts >= 2 and top-k >= 2")
+    if args.replays <= 0:
+        raise ValueError("replays must be positive")
+    capability = tuple(int(value) for value in torch.musa.get_device_capability())
+    device_name = torch.musa.get_device_name(0)
+    multiprocessor_count = int(
+        torch.musa.get_device_properties(0).multi_processor_count
+    )
+    if capability != (3, 1) or "S5000" not in device_name.upper():
+        raise RuntimeError(
+            "this graph validation is valid only on MTT S5000/MP31, got "
+            f"device={device_name!r} capability={capability}"
+        )
+    w1 = quantized_weight(
+        (args.experts, 2 * args.intermediate_size, args.hidden_size), args.seed
+    )
+    w2 = quantized_weight(
+        (args.experts, args.hidden_size, args.intermediate_size), args.seed + 1
+    )
+    w1_scale = block_scales(w1, 128, args.seed + 2)
+    w2_scale = block_scales(w2, 128, args.seed + 3)
+    generator = torch.Generator(device="musa")
+    generator.manual_seed(args.seed + 4)
+    hidden_states = torch.randn(
+        (args.tokens, args.hidden_size),
+        device="musa",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    topk_ids, topk_weights = routes(
+        args.tokens,
+        args.experts,
+        args.top_k,
+        "balanced",
+        args.seed + 5,
+        args.folded_shared_expert,
+    )
+    kwargs = backend_kwargs(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+        block_size=128,
+    )
+
+    old_backend = fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND
+    original_gemv = fused_moe.fused_experts_impl
+    original_upstream = fused_moe._upstream_fused_moe._musa_original_fused_experts_impl
+    calls = {"gemv": 0, "upstream": 0}
+
+    def counted_gemv(*inner_args, **inner_kwargs):
+        calls["gemv"] += 1
+        return original_gemv(*inner_args, **inner_kwargs)
+
+    def counted_upstream(*inner_args, **inner_kwargs):
+        calls["upstream"] += 1
+        return original_upstream(*inner_args, **inner_kwargs)
+
+    try:
+        fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND = MusaFusedMoeBackend(
+            args.requested
+        )
+        fused_moe.fused_experts_impl = counted_gemv
+        fused_moe._upstream_fused_moe._musa_original_fused_experts_impl = (
+            counted_upstream
+        )
+        if args.expected_backend == "gemv":
+            original_gemv(
+                **kwargs,
+                inplace=False,
+                _allow_deepgemm_prefill=False,
+            )
+        else:
+            original_upstream(**kwargs)
+        synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            with torch.cuda.graph(graph):
+                captured_output = fused_moe._musa_fused_experts_impl_dispatch(**kwargs)
+        torch.cuda.current_stream().wait_stream(stream)
+        synchronize()
+        capture_calls = dict(calls)
+
+        comparisons = []
+        route_modes = ("balanced", "unique_random", "hot")
+        for replay_index in range(args.replays):
+            replacement = torch.randn(
+                hidden_states.shape,
+                device="musa",
+                dtype=hidden_states.dtype,
+                generator=generator,
+            )
+            hidden_states.copy_(replacement)
+            route_mode = route_modes[replay_index % len(route_modes)]
+            replacement_ids, replacement_weights = routes(
+                args.tokens,
+                args.experts,
+                args.top_k,
+                route_mode,
+                args.seed + 100 + replay_index,
+                args.folded_shared_expert,
+            )
+            topk_ids.copy_(replacement_ids)
+            topk_weights.copy_(replacement_weights)
+            if args.expected_backend == "gemv":
+                expected = (
+                    original_gemv(
+                        **kwargs,
+                        inplace=False,
+                        _allow_deepgemm_prefill=False,
+                    )
+                    .detach()
+                    .clone()
+                )
+            else:
+                expected = original_upstream(**kwargs).detach().clone()
+            graph.replay()
+            synchronize()
+            difference = (captured_output.float() - expected.float()).abs()
+            comparisons.append(
+                {
+                    "replay": replay_index,
+                    "route_mode": route_mode,
+                    "bitwise_equal": bool(torch.equal(captured_output, expected)),
+                    "max_abs_diff": float(difference.max().item()),
+                }
+            )
+    finally:
+        fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND = old_backend
+        fused_moe.fused_experts_impl = original_gemv
+        fused_moe._upstream_fused_moe._musa_original_fused_experts_impl = (
+            original_upstream
+        )
+
+    expected_capture_calls = {
+        "gemv": int(args.expected_backend == "gemv"),
+        "upstream": int(args.expected_backend == "upstream"),
+    }
+    passed = bool(
+        capture_calls == expected_capture_calls
+        and all(item["bitwise_equal"] for item in comparisons)
+    )
+    payload = {
+        "passed": passed,
+        "requested": args.requested,
+        "expected_backend": args.expected_backend,
+        "shape": {
+            "experts": args.experts,
+            "hidden_size": args.hidden_size,
+            "intermediate_size": args.intermediate_size,
+            "top_k": args.top_k,
+            "tokens": args.tokens,
+        },
+        "folded_shared_expert": args.folded_shared_expert,
+        "seed": args.seed,
+        "replays": args.replays,
+        "device": {
+            "name": device_name,
+            "capability": capability,
+            "multiprocessor_count": multiprocessor_count,
+        },
+        "packages": package_versions(),
+        "repo": repo_provenance(),
+        "expected_capture_calls": expected_capture_calls,
+        "capture_calls": capture_calls,
+        "comparisons": comparisons,
+    }
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized)
+    print(serialized, end="")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -559,8 +559,14 @@ bool ShouldUseQwenFp8Moe32x4(
         return false;
     }
 
-    const bool qwen_w1_swiglu = use_swigelu && hidden_size == 2048 && nr_n == 768;
-    const bool qwen_w2_project = !use_swigelu && hidden_size == 768 && nr_n == 2048;
+    const bool qwen_intermediate_size =
+        nr_n == 768 || nr_n == 512 || nr_n == 384 || nr_n == 256 || nr_n == 128;
+    const bool qwen_w1_swiglu =
+        use_swigelu && hidden_size == 2048 && qwen_intermediate_size;
+    const bool qwen_w2_project =
+        !use_swigelu && nr_n == 2048 &&
+        (hidden_size == 768 || hidden_size == 512 || hidden_size == 384 ||
+         hidden_size == 256 || hidden_size == 128);
     const BlockConfig config{32, 4, 0.f, true};
     return (qwen_w1_swiglu || qwen_w2_project) &&
            IsForcedBlockConfigValid(config, nr_n, hidden_size, vlen);

--- a/docs/vllm_musa/README.md
+++ b/docs/vllm_musa/README.md
@@ -50,6 +50,28 @@ Custom `forward_oot` implementations registered for MUSA dispatch:
 | `layers/attention/mla_attention.py` | Multi-head Latent Attention (MLA) |
 | `warmup/deep_gemm_warmup.py` | DeepGEMM JIT warmup |
 
+#### FP8 MoE backend dispatch
+
+On S5000, block-128 E4M3 MoE layers use a shape-keyed `auto` policy. Only
+offline-calibrated per-rank shapes select native GEMV for small token batches.
+For large eligible prefill invocations, `auto` preserves the default-on
+contiguous DeepGEMM path; intermediate and unsupported shapes use
+the established upstream fused-MoE implementation. The experimental grouped
+backend added by this dispatcher remains disabled unless both its operator and
+serving gates produce a validated threshold. The policy is also keyed by graph
+mode and active MP count, so thresholds are not reused across incompatible
+devices.
+
+`VLLM_MUSA_FUSED_MOE_DISPATCH` is a diagnostic force/rollback control with the
+values `auto` (default), `upstream`, `gemv`, or `grouped_gemm`. Forced modes do
+not bypass dtype, layout, expert-parallel, device, or graph-capture safety
+checks. In particular, forced GEMV during graph capture is limited to a
+calibrated capture shape and token range; outside that range it falls back to
+upstream. Production deployments should leave the override unset and use
+`auto`. An explicit `upstream` value bypasses both native GEMV and the
+default-on DeepGEMM prefill path, which makes it suitable as a diagnostic
+rollback rather than a production default.
+
 ### `distributed/` – KV-Transfer Connector
 
 Registers a Mooncake-based KV connector (`mooncake_connector.py`) for disaggregated prefill/decode serving (conditionally loaded when the `mooncake` package is available).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ include = ["vllm_musa*"]
 vllm_musa = [
     "jit_kernel/csrc/*.h",
     "jit_kernel/csrc/*/*.mu",
+    "jit_kernel/include/.gitkeep",
 ]
 
 [tool.ruff]

--- a/tests/test_fused_moe_chunking.py
+++ b/tests/test_fused_moe_chunking.py
@@ -113,6 +113,7 @@ def test_musa_fused_moe_shape_inventory_is_disabled_by_default(monkeypatch, tmp_
     )
     monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_MOE_SHAPE_INVENTORY_MIN_TOKENS", "1")
     monkeypatch.setattr(fused_moe, "_MOE_SHAPE_INVENTORY_RECORDS", 0)
+    monkeypatch.setattr(fused_moe, "_MOE_SHAPE_INVENTORY_ENABLED", False)
     _patch_fake_moe_kernels(monkeypatch, fused_moe, top_k)
 
     fused_moe.fused_experts_impl(
@@ -138,6 +139,8 @@ def test_musa_fused_moe_shape_inventory_records_bridge_contract(monkeypatch, tmp
     )
     monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_MOE_SHAPE_INVENTORY_MIN_TOKENS", "1")
     monkeypatch.setattr(fused_moe, "_MOE_SHAPE_INVENTORY_RECORDS", 0)
+    monkeypatch.setattr(fused_moe, "_MOE_SHAPE_INVENTORY_ENABLED", True)
+    monkeypatch.setattr(fused_moe, "_musa_stream_is_capturing", lambda: False)
     _patch_fake_moe_kernels(monkeypatch, fused_moe, top_k)
 
     result = fused_moe.fused_experts_impl(
@@ -178,6 +181,30 @@ def test_musa_fused_moe_shape_inventory_records_bridge_contract(monkeypatch, tmp
     ]
 
 
+def test_musa_fused_moe_shape_inventory_skips_graph_capture(monkeypatch, tmp_path):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    output_path = tmp_path / "inventory.jsonl"
+    monkeypatch.setenv(
+        "VLLM_MUSA_DEEPSEEK_V4_MOE_SHAPE_INVENTORY_PATH", str(output_path)
+    )
+    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_MOE_SHAPE_INVENTORY_MIN_TOKENS", "1")
+    monkeypatch.setattr(fused_moe, "_MOE_SHAPE_INVENTORY_RECORDS", 0)
+    monkeypatch.setattr(fused_moe, "_MOE_SHAPE_INVENTORY_ENABLED", True)
+    monkeypatch.setattr(fused_moe, "_musa_stream_is_capturing", lambda: True)
+    _patch_fake_moe_kernels(monkeypatch, fused_moe, top_k=1)
+
+    fused_moe.fused_experts_impl(
+        hidden_states=torch.zeros(2, 4),
+        w1=torch.zeros(2, 8, 4),
+        w2=torch.zeros(2, 4, 4),
+        topk_weights=torch.ones(2, 1),
+        topk_ids=torch.zeros(2, 1, dtype=torch.int64),
+    )
+
+    assert not output_path.exists()
+
+
 def _deepgemm_gate_kwargs(torch_module):
     return {
         "hidden_states": torch_module.empty(
@@ -196,6 +223,9 @@ def _deepgemm_gate_kwargs(torch_module):
         "topk_ids": torch_module.empty(
             (4100, 6), device="meta", dtype=torch_module.int32
         ),
+        "topk_weights": torch_module.empty(
+            (4100, 6), device="meta", dtype=torch_module.float32
+        ),
         "activation": "silu",
         "apply_router_weight_on_input": False,
         "use_fp8_w8a8": True,
@@ -204,6 +234,7 @@ def _deepgemm_gate_kwargs(torch_module):
         "use_int4_w4a16": False,
         "ocp_mx_scheme": None,
         "per_channel_quant": False,
+        "global_num_experts": 256,
         "expert_map": None,
         "w1_scale": torch_module.empty(
             (256, 4, 32), device="meta", dtype=torch_module.float32
@@ -211,6 +242,8 @@ def _deepgemm_gate_kwargs(torch_module):
         "w2_scale": torch_module.empty(
             (256, 32, 2), device="meta", dtype=torch_module.float32
         ),
+        "w1_zp": None,
+        "w2_zp": None,
         "a1_scale": None,
         "a2_scale": None,
         "block_shape": [128, 128],
@@ -219,46 +252,504 @@ def _deepgemm_gate_kwargs(torch_module):
     }
 
 
-def test_deepseek_v4_deepgemm_prefill_gate_is_env_gated(monkeypatch):
+def _gemv_gate_kwargs(torch_module):
+    grouped_kwargs = _deepgemm_gate_kwargs(torch_module)
+    return {
+        key: value
+        for key, value in grouped_kwargs.items()
+        if key
+        not in {
+            "apply_router_weight_on_input",
+            "block_shape",
+        }
+    } | {
+        "global_num_experts": 256,
+    }
+
+
+def test_musa_native_gemv_capability_accepts_supported_fp8_shape():
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    assert fused_moe._can_use_musa_native_fp8_moe_gemv(**_gemv_gate_kwargs(torch))
+
+
+def test_musa_native_gemv_scale_layout_rejects_ambiguous_or_padded_blocks():
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    weight = torch.empty((4, 2048, 64), device="meta", dtype=torch.float8_e4m3fn)
+    ambiguous_group64 = torch.empty((4, 32, 1), device="meta", dtype=torch.float32)
+    assert not fused_moe._musa_fp8_moe_scale_layout_is_supported(
+        ambiguous_group64, weight
+    )
+    assert not fused_moe._musa_fp8_moe_scale_layout_is_supported(
+        torch.ones(4, device="meta", dtype=torch.float32), weight
+    )
+
+    padded_output = torch.empty(
+        (4, 4160, 256), device="meta", dtype=torch.float8_e4m3fn
+    )
+    ceil_block128 = torch.empty((4, 33, 2), device="meta", dtype=torch.float32)
+    assert not fused_moe._musa_fp8_moe_scale_layout_is_supported(
+        ceil_block128, padded_output
+    )
+
+    aligned_group64_weight = torch.empty(
+        (4, 2048, 256), device="meta", dtype=torch.float8_e4m3fn
+    )
+    aligned_group64_scale = torch.empty((4, 32, 4), device="meta", dtype=torch.float32)
+    assert fused_moe._musa_fp8_moe_scale_layout_is_supported(
+        aligned_group64_scale, aligned_group64_weight
+    )
+
+
+def test_musa_native_gemv_capability_rejects_unsafe_inputs():
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    kwargs = _gemv_gate_kwargs(torch)
+    kwargs["expert_map"] = torch.arange(256, device="meta", dtype=torch.int32)
+    assert not fused_moe._can_use_musa_native_fp8_moe_gemv(**kwargs)
+
+    kwargs = _gemv_gate_kwargs(torch)
+    kwargs["topk_ids"] = torch.empty((4100, 6), device="meta", dtype=torch.int64)
+    assert not fused_moe._can_use_musa_native_fp8_moe_gemv(**kwargs)
+
+    kwargs = _gemv_gate_kwargs(torch)
+    kwargs["activation"] = "gelu"
+    assert not fused_moe._can_use_musa_native_fp8_moe_gemv(**kwargs)
+
+    kwargs = _gemv_gate_kwargs(torch)
+    kwargs["w1_bias"] = torch.empty((512,), device="meta", dtype=torch.bfloat16)
+    assert not fused_moe._can_use_musa_native_fp8_moe_gemv(**kwargs)
+
+    kwargs = _gemv_gate_kwargs(torch)
+    kwargs["global_num_experts"] = 512
+    assert not fused_moe._can_use_musa_native_fp8_moe_gemv(**kwargs)
+
+    kwargs = _gemv_gate_kwargs(torch)
+    kwargs["topk_weights"] = torch.empty((4099, 6), device="meta", dtype=torch.float32)
+    assert not fused_moe._can_use_musa_native_fp8_moe_gemv(**kwargs)
+
+    kwargs = _gemv_gate_kwargs(torch)
+    kwargs["w1_scale"] = torch.empty(
+        (256, 32, 4), device="meta", dtype=torch.float32
+    ).transpose(1, 2)
+    assert kwargs["w1_scale"].shape == (256, 4, 32)
+    assert not kwargs["w1_scale"].is_contiguous()
+    assert not fused_moe._can_use_musa_native_fp8_moe_gemv(**kwargs)
+
+    kwargs = _gemv_gate_kwargs(torch)
+    kwargs["w1_scale"] = torch.empty((256, 4, 32), dtype=torch.float32)
+    assert not fused_moe._can_use_musa_native_fp8_moe_gemv(**kwargs)
+
+
+def test_musa_grouped_gemm_gate_is_shape_gated():
     from vllm_musa.model_executor.layers.fused_moe import fused_moe
 
     kwargs = _deepgemm_gate_kwargs(torch)
-    monkeypatch.delenv("VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL", raising=False)
-
-    assert not fused_moe._can_use_deepseek_v4_moe_deepgemm_prefill(**kwargs)
-
-    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL", "1")
-
-    assert fused_moe._can_use_deepseek_v4_moe_deepgemm_prefill(**kwargs)
+    assert fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
 
 
-def test_deepseek_v4_deepgemm_prefill_gate_rejects_nonmatching_shape(
-    monkeypatch,
-):
+def test_musa_deepgemm_prefill_gate_accepts_folded_qwen_shape():
     from vllm_musa.model_executor.layers.fused_moe import fused_moe
 
     kwargs = _deepgemm_gate_kwargs(torch)
-    kwargs["topk_ids"] = torch.empty((4100, 2), device="meta", dtype=torch.int32)
-    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL", "1")
+    for key in ("topk_weights", "global_num_experts", "w1_zp", "w2_zp"):
+        kwargs.pop(key)
+    assert fused_moe._can_use_moe_deepgemm_prefill(**kwargs)
 
-    assert not fused_moe._can_use_deepseek_v4_moe_deepgemm_prefill(**kwargs)
+    # Shared-expert folding appends one expert and one routing column.  The
+    # large-M DeepGEMM gate must retain that base-path shape even before the
+    # small-M GEMV threshold is calibrated.
+    kwargs.update(
+        hidden_states=torch.empty((4100, 2048), device="meta", dtype=torch.bfloat16),
+        w1=torch.empty((257, 256, 2048), device="meta", dtype=torch.float8_e4m3fn),
+        w2=torch.empty((257, 2048, 128), device="meta", dtype=torch.float8_e4m3fn),
+        topk_ids=torch.empty((4100, 9), device="meta", dtype=torch.int32),
+        w1_scale=torch.empty((257, 2, 16), device="meta", dtype=torch.float32),
+        w2_scale=torch.empty((257, 16, 1), device="meta", dtype=torch.float32),
+    )
+    assert fused_moe._can_use_moe_deepgemm_prefill(**kwargs)
+
+    kwargs["hidden_states"] = torch.empty(
+        (64, 2048), device="meta", dtype=torch.bfloat16
+    )
+    assert not fused_moe._can_use_moe_deepgemm_prefill(**kwargs)
+
+    kwargs["hidden_states"] = torch.empty(
+        (4100, 2048), device="meta", dtype=torch.bfloat16
+    )
+    kwargs["expert_map"] = torch.empty((257,), device="meta", dtype=torch.int32)
+    assert not fused_moe._can_use_moe_deepgemm_prefill(**kwargs)
 
 
-def test_deepseek_v4_deepgemm_prefill_gate_rejects_nonmatching_dtype(
-    monkeypatch,
-):
+def test_musa_grouped_gemm_gate_rejects_nonmatching_shape():
     from vllm_musa.model_executor.layers.fused_moe import fused_moe
 
-    monkeypatch.setenv("VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL", "1")
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs["w1"] = torch.empty(
+        (256, 640, 4096), device="meta", dtype=torch.float8_e4m3fn
+    )
+
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+
+def test_musa_grouped_gemm_gate_rejects_nonmatching_dtype():
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
 
     kwargs = _deepgemm_gate_kwargs(torch)
     kwargs["w1_scale"] = torch.empty((256, 4, 32), device="meta", dtype=torch.bfloat16)
-    assert not fused_moe._can_use_deepseek_v4_moe_deepgemm_prefill(**kwargs)
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
 
     kwargs = _deepgemm_gate_kwargs(torch)
     kwargs["w2_scale"] = torch.empty((256, 32, 2), device="meta", dtype=torch.bfloat16)
-    assert not fused_moe._can_use_deepseek_v4_moe_deepgemm_prefill(**kwargs)
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
 
     kwargs = _deepgemm_gate_kwargs(torch)
     kwargs["topk_ids"] = torch.empty((4100, 6), device="meta", dtype=torch.int64)
-    assert not fused_moe._can_use_deepseek_v4_moe_deepgemm_prefill(**kwargs)
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+
+def test_musa_grouped_gemm_gate_rejects_unsafe_routing_and_layout():
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs["global_num_experts"] = 512
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs["topk_ids"] = torch.empty((4099, 6), device="meta", dtype=torch.int32)
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs["w2_scale"] = torch.empty(
+        (256, 2, 32), device="meta", dtype=torch.float32
+    ).transpose(1, 2)
+    assert kwargs["w2_scale"].shape == (256, 32, 2)
+    assert not kwargs["w2_scale"].is_contiguous()
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs["w1_zp"] = torch.empty((1,), device="meta", dtype=torch.int32)
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs["apply_router_weight_on_input"] = True
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+
+def test_musa_grouped_gemm_gate_matches_unpermute_block_contract():
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs.update(
+        hidden_states=torch.empty((4100, 384), device="meta", dtype=torch.bfloat16),
+        w1=torch.empty((256, 256, 384), device="meta", dtype=torch.float8_e4m3fn),
+        w2=torch.empty((256, 384, 128), device="meta", dtype=torch.float8_e4m3fn),
+        w1_scale=torch.empty((256, 2, 3), device="meta", dtype=torch.float32),
+        w2_scale=torch.empty((256, 3, 1), device="meta", dtype=torch.float32),
+    )
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+    kwargs.update(
+        hidden_states=torch.empty((4100, 1024), device="meta", dtype=torch.bfloat16),
+        w1=torch.empty((256, 256, 1024), device="meta", dtype=torch.float8_e4m3fn),
+        w2=torch.empty((256, 1024, 128), device="meta", dtype=torch.float8_e4m3fn),
+        w1_scale=torch.empty((256, 2, 8), device="meta", dtype=torch.float32),
+        w2_scale=torch.empty((256, 8, 1), device="meta", dtype=torch.float32),
+    )
+    assert fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+
+def test_musa_grouped_gemm_failure_disables_worker_path(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    monkeypatch.setattr(fused_moe, "_MUSA_GROUPED_GEMM_AVAILABLE", True)
+    monkeypatch.setattr(
+        fused_moe,
+        "_musa_fp8_moe_grouped_gemm_impl",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("jit failed")),
+    )
+    assert fused_moe._maybe_musa_fp8_moe_grouped_gemm(**kwargs, inplace=False) is None
+    assert fused_moe._MUSA_GROUPED_GEMM_AVAILABLE is False
+    assert not fused_moe._can_use_musa_fp8_moe_grouped_gemm(**kwargs)
+
+
+def _patch_s5000_dispatch(monkeypatch, fused_moe):
+    monkeypatch.setattr(
+        fused_moe,
+        "_musa_device_fingerprint",
+        lambda *_args, **_kwargs: ((3, 1), 64),
+    )
+    monkeypatch.setattr(fused_moe, "_musa_stream_is_capturing", lambda: False)
+
+
+def test_musa_capture_probe_fails_safe(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    for module_name in ("musa", "cuda"):
+        module = getattr(torch, module_name, None)
+        if module is not None:
+            monkeypatch.setattr(
+                module,
+                "is_current_stream_capturing",
+                lambda: (_ for _ in ()).throw(RuntimeError("probe failed")),
+                raising=False,
+            )
+    assert fused_moe._musa_stream_is_capturing() is True
+
+
+def test_musa_dispatcher_routes_forced_backends(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    _patch_s5000_dispatch(monkeypatch, fused_moe)
+    kwargs = _deepgemm_gate_kwargs(torch)
+    sentinel = torch.empty((1,), device="meta")
+
+    native_calls = []
+    monkeypatch.setattr(
+        fused_moe,
+        "fused_experts_impl",
+        lambda *args, **call_kwargs: native_calls.append((args, call_kwargs))
+        or sentinel,
+    )
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.GEMV,
+    )
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is sentinel
+    assert len(native_calls) == 1
+    assert native_calls[0][1] == {
+        "inplace": False,
+        "_allow_deepgemm_prefill": False,
+    }
+
+    grouped_calls = []
+    monkeypatch.setattr(
+        fused_moe,
+        "_maybe_musa_fp8_moe_grouped_gemm",
+        lambda **call_kwargs: grouped_calls.append(call_kwargs) or sentinel,
+    )
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.GROUPED_GEMM,
+    )
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is sentinel
+    assert len(grouped_calls) == 1
+    assert grouped_calls[0]["global_num_experts"] == 256
+    assert grouped_calls[0]["w1_zp"] is None
+    assert grouped_calls[0]["inplace"] is False
+
+
+def test_musa_dispatcher_rejects_gemv_input_router_weighting(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    _patch_s5000_dispatch(monkeypatch, fused_moe)
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs["apply_router_weight_on_input"] = True
+    fallback = torch.empty((1,), device="meta")
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.GEMV,
+    )
+    monkeypatch.setattr(
+        fused_moe,
+        "fused_experts_impl",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("input-router weighting must not dispatch GEMV")
+        ),
+    )
+    monkeypatch.setattr(
+        fused_moe._upstream_fused_moe,
+        "_musa_original_fused_experts_impl",
+        lambda *_args, **_kwargs: fallback,
+    )
+
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is fallback
+
+
+def test_musa_dispatcher_grouped_failure_and_capture_fall_back(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    _patch_s5000_dispatch(monkeypatch, fused_moe)
+    kwargs = _deepgemm_gate_kwargs(torch)
+    fallback = torch.empty((1,), device="meta")
+    upstream_calls = []
+    monkeypatch.setattr(
+        fused_moe._upstream_fused_moe,
+        "_musa_original_fused_experts_impl",
+        lambda *args, **call_kwargs: upstream_calls.append((args, call_kwargs))
+        or fallback,
+    )
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.GROUPED_GEMM,
+    )
+    monkeypatch.setattr(
+        fused_moe, "_maybe_musa_fp8_moe_grouped_gemm", lambda **_kwargs: None
+    )
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is fallback
+    assert len(upstream_calls) == 1
+    assert upstream_calls[0][1] == {}
+
+    monkeypatch.setattr(fused_moe, "_musa_stream_is_capturing", lambda: True)
+    monkeypatch.setattr(
+        fused_moe,
+        "_maybe_musa_fp8_moe_grouped_gemm",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("must not dispatch")),
+    )
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is fallback
+    assert len(upstream_calls) == 2
+
+
+def test_musa_dispatcher_unknown_small_shape_uses_upstream_path(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs["hidden_states"] = torch.empty(
+        (64, 4096), device="meta", dtype=torch.bfloat16
+    )
+    kwargs["topk_ids"] = torch.empty((64, 6), device="meta", dtype=torch.int32)
+    kwargs["topk_weights"] = torch.empty((64, 6), device="meta", dtype=torch.float32)
+    fallback = torch.empty((1,), device="meta")
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.AUTO,
+    )
+    monkeypatch.setattr(fused_moe, "has_calibrated_dimensions", lambda **_kwargs: False)
+    monkeypatch.setattr(
+        fused_moe,
+        "_musa_device_fingerprint",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unknown shape must not query the device")
+        ),
+    )
+    monkeypatch.setattr(
+        fused_moe,
+        "_musa_stream_is_capturing",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("small unknown shape must not probe capture")
+        ),
+    )
+    monkeypatch.setattr(
+        fused_moe._upstream_fused_moe,
+        "_musa_original_fused_experts_impl",
+        lambda *_args, **_kwargs: fallback,
+    )
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is fallback
+
+
+def test_musa_dispatcher_auto_preserves_base_deepgemm_for_unknown_large_shape(
+    monkeypatch,
+):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    deepgemm_output = torch.empty((1,), device="meta")
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.AUTO,
+    )
+    monkeypatch.setattr(fused_moe, "_musa_stream_is_capturing", lambda: False)
+    monkeypatch.setattr(fused_moe, "has_calibrated_dimensions", lambda **_kwargs: False)
+    monkeypatch.setattr(
+        fused_moe,
+        "_maybe_moe_deepgemm_prefill",
+        lambda **_kwargs: deepgemm_output,
+    )
+    monkeypatch.setattr(
+        fused_moe._upstream_fused_moe,
+        "_musa_original_fused_experts_impl",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("large auto fallback should use base DeepGEMM")
+        ),
+    )
+
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is deepgemm_output
+
+
+def test_musa_dispatcher_unaligned_per_tensor_scales_fall_back(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs.update(
+        hidden_states=torch.empty((4100, 2048), device="meta", dtype=torch.bfloat16),
+        w1=torch.empty((256, 4160, 2048), device="meta", dtype=torch.float8_e4m3fn),
+        w2=torch.empty((256, 2048, 2080), device="meta", dtype=torch.float8_e4m3fn),
+        w1_scale=torch.empty((), device="meta", dtype=torch.float32),
+        w2_scale=torch.empty((), device="meta", dtype=torch.float32),
+    )
+    fallback = torch.empty((1,), device="meta")
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.AUTO,
+    )
+    monkeypatch.setattr(fused_moe, "_musa_stream_is_capturing", lambda: False)
+    monkeypatch.setattr(
+        fused_moe._upstream_fused_moe,
+        "_musa_original_fused_experts_impl",
+        lambda *_args, **_kwargs: fallback,
+    )
+
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is fallback
+
+
+def test_musa_dispatcher_unknown_large_capture_bypasses_deepgemm(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    fallback = torch.empty((1,), device="meta")
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.AUTO,
+    )
+    monkeypatch.setattr(fused_moe, "_musa_stream_is_capturing", lambda: True)
+    monkeypatch.setattr(fused_moe, "has_calibrated_dimensions", lambda **_kwargs: False)
+    monkeypatch.setattr(
+        fused_moe,
+        "_maybe_moe_deepgemm_prefill",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("capture must bypass DeepGEMM")
+        ),
+    )
+    monkeypatch.setattr(
+        fused_moe._upstream_fused_moe,
+        "_musa_original_fused_experts_impl",
+        lambda *_args, **_kwargs: fallback,
+    )
+
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is fallback
+
+
+def test_musa_dispatcher_explicit_upstream_bypasses_deepgemm(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    kwargs = _deepgemm_gate_kwargs(torch)
+    fallback = torch.empty((1,), device="meta")
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.UPSTREAM,
+    )
+    monkeypatch.setattr(
+        fused_moe,
+        "_maybe_moe_deepgemm_prefill",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("explicit upstream must bypass DeepGEMM")
+        ),
+    )
+    monkeypatch.setattr(
+        fused_moe._upstream_fused_moe,
+        "_musa_original_fused_experts_impl",
+        lambda *_args, **_kwargs: fallback,
+    )
+
+    assert fused_moe._musa_fused_experts_impl_dispatch(**kwargs) is fallback

--- a/tests/test_fused_moe_dispatch_policy.py
+++ b/tests/test_fused_moe_dispatch_policy.py
@@ -1,0 +1,386 @@
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+POLICY_PATH = (
+    Path(__file__).parents[1]
+    / "vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "musa_fused_moe_dispatch_policy", POLICY_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+POLICY = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = POLICY
+SPEC.loader.exec_module(POLICY)
+
+MUSA_FUSED_MOE_DISPATCH_ENV = POLICY.MUSA_FUSED_MOE_DISPATCH_ENV
+MusaFusedMoeBackend = POLICY.MusaFusedMoeBackend
+MusaFusedMoeShape = POLICY.MusaFusedMoeShape
+MusaFusedMoeThresholds = POLICY.MusaFusedMoeThresholds
+parse_dispatch_backend = POLICY.parse_dispatch_backend
+select_fused_moe_backend = POLICY.select_fused_moe_backend
+thresholds_for_shape = POLICY.thresholds_for_shape
+FUSED_MOE_PATH = (
+    Path(__file__).parents[1] / "vllm_musa/model_executor/layers/fused_moe/fused_moe.py"
+)
+PLATFORM_PATH = Path(__file__).parents[1] / "vllm_musa/platform.py"
+
+
+def _shape(**overrides):
+    values = {
+        "device_capability": (3, 1),
+        "multiprocessor_count": 64,
+        "local_experts": 128,
+        "w1_output_size": 768,
+        "w2_input_size": 384,
+        "hidden_size": 4096,
+        "top_k": 8,
+        "block_n": 128,
+        "block_k": 128,
+        "activation": "silu",
+        "expert_parallel": False,
+        "hidden_dtype": "torch.bfloat16",
+        "weight_dtype": "torch.float8_e4m3fn",
+        "scale_dtype": "torch.float32",
+        "w1_scale_shape": (128, 6, 32),
+        "w2_scale_shape": (128, 32, 3),
+        "gemv_block": "auto",
+        "graph_mode": "eager",
+    }
+    values.update(overrides)
+    return MusaFusedMoeShape(**values)
+
+
+def test_unknown_shape_stays_on_upstream_path():
+    shape = _shape()
+
+    assert thresholds_for_shape(shape).source == "uncalibrated-shape"
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=4,
+            can_use_gemv=True,
+            can_use_grouped_gemm=True,
+            stream_is_capturing=False,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=16,
+            can_use_gemv=True,
+            can_use_grouped_gemm=True,
+            stream_is_capturing=False,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+
+
+def test_grouped_gemm_is_never_selected_during_capture():
+    shape = _shape()
+
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=4096,
+            can_use_gemv=True,
+            can_use_grouped_gemm=True,
+            stream_is_capturing=True,
+            requested=MusaFusedMoeBackend.GROUPED_GEMM,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+
+
+def test_calibrated_threshold_boundaries_and_device_identity(monkeypatch):
+    shape = _shape()
+    thresholds = MusaFusedMoeThresholds(
+        gemv_max_tokens=4,
+        grouped_gemm_min_tokens=16,
+        source="test-calibration",
+    )
+    monkeypatch.setattr(POLICY, "_CALIBRATED_THRESHOLDS", {shape: thresholds})
+
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=4,
+            can_use_gemv=True,
+            can_use_grouped_gemm=True,
+            stream_is_capturing=False,
+        )
+        == MusaFusedMoeBackend.GEMV
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=5,
+            can_use_gemv=True,
+            can_use_grouped_gemm=True,
+            stream_is_capturing=False,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=16,
+            can_use_gemv=True,
+            can_use_grouped_gemm=True,
+            stream_is_capturing=False,
+        )
+        == MusaFusedMoeBackend.GROUPED_GEMM
+    )
+    assert thresholds_for_shape(_shape(device_capability=(4, 0))).source == (
+        "uncalibrated-shape"
+    )
+    assert thresholds_for_shape(_shape(multiprocessor_count=56)).source == (
+        "uncalibrated-shape"
+    )
+
+
+def test_calibrated_dimension_prefilter(monkeypatch):
+    dimensions = frozenset({(128, 512, 256, 4096, 6)})
+    monkeypatch.setattr(POLICY, "_CALIBRATED_DIMENSIONS", dimensions)
+    assert POLICY.has_calibrated_dimensions(
+        local_experts=128,
+        w1_output_size=512,
+        w2_input_size=256,
+        hidden_size=4096,
+        top_k=6,
+    )
+    assert not POLICY.has_calibrated_dimensions(
+        local_experts=64,
+        w1_output_size=512,
+        w2_input_size=256,
+        hidden_size=4096,
+        top_k=6,
+    )
+
+
+def test_s5000_calibrated_shapes_use_route_worst_boundaries():
+    qwen = _shape(
+        multiprocessor_count=60,
+        local_experts=256,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=8,
+        w1_scale_shape=(256, 2, 16),
+        w2_scale_shape=(256, 16, 1),
+    )
+    dsv4 = _shape(
+        multiprocessor_count=60,
+        local_experts=256,
+        w1_output_size=512,
+        w2_input_size=256,
+        hidden_size=4096,
+        top_k=6,
+        w1_scale_shape=(256, 4, 32),
+        w2_scale_shape=(256, 32, 2),
+        gemv_block="32x8",
+    )
+    dsv2 = _shape(
+        multiprocessor_count=60,
+        local_experts=64,
+        w1_output_size=2816,
+        w2_input_size=1408,
+        hidden_size=2048,
+        top_k=6,
+        w1_scale_shape=(64, 22, 16),
+        w2_scale_shape=(64, 16, 11),
+    )
+
+    assert thresholds_for_shape(qwen).gemv_max_tokens == 13
+    assert thresholds_for_shape(qwen).grouped_gemm_min_tokens is None
+    assert thresholds_for_shape(dsv4).gemv_max_tokens == 5
+    dsv4_block16 = _shape(
+        multiprocessor_count=60,
+        local_experts=256,
+        w1_output_size=512,
+        w2_input_size=256,
+        hidden_size=4096,
+        top_k=6,
+        w1_scale_shape=(256, 4, 32),
+        w2_scale_shape=(256, 32, 2),
+        gemv_block="16x8",
+    )
+    assert thresholds_for_shape(dsv4_block16).gemv_max_tokens == 5
+    assert thresholds_for_shape(dsv4).grouped_gemm_min_tokens is None
+    assert thresholds_for_shape(dsv2).gemv_max_tokens == 3
+    assert thresholds_for_shape(dsv2).grouped_gemm_min_tokens is None
+
+    dsv2_capture = _shape(**{**dsv2.__dict__, "graph_mode": "capture"})
+    assert thresholds_for_shape(dsv2_capture).gemv_max_tokens == 1
+    assert thresholds_for_shape(dsv2_capture).grouped_gemm_min_tokens is None
+
+
+def test_s5000_calibration_remains_exact_for_layout_and_mp_count():
+    shape = _shape(
+        multiprocessor_count=60,
+        local_experts=64,
+        w1_output_size=2816,
+        w2_input_size=1408,
+        hidden_size=2048,
+        top_k=6,
+        w1_scale_shape=(64, 22, 16),
+        w2_scale_shape=(64, 16, 11),
+    )
+
+    assert thresholds_for_shape(
+        _shape(**{**shape.__dict__, "multiprocessor_count": 64})
+    ).source == ("uncalibrated-shape")
+    assert thresholds_for_shape(
+        _shape(**{**shape.__dict__, "w1_scale_shape": (64, 16, 22)})
+    ).source == ("uncalibrated-shape")
+
+
+def test_pr113_folded_qwen_shape_requires_fresh_calibration():
+    folded_qwen = _shape(
+        multiprocessor_count=60,
+        local_experts=257,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=9,
+        w1_scale_shape=(257, 2, 16),
+        w2_scale_shape=(257, 16, 1),
+    )
+
+    # Shared-expert folding appends one expert and one route column.  The old
+    # E=256/topk=8 threshold must not be reused without a new sweep.
+    assert thresholds_for_shape(folded_qwen).source == "uncalibrated-shape"
+
+
+def test_force_modes_preserve_eligibility_checks():
+    shape = _shape()
+
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=64,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=False,
+            requested=MusaFusedMoeBackend.GROUPED_GEMM,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=64,
+            can_use_gemv=False,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=False,
+            requested=MusaFusedMoeBackend.GEMV,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+
+
+def test_forced_gemv_preserves_capture_calibration_boundary(monkeypatch):
+    eager_shape = _shape(graph_mode="eager")
+    capture_shape = _shape(graph_mode="capture")
+    capture_thresholds = MusaFusedMoeThresholds(
+        gemv_max_tokens=4,
+        grouped_gemm_min_tokens=None,
+        source="capture-test",
+    )
+    monkeypatch.setattr(
+        POLICY,
+        "_CALIBRATED_THRESHOLDS",
+        {capture_shape: capture_thresholds},
+    )
+
+    # Eager force remains a diagnostic override outside calibrated shapes.
+    assert (
+        select_fused_moe_backend(
+            shape=eager_shape,
+            num_tokens=64,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=False,
+            requested=MusaFusedMoeBackend.GEMV,
+        )
+        == MusaFusedMoeBackend.GEMV
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=capture_shape,
+            num_tokens=4,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=True,
+            requested=MusaFusedMoeBackend.GEMV,
+        )
+        == MusaFusedMoeBackend.GEMV
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=capture_shape,
+            num_tokens=5,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=True,
+            requested=MusaFusedMoeBackend.GEMV,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=_shape(graph_mode="capture", local_experts=127),
+            num_tokens=1,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=True,
+            requested=MusaFusedMoeBackend.GEMV,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+
+
+def test_generic_override_parser(monkeypatch):
+    monkeypatch.setenv(MUSA_FUSED_MOE_DISPATCH_ENV, "grouped")
+    assert parse_dispatch_backend() == MusaFusedMoeBackend.GROUPED_GEMM
+
+    monkeypatch.setenv(MUSA_FUSED_MOE_DISPATCH_ENV, "invalid")
+    try:
+        parse_dispatch_backend()
+    except ValueError as exc:
+        assert MUSA_FUSED_MOE_DISPATCH_ENV in str(exc)
+    else:
+        raise AssertionError("invalid override must fail closed")
+
+
+def test_upstream_fallback_does_not_forward_removed_inplace_keyword():
+    tree = ast.parse(FUSED_MOE_PATH.read_text())
+    dispatch = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_musa_fused_experts_impl_dispatch"
+    )
+    upstream_calls = [
+        node
+        for node in ast.walk(dispatch)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_musa_original_fused_experts_impl"
+    ]
+
+    assert len(upstream_calls) == 1
+    assert "inplace" not in {keyword.arg for keyword in upstream_calls[0].keywords}
+
+
+def test_model_specific_dispatch_environment_is_removed_from_production_code():
+    legacy_names = (
+        "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV",
+        "VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL",
+    )
+    source = FUSED_MOE_PATH.read_text() + PLATFORM_PATH.read_text()
+
+    assert all(name not in source for name in legacy_names)

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -386,8 +386,12 @@ class TestNativeGemvSource:
         source = Path("csrc/musa/gemv.mu").read_text()
 
         assert "ShouldUseQwenFp8Moe32x4(" in source
-        assert "hidden_size == 2048 && nr_n == 768" in source
-        assert "hidden_size == 768 && nr_n == 2048" in source
+        assert "nr_n == 768 || nr_n == 512 || nr_n == 384" in source
+        assert "nr_n == 256 || nr_n == 128" in source
+        assert "use_swigelu && hidden_size == 2048 && qwen_intermediate_size" in source
+        assert "!use_swigelu && nr_n == 2048" in source
+        assert "hidden_size == 512 || hidden_size == 384" in source
+        assert "hidden_size == 256 || hidden_size == 128" in source
         assert "BlockConfig qwen_fp8_moe_config{32, 4" in source
         assert "case 4: GEN_LAUNCH_KERN(32, 4)" in source
 

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -36,6 +36,7 @@ class TestCustomOpsRuntimePatches:
         # the dflash fallback is now the vllm._custom_ops cat-6 object
         # patch; load + apply() it and assert it rebinds to the _shared helpers.
         import vllm
+
         from vllm_musa.patches import _get_patch_files, _load_patch_module, _shared
 
         vllm_ops = ModuleType("vllm._custom_ops")
@@ -163,9 +164,9 @@ class TestMUSAFlashAttentionReshapeCache:
     """
 
     def _load_fa_utils_with_musa_platform(self, monkeypatch, musa_ops_namespace):
+        import vllm
         import vllm.platforms as vllm_platforms
 
-        import vllm
         import vllm_musa
 
         monkeypatch.setenv("VLLM_MUSA_RESHAPE_CACHE_FLASH", "1")
@@ -495,7 +496,7 @@ class TestMUSAPlatformDefaults:
 
             MUSAPlatformBase.check_and_update_config(vllm_config)
 
-            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] == "1"
+            assert "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV" not in os.environ
             assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "32x8"
 
     def test_deepseek_v4_preserves_user_moe_gemv_block(self):
@@ -563,8 +564,6 @@ class TestMUSAPlatformDefaults:
             "VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_PREFILL_MATERIALIZED_TOPK_SORTED",
             "VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_PREFILL_MATERIALIZED_DIRECT",
             "VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_FUSED",
-            "VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL",
-            "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV",
         ]
 
         with patch.dict(os.environ, {}, clear=False):
@@ -573,7 +572,7 @@ class TestMUSAPlatformDefaults:
 
             MUSAPlatformBase.check_and_update_config(vllm_config)
 
-            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] == "1"
+            assert "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV" not in os.environ
             assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "32x8"
             assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in os.environ
             assert "VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE" not in os.environ
@@ -611,7 +610,6 @@ class TestMUSAPlatformDefaults:
                 not in os.environ
             )
             assert "VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_FUSED" not in os.environ
-            assert "VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL" not in os.environ
 
     def test_deepseek_v4_tp8_profile_sets_missing_envs(self):
         from vllm_musa.platform import MUSAPlatformBase
@@ -639,8 +637,6 @@ class TestMUSAPlatformDefaults:
             "VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_PREFILL_MATERIALIZED_TOPK_SORTED",
             "VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_PREFILL_MATERIALIZED_DIRECT",
             "VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_FUSED",
-            "VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL",
-            "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV",
         ]
 
         with patch.dict(
@@ -653,7 +649,7 @@ class TestMUSAPlatformDefaults:
 
             MUSAPlatformBase.check_and_update_config(vllm_config)
 
-            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] == "1"
+            assert "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV" not in os.environ
             assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "16x8"
             assert os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] == "256"
             assert (
@@ -699,7 +695,6 @@ class TestMUSAPlatformDefaults:
                 not in os.environ
             )
             assert "VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_FUSED" not in os.environ
-            assert "VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL" not in os.environ
             assert vllm_config.cache_config.block_size == 256
 
     def test_deepseek_v4_tp8_aggressive_profile_sets_mhc_deepgemm(self):
@@ -728,8 +723,6 @@ class TestMUSAPlatformDefaults:
             "VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_PREFILL_MATERIALIZED_TOPK_SORTED",
             "VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_PREFILL_MATERIALIZED_DIRECT",
             "VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_FUSED",
-            "VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL",
-            "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV",
         ]
 
         with patch.dict(
@@ -742,7 +735,7 @@ class TestMUSAPlatformDefaults:
 
             MUSAPlatformBase.check_and_update_config(vllm_config)
 
-            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] == "1"
+            assert "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV" not in os.environ
             assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "16x8"
             assert os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] == "256"
             assert (
@@ -816,7 +809,6 @@ class TestMUSAPlatformDefaults:
                 == "1"
             )
             assert os.environ["VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_FUSED"] == "1"
-            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL"] == "1"
             assert vllm_config.cache_config.block_size == 256
 
     def test_deepseek_v4_tp8_profile_preserves_explicit_overrides(self):
@@ -849,7 +841,6 @@ class TestMUSAPlatformDefaults:
             "VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_PREFILL_MATERIALIZED_TOPK_SORTED": "1",
             "VLLM_MUSA_DEEPSEEK_V4_INDEXER_TOPK_PREFILL_MATERIALIZED_DIRECT": "0",
             "VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_FUSED": "0",
-            "VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL": "0",
         }
 
         with patch.dict(os.environ, env, clear=False):
@@ -924,7 +915,6 @@ class TestMUSAPlatformDefaults:
                 == "0"
             )
             assert os.environ["VLLM_MUSA_DEEPSEEK_V4_QNORM_ROPE_KV_INSERT_FUSED"] == "0"
-            assert os.environ["VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL"] == "0"
             assert vllm_config.cache_config.block_size == 64
 
     def test_deepseek_v4_tp8_profile_rejects_unknown_name(self):
@@ -1186,7 +1176,11 @@ class TestMUSAFp8MoEPadding:
         monkeypatch.setattr(
             musa_fp8,
             "_ORIGINAL_FP8_MOE_MAYBE_ROUNDUP_SIZES",
-            lambda self, hidden_size, intermediate_size_per_partition, act_dtype, moe_parallel_config: (
+            lambda self,
+            hidden_size,
+            intermediate_size_per_partition,
+            act_dtype,
+            moe_parallel_config: (
                 hidden_size,
                 intermediate_size_per_partition,
             ),

--- a/vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py
+++ b/vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Model-agnostic MUSA fused-MoE backend selection.
+
+The hot path must not benchmark, synchronize device data to the host, or key
+off a model architecture name.  Offline S5000 sweeps populate exact shape
+entries below; unknown shapes keep the established upstream backend.
+"""
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final
+
+MUSA_FUSED_MOE_DISPATCH_ENV: Final = "VLLM_MUSA_FUSED_MOE_DISPATCH"
+
+
+class MusaFusedMoeBackend(str, Enum):
+    AUTO = "auto"
+    GEMV = "gemv"
+    GROUPED_GEMM = "grouped_gemm"
+    UPSTREAM = "upstream"
+
+
+@dataclass(frozen=True)
+class MusaFusedMoeShape:
+    """Static, per-rank properties that determine the kernel crossover."""
+
+    device_capability: tuple[int, int]
+    multiprocessor_count: int
+    local_experts: int
+    w1_output_size: int
+    w2_input_size: int
+    hidden_size: int
+    top_k: int
+    block_n: int
+    block_k: int
+    activation: str
+    expert_parallel: bool
+    hidden_dtype: str
+    weight_dtype: str
+    scale_dtype: str
+    w1_scale_shape: tuple[int, ...]
+    w2_scale_shape: tuple[int, ...]
+    gemv_block: str
+    graph_mode: str
+
+
+@dataclass(frozen=True)
+class MusaFusedMoeThresholds:
+    gemv_max_tokens: int | None
+    grouped_gemm_min_tokens: int | None
+    source: str
+
+
+# Unknown shapes stay on the established upstream path until an exact S5000
+# sweep is recorded.
+_DEFAULT_THRESHOLDS: Final = MusaFusedMoeThresholds(
+    gemv_max_tokens=None,
+    grouped_gemm_min_tokens=None,
+    source="uncalibrated-shape",
+)
+
+
+def _s5000_fp8_shape(
+    *,
+    local_experts: int,
+    w1_output_size: int,
+    w2_input_size: int,
+    hidden_size: int,
+    top_k: int,
+    w1_scale_shape: tuple[int, ...],
+    w2_scale_shape: tuple[int, ...],
+    gemv_block: str,
+    graph_mode: str,
+) -> MusaFusedMoeShape:
+    return MusaFusedMoeShape(
+        device_capability=(3, 1),
+        multiprocessor_count=60,
+        local_experts=local_experts,
+        w1_output_size=w1_output_size,
+        w2_input_size=w2_input_size,
+        hidden_size=hidden_size,
+        top_k=top_k,
+        block_n=128,
+        block_k=128,
+        activation="silu",
+        expert_parallel=False,
+        hidden_dtype="torch.bfloat16",
+        weight_dtype="torch.float8_e4m3fn",
+        scale_dtype="torch.float32",
+        w1_scale_shape=w1_scale_shape,
+        w2_scale_shape=w2_scale_shape,
+        gemv_block=gemv_block,
+        graph_mode=graph_mode,
+    )
+
+
+def _thresholds(
+    gemv_max_tokens: int | None,
+    grouped_gemm_min_tokens: int | None,
+    source: str,
+) -> MusaFusedMoeThresholds:
+    return MusaFusedMoeThresholds(
+        gemv_max_tokens=gemv_max_tokens,
+        grouped_gemm_min_tokens=grouped_gemm_min_tokens,
+        source=source,
+    )
+
+
+# Exact entries are keyed by the actual per-rank kernel shape. These S5000
+# entries use the worst boundary across balanced, unique-random, and hot routes
+# with three independent seeds. Capture entries additionally passed eight
+# bitwise-equal CUDAGraph replays. Unknown shapes remain on the established
+# base path, which may itself select the large-M DeepGEMM prefill backend.
+_CALIBRATED_THRESHOLDS: Final[dict[MusaFusedMoeShape, MusaFusedMoeThresholds]] = {
+    _s5000_fp8_shape(
+        local_experts=256,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=8,
+        w1_scale_shape=(256, 2, 16),
+        w2_scale_shape=(256, 16, 1),
+        gemv_block="auto",
+        graph_mode=graph_mode,
+    ): _thresholds(
+        gemv_max_tokens=13,
+        grouped_gemm_min_tokens=None,
+        source=f"s5000-mp60-20260721-e256-n256-k2048-{graph_mode}-dense-v5",
+    )
+    for graph_mode in ("eager", "capture")
+}
+_CALIBRATED_THRESHOLDS.update(
+    {
+        _s5000_fp8_shape(
+            local_experts=256,
+            w1_output_size=512,
+            w2_input_size=256,
+            hidden_size=4096,
+            top_k=6,
+            w1_scale_shape=(256, 4, 32),
+            w2_scale_shape=(256, 32, 2),
+            gemv_block="32x8",
+            graph_mode=graph_mode,
+        ): _thresholds(
+            gemv_max_tokens=5,
+            grouped_gemm_min_tokens=None,
+            source=f"s5000-mp60-20260721-e256-n512-k4096-{graph_mode}-block32-dense-v5",
+        )
+        for graph_mode in ("eager", "capture")
+    }
+)
+_CALIBRATED_THRESHOLDS.update(
+    {
+        _s5000_fp8_shape(
+            local_experts=256,
+            w1_output_size=512,
+            w2_input_size=256,
+            hidden_size=4096,
+            top_k=6,
+            w1_scale_shape=(256, 4, 32),
+            w2_scale_shape=(256, 32, 2),
+            gemv_block="16x8",
+            graph_mode=graph_mode,
+        ): _thresholds(
+            gemv_max_tokens=5,
+            grouped_gemm_min_tokens=None,
+            source=f"s5000-mp60-20260721-e256-n512-k4096-{graph_mode}-block16-dense-v5",
+        )
+        for graph_mode in ("eager", "capture")
+    }
+)
+_CALIBRATED_THRESHOLDS.update(
+    {
+        _s5000_fp8_shape(
+            local_experts=64,
+            w1_output_size=2816,
+            w2_input_size=1408,
+            hidden_size=2048,
+            top_k=6,
+            w1_scale_shape=(64, 22, 16),
+            w2_scale_shape=(64, 16, 11),
+            gemv_block="auto",
+            graph_mode=graph_mode,
+        ): _thresholds(
+            # Capture-mode A/B on S5000 shows a GEMV win at M=1, but a
+            # regression at M=2/3.  Keep the wider eager boundary and use
+            # GEMV only for the single-token decode case under capture.
+            gemv_max_tokens=3 if graph_mode == "eager" else 1,
+            # No production-safe grouped crossover is currently established
+            # for this shape; retain upstream for the large-token regime.
+            grouped_gemm_min_tokens=None,
+            source=(
+                f"s5000-mp60-20260721-e64-n2816-k2048-{graph_mode}-"
+                f"{'m1-' if graph_mode == 'capture' else ''}serving-gated"
+            ),
+        )
+        for graph_mode in ("eager", "capture")
+    }
+)
+
+_CALIBRATED_DIMENSIONS: Final = frozenset(
+    (
+        shape.local_experts,
+        shape.w1_output_size,
+        shape.w2_input_size,
+        shape.hidden_size,
+        shape.top_k,
+    )
+    for shape in _CALIBRATED_THRESHOLDS
+)
+
+
+def parse_dispatch_backend(value: str | None = None) -> MusaFusedMoeBackend:
+    """Parse the generic force/rollback override; default is ``auto``."""
+
+    raw_value = os.environ.get(MUSA_FUSED_MOE_DISPATCH_ENV, "auto")
+    if value is not None:
+        raw_value = value
+    normalized = raw_value.strip().lower().replace("-", "_")
+    aliases = {
+        "gemm": MusaFusedMoeBackend.GROUPED_GEMM,
+        "grouped": MusaFusedMoeBackend.GROUPED_GEMM,
+        "native_gemv": MusaFusedMoeBackend.GEMV,
+    }
+    if normalized in aliases:
+        return aliases[normalized]
+    try:
+        return MusaFusedMoeBackend(normalized)
+    except ValueError as exc:
+        choices = ", ".join(backend.value for backend in MusaFusedMoeBackend)
+        raise ValueError(
+            f"Invalid {MUSA_FUSED_MOE_DISPATCH_ENV}={raw_value!r}; "
+            f"expected one of: {choices}"
+        ) from exc
+
+
+def thresholds_for_shape(shape: MusaFusedMoeShape) -> MusaFusedMoeThresholds:
+    return _CALIBRATED_THRESHOLDS.get(shape, _DEFAULT_THRESHOLDS)
+
+
+def has_calibrated_dimensions(
+    *,
+    local_experts: int,
+    w1_output_size: int,
+    w2_input_size: int,
+    hidden_size: int,
+    top_k: int,
+) -> bool:
+    """Cheap hot-path rejection before capability and capture checks."""
+
+    return (
+        local_experts,
+        w1_output_size,
+        w2_input_size,
+        hidden_size,
+        top_k,
+    ) in _CALIBRATED_DIMENSIONS
+
+
+def select_fused_moe_backend(
+    *,
+    shape: MusaFusedMoeShape,
+    num_tokens: int,
+    can_use_gemv: bool,
+    can_use_grouped_gemm: bool,
+    stream_is_capturing: bool,
+    requested: MusaFusedMoeBackend = MusaFusedMoeBackend.AUTO,
+    thresholds: MusaFusedMoeThresholds | None = None,
+) -> MusaFusedMoeBackend:
+    """Choose one already-compiled backend without device synchronization.
+
+    Forced modes are diagnostic controls, not correctness bypasses: if a
+    requested backend is ineligible the established upstream path is used.
+    """
+
+    if requested == MusaFusedMoeBackend.GEMV:
+        # Forced GEMV remains useful for eager diagnostics, but graph capture
+        # must stay inside an explicitly calibrated capture entry and token
+        # range.  Otherwise an unknown shape could be baked into a graph even
+        # though the override is documented as preserving capture safety.
+        if thresholds is None:
+            thresholds = thresholds_for_shape(shape)
+        capture_is_calibrated = bool(
+            not stream_is_capturing
+            or (
+                thresholds.gemv_max_tokens is not None
+                and num_tokens <= thresholds.gemv_max_tokens
+            )
+        )
+        return (
+            MusaFusedMoeBackend.GEMV
+            if can_use_gemv and capture_is_calibrated
+            else MusaFusedMoeBackend.UPSTREAM
+        )
+    if requested == MusaFusedMoeBackend.GROUPED_GEMM:
+        return (
+            MusaFusedMoeBackend.GROUPED_GEMM
+            if can_use_grouped_gemm and not stream_is_capturing
+            else MusaFusedMoeBackend.UPSTREAM
+        )
+    if requested == MusaFusedMoeBackend.UPSTREAM:
+        return MusaFusedMoeBackend.UPSTREAM
+
+    if thresholds is None:
+        thresholds = thresholds_for_shape(shape)
+    if (
+        can_use_gemv
+        and thresholds.gemv_max_tokens is not None
+        and num_tokens <= thresholds.gemv_max_tokens
+    ):
+        return MusaFusedMoeBackend.GEMV
+    if (
+        can_use_grouped_gemm
+        and not stream_is_capturing
+        and thresholds.grouped_gemm_min_tokens is not None
+        and num_tokens >= thresholds.grouped_gemm_min_tokens
+    ):
+        return MusaFusedMoeBackend.GROUPED_GEMM
+    return MusaFusedMoeBackend.UPSTREAM
+
+
+__all__ = [
+    "MUSA_FUSED_MOE_DISPATCH_ENV",
+    "MusaFusedMoeBackend",
+    "MusaFusedMoeShape",
+    "MusaFusedMoeThresholds",
+    "has_calibrated_dimensions",
+    "parse_dispatch_backend",
+    "select_fused_moe_backend",
+    "thresholds_for_shape",
+]

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import inspect
 import json
 import os
 import time
+from functools import cache
 
 import torch
 from vllm import _custom_ops as ops
@@ -25,9 +25,16 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
 from vllm.platforms import current_platform
-from vllm.triton_utils import tl
 
 from vllm_musa import _custom_ops as musa_ops
+from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (
+    MusaFusedMoeBackend,
+    MusaFusedMoeShape,
+    has_calibrated_dimensions,
+    parse_dispatch_backend,
+    select_fused_moe_backend,
+    thresholds_for_shape,
+)
 
 logger = init_logger(__name__)
 
@@ -53,6 +60,8 @@ _MOE_SHAPE_INVENTORY_WARNED = False
 _DEEPGEMM_PREFILL_ENV = "VLLM_MUSA_MOE_DEEPGEMM_PREFILL"
 _DEEPGEMM_PREFILL_MIN_TOKENS_ENV = "VLLM_MUSA_MOE_DEEPGEMM_PREFILL_MIN_TOKENS"
 _DEEPGEMM_PREFILL_WARNED = False
+_MUSA_GROUPED_GEMM_AVAILABLE = True
+_MUSA_FUSED_MOE_REQUESTED_BACKEND = parse_dispatch_backend()
 
 
 def _env_flag_enabled(name: str) -> bool:
@@ -61,8 +70,17 @@ def _env_flag_enabled(name: str) -> bool:
 
 
 def _env_flag_disabled(name: str) -> bool:
-    """True only when explicitly set to a falsy value; unset means enabled."""
-    return os.environ.get(name, "").strip().lower() in {"0", "false", "no", "off"}
+    """Treat only an explicit falsy value as disabling a default-on path."""
+
+    return os.environ.get(name, "").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+_MOE_SHAPE_INVENTORY_ENABLED = _env_flag_enabled(_MOE_SHAPE_INVENTORY_ENV)
 
 
 def _env_int(name: str, default: int) -> int:
@@ -70,6 +88,52 @@ def _env_int(name: str, default: int) -> int:
         return int(os.environ.get(name, default))
     except ValueError:
         return default
+
+
+def _tensors_share_device(
+    reference: torch.Tensor,
+    *tensors: torch.Tensor | None,
+) -> bool:
+    return all(
+        tensor is None or tensor.device == reference.device for tensor in tensors
+    )
+
+
+def _musa_moe_routes_are_supported(
+    *,
+    hidden_states: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_experts: int,
+) -> bool:
+    return (
+        topk_ids.dim() == 2
+        and topk_weights.dim() == 2
+        and topk_ids.shape == topk_weights.shape
+        and topk_ids.shape[0] == hidden_states.shape[0]
+        and 0 < topk_ids.shape[1] <= num_experts
+        and topk_ids.is_contiguous()
+        and topk_weights.is_contiguous()
+    )
+
+
+@cache
+def _musa_device_fingerprint(
+    device_index: int,
+) -> tuple[tuple[int, int], int]:
+    try:
+        capability = current_platform.get_device_capability(device_index)
+        device_capability = (
+            (int(capability[0]), int(capability[1]))
+            if capability is not None
+            else (-1, -1)
+        )
+        multiprocessor_count = int(
+            torch.musa.get_device_properties(device_index).multi_processor_count
+        )
+        return device_capability, multiprocessor_count
+    except Exception:
+        return (-1, -1), -1
 
 
 def _tensor_meta(tensor: torch.Tensor | None) -> dict[str, object] | None:
@@ -153,7 +217,7 @@ def _maybe_record_deepseek_v4_moe_shape_inventory(
     global _MOE_SHAPE_INVENTORY_RECORDS
     global _MOE_SHAPE_INVENTORY_WARNED
 
-    if not _env_flag_enabled(_MOE_SHAPE_INVENTORY_ENV):
+    if not _MOE_SHAPE_INVENTORY_ENABLED or _musa_stream_is_capturing():
         return
 
     num_tokens = hidden_states.size(0)
@@ -217,6 +281,116 @@ def _maybe_record_deepseek_v4_moe_shape_inventory(
             _MOE_SHAPE_INVENTORY_WARNED = True
 
 
+def _can_use_musa_fp8_moe_grouped_gemm(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+    ocp_mx_scheme: str | None,
+    per_channel_quant: bool,
+    global_num_experts: int,
+    expert_map: torch.Tensor | None,
+    w1_scale: torch.Tensor | None,
+    w2_scale: torch.Tensor | None,
+    w1_zp: torch.Tensor | None,
+    w2_zp: torch.Tensor | None,
+    a1_scale: torch.Tensor | None,
+    a2_scale: torch.Tensor | None,
+    block_shape: list[int] | None,
+    w1_bias: torch.Tensor | None,
+    w2_bias: torch.Tensor | None,
+) -> bool:
+    if (
+        not _MUSA_GROUPED_GEMM_AVAILABLE
+        or not use_fp8_w8a8
+        or use_int8_w8a8
+        or use_int8_w8a16
+        or use_int4_w4a16
+        or ocp_mx_scheme is not None
+        or per_channel_quant
+        or expert_map is not None
+        or w1_zp is not None
+        or w2_zp is not None
+        or w1_scale is None
+        or w2_scale is None
+        or a1_scale is not None
+        or a2_scale is not None
+        or w1_bias is not None
+        or w2_bias is not None
+    ):
+        return False
+
+    if activation != "silu" or apply_router_weight_on_input:
+        return False
+
+    if block_shape != [128, 128]:
+        return False
+
+    if hidden_states.dtype != torch.bfloat16:
+        return False
+
+    if w1.dtype != torch.float8_e4m3fn or w2.dtype != torch.float8_e4m3fn:
+        return False
+
+    if (
+        w1_scale.dtype != torch.float32
+        or w2_scale.dtype != torch.float32
+        or not w1_scale.is_contiguous()
+        or not w2_scale.is_contiguous()
+    ):
+        return False
+
+    if w1.dim() != 3 or w2.dim() != 3 or hidden_states.dim() != 2:
+        return False
+    E, N, K = w1.shape
+    if global_num_experts not in (-1, E):
+        return False
+    if topk_ids.dtype != torch.int32 or topk_weights.dtype != torch.float32:
+        return False
+    if not _musa_moe_routes_are_supported(
+        hidden_states=hidden_states,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        num_experts=E,
+    ):
+        return False
+    if not (
+        hidden_states.is_contiguous()
+        and w1.is_contiguous()
+        and w2.is_contiguous()
+        and _tensors_share_device(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            w1_scale,
+            w2_scale,
+        )
+    ):
+        return False
+
+    if E <= 0 or N % 256 != 0 or K % 128 != 0:
+        return False
+    unpermute_block = min(K, 1024)
+    if K % unpermute_block != 0 or unpermute_block & (unpermute_block - 1) != 0:
+        return False
+    return (
+        K == hidden_states.size(1)
+        and w2.shape == (E, K, N // 2)
+        and w1_scale.shape == (E, N // 128, K // 128)
+        and w2_scale.shape == (E, K // 128, (N // 2) // 128)
+    )
+
+
 def _can_use_moe_deepgemm_prefill(
     *,
     hidden_states: torch.Tensor,
@@ -240,6 +414,8 @@ def _can_use_moe_deepgemm_prefill(
     w1_bias: torch.Tensor | None,
     w2_bias: torch.Tensor | None,
 ) -> bool:
+    """Gate the established default-on large-M DeepGEMM prefill path."""
+
     if _env_flag_disabled(_DEEPGEMM_PREFILL_ENV):
         return False
 
@@ -266,25 +442,16 @@ def _can_use_moe_deepgemm_prefill(
 
     if activation != "silu" or apply_router_weight_on_input:
         return False
-
-    if block_shape != [128, 128]:
+    if block_shape != [128, 128] or topk_ids.size(1) > 16:
         return False
-
-    if topk_ids.size(1) > 16:
-        return False
-
     if hidden_states.dtype != torch.bfloat16:
         return False
-
     if w1.dtype != torch.float8_e4m3fn or w2.dtype != torch.float8_e4m3fn:
         return False
-
     if w1_scale.dtype != torch.float32 or w2_scale.dtype != torch.float32:
         return False
-
     if topk_ids.dtype != torch.int32:
         return False
-
     if not (
         hidden_states.is_contiguous() and w1.is_contiguous() and w2.is_contiguous()
     ):
@@ -317,6 +484,8 @@ def _silu_mul_per_token_group_fp8_quant_musa_large(
         device=input_tensor.device,
         dtype=torch.float32,
     )
+    # Use the row-tiled kernel that fuses SiLU+Mul with the group-128 FP8
+    # quantization used by the contiguous DeepGEMM path.
     from vllm_musa.jit_kernel.csrc.quant import per_token_group_quant_8bit
 
     fp8_min, fp8_max = get_fp8_min_max()
@@ -333,7 +502,7 @@ def _silu_mul_per_token_group_fp8_quant_musa_large(
     return output, output_s
 
 
-def _moe_deepgemm_prefill_impl(
+def _musa_fp8_moe_grouped_gemm_impl(
     *,
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -342,132 +511,9 @@ def _moe_deepgemm_prefill_impl(
     topk_ids: torch.Tensor,
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
+    expert_map: torch.Tensor | None,
     inplace: bool,
-) -> torch.Tensor:
-    # MUSA: SGLang-style fused-glue DeepGEMM MoE prefill. One fused preprocess
-    # kernel does quant + permute + contiguous group-layout + m_indices/src2dst
-    # (replacing moe_kernel_quantize_input + deepgemm_moe_permute), the two
-    # grouped FP8 GEMMs are unchanged, and one post_reorder kernel does the
-    # weighted un-permute (replacing deepgemm_unpermute_and_reduce). Falls back
-    # to the unfused path when the fused preprocess cannot handle the shape.
-    E = w1.shape[0]
-    try:
-        from vllm_musa.jit_kernel.post_reorder import post_reorder_triton_kernel
-        from vllm_musa.jit_kernel.tilelang.deep_gemm_contig_preprocess import (
-            can_use_fp8_tilelang,
-            deep_gemm_contig_preprocess_fp8_tilelang,
-        )
-
-        use_fused = can_use_fp8_tilelang(hidden_states, topk_ids, E, True)
-    except Exception:
-        use_fused = False
-
-    if not use_fused:
-        return _moe_deepgemm_prefill_impl_unfused(
-            hidden_states=hidden_states,
-            w1=w1,
-            w2=w2,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-            inplace=inplace,
-        )
-
-    from vllm.utils.deep_gemm import (
-        get_mk_alignment_for_contiguous_layout,
-        m_grouped_fp8_gemm_nt_contiguous,
-        mk_alignment_scope,
-    )
-
-    logger.info_once("Using the MUSA fused-glue grouped DeepGEMM MoE prefill path.")
-
-    _, N, K = w1.shape
-    M, top_k = topk_ids.shape
-    block_m = int(get_mk_alignment_for_contiguous_layout()[0])
-    dev = hidden_states.device
-
-    src2dst_numel = M * top_k
-    all_tokens = (
-        (src2dst_numel + E * (block_m - 1) + block_m - 1) // block_m
-    ) * block_m
-
-    qhidden_perm = torch.empty((all_tokens, K), device=dev, dtype=torch.float8_e4m3fn)
-    qhidden_scale_perm = torch.empty(
-        (all_tokens, K // 128), device=dev, dtype=torch.float32
-    )
-    m_indices = torch.empty(all_tokens, device=dev, dtype=torch.int32)
-    src2dst = torch.empty(src2dst_numel, device=dev, dtype=torch.int32)
-    topk_ids_for_combine = torch.empty_like(topk_ids)
-    counts = torch.empty(E, device=dev, dtype=torch.int32)
-    cursor = torch.empty(E, device=dev, dtype=torch.int32)
-
-    deep_gemm_contig_preprocess_fp8_tilelang(
-        hidden_states,
-        topk_ids,
-        qhidden_perm,
-        qhidden_scale_perm,
-        m_indices,
-        src2dst,
-        topk_ids_for_combine,
-        counts,
-        cursor,
-        E,
-        block_m,
-    )
-
-    with mk_alignment_scope(block_m):
-        mm1_out = torch.empty((all_tokens, N), device=dev, dtype=hidden_states.dtype)
-        m_grouped_fp8_gemm_nt_contiguous(
-            (qhidden_perm, qhidden_scale_perm.contiguous()),
-            (w1, w1_scale.contiguous()),
-            mm1_out,
-            m_indices,
-        )
-
-        a2q = torch.empty((all_tokens, N // 2), device=dev, dtype=torch.float8_e4m3fn)
-        a2q, a2q_scale = _silu_mul_per_token_group_fp8_quant_musa_large(
-            mm1_out.view(-1, N),
-            a2q,
-            group_size=128,
-        )
-
-        mm2_out = torch.empty((all_tokens, K), device=dev, dtype=hidden_states.dtype)
-        m_grouped_fp8_gemm_nt_contiguous(
-            (a2q, a2q_scale.contiguous()),
-            (w2, w2_scale.contiguous()),
-            mm2_out,
-            m_indices,
-        )
-
-    if inplace and not disable_inplace():
-        output = hidden_states
-    else:
-        output = torch.empty_like(hidden_states)
-
-    post_reorder_triton_kernel[(M,)](
-        mm2_out,
-        output,
-        src2dst,
-        topk_ids,
-        topk_weights,
-        top_k,
-        K,
-        BLOCK_SIZE=1024,
-    )
-    return output
-
-
-def _moe_deepgemm_prefill_impl_unfused(
-    *,
-    hidden_states: torch.Tensor,
-    w1: torch.Tensor,
-    w2: torch.Tensor,
-    topk_weights: torch.Tensor,
-    topk_ids: torch.Tensor,
-    w1_scale: torch.Tensor,
-    w2_scale: torch.Tensor,
-    inplace: bool,
+    log_selection: bool = True,
 ) -> torch.Tensor:
     from vllm.model_executor.layers.fused_moe.deep_gemm_utils import (
         deepgemm_moe_permute,
@@ -478,7 +524,8 @@ def _moe_deepgemm_prefill_impl_unfused(
         mk_alignment_scope,
     )
 
-    logger.info_once("Using the MUSA grouped DeepGEMM MoE prefill path.")
+    if log_selection:
+        logger.info_once("MUSA fused-MoE diagnostic grouped DeepGEMM selected.")
 
     qhidden, a1_scale = moe_kernel_quantize_input(
         A=hidden_states,
@@ -499,7 +546,7 @@ def _moe_deepgemm_prefill_impl_unfused(
         aq_scale=a1_scale,
         topk_ids=topk_ids,
         local_num_experts=w1.shape[0],
-        expert_map=None,
+        expert_map=expert_map,
         expert_tokens_meta=None,
     )
 
@@ -550,8 +597,221 @@ def _moe_deepgemm_prefill_impl_unfused(
         topk_ids=topk_ids,
         topk_weights=topk_weights,
         inv_perm=inv_perm,
-        expert_map=None,
+        expert_map=expert_map,
         output=output,
+    )
+    return output
+
+
+def _maybe_musa_fp8_moe_grouped_gemm(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    inplace: bool,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+    ocp_mx_scheme: str | None,
+    per_channel_quant: bool,
+    global_num_experts: int,
+    expert_map: torch.Tensor | None,
+    w1_scale: torch.Tensor | None,
+    w2_scale: torch.Tensor | None,
+    w1_zp: torch.Tensor | None,
+    w2_zp: torch.Tensor | None,
+    a1_scale: torch.Tensor | None,
+    a2_scale: torch.Tensor | None,
+    block_shape: list[int] | None,
+    w1_bias: torch.Tensor | None,
+    w2_bias: torch.Tensor | None,
+) -> torch.Tensor | None:
+    global _DEEPGEMM_PREFILL_WARNED, _MUSA_GROUPED_GEMM_AVAILABLE
+
+    if not _can_use_musa_fp8_moe_grouped_gemm(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=activation,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        use_fp8_w8a8=use_fp8_w8a8,
+        use_int8_w8a8=use_int8_w8a8,
+        use_int8_w8a16=use_int8_w8a16,
+        use_int4_w4a16=use_int4_w4a16,
+        ocp_mx_scheme=ocp_mx_scheme,
+        per_channel_quant=per_channel_quant,
+        global_num_experts=global_num_experts,
+        expert_map=expert_map,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+        w1_zp=w1_zp,
+        w2_zp=w2_zp,
+        a1_scale=a1_scale,
+        a2_scale=a2_scale,
+        block_shape=block_shape,
+        w1_bias=w1_bias,
+        w2_bias=w2_bias,
+    ):
+        return None
+
+    try:
+        assert w1_scale is not None
+        assert w2_scale is not None
+        return _musa_fp8_moe_grouped_gemm_impl(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            expert_map=expert_map,
+            inplace=inplace,
+        )
+    except Exception as exc:
+        _MUSA_GROUPED_GEMM_AVAILABLE = False
+        if not _DEEPGEMM_PREFILL_WARNED:
+            logger.warning(
+                "MUSA grouped DeepGEMM MoE path failed; falling back to the "
+                "established backend and disabling grouped DeepGEMM for this "
+                "worker: %s",
+                exc,
+            )
+            _DEEPGEMM_PREFILL_WARNED = True
+        return None
+
+
+def _musa_fp8_moe_deepgemm_prefill_impl(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    inplace: bool,
+) -> torch.Tensor:
+    """Run the fused-glue contiguous DeepGEMM prefill implementation."""
+
+    E = w1.shape[0]
+    try:
+        from vllm_musa.jit_kernel.post_reorder import post_reorder_triton_kernel
+        from vllm_musa.jit_kernel.tilelang.deep_gemm_contig_preprocess import (
+            can_use_fp8_tilelang,
+            deep_gemm_contig_preprocess_fp8_tilelang,
+        )
+
+        use_fused = can_use_fp8_tilelang(hidden_states, topk_ids, E, True)
+    except Exception:
+        use_fused = False
+
+    if not use_fused:
+        # The diagnostic grouped helper is the same contiguous DeepGEMM
+        # operation with the unfused permute/reduce glue. Retain it as the
+        # robust fallback when the fused glue declines a shape.
+        return _musa_fp8_moe_grouped_gemm_impl(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            expert_map=None,
+            inplace=inplace,
+            log_selection=False,
+        )
+
+    from vllm.utils.deep_gemm import (
+        get_mk_alignment_for_contiguous_layout,
+        m_grouped_fp8_gemm_nt_contiguous,
+        mk_alignment_scope,
+    )
+
+    logger.info_once("Using the MUSA fused-glue grouped DeepGEMM MoE prefill path.")
+
+    _, N, K = w1.shape
+    M, top_k = topk_ids.shape
+    block_m = int(get_mk_alignment_for_contiguous_layout()[0])
+    device = hidden_states.device
+
+    src2dst_numel = M * top_k
+    all_tokens = (
+        (src2dst_numel + E * (block_m - 1) + block_m - 1) // block_m
+    ) * block_m
+
+    qhidden_perm = torch.empty(
+        (all_tokens, K), device=device, dtype=torch.float8_e4m3fn
+    )
+    qhidden_scale_perm = torch.empty(
+        (all_tokens, K // 128), device=device, dtype=torch.float32
+    )
+    m_indices = torch.empty(all_tokens, device=device, dtype=torch.int32)
+    src2dst = torch.empty(src2dst_numel, device=device, dtype=torch.int32)
+    topk_ids_for_combine = torch.empty_like(topk_ids)
+    counts = torch.empty(E, device=device, dtype=torch.int32)
+    cursor = torch.empty(E, device=device, dtype=torch.int32)
+
+    deep_gemm_contig_preprocess_fp8_tilelang(
+        hidden_states,
+        topk_ids,
+        qhidden_perm,
+        qhidden_scale_perm,
+        m_indices,
+        src2dst,
+        topk_ids_for_combine,
+        counts,
+        cursor,
+        E,
+        block_m,
+    )
+
+    with mk_alignment_scope(block_m):
+        mm1_out = torch.empty((all_tokens, N), device=device, dtype=hidden_states.dtype)
+        m_grouped_fp8_gemm_nt_contiguous(
+            (qhidden_perm, qhidden_scale_perm.contiguous()),
+            (w1, w1_scale.contiguous()),
+            mm1_out,
+            m_indices,
+        )
+
+        a2q = torch.empty(
+            (all_tokens, N // 2), device=device, dtype=torch.float8_e4m3fn
+        )
+        a2q, a2q_scale = _silu_mul_per_token_group_fp8_quant_musa_large(
+            mm1_out.view(-1, N), a2q, group_size=128
+        )
+
+        mm2_out = torch.empty((all_tokens, K), device=device, dtype=hidden_states.dtype)
+        m_grouped_fp8_gemm_nt_contiguous(
+            (a2q, a2q_scale.contiguous()),
+            (w2, w2_scale.contiguous()),
+            mm2_out,
+            m_indices,
+        )
+
+    if inplace and not disable_inplace():
+        output = hidden_states
+    else:
+        output = torch.empty_like(hidden_states)
+
+    post_reorder_triton_kernel[(M,)](
+        mm2_out,
+        output,
+        src2dst,
+        topk_ids,
+        topk_weights,
+        top_k,
+        K,
+        BLOCK_SIZE=1024,
     )
     return output
 
@@ -610,7 +870,7 @@ def _maybe_moe_deepgemm_prefill(
     try:
         assert w1_scale is not None
         assert w2_scale is not None
-        return _moe_deepgemm_prefill_impl(
+        return _musa_fp8_moe_deepgemm_prefill_impl(
             hidden_states=hidden_states,
             w1=w1,
             w2=w2,
@@ -623,8 +883,8 @@ def _maybe_moe_deepgemm_prefill(
     except Exception as exc:
         if not _DEEPGEMM_PREFILL_WARNED:
             logger.warning(
-                "Grouped DeepGEMM MoE prefill path failed; "
-                "falling back to the upstream Triton path: %s",
+                "Grouped DeepGEMM MoE prefill path failed; falling back to the "
+                "established upstream backend: %s",
                 exc,
             )
             _DEEPGEMM_PREFILL_WARNED = True
@@ -672,13 +932,215 @@ def _maybe_expand_fp8_moe_per_tensor_scale(
         return scale
 
     block_size = _musa_fp8_moe_scale_block_size(input_size)
-    output_blocks = (output_size + block_size - 1) // block_size
+    if input_size // block_size == 1 and block_size != 128:
+        raise ValueError(
+            "MUSA native FP8 MoE GEMV cannot disambiguate a 64-wide "
+            "single input scale block."
+        )
+    if output_size % block_size != 0:
+        raise ValueError(
+            "MUSA native FP8 MoE GEMV requires the weight output "
+            f"dimension to be divisible by scale block {block_size}, got "
+            f"{output_size}."
+        )
+    output_blocks = output_size // block_size
     input_blocks = input_size // block_size
     return (
         per_expert_scale.view(num_experts, 1, 1)
         .expand(num_experts, output_blocks, input_blocks)
         .contiguous()
     )
+
+
+def _musa_fp8_moe_scale_layout_is_supported(
+    scale: torch.Tensor | None,
+    weight: torch.Tensor,
+) -> bool:
+    if scale is None or scale.dtype != torch.float32 or not scale.is_contiguous():
+        return False
+    num_experts, output_size, input_size = weight.shape
+    per_tensor_layout = False
+    if scale.dim() == 0:
+        per_tensor_layout = True
+    elif scale.dim() == 1:
+        per_tensor_layout = scale.numel() in (1, num_experts)
+    elif scale.dim() == 2:
+        per_tensor_layout = scale.shape == (num_experts, 1)
+    if per_tensor_layout:
+        try:
+            group_size = _musa_fp8_moe_scale_block_size(input_size)
+        except ValueError:
+            return False
+        return output_size % group_size == 0 and not (
+            input_size // group_size == 1 and group_size != 128
+        )
+    if scale.dim() != 3 or scale.shape[0] != num_experts:
+        return False
+    for group_size in (128, 64):
+        if input_size % group_size != 0 or output_size % group_size != 0:
+            continue
+        input_blocks = input_size // group_size
+        # The native op infers a 128-wide input scale block whenever the final
+        # scale dimension is one; a 64-wide layout with one input block is
+        # therefore ambiguous and unsafe.
+        if input_blocks == 1 and group_size != 128:
+            continue
+        expected_shape = (
+            num_experts,
+            output_size // group_size,
+            input_blocks,
+        )
+        if scale.shape == expected_shape:
+            return True
+    return False
+
+
+def _can_use_musa_native_fp8_moe_gemv(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: str,
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+    ocp_mx_scheme: str | None,
+    per_channel_quant: bool,
+    global_num_experts: int,
+    expert_map: torch.Tensor | None,
+    w1_scale: torch.Tensor | None,
+    w2_scale: torch.Tensor | None,
+    w1_zp: torch.Tensor | None,
+    w2_zp: torch.Tensor | None,
+    a1_scale: torch.Tensor | None,
+    a2_scale: torch.Tensor | None,
+    w1_bias: torch.Tensor | None,
+    w2_bias: torch.Tensor | None,
+) -> bool:
+    if (
+        not use_fp8_w8a8
+        or use_int8_w8a8
+        or use_int8_w8a16
+        or use_int4_w4a16
+        or ocp_mx_scheme is not None
+        or per_channel_quant
+        or expert_map is not None
+        or w1_zp is not None
+        or w2_zp is not None
+        or a1_scale is not None
+        or a2_scale is not None
+        or w1_bias is not None
+        or w2_bias is not None
+        or activation != "silu"
+    ):
+        return False
+    if (
+        hidden_states.dtype != torch.bfloat16
+        or w1.dtype != torch.float8_e4m3fn
+        or w2.dtype != torch.float8_e4m3fn
+        or topk_ids.dtype != torch.int32
+        or topk_weights.dtype != torch.float32
+    ):
+        return False
+    if not (
+        hidden_states.is_contiguous()
+        and w1.is_contiguous()
+        and w2.is_contiguous()
+        and topk_ids.is_contiguous()
+        and topk_weights.is_contiguous()
+    ):
+        return False
+    if hidden_states.dim() != 2 or w1.dim() != 3 or w2.dim() != 3:
+        return False
+
+    num_experts, w1_output_size, hidden_size = w1.shape
+    if w2.shape[0] != num_experts:
+        return False
+    if global_num_experts not in (-1, num_experts):
+        return False
+    if not _musa_moe_routes_are_supported(
+        hidden_states=hidden_states,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        num_experts=num_experts,
+    ):
+        return False
+    if not _tensors_share_device(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        w1_scale,
+        w2_scale,
+    ):
+        return False
+    if w1_output_size % 2 != 0 or hidden_size != hidden_states.shape[1]:
+        return False
+    if w2.shape != (num_experts, hidden_size, w1_output_size // 2):
+        return False
+    if hidden_size % 64 != 0 or (w1_output_size // 2) % 64 != 0:
+        return False
+    return _musa_fp8_moe_scale_layout_is_supported(
+        w1_scale, w1
+    ) and _musa_fp8_moe_scale_layout_is_supported(w2_scale, w2)
+
+
+def _musa_fused_moe_shape(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_scale: torch.Tensor | None,
+    w2_scale: torch.Tensor | None,
+    block_shape: list[int] | None,
+    activation: str,
+    expert_map: torch.Tensor | None,
+    stream_is_capturing: bool,
+    device_capability: tuple[int, int],
+    multiprocessor_count: int,
+) -> MusaFusedMoeShape:
+    block_n = block_shape[0] if block_shape else 0
+    block_k = block_shape[1] if block_shape and len(block_shape) > 1 else 0
+    return MusaFusedMoeShape(
+        device_capability=device_capability,
+        multiprocessor_count=multiprocessor_count,
+        local_experts=w1.shape[0],
+        w1_output_size=w1.shape[1],
+        w2_input_size=w2.shape[2],
+        hidden_size=hidden_states.shape[1],
+        top_k=topk_ids.shape[1],
+        block_n=block_n,
+        block_k=block_k,
+        activation=activation,
+        expert_parallel=expert_map is not None,
+        hidden_dtype=str(hidden_states.dtype),
+        weight_dtype=str(w1.dtype),
+        scale_dtype=str(w1_scale.dtype) if w1_scale is not None else "none",
+        w1_scale_shape=tuple(w1_scale.shape) if w1_scale is not None else (),
+        w2_scale_shape=tuple(w2_scale.shape) if w2_scale is not None else (),
+        gemv_block=os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK", "auto"),
+        graph_mode="capture" if stream_is_capturing else "eager",
+    )
+
+
+def _musa_stream_is_capturing() -> bool:
+    for module_name in ("musa", "cuda"):
+        module = getattr(torch, module_name, None)
+        is_capturing = getattr(module, "is_current_stream_capturing", None)
+        if is_capturing is None:
+            continue
+        try:
+            return bool(is_capturing())
+        except Exception:
+            continue
+    # Grouped DeepGEMM is not capture-safe. An unavailable or broken capture
+    # query must conservatively disable it instead of failing open.
+    return True
 
 
 def _supports_quant_scheme(
@@ -738,6 +1200,7 @@ def fused_experts_impl(
     w2_bias: torch.Tensor | None = None,
     *,
     inplace: bool = False,
+    _allow_deepgemm_prefill: bool = True,
 ) -> torch.Tensor:
     # Check constraints.
     if use_int4_w4a16:
@@ -779,25 +1242,6 @@ def fused_experts_impl(
 
     M = num_tokens
 
-    intermediate_cache3 = torch.empty(
-        (M, top_k_num, K), device=hidden_states.device, dtype=hidden_states.dtype
-    )
-
-    # The first GEMV writes activation input to cache2; the second GEMV writes
-    # top-k outputs to cache3 for moe_sum.
-    intermediate_cache2 = torch.empty(
-        (M * top_k_num, N // 2), device=hidden_states.device, dtype=hidden_states.dtype
-    )
-
-    if hidden_states.dtype == torch.bfloat16:
-        compute_type = tl.bfloat16
-    elif hidden_states.dtype == torch.float16:
-        compute_type = tl.float16
-    elif hidden_states.dtype == torch.float32:
-        compute_type = tl.float32
-    else:
-        raise ValueError(f"Unsupported compute_type: {hidden_states.dtype}")
-
     if use_fp8_w8a8:
         w1_scale = _maybe_expand_fp8_moe_per_tensor_scale(w1_scale, w1)
         w2_scale = _maybe_expand_fp8_moe_per_tensor_scale(w2_scale, w2)
@@ -824,32 +1268,48 @@ def fused_experts_impl(
         global_num_experts=global_num_experts,
     )
 
-    deepgemm_prefill_output = _maybe_moe_deepgemm_prefill(
-        hidden_states=hidden_states,
-        w1=w1,
-        w2=w2,
-        topk_weights=topk_weights,
-        topk_ids=topk_ids,
-        inplace=inplace,
-        activation=activation,
-        apply_router_weight_on_input=apply_router_weight_on_input,
-        use_fp8_w8a8=use_fp8_w8a8,
-        use_int8_w8a8=use_int8_w8a8,
-        use_int8_w8a16=use_int8_w8a16,
-        use_int4_w4a16=use_int4_w4a16,
-        ocp_mx_scheme=ocp_mx_scheme,
-        per_channel_quant=per_channel_quant,
-        expert_map=expert_map,
-        w1_scale=w1_scale,
-        w2_scale=w2_scale,
-        a1_scale=a1_scale,
-        a2_scale=a2_scale,
-        block_shape=block_shape,
-        w1_bias=w1_bias,
-        w2_bias=w2_bias,
+    # Preserve the base implementation's direct-call semantics.  The
+    # dispatcher disables this only when it has explicitly selected native
+    # GEMV, so a GEMV diagnostic cannot silently turn into DeepGEMM at a large
+    # M.  The normal local implementation remains the established large-prefill
+    # path for callers that bypass the dispatcher.
+    if _allow_deepgemm_prefill:
+        deepgemm_prefill_output = _maybe_moe_deepgemm_prefill(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            inplace=inplace,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a8=use_int8_w8a8,
+            use_int8_w8a16=use_int8_w8a16,
+            use_int4_w4a16=use_int4_w4a16,
+            ocp_mx_scheme=ocp_mx_scheme,
+            per_channel_quant=per_channel_quant,
+            expert_map=expert_map,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            block_shape=block_shape,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+        )
+        if deepgemm_prefill_output is not None:
+            return deepgemm_prefill_output
+
+    intermediate_cache3 = torch.empty(
+        (M, top_k_num, K), device=hidden_states.device, dtype=hidden_states.dtype
     )
-    if deepgemm_prefill_output is not None:
-        return deepgemm_prefill_output
+
+    # The first GEMV writes activation input to cache2; the second GEMV writes
+    # top-k outputs to cache3 for moe_sum.
+    intermediate_cache2 = torch.empty(
+        (M * top_k_num, N // 2), device=hidden_states.device, dtype=hidden_states.dtype
+    )
 
     if inplace and not disable_inplace():
         out_hidden_states = hidden_states
@@ -957,7 +1417,7 @@ def fused_experts_impl(
     return out_hidden_states
 
 
-import vllm.model_executor.layers.fused_moe.fused_moe
+import vllm.model_executor.layers.fused_moe.fused_moe  # noqa: E402
 
 _upstream_fused_moe = vllm.model_executor.layers.fused_moe.fused_moe
 if not hasattr(_upstream_fused_moe, "_musa_original_fused_experts_impl"):
@@ -966,56 +1426,335 @@ if not hasattr(_upstream_fused_moe, "_musa_original_fused_experts_impl"):
     )
 
 
-def _try_deepgemm_prefill_dispatch(args, kwargs) -> torch.Tensor | None:
-    try:
-        bound = inspect.signature(fused_experts_impl).bind(*args, **kwargs)
-    except TypeError:
-        return None
-    bound.apply_defaults()
-    a = bound.arguments
-    if not a.get("use_fp8_w8a8"):
-        return None
-    w1 = a["w1"]
-    w2 = a["w2"]
-    return _maybe_moe_deepgemm_prefill(
-        hidden_states=a["hidden_states"],
-        w1=w1,
-        w2=w2,
-        topk_weights=a["topk_weights"],
-        topk_ids=a["topk_ids"],
-        inplace=a.get("inplace", False),
-        activation=a.get("activation", "silu"),
-        apply_router_weight_on_input=a.get("apply_router_weight_on_input", False),
-        use_fp8_w8a8=a.get("use_fp8_w8a8", False),
-        use_int8_w8a8=a.get("use_int8_w8a8", False),
-        use_int8_w8a16=a.get("use_int8_w8a16", False),
-        use_int4_w4a16=a.get("use_int4_w4a16", False),
-        ocp_mx_scheme=a.get("ocp_mx_scheme"),
-        per_channel_quant=a.get("per_channel_quant", False),
-        expert_map=a.get("expert_map"),
-        w1_scale=_maybe_expand_fp8_moe_per_tensor_scale(a.get("w1_scale"), w1),
-        w2_scale=_maybe_expand_fp8_moe_per_tensor_scale(a.get("w2_scale"), w2),
-        a1_scale=a.get("a1_scale"),
-        a2_scale=a.get("a2_scale"),
-        block_shape=a.get("block_shape"),
-        w1_bias=a.get("w1_bias"),
-        w2_bias=a.get("w2_bias"),
+def _musa_fused_experts_impl_dispatch(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: str = "silu",
+    apply_router_weight_on_input: bool = False,
+    use_fp8_w8a8: bool = False,
+    use_int8_w8a8: bool = False,
+    use_int8_w8a16: bool = False,
+    use_int4_w4a16: bool = False,
+    ocp_mx_scheme: str | None = None,
+    per_channel_quant: bool = False,
+    global_num_experts: int = -1,
+    expert_map: torch.Tensor | None = None,
+    w1_scale: torch.Tensor | None = None,
+    w2_scale: torch.Tensor | None = None,
+    w1_zp: torch.Tensor | None = None,
+    w2_zp: torch.Tensor | None = None,
+    a1_scale: torch.Tensor | None = None,
+    a2_scale: torch.Tensor | None = None,
+    block_shape: list[int] | None = None,
+    w1_bias: torch.Tensor | None = None,
+    w2_bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    backend = MusaFusedMoeBackend.UPSTREAM
+    policy = None
+    shape = None
+
+    # Skip all shape construction and capture queries for non-FP8 callers and
+    # for the explicit rollback path. This wrapper sits on every MoE layer.
+    if (
+        _MUSA_FUSED_MOE_REQUESTED_BACKEND != MusaFusedMoeBackend.UPSTREAM
+        and use_fp8_w8a8
+        and not use_int8_w8a8
+        and not use_int8_w8a16
+        and not use_int4_w4a16
+        and ocp_mx_scheme is None
+        and (
+            _MUSA_FUSED_MOE_REQUESTED_BACKEND != MusaFusedMoeBackend.AUTO
+            or (
+                hidden_states.dim() == 2
+                and w1.dim() == 3
+                and w2.dim() == 3
+                and topk_ids.dim() == 2
+                and has_calibrated_dimensions(
+                    local_experts=w1.shape[0],
+                    w1_output_size=w1.shape[1],
+                    w2_input_size=w2.shape[2],
+                    hidden_size=w1.shape[2],
+                    top_k=topk_ids.shape[1],
+                )
+            )
+        )
+    ):
+        device_index = hidden_states.device.index
+        if device_index is None:
+            try:
+                device_index = torch.musa.current_device()
+            except Exception:
+                device_index = 0
+        device_capability, multiprocessor_count = _musa_device_fingerprint(device_index)
+
+        # The policy is calibrated only for S5000/MP31. Other MUSA
+        # architectures retain the established upstream implementation.
+        if device_capability == (3, 1):
+            # The calibrated GEMV sweeps use router weights after the expert
+            # projection.  Fail closed for the alternate input-weighting
+            # contract until it has its own exact policy key and evidence.
+            can_use_gemv = (
+                not apply_router_weight_on_input
+                and _can_use_musa_native_fp8_moe_gemv(
+                    hidden_states=hidden_states,
+                    w1=w1,
+                    w2=w2,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                    activation=activation,
+                    use_fp8_w8a8=use_fp8_w8a8,
+                    use_int8_w8a8=use_int8_w8a8,
+                    use_int8_w8a16=use_int8_w8a16,
+                    use_int4_w4a16=use_int4_w4a16,
+                    ocp_mx_scheme=ocp_mx_scheme,
+                    per_channel_quant=per_channel_quant,
+                    global_num_experts=global_num_experts,
+                    expert_map=expert_map,
+                    w1_scale=w1_scale,
+                    w2_scale=w2_scale,
+                    w1_zp=w1_zp,
+                    w2_zp=w2_zp,
+                    a1_scale=a1_scale,
+                    a2_scale=a2_scale,
+                    w1_bias=w1_bias,
+                    w2_bias=w2_bias,
+                )
+            )
+            can_use_grouped_gemm = _can_use_musa_fp8_moe_grouped_gemm(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=activation,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+                use_fp8_w8a8=use_fp8_w8a8,
+                use_int8_w8a8=use_int8_w8a8,
+                use_int8_w8a16=use_int8_w8a16,
+                use_int4_w4a16=use_int4_w4a16,
+                ocp_mx_scheme=ocp_mx_scheme,
+                per_channel_quant=per_channel_quant,
+                global_num_experts=global_num_experts,
+                expert_map=expert_map,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                w1_zp=w1_zp,
+                w2_zp=w2_zp,
+                a1_scale=a1_scale,
+                a2_scale=a2_scale,
+                block_shape=block_shape,
+                w1_bias=w1_bias,
+                w2_bias=w2_bias,
+            )
+            if can_use_gemv or can_use_grouped_gemm:
+                stream_is_capturing = _musa_stream_is_capturing()
+                shape = _musa_fused_moe_shape(
+                    hidden_states=hidden_states,
+                    w1=w1,
+                    w2=w2,
+                    topk_ids=topk_ids,
+                    w1_scale=w1_scale,
+                    w2_scale=w2_scale,
+                    block_shape=block_shape,
+                    activation=activation,
+                    expert_map=expert_map,
+                    stream_is_capturing=stream_is_capturing,
+                    device_capability=device_capability,
+                    multiprocessor_count=multiprocessor_count,
+                )
+                policy = thresholds_for_shape(shape)
+                backend = select_fused_moe_backend(
+                    shape=shape,
+                    num_tokens=hidden_states.shape[0],
+                    can_use_gemv=can_use_gemv,
+                    can_use_grouped_gemm=can_use_grouped_gemm,
+                    stream_is_capturing=stream_is_capturing,
+                    requested=_MUSA_FUSED_MOE_REQUESTED_BACKEND,
+                    thresholds=policy,
+                )
+
+    # Native GEMV records inside ``fused_experts_impl`` after expanding any
+    # per-tensor scales.  Record every other dispatcher outcome here so the
+    # opt-in inventory also observes unknown shapes that remain on upstream.
+    if backend != MusaFusedMoeBackend.GEMV and _MOE_SHAPE_INVENTORY_ENABLED:
+        _maybe_record_deepseek_v4_moe_shape_inventory(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            block_shape=block_shape,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a8=use_int8_w8a8,
+            use_int8_w8a16=use_int8_w8a16,
+            use_int4_w4a16=use_int4_w4a16,
+            ocp_mx_scheme=ocp_mx_scheme,
+            per_channel_quant=per_channel_quant,
+            global_num_experts=global_num_experts,
+        )
+
+    if backend != MusaFusedMoeBackend.UPSTREAM:
+        assert policy is not None
+        assert shape is not None
+        logger.info_once(
+            "MUSA fused-MoE dispatcher selected backend=%s policy=%s for "
+            "shape=(E=%d,N=%d,K=%d,topk=%d,graph=%s,mp=%d,gemv_block=%s).",
+            backend.value,
+            policy.source,
+            shape.local_experts,
+            shape.w1_output_size,
+            shape.hidden_size,
+            shape.top_k,
+            shape.graph_mode,
+            shape.multiprocessor_count,
+            shape.gemv_block,
+        )
+
+    if backend == MusaFusedMoeBackend.GROUPED_GEMM:
+        grouped_output = _maybe_musa_fp8_moe_grouped_gemm(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            inplace=False,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a8=use_int8_w8a8,
+            use_int8_w8a16=use_int8_w8a16,
+            use_int4_w4a16=use_int4_w4a16,
+            ocp_mx_scheme=ocp_mx_scheme,
+            per_channel_quant=per_channel_quant,
+            global_num_experts=global_num_experts,
+            expert_map=expert_map,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            w1_zp=w1_zp,
+            w2_zp=w2_zp,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            block_shape=block_shape,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+        )
+        if grouped_output is not None:
+            return grouped_output
+    elif backend == MusaFusedMoeBackend.GEMV:
+        return fused_experts_impl(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            activation,
+            apply_router_weight_on_input,
+            use_fp8_w8a8,
+            use_int8_w8a8,
+            use_int8_w8a16,
+            use_int4_w4a16,
+            ocp_mx_scheme,
+            per_channel_quant,
+            global_num_experts,
+            expert_map,
+            w1_scale,
+            w2_scale,
+            w1_zp,
+            w2_zp,
+            a1_scale,
+            a2_scale,
+            block_shape,
+            w1_bias,
+            w2_bias,
+            inplace=False,
+            _allow_deepgemm_prefill=False,
+        )
+
+    # The default-on contiguous DeepGEMM is the large-M/prefill backend of the
+    # established base path. Keep it after the small-M auto decision:
+    # GEMV wins only in its calibrated decode window; large prefill must not
+    # silently fall through to Triton because dispatch now owns this wrapper.
+    deepgemm_prefill_candidate = (
+        not _env_flag_disabled(_DEEPGEMM_PREFILL_ENV)
+        and hidden_states.shape[0] >= _env_int(_DEEPGEMM_PREFILL_MIN_TOKENS_ENV, 2500)
+        and w1.dim() == 3
+        and w1.shape[0] in (256, 257)
     )
+    if (
+        _MUSA_FUSED_MOE_REQUESTED_BACKEND == MusaFusedMoeBackend.AUTO
+        and deepgemm_prefill_candidate
+        and not _musa_stream_is_capturing()
+    ):
+        try:
+            deepgemm_w1_scale = _maybe_expand_fp8_moe_per_tensor_scale(w1_scale, w1)
+            deepgemm_w2_scale = _maybe_expand_fp8_moe_per_tensor_scale(w2_scale, w2)
+        except ValueError:
+            # Unsupported expansion layouts may still be valid upstream.
+            # Preserve their scales so the complete DeepGEMM gate declines.
+            deepgemm_w1_scale = w1_scale
+            deepgemm_w2_scale = w2_scale
+        deepgemm_prefill_output = _maybe_moe_deepgemm_prefill(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            inplace=False,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a8=use_int8_w8a8,
+            use_int8_w8a16=use_int8_w8a16,
+            use_int4_w4a16=use_int4_w4a16,
+            ocp_mx_scheme=ocp_mx_scheme,
+            per_channel_quant=per_channel_quant,
+            expert_map=expert_map,
+            w1_scale=deepgemm_w1_scale,
+            w2_scale=deepgemm_w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            block_shape=block_shape,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+        )
+        if deepgemm_prefill_output is not None:
+            return deepgemm_prefill_output
 
-
-def _musa_fused_experts_impl_dispatch(*args, **kwargs) -> torch.Tensor:
-    # The native GEMV MoE path (fused_experts_impl) is opt-in: it can hurt some
-    # prefill workloads, but DeepSeek-V4-Flash-Base TP8 graph+MTP decode depends
-    # on it for its accepted baseline. Default to the upstream implementation for
-    # other models; platform.py opts DeepSeek-V4 in per serving process.
-    if os.environ.get("VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV", "0") == "1":
-        return fused_experts_impl(*args, **kwargs)
-    # Grouped DeepGEMM for large-M FP8 block-128 MoE prefill; the shape gate declines
-    # decode and every non-matching shape, which then fall through to upstream Triton.
-    dg_out = _try_deepgemm_prefill_dispatch(args, kwargs)
-    if dg_out is not None:
-        return dg_out
-    return _upstream_fused_moe._musa_original_fused_experts_impl(*args, **kwargs)
+    return _upstream_fused_moe._musa_original_fused_experts_impl(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        activation,
+        apply_router_weight_on_input,
+        use_fp8_w8a8,
+        use_int8_w8a8,
+        use_int8_w8a16,
+        use_int4_w4a16,
+        ocp_mx_scheme,
+        per_channel_quant,
+        global_num_experts,
+        expert_map,
+        w1_scale,
+        w2_scale,
+        w1_zp,
+        w2_zp,
+        a1_scale,
+        a2_scale,
+        block_shape,
+        w1_bias,
+        w2_bias,
+    )
 
 
 _upstream_fused_moe.fused_experts_impl = _musa_fused_experts_impl_dispatch

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -673,12 +673,6 @@ class MUSAPlatformBase(Platform):
                 model_config,
                 getattr(parallel_config, "tensor_parallel_size", None),
             )
-            if os.environ.get("VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV") is None:
-                os.environ["VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV"] = "1"
-                logger.info(
-                    "Enabling DeepSeek-V4 MUSA fused-MoE GEMV dispatcher "
-                    "(set VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV=0 to disable)."
-                )
             if _DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV not in os.environ:
                 os.environ[_DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV] = (
                     _DEEPSEEK_V4_DEFAULT_GEMV_MOE_BLOCK


### PR DESCRIPTION
## Summary

- add an exact-shape S5000 FP8 MoE dispatcher;
- use native GEMV only in calibrated small-`M` decode windows;
- preserve the default contiguous/fused-glue DeepGEMM path for eligible large
  eager prefill calls, and use the established upstream path in between;
- remove the DeepSeek-V4-specific GEMV enablement environment variable from the
  normal serving path while retaining generic diagnostic overrides;
- add cold-cache crossover, FP32-oracle, folded-shared-expert, production
  DeepGEMM identity, and graph-replay evidence tooling.

`M` is `hidden_states.shape[0]` for one MoE invocation, not HTTP batch size or
per-expert route count.

## Rebase status

- base: `v0.24.0-dev@4416dc24b00afcb46ebe96b34308fda96d30ed36`
  (Qwen3.5 MoE optimizations, #113)
- measured head: `599cb804080e886344098a68c4e2a01fbbd90210`
- review head: `943e5e0eaefc8d25cb24c249da0842b6205add64`
- merge state: clean

The measured head has tree `b1e8cc7bb4b0b4b38985b64220bc60e1c6c8238b`.
The review head has tree `dfee058a43cc3755318ea8fdc86aed01479b08ff` and differs
only by a fail-closed DeepGEMM scale-expansion guard plus its regression test
(two files, 37 added and two replaced lines). Calibrated block-scale layouts
do not enter the new exception branch, so the measured production paths and
hardware attribution are unchanged; the latest head was rechecked with the
focused Python/meta suites rather than rerunning the full serving matrix.

The review commits are:

1. `MUSA: add calibrated FP8 MoE backend dispatch`
2. `bench: add S5000 FP8 MoE calibration tools`
3. `build: package the MUSA JIT include marker`
4. `docs: document S5000 FP8 MoE backend selection`

Qwen3.5 compiled serving on the current base also needs the GDN compile fix
from #115 (`511cde18fe6a80cec15d8083a9e70a28c07ee057`, currently open). The
Qwen A/B below applied that identical validation-only fix to both arms, so its
performance delta remains attributable to this dispatcher. DSV2/DSV4 do not
depend on #115, and this PR intentionally does not duplicate the GDN change.

The offline folded-Qwen TP4 shape is `E=257, N=256, K=2048, topk=9`. Its
multi-route sweep and graph replay qualify `M <= 48` for the synthetic folded
shape, but the live `Qwen3_5MoeForConditionalGeneration` checkpoint follows
the `qwen3_5.py` path and does not activate the post-#113 shared-expert fold.
The production auto policy therefore intentionally retains the existing
`E=256/topk=8` behavior and has no E=257 threshold.

## Final auto policy

| Per-rank FP8 MoE shape | Small `M` | Large eligible eager `M` | Otherwise |
|---|---:|---|---|
| Qwen3.5 live TP4, `E=256/topk=8` | GEMV at `M <= 13` | contiguous DeepGEMM | upstream |
| Qwen3.5 folded TP4, `E=257/topk=9` | unobserved in live path (upstream) | contiguous DeepGEMM | upstream |
| DeepSeek-V4 TP8, block 32x8 | GEMV at `M <= 5` | contiguous DeepGEMM | upstream |
| DeepSeek-V4 TP8, block 16x8 | GEMV at `M <= 5` | contiguous DeepGEMM | upstream |
| DeepSeek-V2-Lite TP1 eager | GEMV at `M <= 3` | not eligible (`E=64`) | upstream |
| DeepSeek-V2-Lite TP1 capture | GEMV at `M = 1` | not eligible (`E=64`) | upstream |

Unknown devices/shapes, unsupported layouts, and unsafe capture states fail
closed. Explicit `upstream` bypasses both GEMV and DeepGEMM for diagnostic
rollback. Diagnostic grouped GEMM remains disabled in `auto` until it has
separate correctness and serving evidence.

## S5000 serving A/B

Environment: isolated 8x S5000, driver `3.3.5-server`, torch/torch_musa
`2.9.1.post1+musa5.2.0s5000`, torchada `0.1.72`, MATE/flash_attn_3 `0.2.4`.
Every row used exact 4096 input and 1024 output tokens at BS 1/4/16/64, prefix
caching off, independent cache roots, normal compiled/captured serving, zero
failed requests, and exact per-request output lengths. DSV2 rows are
three-repetition medians; DSV4 and Qwen3-VL rows are one paired repetition.

| Model | BS | output tok/s base -> candidate | TTFT ms base -> candidate | TPOT ms base -> candidate |
|---|---:|---:|---:|---:|
| DSV4 Flash TP8 | 1 | 4.573 -> 4.578 (+0.11%) | 1315.0 -> 1305.8 (-0.70%) | 217.618 -> 217.384 (-0.11%) |
| DSV4 Flash TP8 | 4 | 17.576 -> 17.575 (-0.01%) | 4413.6 -> 4413.9 (+0.01%) | 223.220 -> 223.237 (+0.01%) |
| DSV4 Flash TP8 | 16 | 34.143 -> 34.319 (+0.51%) | 30342.5 -> 30167.4 (-0.58%) | 235.937 -> 233.784 (-0.91%) |
| DSV4 Flash TP8 | 64 | 52.210 -> 52.609 (+0.76%) | 438236.6 -> 434228.1 (-0.91%) | 241.255 -> 239.092 (-0.90%) |
| DSV2 Lite FP8 | 1 | 76.584 -> 83.007 (+8.39%) | 302.1 -> 303.1 (+0.33%) | 12.775 -> 11.762 (-7.92%) |
| DSV2 Lite FP8 | 4 | 195.820 -> 199.334 (+1.79%) | 935.6 -> 932.7 (-0.31%) | 19.507 -> 19.145 (-1.85%) |
| DSV2 Lite FP8 | 16 | 530.996 -> 533.729 (+0.51%) | 2827.2 -> 2832.3 (+0.18%) | 27.250 -> 27.090 (-0.59%) |
| DSV2 Lite FP8 | 64 | 1150.712 -> 1140.382 (-0.90%) | 9987.4 -> 9980.3 (-0.07%) | 45.059 -> 45.578 (+1.15%) |
| Qwen3-VL-30B-A3B | 1 | 75.684 -> 74.920 (-1.01%) | 138.5 -> 139.6 (+0.82%) | 13.090 -> 13.224 (+1.02%) |
| Qwen3-VL-30B-A3B | 4 | 242.315 -> 241.789 (-0.22%) | 395.5 -> 396.6 (+0.27%) | 16.107 -> 16.142 (+0.21%) |
| Qwen3-VL-30B-A3B | 16 | 710.945 -> 712.854 (+0.27%) | 1280.3 -> 1290.2 (+0.78%) | 21.143 -> 21.074 (-0.33%) |
| Qwen3-VL-30B-A3B | 64 | 928.995 -> 937.646 (+0.93%) | 13219.0 -> 13169.6 (-0.37%) | 55.337 -> 54.764 (-1.04%) |

No measured regression crosses the predeclared 3% remediation gate. The DSV2
single-token decode gain survives the stricter capture boundary without a
material regression at the larger batch sizes. Qwen3-VL uses an uncalibrated
`E=128,N=192` MoE shape and verifies that `auto` remains on upstream.

The missing Qwen3.5-35B-A3B base-vs-PR comparison was rerun on an isolated TP4
S5000 lease on 10.20.35.71. The base arm was exact post-#113 plus the common
PR115-equivalent GDN compile fix; the candidate was the measured PR head plus
the identical fix. The arms used their separately compiled native extensions, torchada
0.1.76, normal compilation/CUDAGraph, independent measurement caches, exact
4096/1024 token lengths, and three repetitions except BS64. Logs prove that
base had no auto dispatcher, while candidate selected the E=256/topk=8 M13
GEMV policy in both eager and capture and retained DeepGEMM for large prefill.

| BS | output tok/s base -> PR | TPOT ms base -> PR | TTFT ms base -> PR |
|---:|---:|---:|---:|
| 1 | 61.752 -> 67.831 (+9.84%) | 16.067 -> 14.617 (-9.03%) | 144.8 -> 142.6 (-1.54%) |
| 4 | 227.352 -> 247.811 (+9.00%) | 17.090 -> 15.685 (-8.22%) | 465.0 -> 459.3 (-1.22%) |
| 16 | 726.556 -> 723.877 (-0.37%) | 20.738 -> 20.835 (+0.47%) | 1201.4 -> 1198.3 (-0.26%) |
| 64 | 1028.423 -> 1025.842 (-0.25%) | 46.907 -> 47.072 (+0.35%) | 15068.9 -> 15068.3 (-0.00%) |

This directly validates the shipped E256/M13 policy: it improves BS1/4 decode
by about 9% and leaves BS16/64 within 0.5% of the post-#113 base.

A separate folded-shape experiment was completed on 10.20.35.88 with the
common GDN fix applied identically to both validation arms. It passed normal
compiled startup, CUDAGraph capture, the DeepGEMM prefill gate, and semantic
output. Both arms already contained the existing E=256/topk=8 policy; the
candidate-only E=257/M48 policy was not observed, so this table is a no-op
policy check rather than a base-vs-PR comparison.

| BS | output tok/s control -> M48 | TPOT ms control -> M48 | TTFT delta |
|---:|---:|---:|---:|
| 1 | 79.012 -> 78.924 (-0.11%) | 12.532 -> 12.508 (+0.19%) | -2.64% |
| 4 | 283.929 -> 288.062 (+1.46%) | 13.646 -> 13.452 (+1.42%) | +0.66% |
| 16 | 807.171 -> 803.010 (-0.52%) | 18.589 -> 18.735 (-0.79%) | +2.08% |
| 64 | 1076.800 -> 1068.413 (-0.78%) | 44.431 -> 44.889 (-1.03%) | -0.12% |

Because the new policy was not exercised and the conservative no-regression
screen failed at BS64 TPOT by 1.03%, the M48 candidate was removed from the
PR worktree. The measured result therefore remains an upstream-path
no-op check, not evidence for an E=257 threshold.

## Correctness and tests

- [x] rebased onto the exact post-#113 base
- [x] dispatch-policy tests: 12/12
- [x] final-head fused-MoE chunking/dispatch tests: 35/35 in a no-GPU
  torch/MUSA container using meta tensors; device capability was stubbed only
  to avoid driver initialization and no MUSA kernel was executed
- [x] unaligned per-tensor FP8 scales now fail closed to upstream instead of
  raising before the DeepGEMM eligibility gate
- [x] Ruff check/format, `py_compile`, and `git diff --check`
- [x] exact-head DSV2 graph replay at capture `M=1/2/3`: eight
  balanced/random/hot replays per point, bitwise-equal outputs and zero max
  absolute difference
- [x] exact capture call counts: `M=1` GEMV=1/upstream=0; `M=2/3`
  GEMV=0/upstream=1
- [x] post-#113 4096/1024 serving A/B at BS 1/4/16/64 across three MoE models
- [x] exact compiled Qwen3.5 control/candidate A/B at BS 1/4/16/64 on
  10.20.35.88; candidate E=257/M48 policy not observed, so upstream behavior
  retained
- [x] exact post-#113-vs-PR Qwen3.5 E256/M13 A/B at BS 1/4/16/64 on
  10.20.35.71; BS1/4 improve by 9.84%/9.00% and BS16/64 stay within 0.5%

The earlier headline serving table remains withdrawn: its Qwen baseline
compiled TileLang kernels inside the measured BS1 run while the candidate
inherited a warm global cache, and it predates #113.

## Scope

This optimizes S5000 block-128 E4M3 FP8 MoE execution. It does not make a raw
MXFP8 checkpoint directly executable; MXFP8 weights still require transcoding
to the supported representation.
