### PR TITLE
perf(musa): optimize CosyVoice3 Talker sampling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ musa = "vllm_musa:musa_platform_plugin"
 [project.entry-points."vllm.general_plugins"]
 musa_custom_ops = "vllm_musa:register_custom_ops"
 
+[project.entry-points."vllm_omni.general_plugins"]
+musa_custom_ops = "vllm_musa.omni:register_omni_optimizations"
+
 [project.urls]
 Homepage = "https://github.com/MooreThreads/vllm-musa"
 Repository = "https://github.com/MooreThreads/vllm-musa"

--- a/tests/test_cosyvoice3_sampler_behavior.py
+++ b/tests/test_cosyvoice3_sampler_behavior.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Executable behavior tests for the optional CosyVoice3 Omni wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+ROOT = Path(__file__).resolve().parents[1]
+MODEL = ROOT / "vllm_musa/omni/models/cosyvoice3.py"
+HOST_SCALARS = "_vllm_musa_host_sampling_scalars"
+NO_FREQUENCY_PRESENCE = "_vllm_musa_no_frequency_presence_penalties"
+
+
+def _reference_ras_sample(
+    weighted_scores: torch.Tensor,
+    decoded_tokens: list[int],
+    top_p: float,
+    top_k: int,
+    win_size: int,
+    tau_r: float,
+    generator: torch.Generator | None = None,
+) -> int:
+    sorted_scores, sorted_indices = torch.sort(
+        weighted_scores, descending=True, stable=True
+    )
+    sorted_probs = torch.softmax(sorted_scores, dim=-1)
+    cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
+    cutoff = (cumulative_probs - sorted_probs) > top_p
+    sorted_probs[cutoff] = 0
+    if top_k > 0 and top_k < sorted_probs.numel():
+        sorted_probs[top_k:] = 0
+    sampled_idx = torch.multinomial(
+        sorted_probs, num_samples=1, generator=generator
+    ).item()
+    top_id = int(sorted_indices[sampled_idx].item())
+
+    recent = decoded_tokens[-win_size:]
+    if recent.count(top_id) >= tau_r * win_size:
+        weighted_scores[top_id] = -torch.inf
+        top_id = int(
+            torch.multinomial(
+                torch.softmax(weighted_scores, dim=-1),
+                num_samples=1,
+                generator=generator,
+            ).item()
+        )
+    return top_id
+
+
+class _FakeOmniCosyVoice3Model:
+    @staticmethod
+    def _nucleus_sample_one(
+        weighted_scores,
+        *,
+        top_p,
+        top_k,
+        generator,
+    ):
+        sorted_scores, sorted_indices = torch.sort(
+            weighted_scores, descending=True, stable=True
+        )
+        sorted_probs = torch.softmax(sorted_scores, dim=-1)
+        cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
+        cutoff = (cumulative_probs - sorted_probs) > top_p
+        sorted_probs[cutoff] = 0
+        if top_k > 0 and top_k < sorted_probs.numel():
+            sorted_probs[top_k:] = 0
+        sampled_idx = torch.multinomial(
+            sorted_probs, num_samples=1, generator=generator
+        ).item()
+        return int(sorted_indices[sampled_idx].item())
+
+    @staticmethod
+    def _multinomial_sample(probs, *, generator):
+        return torch.multinomial(probs, num_samples=1, generator=generator)
+
+    @staticmethod
+    def _req_scalar(param, req_idx: int, default):
+        if param is None or param.numel() == 0:
+            return default
+        flat = param.reshape(-1)
+        value = flat[min(req_idx, flat.numel() - 1)].item()
+        return int(value) if isinstance(default, int) else float(value)
+
+    def _cosyvoice3_ras_enabled(self, sampling_metadata) -> bool:
+        return bool(getattr(self, "base_ras_enabled", False))
+
+    @classmethod
+    def _ras_sample_one(
+        cls,
+        weighted_scores,
+        decoded_tokens,
+        *,
+        top_p,
+        top_k,
+        win_size,
+        tau_r,
+        generator,
+    ):
+        return _reference_ras_sample(
+            weighted_scores,
+            decoded_tokens,
+            top_p,
+            top_k,
+            win_size,
+            tau_r,
+            generator,
+        )
+
+
+def _install_fake_module(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+) -> types.ModuleType:
+    module = types.ModuleType(name)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_model_module(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+):
+    monkeypatch.setenv("VLLM_MUSA_COSYVOICE3_SAMPLER_MODE", mode)
+
+    for package in (
+        "vllm_omni",
+        "vllm_omni.model_executor",
+        "vllm_omni.model_executor.models",
+        "vllm_omni.model_executor.models.cosyvoice3",
+        "vllm",
+        "vllm.logger",
+        "vllm_musa",
+        "vllm_musa.omni",
+    ):
+        fake_package = _install_fake_module(monkeypatch, package)
+        fake_package.__path__ = []
+
+    base_module = _install_fake_module(
+        monkeypatch,
+        "vllm_omni.model_executor.models.cosyvoice3.cosyvoice3",
+    )
+    base_module.CosyVoice3Model = _FakeOmniCosyVoice3Model
+
+    utils_module = _install_fake_module(
+        monkeypatch,
+        "vllm_omni.model_executor.models.cosyvoice3.utils",
+    )
+    utils_module.ras_sample = _reference_ras_sample
+
+    logger_module = sys.modules["vllm.logger"]
+    logger_module.init_logger = logging.getLogger
+
+    gpu_ar_module = _install_fake_module(monkeypatch, "vllm_musa.omni.gpu_ar")
+    gpu_ar_module.HOST_SAMPLING_SCALARS = HOST_SCALARS
+    gpu_ar_module.NO_FREQUENCY_PRESENCE_PENALTIES = NO_FREQUENCY_PRESENCE
+
+    module_name = f"test_cosyvoice3_model_{mode}_{id(monkeypatch)}"
+    spec = importlib.util.spec_from_file_location(module_name, MODEL)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "recent_tokens",
+    [[], [0]],
+    ids=["ordinary", "repeat_fallback"],
+)
+def test_sync_free_ras_matches_reference_and_generator_state(
+    monkeypatch: pytest.MonkeyPatch,
+    recent_tokens: list[int],
+) -> None:
+    module = _load_model_module(monkeypatch, "sync_free")
+    scores = torch.tensor([10.0, 0.0, -1.0, -2.0])
+    reference_generator = torch.Generator().manual_seed(20260723)
+    candidate_generator = torch.Generator().manual_seed(20260723)
+
+    expected = _reference_ras_sample(
+        scores.clone(),
+        recent_tokens,
+        top_p=0.9,
+        top_k=4,
+        win_size=10,
+        tau_r=0.1,
+        generator=reference_generator,
+    )
+    actual = module.CosyVoice3Model._ras_sample_one(
+        scores.clone(),
+        recent_tokens,
+        top_p=0.9,
+        top_k=4,
+        win_size=10,
+        tau_r=0.1,
+        generator=candidate_generator,
+    )
+
+    assert actual == expected
+    assert torch.equal(
+        torch.rand(8, generator=candidate_generator),
+        torch.rand(8, generator=reference_generator),
+    )
+
+
+def test_sync_free_reads_host_scalars_and_preserves_empty_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_model_module(monkeypatch, "sync_free")
+    model = module.CosyVoice3Model()
+    temperature = torch.tensor([9.0])
+    top_p = torch.tensor([9.0])
+    top_k = torch.tensor([9])
+    model._vllm_musa_sampling_metadata = SimpleNamespace(
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        **{HOST_SCALARS: ([1.0], [0.8], [25])},
+    )
+
+    assert model._req_scalar(temperature, 0, 1.0) == 1.0
+    assert model._req_scalar(top_p, 0, 1.0) == pytest.approx(0.8)
+    assert model._req_scalar(top_k, 0, 0) == 25
+    assert model._req_scalar(None, 0, 0.5) == 0.5
+    assert model._req_scalar(torch.empty(0), 0, 7) == 7
+
+
+def test_baseline_mode_retains_device_scalar_and_reference_ras(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_model_module(monkeypatch, "baseline")
+    model = module.CosyVoice3Model()
+    device_value = torch.tensor([0.75])
+    model._vllm_musa_sampling_metadata = SimpleNamespace(
+        temperature=device_value,
+        **{HOST_SCALARS: ([0.25], [0.8], [25])},
+    )
+
+    assert model._req_scalar(device_value, 0, 1.0) == pytest.approx(0.75)
+
+    scores = torch.tensor([10.0, 0.0, -1.0])
+    reference_generator = torch.Generator().manual_seed(17)
+    baseline_generator = torch.Generator().manual_seed(17)
+    expected = _reference_ras_sample(
+        scores.clone(), [0], 0.9, 3, 10, 0.1, reference_generator
+    )
+    actual = module.CosyVoice3Model._ras_sample_one(
+        scores.clone(),
+        [0],
+        top_p=0.9,
+        top_k=3,
+        win_size=10,
+        tau_r=0.1,
+        generator=baseline_generator,
+    )
+
+    assert actual == expected
+    assert torch.equal(
+        torch.rand(8, generator=baseline_generator),
+        torch.rand(8, generator=reference_generator),
+    )
+
+
+def test_ras_eligibility_uses_host_flag_and_falls_back_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_model_module(monkeypatch, "sync_free")
+    model = module.CosyVoice3Model()
+    model.model_stage = "cosyvoice3_talker"
+    base_metadata = {
+        "max_num_logprobs": None,
+        "temperature": torch.tensor([1.0]),
+        "bad_words_token_ids": {},
+    }
+
+    eligible = SimpleNamespace(
+        **base_metadata,
+        **{NO_FREQUENCY_PRESENCE: True},
+    )
+    penalized = SimpleNamespace(
+        **base_metadata,
+        **{NO_FREQUENCY_PRESENCE: False},
+    )
+    bad_words = SimpleNamespace(
+        **{**base_metadata, "bad_words_token_ids": {0: [[1]]}},
+        **{NO_FREQUENCY_PRESENCE: True},
+    )
+
+    assert model._cosyvoice3_ras_enabled(eligible) is True
+    assert model._cosyvoice3_ras_enabled(penalized) is False
+    assert model._cosyvoice3_ras_enabled(bad_words) is False
+
+    model.base_ras_enabled = True
+    assert model._cosyvoice3_ras_enabled(SimpleNamespace()) is True
+
+
+def test_invalid_mode_falls_back_to_baseline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_model_module(monkeypatch, "unsupported")
+    assert module._SAMPLER_MODE == "baseline"

--- a/tests/test_cosyvoice3_sampler_source.py
+++ b/tests/test_cosyvoice3_sampler_source.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source contracts for the optional CosyVoice3 MUSA sampler wrapper."""
+
+import ast
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN = ROOT / "vllm_musa/omni/__init__.py"
+GPU_AR = ROOT / "vllm_musa/omni/gpu_ar.py"
+MODEL = ROOT / "vllm_musa/omni/models/cosyvoice3.py"
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_vllm_omni_entrypoint_is_lazy_and_optional() -> None:
+    project = _source(ROOT / "pyproject.toml")
+
+    assert '[project.entry-points."vllm_omni.general_plugins"]' in project
+    assert 'musa_custom_ops = "vllm_musa.omni:register_omni_optimizations"' in project
+
+
+def test_omni_plugin_registers_both_model_registries_lazily() -> None:
+    source = _source(PLUGIN)
+
+    assert "vllm_musa.omni.models.cosyvoice3:CosyVoice3Model" in source
+    assert "ModelRegistry.register_model" in source
+    assert "OmniModelRegistry.register_model" in source
+    assert "_MODEL_ARCH_BY_HASH" in source
+    assert "_invalidate_cosyvoice3_model_cache()" in source
+    assert "models.cosyvoice3 import" not in source
+
+
+def test_omni_plugin_invalidates_only_stale_cosyvoice3_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vllm_module = types.ModuleType("vllm")
+    model_executor_module = types.ModuleType("vllm.model_executor")
+    model_loader_module = types.ModuleType("vllm.model_executor.model_loader")
+    loader_utils_module = types.ModuleType("vllm.model_executor.model_loader.utils")
+    loader_utils_module._MODEL_ARCH_BY_HASH = {
+        1: (object(), "CosyVoice3Model"),
+        2: (object(), "OtherModel"),
+    }
+    model_loader_module.utils = loader_utils_module
+    model_executor_module.model_loader = model_loader_module
+    vllm_module.model_executor = model_executor_module
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+    monkeypatch.setitem(sys.modules, "vllm.model_executor", model_executor_module)
+    monkeypatch.setitem(
+        sys.modules, "vllm.model_executor.model_loader", model_loader_module
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.model_loader.utils",
+        loader_utils_module,
+    )
+
+    spec = importlib.util.spec_from_file_location("test_vllm_musa_omni_plugin", PLUGIN)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module._invalidate_cosyvoice3_model_cache() == 1
+    assert list(loader_utils_module._MODEL_ARCH_BY_HASH) == [2]
+
+
+def _load_gpu_ar_module(monkeypatch: pytest.MonkeyPatch):
+    fake_runner_module = types.ModuleType("vllm_omni.worker.gpu_ar_model_runner")
+
+    class FakeGPUARModelRunner:
+        def _sampling_metadata_for_model_sampler(self, sampling_metadata):
+            return sampling_metadata
+
+    fake_runner_module.GPUARModelRunner = FakeGPUARModelRunner
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_omni.worker.gpu_ar_model_runner",
+        fake_runner_module,
+    )
+
+    spec = importlib.util.spec_from_file_location("test_vllm_musa_omni_gpu_ar", GPU_AR)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, FakeGPUARModelRunner
+
+
+def test_gpu_ar_patch_ignores_repetition_penalty_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, runner_cls = _load_gpu_ar_module(monkeypatch)
+    assert module.install_sampling_metadata_patch()
+
+    runner = runner_cls()
+    runner.model_config = SimpleNamespace(model_arch="CosyVoice3Model")
+    runner.input_batch = SimpleNamespace(
+        frequency_penalties_reqs=set(),
+        presence_penalties_reqs=set(),
+        repetition_penalties_reqs={"request-0"},
+        temperature_cpu=[1.0],
+        top_p_cpu=[0.8],
+        top_k_cpu=[25],
+    )
+    model_metadata = SimpleNamespace()
+
+    result = runner._sampling_metadata_for_model_sampler(model_metadata)
+
+    assert result is model_metadata
+    assert getattr(result, module.NO_FREQUENCY_PRESENCE_PENALTIES) is True
+
+
+@pytest.mark.parametrize(
+    ("frequency_reqs", "presence_reqs"),
+    [({"request-0"}, set()), (set(), {"request-0"})],
+)
+def test_gpu_ar_patch_reports_frequency_or_presence_penalties(
+    monkeypatch: pytest.MonkeyPatch,
+    frequency_reqs: set[str],
+    presence_reqs: set[str],
+) -> None:
+    module, runner_cls = _load_gpu_ar_module(monkeypatch)
+    assert module.install_sampling_metadata_patch()
+
+    runner = runner_cls()
+    runner.model_config = SimpleNamespace(model_arch="CosyVoice3Model")
+    runner.input_batch = SimpleNamespace(
+        frequency_penalties_reqs=frequency_reqs,
+        presence_penalties_reqs=presence_reqs,
+        temperature_cpu=[1.0],
+        top_p_cpu=[0.8],
+        top_k_cpu=[25],
+    )
+    result = runner._sampling_metadata_for_model_sampler(SimpleNamespace())
+
+    assert getattr(result, module.NO_FREQUENCY_PRESENCE_PENALTIES) is False
+
+
+def test_gpu_ar_patch_is_idempotent_and_fails_closed_on_metadata_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, runner_cls = _load_gpu_ar_module(monkeypatch)
+    assert module.install_sampling_metadata_patch()
+    patched_method = runner_cls._sampling_metadata_for_model_sampler
+    assert module.install_sampling_metadata_patch()
+    assert runner_cls._sampling_metadata_for_model_sampler is patched_method
+
+    runner = runner_cls()
+    runner.model_config = SimpleNamespace(model_arch="CosyVoice3Model")
+    runner.input_batch = SimpleNamespace()
+    result = runner._sampling_metadata_for_model_sampler(SimpleNamespace())
+
+    assert not hasattr(result, module.NO_FREQUENCY_PRESENCE_PENALTIES)
+
+
+def test_gpu_ar_patch_exports_cpu_sampling_scalars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, runner_cls = _load_gpu_ar_module(monkeypatch)
+    assert module.install_sampling_metadata_patch()
+
+    runner = runner_cls()
+    runner.model_config = SimpleNamespace(model_arch="CosyVoice3Model")
+    runner.input_batch = SimpleNamespace(
+        temperature_cpu=[1.0],
+        top_p_cpu=[0.8],
+        top_k_cpu=[25],
+    )
+    result = runner._sampling_metadata_for_model_sampler(SimpleNamespace())
+
+    assert getattr(result, module.HOST_SAMPLING_SCALARS) == (
+        [1.0],
+        [0.8],
+        [25],
+    )
+
+
+def test_gpu_ar_patch_does_not_touch_other_model_families(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, runner_cls = _load_gpu_ar_module(monkeypatch)
+    assert module.install_sampling_metadata_patch()
+
+    runner = runner_cls()
+    runner.model_config = SimpleNamespace(model_arch="OtherModel")
+    runner.input_batch = SimpleNamespace(
+        frequency_penalties_reqs=set(),
+        presence_penalties_reqs=set(),
+        temperature_cpu=[1.0],
+        top_p_cpu=[0.8],
+        top_k_cpu=[25],
+    )
+    result = runner._sampling_metadata_for_model_sampler(SimpleNamespace())
+
+    assert not hasattr(result, module.NO_FREQUENCY_PRESENCE_PENALTIES)
+    assert not hasattr(result, module.HOST_SAMPLING_SCALARS)
+
+
+def test_ras_eligibility_reuses_host_side_frequency_presence_flag() -> None:
+    source = _source(MODEL)
+    tree = ast.parse(source, MODEL)
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "CosyVoice3Model"
+    )
+    method_names = {
+        node.name for node in class_node.body if isinstance(node, ast.FunctionDef)
+    }
+
+    assert {"_cosyvoice3_ras_enabled", "_ras_sample_one"} <= method_names
+    assert "return bool(no_frequency_presence_penalties)" in source
+    assert "def _req_scalar" in source
+    assert "if param is None or param.numel() == 0" in source
+    assert "HOST_SAMPLING_SCALARS" in source
+    assert "return super()._cosyvoice3_ras_enabled(sampling_metadata)" in source
+    assert "torch.any(" not in source
+    assert "sampling_metadata.no_penalties" not in source
+
+
+def test_cpu_history_count_preserves_ras_fallback_distribution() -> None:
+    source = _source(MODEL)
+
+    assert "sum(int(token) == top_id for token in recent)" in source
+    assert "weighted_scores = weighted_scores.clone()" in source
+    assert 'weighted_scores[top_id] = float("-inf")' in source
+    assert "fallback_probs = weighted_scores.softmax(dim=0)" in source
+    assert "cls._multinomial_sample(" in source
+    assert "torch.as_tensor" not in source

--- a/vllm_musa/omni/__init__.py
+++ b/vllm_musa/omni/__init__.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional vLLM-Omni integrations for the MUSA platform."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_COSYVOICE3_ARCH = "CosyVoice3Model"
+_COSYVOICE3_CLASS = "vllm_musa.omni.models.cosyvoice3:CosyVoice3Model"
+
+
+def _invalidate_cosyvoice3_model_cache() -> int:
+    """Drop CosyVoice3 resolutions made before Omni plugins were loaded."""
+    try:
+        from vllm.model_executor.model_loader import utils as loader_utils
+    except ImportError:
+        return 0
+
+    cache = getattr(loader_utils, "_MODEL_ARCH_BY_HASH", None)
+    if not isinstance(cache, dict):
+        return 0
+
+    stale_keys = [
+        key
+        for key, value in cache.items()
+        if isinstance(value, tuple) and len(value) == 2 and value[1] == _COSYVOICE3_ARCH
+    ]
+    for key in stale_keys:
+        cache.pop(key, None)
+    return len(stale_keys)
+
+
+def register_omni_optimizations() -> None:
+    """Register lazy MUSA wrappers for supported vLLM-Omni models."""
+    from vllm.model_executor.models import ModelRegistry
+    from vllm_omni.model_executor.models.registry import OmniModelRegistry
+
+    from vllm_musa.omni.gpu_ar import install_sampling_metadata_patch
+
+    install_sampling_metadata_patch()
+    ModelRegistry.register_model(_COSYVOICE3_ARCH, _COSYVOICE3_CLASS)
+    OmniModelRegistry.register_model(_COSYVOICE3_ARCH, _COSYVOICE3_CLASS)
+    invalidated = _invalidate_cosyvoice3_model_cache()
+    logger.info(
+        "Registered MUSA CosyVoice3 sampler optimizations "
+        "(invalidated architecture cache entries: %d)",
+        invalidated,
+    )
+
+
+__all__ = ["register_omni_optimizations"]

--- a/vllm_musa/omni/gpu_ar.py
+++ b/vllm_musa/omni/gpu_ar.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA-specific vLLM-Omni autoregressive runner integrations."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+NO_FREQUENCY_PRESENCE_PENALTIES = "_vllm_musa_no_frequency_presence_penalties"
+HOST_SAMPLING_SCALARS = "_vllm_musa_host_sampling_scalars"
+_PATCH_MARKER = "_vllm_musa_cosyvoice3_penalty_metadata_patch"
+_COSYVOICE3_ARCH = "CosyVoice3Model"
+
+
+def install_sampling_metadata_patch() -> bool:
+    """Expose frequency/presence eligibility without a device sync.
+
+    vLLM's input batch already tracks the requests using each penalty in CPU
+    sets.  CosyVoice3 only needs the frequency and presence state, whereas the
+    generic ``SamplingMetadata.no_penalties`` flag also includes repetition
+    penalties.  Attach a model-private boolean after Omni has built its model
+    sampler metadata so the model can preserve that distinction.
+
+    Returns ``False`` when the expected Omni runner is unavailable.  The model
+    wrapper treats a missing attribute as a compatibility fallback and calls
+    the original synchronization-based implementation.
+    """
+    try:
+        from vllm_omni.worker.gpu_ar_model_runner import GPUARModelRunner
+    except (ImportError, AttributeError):
+        logger.warning(
+            "vLLM-Omni GPUARModelRunner is unavailable; "
+            "CosyVoice3 will retain synchronized penalty checks"
+        )
+        return False
+
+    original: Callable[..., Any] = GPUARModelRunner._sampling_metadata_for_model_sampler
+    if getattr(original, _PATCH_MARKER, False):
+        return True
+
+    @wraps(original)
+    def _sampling_metadata_for_model_sampler(self, sampling_metadata):
+        model_metadata = original(self, sampling_metadata)
+        model_config = getattr(self, "model_config", None)
+        if getattr(model_config, "model_arch", None) != _COSYVOICE3_ARCH:
+            return model_metadata
+
+        input_batch = getattr(self, "input_batch", None)
+        frequency_reqs = getattr(input_batch, "frequency_penalties_reqs", None)
+        presence_reqs = getattr(input_batch, "presence_penalties_reqs", None)
+        host_scalars = tuple(
+            getattr(input_batch, name, None)
+            for name in ("temperature_cpu", "top_p_cpu", "top_k_cpu")
+        )
+        if all(value is not None for value in host_scalars):
+            setattr(model_metadata, HOST_SAMPLING_SCALARS, host_scalars)
+        if frequency_reqs is None or presence_reqs is None:
+            return model_metadata
+
+        setattr(
+            model_metadata,
+            NO_FREQUENCY_PRESENCE_PENALTIES,
+            not frequency_reqs and not presence_reqs,
+        )
+        return model_metadata
+
+    setattr(_sampling_metadata_for_model_sampler, _PATCH_MARKER, True)
+    GPUARModelRunner._sampling_metadata_for_model_sampler = (
+        _sampling_metadata_for_model_sampler
+    )
+    logger.info("Installed MUSA CosyVoice3 host-side penalty metadata integration")
+    return True
+
+
+__all__ = [
+    "HOST_SAMPLING_SCALARS",
+    "NO_FREQUENCY_PRESENCE_PENALTIES",
+    "install_sampling_metadata_patch",
+]

--- a/vllm_musa/omni/models/__init__.py
+++ b/vllm_musa/omni/models/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA wrappers for optional vLLM-Omni models."""

--- a/vllm_musa/omni/models/cosyvoice3.py
+++ b/vllm_musa/omni/models/cosyvoice3.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA-specific CosyVoice3 Talker sampling optimizations."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+
+import torch
+from vllm_omni.model_executor.models.cosyvoice3.cosyvoice3 import (
+    CosyVoice3Model as _OmniCosyVoice3Model,
+)
+
+from vllm_musa.omni.gpu_ar import (
+    HOST_SAMPLING_SCALARS,
+    NO_FREQUENCY_PRESENCE_PENALTIES,
+)
+
+logger = logging.getLogger(__name__)
+
+_SAMPLER_MODE_ENV = "VLLM_MUSA_COSYVOICE3_SAMPLER_MODE"
+_VALID_SAMPLER_MODES = {"baseline", "sync_free"}
+
+
+def _sampler_mode() -> str:
+    value = os.getenv(_SAMPLER_MODE_ENV, "sync_free").strip().lower()
+    if value not in _VALID_SAMPLER_MODES:
+        logger.warning(
+            "Invalid %s=%r; falling back to baseline sampling",
+            _SAMPLER_MODE_ENV,
+            value,
+        )
+        return "baseline"
+    return value
+
+
+_SAMPLER_MODE = _sampler_mode()
+
+
+class CosyVoice3Model(_OmniCosyVoice3Model):
+    """CosyVoice3 wrapper that removes decode-time sampling stalls."""
+
+    def _req_scalar(self, param, req_idx: int, default):
+        """Read per-request scalars from CPU arrays when available."""
+        if param is None or param.numel() == 0:
+            return default
+        if _SAMPLER_MODE != "baseline":
+            metadata = getattr(self, "_vllm_musa_sampling_metadata", None)
+            host_scalars = getattr(metadata, HOST_SAMPLING_SCALARS, None)
+            if host_scalars is not None:
+                for device_param, host_param in zip(
+                    (
+                        getattr(metadata, "temperature", None),
+                        getattr(metadata, "top_p", None),
+                        getattr(metadata, "top_k", None),
+                    ),
+                    host_scalars,
+                    strict=True,
+                ):
+                    if param is not device_param or host_param is None:
+                        continue
+                    if len(host_param) == 0:
+                        return default
+                    index = min(req_idx, len(host_param) - 1)
+                    value = host_param[index]
+                    return int(value) if isinstance(default, int) else float(value)
+        return super()._req_scalar(param, req_idx, default)
+
+    def _cosyvoice3_ras_enabled(self, sampling_metadata) -> bool:
+        if _SAMPLER_MODE == "baseline":
+            return super()._cosyvoice3_ras_enabled(sampling_metadata)
+        self._vllm_musa_sampling_metadata = sampling_metadata
+        no_frequency_presence_penalties = getattr(
+            sampling_metadata,
+            NO_FREQUENCY_PRESENCE_PENALTIES,
+            None,
+        )
+        if no_frequency_presence_penalties is None:
+            return super()._cosyvoice3_ras_enabled(sampling_metadata)
+        if self.model_stage != "cosyvoice3_talker":
+            return False
+        if sampling_metadata.max_num_logprobs is not None:
+            return False
+        if sampling_metadata.temperature is None:
+            return False
+        if bool(sampling_metadata.bad_words_token_ids):
+            return False
+        return bool(no_frequency_presence_penalties)
+
+    @classmethod
+    def _ras_sample_one(
+        cls,
+        weighted_scores: torch.Tensor,
+        decoded_tokens: Sequence[int],
+        *,
+        top_p: float,
+        top_k: int,
+        win_size: int,
+        tau_r: float,
+        generator: torch.Generator | None,
+    ) -> int:
+        if _SAMPLER_MODE == "baseline":
+            return super()._ras_sample_one(
+                weighted_scores,
+                decoded_tokens,
+                top_p=top_p,
+                top_k=top_k,
+                win_size=win_size,
+                tau_r=tau_r,
+                generator=generator,
+            )
+
+        top_id = cls._nucleus_sample_one(
+            weighted_scores,
+            top_p=top_p,
+            top_k=top_k,
+            generator=generator,
+        )
+        if win_size > 0 and decoded_tokens:
+            # ``top_id`` is already host-visible.  Counting a ten-token Python
+            # history avoids a tensor allocation, H2D copy, kernel launch, and
+            # a second D2H synchronization on every autoregressive step.
+            recent = decoded_tokens[-win_size:]
+            rep_num = sum(int(token) == top_id for token in recent)
+            if rep_num >= win_size * tau_r:
+                weighted_scores = weighted_scores.clone()
+                weighted_scores[top_id] = float("-inf")
+                fallback_probs = weighted_scores.softmax(dim=0)
+                top_id = int(
+                    cls._multinomial_sample(
+                        fallback_probs,
+                        generator=generator,
+                    ).item()
+                )
+        return top_id
+
+
+logger.info("CosyVoice3 MUSA sampler mode: %s", _SAMPLER_MODE)
+
+__all__ = ["CosyVoice3Model"]


### PR DESCRIPTION
## Summary

Add an optional vLLM-Omni integration in vLLM-MUSA for the CosyVoice3 Talker
sampling path.

This change:

- registers a lazy MUSA CosyVoice3 wrapper through the
  `vllm_omni.general_plugins` entry point and both model registries;
- forwards existing CPU-side sampling arrays and frequency/presence request
  sets to the model sampler;
- removes decode-time GPU-to-CPU synchronization for penalty eligibility and
  recent-token repetition counting;
- preserves the baseline mode and metadata-drift fallback paths;
- invalidates only stale CosyVoice3 architecture-cache entries resolved before
  the Omni plugin was loaded.

The implementation is limited to vLLM-MUSA. vLLM-Omni, model weights, and
Code2Wav are not modified.

## Performance

Measured on one MTT S5000 with the normal compiled serving path:

- BF16, TP1, MUSA FlashAttention 3;
- async scheduling and `torch.compile` enabled;
- FULL + PIECEWISE graph capture;
- 2 warmups followed by 5 measured runs;
- 1,009 generated speech tokens and a 40.36-second streaming-class proxy.

| Variant | Mean RTF | Median RTF | P95 RTF | Mean TPOT |
| --- | ---: | ---: | ---: | ---: |
| Baseline | 0.148198 | 0.147662 | 0.150653 | 5.9279 ms |
| Optimized | 0.131479 | 0.131009 | 0.133321 | 5.2592 ms |

The optimized Talker path reduces mean RTF and TPOT by 11.28% and reaches the
requested `0.1xx` range. Throughput increases from 168.714 to 190.161 tokens/s.

## Correctness and profiling

All measured baseline and optimized runs produced 1,009 speech tokens,
checksum `1662925838`, one EOS token, `finish_reason=stop`, identical first and
last token windows, and no request errors.

Across a 64-step decode profile:

- `aten::is_nonzero`: `192 -> 64`;
- `aten::any`: `128 -> 0`;
- `aten::sum`: `64 -> 0`;
- `aten::item`: `1155 -> 579`;
- `musaStreamSynchronize`: `582 -> 134`.

## Validation

- `ruff format --check` and `ruff check`: passed.
- Local focused suite: 11 passed, 1 skipped because the local host has no
  Torch installation.
- Exact S5000 image focused suite: 17 passed.
- Real entry-point discovery, both model registries, architecture-cache
  invalidation, and dynamic `SamplingMetadata` attributes: passed.
- A real S5000 Talker request completed successfully on the exact final code.

## Scope and limitations

The reported RTF is Talker/LLM-only. It is not directly comparable with the
0.261 full Talker + Code2Wav RTF reported by vLLM-Omni PR 5164.

Full Talker -> Code2Wav waveform and audio-quality validation remains outside
this vLLM-MUSA PR.

The wrapper uses the v0.24.0-dev private `_MODEL_ARCH_BY_HASH` cache to
invalidate a stale pre-plugin CosyVoice3 resolution. It is guarded and verified
on this base, but should be revisited if the upstream model-loader cache API
changes.
