### PR TITLE
perf(musa): optimize Qwen2 decode for CosyVoice3

### DIFF
--- a/csrc/musa/fused_add_rmsnorm.mu
+++ b/csrc/musa/fused_add_rmsnorm.mu
@@ -7,6 +7,7 @@
 #include "torch_musa/csrc/core/MUSAGuard.h"
 
 #include <cstdlib>
+#include <type_traits>
 
 #include "vec_utils.muh"
 
@@ -125,6 +126,7 @@ __global__ void __launch_bounds__(BLOCK_X, 1) fused_add_rmsnorm_kernel(
 template <typename T>
 void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
                                 int rows, int hidden_size, float epsilon,
+                                bool use_qwen2_small_hidden_launch,
                                 musaStream_t stream) {
   const int vec_hidden_size = hidden_size / 8;
 
@@ -150,6 +152,11 @@ void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
     block_x = 256;
   } else if (rows >= 8 && vec_hidden_size >= 1280) {
     block_x = 512;
+  } else if (use_qwen2_small_hidden_launch &&
+             std::is_same<T, __mt_bfloat16>::value && rows > 0 &&
+             rows <= 16 && hidden_size == 896) {
+    // MUSA: reduce idle threads and reduction overhead for small-row H=896.
+    block_x = 256;
   } else {
     block_x = 1024;
   }
@@ -228,13 +235,15 @@ void musa_fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
         static_cast<__half*>(input.data_ptr()),
         static_cast<__half*>(residual.data_ptr()),
         static_cast<const __half*>(weight.data_ptr()), rows, hidden_size,
-        static_cast<float>(epsilon), stream);
+        static_cast<float>(epsilon), false, stream);
   } else if (input.scalar_type() == at::ScalarType::BFloat16) {
+    const bool use_qwen2_small_hidden_launch =
+        at::musa::getMUSAArch(input.get_device()) == 310;
     vllm_musa::dispatch_fused_add_rmsnorm<__mt_bfloat16>(
         static_cast<__mt_bfloat16*>(input.data_ptr()),
         static_cast<__mt_bfloat16*>(residual.data_ptr()),
         static_cast<const __mt_bfloat16*>(weight.data_ptr()), rows, hidden_size,
-        static_cast<float>(epsilon), stream);
+        static_cast<float>(epsilon), use_qwen2_small_hidden_launch, stream);
   } else {
     TORCH_CHECK(false, "only fp16 and bf16 are supported");
   }

--- a/csrc/musa/fused_add_rmsnorm.mu
+++ b/csrc/musa/fused_add_rmsnorm.mu
@@ -126,7 +126,6 @@ __global__ void __launch_bounds__(BLOCK_X, 1) fused_add_rmsnorm_kernel(
 template <typename T>
 void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
                                 int rows, int hidden_size, float epsilon,
-                                bool use_qwen2_small_hidden_launch,
                                 musaStream_t stream) {
   const int vec_hidden_size = hidden_size / 8;
 
@@ -152,10 +151,10 @@ void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
     block_x = 256;
   } else if (rows >= 8 && vec_hidden_size >= 1280) {
     block_x = 512;
-  } else if (use_qwen2_small_hidden_launch &&
-             std::is_same<T, __mt_bfloat16>::value && rows > 0 &&
+  } else if (std::is_same<T, __mt_bfloat16>::value && rows > 0 &&
              rows <= 16 && hidden_size == 896) {
-    // MUSA: reduce idle threads and reduction overhead for small-row H=896.
+    // S5000/Qwen2: reduce idle threads and reduction overhead for small-row
+    // H=896.
     block_x = 256;
   } else {
     block_x = 1024;
@@ -235,15 +234,13 @@ void musa_fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
         static_cast<__half*>(input.data_ptr()),
         static_cast<__half*>(residual.data_ptr()),
         static_cast<const __half*>(weight.data_ptr()), rows, hidden_size,
-        static_cast<float>(epsilon), false, stream);
+        static_cast<float>(epsilon), stream);
   } else if (input.scalar_type() == at::ScalarType::BFloat16) {
-    const bool use_qwen2_small_hidden_launch =
-        at::musa::getMUSAArch(input.get_device()) == 310;
     vllm_musa::dispatch_fused_add_rmsnorm<__mt_bfloat16>(
         static_cast<__mt_bfloat16*>(input.data_ptr()),
         static_cast<__mt_bfloat16*>(residual.data_ptr()),
         static_cast<const __mt_bfloat16*>(weight.data_ptr()), rows, hidden_size,
-        static_cast<float>(epsilon), use_qwen2_small_hidden_launch, stream);
+        static_cast<float>(epsilon), stream);
   } else {
     TORCH_CHECK(false, "only fp16 and bf16 are supported");
   }

--- a/tests/jit_kernel/test_csrc_jit_kernels.py
+++ b/tests/jit_kernel/test_csrc_jit_kernels.py
@@ -405,6 +405,32 @@ def test_ir_fused_add_rmsnorm_preserves_functional_and_inplace_contracts() -> No
     _assert_close(residual_out, expected_residual, atol=0.0, rtol=0.0)
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("rows", [1, 16])
+def test_ir_fused_add_rmsnorm_qwen2_small_hidden_contract(
+    dtype: torch.dtype,
+    rows: int,
+) -> None:
+    from vllm_musa.kernels.musa_ops import (
+        fused_add_rms_norm as musa_fused_add_rms_norm,
+    )
+
+    torch.manual_seed(896 + rows)
+    device = torch.device("musa")
+    eps = 1e-6
+    x = torch.randn((rows, 896), device=device, dtype=dtype)
+    residual = torch.randn_like(x)
+    weight = torch.randn((896,), device=device, dtype=dtype)
+    expected, expected_residual = _fused_add_rmsnorm_ref(x, residual, weight, eps)
+
+    output, residual_out = musa_fused_add_rms_norm.impl_fn(x, residual, weight, eps)
+
+    assert output.data_ptr() == x.data_ptr()
+    assert residual_out.data_ptr() == residual.data_ptr()
+    _assert_close(output, expected)
+    _assert_close(residual_out, expected_residual, atol=0.0, rtol=0.0)
+
+
 def _topk_softmax_ref(
     gating: torch.Tensor,
     topk: int,

--- a/tests/kernels/test_qwen2_rope_kv.py
+++ b/tests/kernels/test_qwen2_rope_kv.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm_musa.kernels import qwen2_rope_kv
+
+requires_musa = pytest.mark.skipif(
+    not hasattr(torch, "musa") or not torch.musa.is_available(),
+    reason="requires a MUSA device",
+)
+
+
+def _make_exact_inputs(num_tokens: int = 1) -> dict[str, object]:
+    packed_qkv = torch.empty((num_tokens, 1152), dtype=torch.bfloat16)
+    query = packed_qkv[:, :896].view(num_tokens, 14, 64)
+    key = packed_qkv[:, 896:1024].view(num_tokens, 2, 64)
+    value = packed_qkv[:, 1024:].view(num_tokens, 2, 64)
+    return {
+        "query": query,
+        "key": key,
+        "value": value,
+        "positions": torch.arange(num_tokens, dtype=torch.int64),
+        "cos_sin_cache": torch.empty((2048, 64), dtype=torch.bfloat16),
+        "is_neox": True,
+        "key_cache": torch.empty((4, 64, 2, 64), dtype=torch.bfloat16),
+        "value_cache": torch.empty((4, 64, 2, 64), dtype=torch.bfloat16),
+        "slot_mapping": torch.arange(num_tokens, dtype=torch.int64),
+    }
+
+
+def _allow_cpu_as_musa(monkeypatch) -> None:
+    monkeypatch.setattr(qwen2_rope_kv, "_is_musa_tensor", lambda _tensor: True)
+
+
+def test_qwen2_rope_kv_exact_gate_accepts_packed_qkv_views(monkeypatch):
+    _allow_cpu_as_musa(monkeypatch)
+    inputs = _make_exact_inputs()
+
+    assert qwen2_rope_kv.supports_qwen2_rope_kv_cache(**inputs)
+
+
+def test_qwen2_rope_kv_gate_rejects_short_slot_mapping(monkeypatch):
+    _allow_cpu_as_musa(monkeypatch)
+    inputs = _make_exact_inputs()
+    inputs["slot_mapping"] = torch.empty(0, dtype=torch.int64)
+
+    assert not qwen2_rope_kv.supports_qwen2_rope_kv_cache(**inputs)
+
+
+def test_qwen2_rope_kv_gate_rejects_non_neox_and_wrong_shape(monkeypatch):
+    _allow_cpu_as_musa(monkeypatch)
+    inputs = _make_exact_inputs()
+    inputs["is_neox"] = False
+    assert not qwen2_rope_kv.supports_qwen2_rope_kv_cache(**inputs)
+
+    inputs = _make_exact_inputs()
+    inputs["query"] = torch.empty((1, 16, 64), dtype=torch.bfloat16)
+    assert not qwen2_rope_kv.supports_qwen2_rope_kv_cache(**inputs)
+
+
+def test_qwen2_rope_kv_gate_rejects_non_nhd_cache(monkeypatch):
+    _allow_cpu_as_musa(monkeypatch)
+    inputs = _make_exact_inputs()
+    inputs["key_cache"] = torch.empty((4, 2, 64, 64), dtype=torch.bfloat16).permute(
+        0, 2, 1, 3
+    )
+
+    assert not qwen2_rope_kv.supports_qwen2_rope_kv_cache(**inputs)
+
+
+def _cos_sin_cache(device: torch.device) -> torch.Tensor:
+    positions = torch.arange(4096, device=device, dtype=torch.float32)[:, None]
+    frequency = torch.arange(0, 64, 2, device=device, dtype=torch.float32) / 64
+    angles = positions / (1_000_000.0**frequency)[None, :]
+    return torch.cat((angles.cos(), angles.sin()), dim=-1).to(torch.bfloat16)
+
+
+@requires_musa
+@pytest.mark.parametrize("slot", [-1, 0, 63, 64, 191])
+def test_qwen2_rope_kv_kernel_matches_native_path(slot: int):
+    from vllm_musa import _custom_ops as musa_ops
+    from vllm_musa.jit_kernel.csrc.rope import rotary_embedding
+
+    device = torch.device("musa:0")
+    torch.manual_seed(6002921)
+    source = torch.randn((1, 1152), device=device, dtype=torch.bfloat16)
+    positions = torch.tensor([317], device=device, dtype=torch.int64)
+    cos_sin_cache = _cos_sin_cache(device)
+    slot_mapping = torch.tensor([slot], device=device, dtype=torch.int64)
+    cache_source = torch.randn((3, 64, 2, 64), device=device, dtype=torch.bfloat16)
+
+    def make_case():
+        packed = source.clone()
+        query = packed[:, :896].view(1, 14, 64)
+        key = packed[:, 896:1024].view(1, 2, 64)
+        value = packed[:, 1024:].view(1, 2, 64)
+        key_cache = cache_source.clone()
+        value_cache = cache_source.clone()
+        return packed, query, key, value, key_cache, value_cache
+
+    reference = make_case()
+    rotary_embedding(
+        positions,
+        reference[1],
+        reference[2],
+        64,
+        cos_sin_cache,
+        True,
+    )
+    musa_ops.musa_reshape_and_cache_flash_nhd(
+        reference[2],
+        reference[3],
+        reference[4],
+        reference[5],
+        slot_mapping,
+    )
+
+    candidate = make_case()
+    assert qwen2_rope_kv.try_qwen2_rope_kv_cache(
+        candidate[1],
+        candidate[2],
+        candidate[3],
+        positions,
+        cos_sin_cache,
+        True,
+        candidate[4],
+        candidate[5],
+        slot_mapping,
+    )
+    torch.musa.synchronize()
+
+    torch.testing.assert_close(candidate[0], reference[0], rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(candidate[4], reference[4], rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(candidate[5], reference[5], rtol=0, atol=0)

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -253,6 +253,47 @@ class TestMUSAPlatformBase:
         )
         assert config.compilation_config.compile_ranges_endpoints == []
 
+    def test_qwen2_rope_kv_fusion_exact_config_gate(self):
+        import torch
+
+        from vllm_musa.platform import _is_qwen2_rope_kv_fusion_config
+        from vllm_musa.utils.environ import envs
+
+        def make_config(model_type: str, kv_heads, intermediate_size):
+            return SimpleNamespace(
+                model_config=SimpleNamespace(
+                    hf_text_config=SimpleNamespace(
+                        model_type=model_type,
+                        hidden_size=896,
+                        intermediate_size=intermediate_size,
+                        num_hidden_layers=24,
+                        num_attention_heads=14,
+                        num_key_value_heads=kv_heads,
+                    ),
+                    dtype=torch.bfloat16,
+                    quantization=None,
+                    enforce_eager=False,
+                ),
+                parallel_config=SimpleNamespace(
+                    tensor_parallel_size=1,
+                    pipeline_parallel_size=1,
+                    data_parallel_size=1,
+                    decode_context_parallel_size=1,
+                ),
+                quant_config=None,
+                speculative_config=None,
+            )
+
+        with envs.VLLM_MUSA_QWEN2_ROPE_KV_FUSION.override(True):
+            assert not _is_qwen2_rope_kv_fusion_config(make_config("qwen2", None, None))
+            assert _is_qwen2_rope_kv_fusion_config(
+                make_config("cosyvoice3", None, None)
+            )
+            config = make_config("qwen2", 2, 4864)
+            assert _is_qwen2_rope_kv_fusion_config(config)
+            config.quant_config = object()
+            assert not _is_qwen2_rope_kv_fusion_config(config)
+
     def test_supports_fp8_for_musa_3_1(self):
         """Test that FP8 is supported on MUSA capability 3.1."""
         from vllm.platforms.interface import DeviceCapability

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -291,6 +291,13 @@ class TestMUSAPlatformBase:
             )
             config = make_config("qwen2", 2, 4864)
             assert _is_qwen2_rope_kv_fusion_config(config)
+            config.cache_config = SimpleNamespace(
+                cache_dtype="bfloat16", block_size=64
+            )
+            assert _is_qwen2_rope_kv_fusion_config(config)
+            config.cache_config.block_size = 128
+            assert not _is_qwen2_rope_kv_fusion_config(config)
+            config.cache_config.block_size = 64
             config.quant_config = object()
             assert not _is_qwen2_rope_kv_fusion_config(config)
 

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -335,15 +335,15 @@ class TestMUSANativeKernelReviewHardening:
         ).read_text()
 
         gate_start = source.index(
-            "use_qwen2_small_hidden_launch &&\n"
-            "             std::is_same<T, __mt_bfloat16>::value && rows > 0 &&"
+            "std::is_same<T, __mt_bfloat16>::value && rows > 0 &&"
         )
         gate = source[gate_start : source.index("} else", gate_start)]
         assert "block_x = 256" in gate
         assert "std::is_same<T, __mt_bfloat16>::value" in gate
         assert "rows > 0" in gate
         assert "rows <= 16 && hidden_size == 896" in gate
-        assert "at::musa::getMUSAArch(input.get_device()) == 310" in source
+        assert "use_qwen2_small_hidden_launch" not in source
+        assert "getMUSAArch" not in source
 
 
 class TestMUSAPlatformDefaults:

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -329,6 +329,22 @@ class TestMUSANativeKernelReviewHardening:
         assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X must be one of" in source
         assert "128, 256, 512, or 1024" in source
 
+    def test_fused_rmsnorm_qwen2_small_hidden_uses_256_threads(self):
+        source = (
+            Path(__file__).parents[1] / "csrc/musa/fused_add_rmsnorm.mu"
+        ).read_text()
+
+        gate_start = source.index(
+            "use_qwen2_small_hidden_launch &&\n"
+            "             std::is_same<T, __mt_bfloat16>::value && rows > 0 &&"
+        )
+        gate = source[gate_start : source.index("} else", gate_start)]
+        assert "block_x = 256" in gate
+        assert "std::is_same<T, __mt_bfloat16>::value" in gate
+        assert "rows > 0" in gate
+        assert "rows <= 16 && hidden_size == 896" in gate
+        assert "at::musa::getMUSAArch(input.get_device()) == 310" in source
+
 
 class TestMUSAPlatformDefaults:
     """Tests for MUSA platform-level vLLM config defaults.

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -83,6 +83,77 @@ class TestCompilationBackendPatch:
             ["input"],
         )
 
+    def test_qwen2_presplit_keeps_baseline_split_and_hashes_helper(self, monkeypatch):
+        from vllm_musa import platform
+        from vllm_musa.compilation import qwen2_rope_kv_presplit as presplit
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_file = next(
+            f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
+        )
+        patch_module = _load_patch_module(patch_file)
+        monkeypatch.setattr(
+            platform, "_is_qwen2_rope_kv_fusion_config", lambda _config: True
+        )
+        monkeypatch.setattr(
+            presplit,
+            "plan_qwen2_rope_kv_presplit",
+            lambda _graph: tuple(range(24)),
+        )
+        monkeypatch.setattr(
+            presplit,
+            "apply_qwen2_rope_kv_presplit",
+            lambda _graph, candidates: len(candidates),
+        )
+        compilation_config = SimpleNamespace(
+            use_inductor_graph_partition=False,
+            splitting_ops=["vllm::unified_kv_cache_update", "vllm::attention"],
+            traced_files=set(),
+        )
+        backend = SimpleNamespace(
+            vllm_config=object(), compilation_config=compilation_config
+        )
+
+        assert patch_module._try_qwen2_rope_kv_presplit(backend, object()) == 24
+        assert compilation_config.splitting_ops == [
+            "vllm::unified_kv_cache_update",
+            "vllm::attention",
+            "vllm::fused_rope_and_unified_kv_cache_update",
+        ]
+        assert str(Path(presplit.__file__).resolve()) in compilation_config.traced_files
+        assert str(Path(patch_module.__file__).resolve()) in (
+            compilation_config.traced_files
+        )
+
+    def test_qwen2_presplit_mismatch_keeps_baseline_config(self, monkeypatch):
+        from vllm_musa import platform
+        from vllm_musa.compilation import qwen2_rope_kv_presplit as presplit
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_file = next(
+            f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
+        )
+        patch_module = _load_patch_module(patch_file)
+        monkeypatch.setattr(
+            platform, "_is_qwen2_rope_kv_fusion_config", lambda _config: True
+        )
+        monkeypatch.setattr(
+            presplit, "plan_qwen2_rope_kv_presplit", lambda _graph: None
+        )
+        splitting_ops = ["vllm::unified_kv_cache_update", "vllm::attention"]
+        compilation_config = SimpleNamespace(
+            use_inductor_graph_partition=False,
+            splitting_ops=splitting_ops,
+            traced_files=set(),
+        )
+        backend = SimpleNamespace(
+            vllm_config=object(), compilation_config=compilation_config
+        )
+
+        assert patch_module._try_qwen2_rope_kv_presplit(backend, object()) == 0
+        assert compilation_config.splitting_ops is splitting_ops
+        assert compilation_config.traced_files == set()
+
     def test_live_functorch_config_patch_skips_missing_keys(self):
         from contextlib import nullcontext
 

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -96,6 +96,9 @@ class TestCompilationBackendPatch:
             platform, "_is_qwen2_rope_kv_fusion_config", lambda _config: True
         )
         monkeypatch.setattr(
+            presplit, "qwen2_rope_kv_backend_supported", lambda _config: True
+        )
+        monkeypatch.setattr(
             presplit,
             "plan_qwen2_rope_kv_presplit",
             lambda _graph: tuple(range(24)),
@@ -138,7 +141,39 @@ class TestCompilationBackendPatch:
             platform, "_is_qwen2_rope_kv_fusion_config", lambda _config: True
         )
         monkeypatch.setattr(
+            presplit, "qwen2_rope_kv_backend_supported", lambda _config: True
+        )
+        monkeypatch.setattr(
             presplit, "plan_qwen2_rope_kv_presplit", lambda _graph: None
+        )
+        splitting_ops = ["vllm::unified_kv_cache_update", "vllm::attention"]
+        compilation_config = SimpleNamespace(
+            use_inductor_graph_partition=False,
+            splitting_ops=splitting_ops,
+            traced_files=set(),
+        )
+        backend = SimpleNamespace(
+            vllm_config=object(), compilation_config=compilation_config
+        )
+
+        assert patch_module._try_qwen2_rope_kv_presplit(backend, object()) == 0
+        assert compilation_config.splitting_ops is splitting_ops
+        assert compilation_config.traced_files == set()
+
+    def test_qwen2_presplit_rejects_unsupported_attention_backend(self, monkeypatch):
+        from vllm_musa import platform
+        from vllm_musa.compilation import qwen2_rope_kv_presplit as presplit
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_file = next(
+            f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
+        )
+        patch_module = _load_patch_module(patch_file)
+        monkeypatch.setattr(
+            platform, "_is_qwen2_rope_kv_fusion_config", lambda _config: True
+        )
+        monkeypatch.setattr(
+            presplit, "qwen2_rope_kv_backend_supported", lambda _config: False
         )
         splitting_ops = ["vllm::unified_kv_cache_update", "vllm::attention"]
         compilation_config = SimpleNamespace(

--- a/tests/test_qwen2_rope_kv_presplit.py
+++ b/tests/test_qwen2_rope_kv_presplit.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import operator
+
+import pytest
+import torch
+from torch import fx
+from vllm.compilation.passes.fusion import rope_kvcache_fusion  # noqa: F401
+from vllm.model_executor.layers.attention import attention  # noqa: F401
+
+import vllm_musa.jit_kernel.csrc.rope  # noqa: F401
+from vllm_musa.compilation.qwen2_rope_kv_presplit import (
+    FUSED_SPLITTING_OP,
+    KV_UPDATE_SPLITTING_OP,
+    _arg,
+    _is_call,
+    apply_qwen2_rope_kv_presplit,
+    plan_qwen2_rope_kv_presplit,
+)
+
+
+def _set_tensor_meta(node: fx.Node, shape: tuple[int, ...], dtype=torch.bfloat16):
+    node.meta["example_value"] = torch.empty(shape, dtype=dtype)
+
+
+def _make_graph(
+    sites: int,
+    *,
+    malformed_site: int | None = None,
+    duplicate_layer_name: bool = False,
+) -> fx.GraphModule:
+    graph = fx.Graph()
+    qkv = graph.placeholder("qkv")
+    positions = graph.placeholder("positions")
+    cos_sin_cache = graph.placeholder("cos_sin_cache")
+    output = graph.placeholder("output")
+    attention_nodes = []
+
+    for index in range(sites):
+        split = graph.call_method(
+            "split",
+            args=(qkv, [896, 128, 128]),
+            kwargs={"dim": -1},
+        )
+        query_base = graph.call_function(operator.getitem, args=(split, 0))
+        key_base = graph.call_function(operator.getitem, args=(split, 1))
+        value_base = graph.call_function(operator.getitem, args=(split, 2))
+        graph.call_function(
+            torch.ops.vllm.musa_rotary_embedding.default,
+            args=(positions, query_base, key_base, 64, cos_sin_cache, True),
+        )
+        query = graph.call_method("view", args=(query_base, -1, 14, 64))
+        key = graph.call_method("view", args=(key_base, -1, 2, 64))
+        value = graph.call_method("view", args=(value_base, -1, 2, 64))
+        query_dtype = torch.float32 if index == malformed_site else torch.bfloat16
+        _set_tensor_meta(query, (1, 14, 64), query_dtype)
+        _set_tensor_meta(key, (1, 2, 64))
+        _set_tensor_meta(value, (1, 2, 64))
+
+        layer_index = 0 if duplicate_layer_name else index
+        layer_name = f"model.layers.{layer_index}.self_attn.attn"
+        kv_update = graph.call_function(
+            torch.ops.vllm.unified_kv_cache_update.default,
+            args=(key, value, layer_name),
+        )
+        attention_node = graph.call_function(
+            torch.ops.vllm.unified_attention_with_output.default,
+            args=(query, key, value, output, layer_name),
+            kwargs={"kv_cache_dummy_dep": kv_update},
+        )
+        attention_nodes.append(attention_node)
+
+    graph.output(tuple(attention_nodes))
+    return fx.GraphModule({}, graph)
+
+
+def _count_calls(graph_module: fx.GraphModule, qualified_name: str) -> int:
+    return sum(_is_call(node, qualified_name) for node in graph_module.graph.nodes)
+
+
+def test_qwen2_rope_kv_presplit_rewrites_all_24_sites():
+    graph_module = _make_graph(24)
+    candidates = plan_qwen2_rope_kv_presplit(graph_module)
+
+    assert candidates is not None
+    assert apply_qwen2_rope_kv_presplit(graph_module, candidates) == 24
+    assert _count_calls(graph_module, "vllm::musa_rotary_embedding") == 0
+    assert _count_calls(graph_module, KV_UPDATE_SPLITTING_OP) == 0
+    assert _count_calls(graph_module, FUSED_SPLITTING_OP) == 24
+
+    for node in graph_module.graph.nodes:
+        if _is_call(node, "vllm::unified_attention_with_output"):
+            assert _is_call(_arg(node, 7, "kv_cache_dummy_dep"), FUSED_SPLITTING_OP)
+    graph_module.graph.lint()
+
+
+@pytest.mark.parametrize(
+    ("sites", "malformed_site", "duplicate_layer_name"),
+    [
+        (23, None, False),
+        (25, None, False),
+        (24, 7, False),
+        (24, None, True),
+    ],
+)
+def test_qwen2_rope_kv_presplit_is_atomic_on_mismatch(
+    sites: int,
+    malformed_site: int | None,
+    duplicate_layer_name: bool,
+):
+    graph_module = _make_graph(
+        sites,
+        malformed_site=malformed_site,
+        duplicate_layer_name=duplicate_layer_name,
+    )
+    graph_before = str(graph_module.graph)
+
+    assert plan_qwen2_rope_kv_presplit(graph_module) is None
+    assert str(graph_module.graph) == graph_before
+    assert _count_calls(graph_module, "vllm::musa_rotary_embedding") == sites
+    assert _count_calls(graph_module, KV_UPDATE_SPLITTING_OP) == sites
+    assert _count_calls(graph_module, FUSED_SPLITTING_OP) == 0

--- a/tests/test_qwen2_rope_kv_presplit.py
+++ b/tests/test_qwen2_rope_kv_presplit.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import operator
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -17,6 +18,7 @@ from vllm_musa.compilation.qwen2_rope_kv_presplit import (
     _is_call,
     apply_qwen2_rope_kv_presplit,
     plan_qwen2_rope_kv_presplit,
+    qwen2_rope_kv_backend_supported,
 )
 
 
@@ -121,3 +123,30 @@ def test_qwen2_rope_kv_presplit_is_atomic_on_mismatch(
     assert _count_calls(graph_module, "vllm::musa_rotary_embedding") == sites
     assert _count_calls(graph_module, KV_UPDATE_SPLITTING_OP) == sites
     assert _count_calls(graph_module, FUSED_SPLITTING_OP) == 0
+
+
+def test_qwen2_rope_kv_backend_gate_requires_all_24_layers(monkeypatch):
+    def set_layers(count: int, unsupported: int | None = None) -> None:
+        layers = {
+            f"model.layers.{index}.self_attn.attn": SimpleNamespace(
+                impl=SimpleNamespace(
+                    fused_rope_kvcache_supported=lambda index=index: (
+                        index != unsupported
+                    )
+                )
+            )
+            for index in range(count)
+        }
+        monkeypatch.setattr(
+            "vllm.config.get_layers_from_vllm_config",
+            lambda _config, _layer_type: layers,
+        )
+
+    set_layers(24)
+    assert qwen2_rope_kv_backend_supported(object())
+
+    set_layers(23)
+    assert not qwen2_rope_kv_backend_supported(object())
+
+    set_layers(24, unsupported=7)
+    assert not qwen2_rope_kv_backend_supported(object())

--- a/tests/test_qwen2_rope_kv_presplit.py
+++ b/tests/test_qwen2_rope_kv_presplit.py
@@ -126,7 +126,9 @@ def test_qwen2_rope_kv_presplit_is_atomic_on_mismatch(
 
 
 def test_qwen2_rope_kv_backend_gate_requires_all_24_layers(monkeypatch):
-    def set_layers(count: int, unsupported: int | None = None) -> None:
+    def set_layers(
+        count: int, unsupported: int | None = None
+    ) -> dict[str, SimpleNamespace]:
         layers = {
             f"model.layers.{index}.self_attn.attn": SimpleNamespace(
                 impl=SimpleNamespace(
@@ -141,6 +143,7 @@ def test_qwen2_rope_kv_backend_gate_requires_all_24_layers(monkeypatch):
             "vllm.config.get_layers_from_vllm_config",
             lambda _config, _layer_type: layers,
         )
+        return layers
 
     set_layers(24)
     assert qwen2_rope_kv_backend_supported(object())
@@ -149,4 +152,13 @@ def test_qwen2_rope_kv_backend_gate_requires_all_24_layers(monkeypatch):
     assert not qwen2_rope_kv_backend_supported(object())
 
     set_layers(24, unsupported=7)
+    assert not qwen2_rope_kv_backend_supported(object())
+
+    layers = set_layers(24)
+
+    def raise_backend_error() -> bool:
+        raise RuntimeError("backend capability probe failed")
+
+    failing_impl = layers["model.layers.7.self_attn.attn"].impl
+    failing_impl.fused_rope_kvcache_supported = raise_backend_error
     assert not qwen2_rope_kv_backend_supported(object())

--- a/vllm_musa/compilation/qwen2_rope_kv_presplit.py
+++ b/vllm_musa/compilation/qwen2_rope_kv_presplit.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import operator
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torch import fx
+
+KV_UPDATE_SPLITTING_OP = "vllm::unified_kv_cache_update"
+FUSED_SPLITTING_OP = "vllm::fused_rope_and_unified_kv_cache_update"
+EXPECTED_FUSION_SITES = 24
+
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class Qwen2RopeKVCandidate:
+    rope: fx.Node
+    kv_update: fx.Node
+    attention: fx.Node
+    query: fx.Node
+    key: fx.Node
+    value: fx.Node
+    positions: fx.Node
+    cos_sin_cache: fx.Node
+    is_neox: bool
+    layer_name: str
+
+
+def _is_call(node: fx.Node, qualified_name: str) -> bool:
+    if node.op != "call_function":
+        return False
+    target = str(node.target)
+    expected = qualified_name.replace("::", ".")
+    return target == expected or target == f"{expected}.default"
+
+
+def _arg(
+    node: fx.Node,
+    index: int,
+    name: str,
+    default: Any = _MISSING,
+) -> Any:
+    if name in node.kwargs:
+        return node.kwargs[name]
+    if len(node.args) > index:
+        return node.args[index]
+    if default is not _MISSING:
+        return default
+    return _MISSING
+
+
+def _tensor_value(node: fx.Node) -> Any:
+    for key in ("val", "example_value"):
+        value = node.meta.get(key)
+        if value is not None:
+            return value
+    return node.meta.get("tensor_meta")
+
+
+def _shape_tail(node: fx.Node) -> tuple[Any, Any] | None:
+    value = _tensor_value(node)
+    shape = getattr(value, "shape", None)
+    if shape is None or len(shape) < 2:
+        return None
+    return shape[-2], shape[-1]
+
+
+def _dtype(node: fx.Node) -> torch.dtype | None:
+    return getattr(_tensor_value(node), "dtype", None)
+
+
+def _view_base(node: fx.Node, heads: int) -> fx.Node | None:
+    is_view = node.op == "call_method" and node.target in {"view", "reshape"}
+    is_view = is_view or any(
+        _is_call(node, target)
+        for target in (
+            "aten::view",
+            "aten::reshape",
+            "aten::_unsafe_view",
+        )
+    )
+    if not is_view or not node.args or not isinstance(node.args[0], fx.Node):
+        return None
+    if _shape_tail(node) != (heads, 64):
+        return None
+    return node.args[0]
+
+
+def _split_getitem(node: fx.Node, index: int) -> fx.Node | None:
+    if (
+        node.op != "call_function"
+        or node.target is not operator.getitem
+        or len(node.args) != 2
+        or node.args[1] != index
+        or not isinstance(node.args[0], fx.Node)
+    ):
+        return None
+    return node.args[0]
+
+
+def _is_exact_qkv_split(node: fx.Node) -> bool:
+    if node.op == "call_method" and node.target == "split":
+        sizes = _arg(node, 1, "split_size")
+        dim = _arg(node, 2, "dim", 0)
+    elif _is_call(node, "aten::split_with_sizes"):
+        sizes = _arg(node, 1, "split_sizes")
+        dim = _arg(node, 2, "dim", 0)
+    else:
+        return False
+    return (
+        isinstance(sizes, (list, tuple))
+        and list(sizes) == [896, 128, 128]
+        and dim in (-1, 1)
+    )
+
+
+def _only_users(node: fx.Node, expected: set[fx.Node]) -> bool:
+    return set(node.users) == expected
+
+
+def plan_qwen2_rope_kv_presplit(
+    graph_module: fx.GraphModule,
+    expected_sites: int = EXPECTED_FUSION_SITES,
+) -> tuple[Qwen2RopeKVCandidate, ...] | None:
+    """Plan an all-or-nothing raw-FX rewrite for the exact Qwen2 graph."""
+    nodes = tuple(graph_module.graph.nodes)
+    all_rope = [node for node in nodes if _is_call(node, "vllm::musa_rotary_embedding")]
+    all_kv = [node for node in nodes if _is_call(node, KV_UPDATE_SPLITTING_OP)]
+    if len(all_rope) != expected_sites or len(all_kv) != expected_sites:
+        return None
+
+    candidates: list[Qwen2RopeKVCandidate] = []
+    seen_rope: set[fx.Node] = set()
+    seen_layer_names: set[str] = set()
+
+    for kv_update in all_kv:
+        if len(kv_update.users) != 1:
+            return None
+        attention = next(iter(kv_update.users))
+        if not _is_call(attention, "vllm::unified_attention_with_output"):
+            return None
+
+        query = _arg(attention, 0, "query")
+        key = _arg(attention, 1, "key")
+        value = _arg(attention, 2, "value")
+        dummy = _arg(attention, 7, "kv_cache_dummy_dep", None)
+        layer_name = _arg(attention, 4, "layer_name")
+        if (
+            not all(isinstance(node, fx.Node) for node in (query, key, value))
+            or dummy is not kv_update
+            or not isinstance(layer_name, str)
+            or _arg(kv_update, 0, "key") is not key
+            or _arg(kv_update, 1, "value") is not value
+            or _arg(kv_update, 2, "layer_name") != layer_name
+            or layer_name in seen_layer_names
+        ):
+            return None
+
+        query_base = _view_base(query, 14)
+        key_base = _view_base(key, 2)
+        value_base = _view_base(value, 2)
+        if not all(
+            isinstance(node, fx.Node) for node in (query_base, key_base, value_base)
+        ):
+            return None
+
+        query_split = _split_getitem(query_base, 0)
+        key_split = _split_getitem(key_base, 1)
+        value_split = _split_getitem(value_base, 2)
+        if (
+            query_split is None
+            or query_split is not key_split
+            or query_split is not value_split
+            or not _is_exact_qkv_split(query_split)
+            or any(_dtype(node) != torch.bfloat16 for node in (query, key, value))
+        ):
+            return None
+
+        rope_candidates = {
+            user
+            for user in query_base.users
+            if _is_call(user, "vllm::musa_rotary_embedding")
+        } & {
+            user
+            for user in key_base.users
+            if _is_call(user, "vllm::musa_rotary_embedding")
+        }
+        if len(rope_candidates) != 1:
+            return None
+        rope = rope_candidates.pop()
+        positions = _arg(rope, 0, "positions")
+        cos_sin_cache = _arg(rope, 4, "cos_sin_cache")
+        is_neox = _arg(rope, 5, "is_neox")
+        if (
+            rope in seen_rope
+            or rope.users
+            or not isinstance(positions, fx.Node)
+            or not isinstance(cos_sin_cache, fx.Node)
+            or _arg(rope, 1, "query") is not query_base
+            or _arg(rope, 2, "key") is not key_base
+            or _arg(rope, 3, "head_size") != 64
+            or is_neox is not True
+            or not _only_users(query_base, {query, rope})
+            or not _only_users(key_base, {key, rope})
+            or not _only_users(value_base, {value})
+            or not _only_users(query, {attention})
+            or not _only_users(key, {kv_update, attention})
+            or not _only_users(value, {kv_update, attention})
+        ):
+            return None
+
+        candidates.append(
+            Qwen2RopeKVCandidate(
+                rope=rope,
+                kv_update=kv_update,
+                attention=attention,
+                query=query,
+                key=key,
+                value=value,
+                positions=positions,
+                cos_sin_cache=cos_sin_cache,
+                is_neox=True,
+                layer_name=layer_name,
+            )
+        )
+        seen_rope.add(rope)
+        seen_layer_names.add(layer_name)
+
+    if len(candidates) != expected_sites or seen_rope != set(all_rope):
+        return None
+    return tuple(candidates)
+
+
+def apply_qwen2_rope_kv_presplit(
+    graph_module: fx.GraphModule,
+    candidates: tuple[Qwen2RopeKVCandidate, ...],
+) -> int:
+    """Apply a previously validated plan; invariant failures are fatal."""
+    # Importing the upstream pass module registers the fused outer custom op.
+    from vllm.compilation.passes.fusion import rope_kvcache_fusion  # noqa: F401
+
+    fused_op = torch.ops.vllm.fused_rope_and_unified_kv_cache_update.default
+    graph = graph_module.graph
+    for candidate in candidates:
+        with graph.inserting_before(candidate.kv_update):
+            fused = graph.call_function(
+                fused_op,
+                kwargs={
+                    "query": candidate.query,
+                    "key": candidate.key,
+                    "value": candidate.value,
+                    "positions": candidate.positions,
+                    "cos_sin_cache": candidate.cos_sin_cache,
+                    "is_neox": candidate.is_neox,
+                    "layer_name": candidate.layer_name,
+                },
+            )
+        fused.meta = dict(candidate.kv_update.meta)
+        candidate.kv_update.replace_all_uses_with(fused)
+        graph.erase_node(candidate.kv_update)
+        if candidate.rope.users:
+            raise RuntimeError("MUSA Qwen2 RoPE node gained an unexpected user")
+        graph.erase_node(candidate.rope)
+
+    graph.lint()
+    graph_module.recompile()
+    return len(candidates)
+
+
+__all__ = [
+    "EXPECTED_FUSION_SITES",
+    "FUSED_SPLITTING_OP",
+    "KV_UPDATE_SPLITTING_OP",
+    "Qwen2RopeKVCandidate",
+    "apply_qwen2_rope_kv_presplit",
+    "plan_qwen2_rope_kv_presplit",
+]

--- a/vllm_musa/compilation/qwen2_rope_kv_presplit.py
+++ b/vllm_musa/compilation/qwen2_rope_kv_presplit.py
@@ -15,6 +15,31 @@ EXPECTED_FUSION_SITES = 24
 _MISSING = object()
 
 
+def qwen2_rope_kv_backend_supported(vllm_config: Any) -> bool:
+    """Return whether every configured attention layer supports the fused op.
+
+    The raw-FX matcher can prove tensor relationships, but it cannot prove
+    which AttentionImpl will execute the upstream fused outer op.  Check the
+    instantiated layers before changing the graph so a future backend/config
+    selection change fails closed instead of reaching a base
+    ``do_rope_and_kv_cache_update`` implementation.
+    """
+    try:
+        from vllm.config import get_layers_from_vllm_config
+        from vllm.model_executor.layers.attention.attention import Attention
+
+        layers = get_layers_from_vllm_config(vllm_config, Attention)
+    except Exception:
+        return False
+
+    if len(layers) != EXPECTED_FUSION_SITES:
+        return False
+    return all(
+        getattr(layer.impl, "fused_rope_kvcache_supported", lambda: False)()
+        for layer in layers.values()
+    )
+
+
 @dataclass(frozen=True)
 class Qwen2RopeKVCandidate:
     rope: fx.Node
@@ -277,4 +302,5 @@ __all__ = [
     "Qwen2RopeKVCandidate",
     "apply_qwen2_rope_kv_presplit",
     "plan_qwen2_rope_kv_presplit",
+    "qwen2_rope_kv_backend_supported",
 ]

--- a/vllm_musa/compilation/qwen2_rope_kv_presplit.py
+++ b/vllm_musa/compilation/qwen2_rope_kv_presplit.py
@@ -34,10 +34,13 @@ def qwen2_rope_kv_backend_supported(vllm_config: Any) -> bool:
 
     if len(layers) != EXPECTED_FUSION_SITES:
         return False
-    return all(
-        getattr(layer.impl, "fused_rope_kvcache_supported", lambda: False)()
-        for layer in layers.values()
-    )
+    try:
+        return all(
+            getattr(layer.impl, "fused_rope_kvcache_supported", lambda: False)()
+            for layer in layers.values()
+        )
+    except Exception:
+        return False
 
 
 @dataclass(frozen=True)

--- a/vllm_musa/kernels/qwen2_rope_kv.py
+++ b/vllm_musa/kernels/qwen2_rope_kv.py
@@ -1,0 +1,371 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exact-shape Qwen2 RoPE and NHD KV-cache update for MUSA.
+
+This module is intentionally not imported from :mod:`vllm_musa.kernels`.
+The flash-attention backend imports it lazily only when the upstream
+RoPE/KV-cache fusion pass has selected the fused path.
+
+The kernel covers the single validated CosyVoice/Qwen2 shape only:
+BF16 Q14/KV2 with a 64-element NeoX rotary head and a 64-token NHD cache
+block.  Unsupported calls fail closed so the backend can retain the existing
+RoPE plus reshape-and-cache fallback.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+from vllm.triton_utils import tl, triton
+
+_NUM_Q_HEADS = 14
+_NUM_KV_HEADS = 2
+_HEAD_DIM = 64
+_HALF_HEAD_DIM = _HEAD_DIM // 2
+_Q_SIZE = _NUM_Q_HEADS * _HEAD_DIM
+_KV_SIZE = _NUM_KV_HEADS * _HEAD_DIM
+_PACKED_WIDTH = _Q_SIZE + 2 * _KV_SIZE
+_CACHE_BLOCK_SIZE = 64
+_MAX_FUSED_TOKENS = 1
+_BLOCK_HEADS = 4
+
+
+@triton.jit
+def _qwen2_rope_kv_cache_kernel(
+    packed_ptr,
+    positions_ptr,
+    cos_sin_cache_ptr,
+    key_cache_ptr,
+    value_cache_ptr,
+    slot_mapping_ptr,
+    packed_stride_t,
+    cos_sin_stride_t,
+    key_cache_stride_b,
+    key_cache_stride_s,
+    value_cache_stride_b,
+    value_cache_stride_s,
+    NUM_Q_HEADS: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    HALF_HEAD_DIM: tl.constexpr,
+    Q_SIZE: tl.constexpr,
+    KV_SIZE: tl.constexpr,
+    CACHE_BLOCK_SIZE: tl.constexpr,
+    BLOCK_HEADS: tl.constexpr,
+):
+    """Rotate one token/head tile and scatter its K/V cache entries."""
+    token = tl.program_id(0).to(tl.int64)
+    heads = (tl.program_id(1) * BLOCK_HEADS + tl.arange(0, BLOCK_HEADS))[:, None]
+    half_dims = tl.arange(0, HALF_HEAD_DIM)[None, :]
+    full_dims = tl.arange(0, HEAD_DIM)[None, :]
+    total_heads = NUM_Q_HEADS + NUM_KV_HEADS
+    valid_head = heads < total_heads
+    is_q = heads < NUM_Q_HEADS
+    is_k = (heads >= NUM_Q_HEADS) & valid_head
+    kv_heads = tl.where(is_k, heads - NUM_Q_HEADS, 0)
+
+    position = tl.load(positions_ptr + token).to(tl.int64)
+    cache_base = position * cos_sin_stride_t
+    cosine = tl.load(cos_sin_cache_ptr + cache_base + half_dims).to(tl.float32)
+    sine = tl.load(cos_sin_cache_ptr + cache_base + half_dims + HALF_HEAD_DIM).to(
+        tl.float32
+    )
+
+    row_base = token * packed_stride_t + tl.where(
+        is_q,
+        heads * HEAD_DIM,
+        Q_SIZE + kv_heads * HEAD_DIM,
+    )
+    q_x = tl.load(
+        packed_ptr + row_base + half_dims,
+        mask=is_q & valid_head,
+        other=0.0,
+    ).to(tl.float32)
+    q_y = tl.load(
+        packed_ptr + row_base + HALF_HEAD_DIM + half_dims,
+        mask=is_q & valid_head,
+        other=0.0,
+    ).to(tl.float32)
+    q_rot_x = (q_x * cosine - q_y * sine).to(tl.bfloat16)
+    q_rot_y = (q_y * cosine + q_x * sine).to(tl.bfloat16)
+    tl.store(
+        packed_ptr + row_base + half_dims,
+        q_rot_x,
+        mask=is_q & valid_head,
+    )
+    tl.store(
+        packed_ptr + row_base + HALF_HEAD_DIM + half_dims,
+        q_rot_y,
+        mask=is_q & valid_head,
+    )
+
+    k_x = tl.load(packed_ptr + row_base + half_dims, mask=is_k, other=0.0).to(
+        tl.float32
+    )
+    k_y = tl.load(
+        packed_ptr + row_base + HALF_HEAD_DIM + half_dims,
+        mask=is_k,
+        other=0.0,
+    ).to(tl.float32)
+    k_rot_x = (k_x * cosine - k_y * sine).to(tl.bfloat16)
+    k_rot_y = (k_y * cosine + k_x * sine).to(tl.bfloat16)
+    tl.store(packed_ptr + row_base + half_dims, k_rot_x, mask=is_k)
+    tl.store(
+        packed_ptr + row_base + HALF_HEAD_DIM + half_dims,
+        k_rot_y,
+        mask=is_k,
+    )
+
+    # Negative slots are padding and must leave both cache tensors untouched.
+    slot = tl.load(slot_mapping_ptr + token).to(tl.int64)
+    has_slot = slot >= 0
+    safe_slot = tl.where(has_slot, slot, 0)
+    block = safe_slot // CACHE_BLOCK_SIZE
+    block_offset = safe_slot - block * CACHE_BLOCK_SIZE
+    cache_mask = is_k & has_slot
+    key_cache_base = (
+        block * key_cache_stride_b
+        + block_offset * key_cache_stride_s
+        + kv_heads * HEAD_DIM
+    )
+    tl.store(
+        key_cache_ptr + key_cache_base + half_dims,
+        k_rot_x,
+        mask=cache_mask,
+    )
+    tl.store(
+        key_cache_ptr + key_cache_base + half_dims + HALF_HEAD_DIM,
+        k_rot_y,
+        mask=cache_mask,
+    )
+    value = tl.load(
+        packed_ptr
+        + token * packed_stride_t
+        + Q_SIZE
+        + KV_SIZE
+        + kv_heads * HEAD_DIM
+        + full_dims,
+        mask=cache_mask,
+        other=0.0,
+    )
+    value_cache_base = (
+        block * value_cache_stride_b
+        + block_offset * value_cache_stride_s
+        + kv_heads * HEAD_DIM
+    )
+    tl.store(
+        value_cache_ptr + value_cache_base + full_dims,
+        value,
+        mask=cache_mask,
+    )
+
+
+def _is_musa_tensor(tensor: Tensor) -> bool:
+    return tensor.device.type == "musa"
+
+
+def _qwen2_rope_kv_cache_support(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    positions: Tensor,
+    cos_sin_cache: Tensor,
+    is_neox: bool,
+    key_cache: Tensor,
+    value_cache: Tensor,
+    slot_mapping: Tensor,
+) -> tuple[bool, str]:
+    tensors = (
+        query,
+        key,
+        value,
+        positions,
+        cos_sin_cache,
+        key_cache,
+        value_cache,
+        slot_mapping,
+    )
+    if not all(_is_musa_tensor(tensor) for tensor in tensors):
+        return False, "all tensors must be on MUSA"
+    if len({tensor.device for tensor in tensors}) != 1:
+        return False, "all tensors must be on the same MUSA device"
+    if not is_neox:
+        return False, "only NeoX rotary layout is supported"
+
+    data_tensors = (query, key, value, cos_sin_cache, key_cache, value_cache)
+    if any(tensor.dtype != torch.bfloat16 for tensor in data_tensors):
+        return False, "query/key/value/cos-sin/cache tensors must be BF16"
+    if positions.dtype != torch.int64 or slot_mapping.dtype != torch.int64:
+        return False, "positions and slot_mapping must be int64"
+
+    num_tokens = query.shape[0] if query.dim() == 3 else -1
+    if query.shape != (num_tokens, _NUM_Q_HEADS, _HEAD_DIM):
+        return False, "query must have shape [tokens, 14, 64]"
+    expected_kv_shape = (num_tokens, _NUM_KV_HEADS, _HEAD_DIM)
+    if key.shape != expected_kv_shape or value.shape != expected_kv_shape:
+        return False, "key and value must have shape [tokens, 2, 64]"
+    if not 0 <= num_tokens <= _MAX_FUSED_TOKENS:
+        return False, f"token count must be in [0, {_MAX_FUSED_TOKENS}]"
+    if positions.shape != (num_tokens,):
+        return False, "positions must be 1D and match the token count"
+    if slot_mapping.shape != (num_tokens,):
+        return False, "slot_mapping must be 1D and match the token count"
+
+    expected_cache_tail = (_CACHE_BLOCK_SIZE, _NUM_KV_HEADS, _HEAD_DIM)
+    if key_cache.dim() != 4 or key_cache.shape[1:] != expected_cache_tail:
+        return False, "key_cache must have NHD shape [blocks, 64, 2, 64]"
+    if (
+        value_cache.shape != key_cache.shape
+        or value_cache.stride() != key_cache.stride()
+    ):
+        return False, "value_cache shape and strides must match key_cache"
+    if key_cache.shape[0] == 0:
+        return False, "cache must contain at least one block"
+
+    for name, tensor, row_width in (
+        ("query", query, _NUM_Q_HEADS * _HEAD_DIM),
+        ("key", key, _NUM_KV_HEADS * _HEAD_DIM),
+        ("value", value, _NUM_KV_HEADS * _HEAD_DIM),
+    ):
+        if tensor.stride(2) != 1 or tensor.stride(1) != _HEAD_DIM:
+            return False, f"{name} head and head-dim axes must be contiguous"
+        if tensor.stride(0) < row_width:
+            return False, f"{name} token rows must not overlap"
+
+    # The fused pass presents Q/K/V as views of the contiguous packed QKV
+    # result.  Keeping this alias gate is what lets the kernel use the
+    # compile-time packed offsets and avoids a second, stride-heavy variant.
+    element_size = query.element_size()
+    if (
+        query.data_ptr() + _Q_SIZE * element_size != key.data_ptr()
+        or query.data_ptr() + (_Q_SIZE + _KV_SIZE) * element_size != value.data_ptr()
+    ):
+        return False, "Q/K/V must be packed aliases"
+
+    cache_row_width = _NUM_KV_HEADS * _HEAD_DIM
+    cache_block_width = _CACHE_BLOCK_SIZE * cache_row_width
+    if (
+        key_cache.stride(3) != 1
+        or key_cache.stride(2) != _HEAD_DIM
+        or key_cache.stride(1) != cache_row_width
+        or key_cache.stride(0) < cache_block_width
+    ):
+        return False, "cache tensors must use non-overlapping NHD strides"
+    if cos_sin_cache.dim() != 2 or cos_sin_cache.shape[1] != _HEAD_DIM:
+        return False, "cos_sin_cache must have shape [positions, 64]"
+    if cos_sin_cache.stride(1) != 1 or cos_sin_cache.stride(0) < _HEAD_DIM:
+        return False, "cos_sin_cache rows must be contiguous and non-overlapping"
+    if not positions.is_contiguous() or not slot_mapping.is_contiguous():
+        return False, "positions and slot_mapping must be contiguous"
+    return True, ""
+
+
+def supports_qwen2_rope_kv_cache(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    positions: Tensor,
+    cos_sin_cache: Tensor,
+    is_neox: bool,
+    key_cache: Tensor,
+    value_cache: Tensor,
+    slot_mapping: Tensor,
+) -> bool:
+    """Return whether the exact Qwen2 fused kernel can handle a call."""
+    supported, _ = _qwen2_rope_kv_cache_support(
+        query,
+        key,
+        value,
+        positions,
+        cos_sin_cache,
+        is_neox,
+        key_cache,
+        value_cache,
+        slot_mapping,
+    )
+    return supported
+
+
+def try_qwen2_rope_kv_cache(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    positions: Tensor,
+    cos_sin_cache: Tensor,
+    is_neox: bool,
+    key_cache: Tensor,
+    value_cache: Tensor,
+    slot_mapping: Tensor,
+) -> bool:
+    """Apply fused RoPE/cache update, returning ``False`` for fallback calls.
+
+    ``query`` and ``key`` are mutated in place.  For every non-negative slot,
+    the corresponding rotated key and unmodified value are written into the
+    NHD paged caches.  Negative slots do not modify either cache.
+    """
+    supported, _ = _qwen2_rope_kv_cache_support(
+        query,
+        key,
+        value,
+        positions,
+        cos_sin_cache,
+        is_neox,
+        key_cache,
+        value_cache,
+        slot_mapping,
+    )
+    if not supported:
+        return False
+
+    _launch_qwen2_rope_kv_cache(
+        query,
+        positions,
+        cos_sin_cache,
+        key_cache,
+        value_cache,
+        slot_mapping,
+    )
+    return True
+
+
+def _launch_qwen2_rope_kv_cache(
+    query: Tensor,
+    positions: Tensor,
+    cos_sin_cache: Tensor,
+    key_cache: Tensor,
+    value_cache: Tensor,
+    slot_mapping: Tensor,
+) -> None:
+    """Launch after the caller has established the exact support envelope."""
+    num_tokens = query.shape[0]
+    if num_tokens == 0:
+        return
+    _qwen2_rope_kv_cache_kernel[
+        (num_tokens, triton.cdiv(_NUM_Q_HEADS + _NUM_KV_HEADS, _BLOCK_HEADS))
+    ](
+        query,
+        positions,
+        cos_sin_cache,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        _PACKED_WIDTH,
+        cos_sin_cache.stride(0),
+        key_cache.stride(0),
+        key_cache.stride(1),
+        value_cache.stride(0),
+        value_cache.stride(1),
+        NUM_Q_HEADS=_NUM_Q_HEADS,
+        NUM_KV_HEADS=_NUM_KV_HEADS,
+        HEAD_DIM=_HEAD_DIM,
+        HALF_HEAD_DIM=_HALF_HEAD_DIM,
+        Q_SIZE=_Q_SIZE,
+        KV_SIZE=_KV_SIZE,
+        CACHE_BLOCK_SIZE=_CACHE_BLOCK_SIZE,
+        BLOCK_HEADS=_BLOCK_HEADS,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+__all__ = ["supports_qwen2_rope_kv_cache", "try_qwen2_rope_kv_cache"]

--- a/vllm_musa/patches/manifest.py
+++ b/vllm_musa/patches/manifest.py
@@ -189,7 +189,10 @@ _CAT6: list[DivSpec] = [
         upstream_path="vllm/compilation/backends.py",
         apply_phase="runtime",
         required=False,
-        intent="VllmBackend.__call__ ignores unsupported torch.compile backend kwargs",
+        intent=(
+            "VllmBackend accepts unsupported torch.compile kwargs and applies the "
+            "exact Qwen2 RoPE+KV raw-FX pre-split rewrite"
+        ),
     ),
     DivSpec(
         id="vllm__compilation__compiler_interface",

--- a/vllm_musa/patches/vllm__compilation__backends.patch.py
+++ b/vllm_musa/patches/vllm__compilation__backends.patch.py
@@ -1,15 +1,69 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MUSA cat-6 object patch: accept (and ignore) torch.compile backend keyword
-options on this vLLM snapshot (was inline
-``_patch_vllm_backend_call_options``)."""
+"""MUSA cat-6 object patch for the vLLM compilation backend.
+
+Accept torch.compile backend keyword options on this vLLM snapshot and apply
+the exact Qwen2 RoPE+KV-cache rewrite before vLLM splits the raw FX graph.
+"""
 
 from functools import wraps
+from pathlib import Path
 
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
 PATCHES: list = []
+
+
+def _try_qwen2_rope_kv_presplit(backend, graph) -> int:
+    vllm_config = getattr(backend, "vllm_config", None)
+    compilation_config = getattr(backend, "compilation_config", None)
+    if vllm_config is None or compilation_config is None:
+        return 0
+
+    from vllm_musa.compilation import qwen2_rope_kv_presplit as presplit
+    from vllm_musa.platform import _is_qwen2_rope_kv_fusion_config
+
+    if not _is_qwen2_rope_kv_fusion_config(vllm_config):
+        return 0
+
+    splitting_ops = compilation_config.splitting_ops
+    if (
+        compilation_config.use_inductor_graph_partition
+        or splitting_ops is None
+        or presplit.KV_UPDATE_SPLITTING_OP not in splitting_ops
+    ):
+        logger.warning_once(
+            "MUSA Qwen2 RoPE+KV fusion requires the baseline Dynamo KV-cache "
+            "split; keeping the unfused graph."
+        )
+        return 0
+
+    candidates = presplit.plan_qwen2_rope_kv_presplit(graph)
+    if candidates is None:
+        logger.warning_once(
+            "MUSA Qwen2 RoPE+KV fusion did not find the exact 24-layer raw FX "
+            "graph; keeping the baseline split graph."
+        )
+        return 0
+
+    matched = presplit.apply_qwen2_rope_kv_presplit(graph, candidates)
+    if presplit.FUSED_SPLITTING_OP not in splitting_ops:
+        compilation_config.splitting_ops = [
+            *splitting_ops,
+            presplit.FUSED_SPLITTING_OP,
+        ]
+
+    compilation_config.traced_files.update(
+        {
+            str(Path(__file__).resolve()),
+            str(Path(presplit.__file__).resolve()),
+        }
+    )
+    logger.info_once(
+        "Applied the MUSA Qwen2 RoPE+KV pre-split fusion to %d layers.", matched
+    )
+    return matched
 
 
 def apply() -> None:
@@ -25,6 +79,7 @@ def apply() -> None:
 
     @wraps(original_call)
     def call_with_ignored_options(self, graph, example_inputs, **kwargs):
+        _try_qwen2_rope_kv_presplit(self, graph)
         return original_call(self, graph, example_inputs)
 
     call_with_ignored_options._musa_accepts_backend_options = True

--- a/vllm_musa/patches/vllm__compilation__backends.patch.py
+++ b/vllm_musa/patches/vllm__compilation__backends.patch.py
@@ -27,6 +27,14 @@ def _try_qwen2_rope_kv_presplit(backend, graph) -> int:
     if not _is_qwen2_rope_kv_fusion_config(vllm_config):
         return 0
 
+    if not presplit.qwen2_rope_kv_backend_supported(vllm_config):
+        logger.warning_once(
+            "MUSA Qwen2 RoPE+KV fusion requires all 24 attention layers to "
+            "use the MUSA FlashAttention3 fused-cache implementation; "
+            "keeping the baseline split graph."
+        )
+        return 0
+
     splitting_ops = compilation_config.splitting_ops
     if (
         compilation_config.use_inductor_graph_partition

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -197,6 +197,59 @@ def _is_validated_qwen3_8b_fp8_single_gpu(vllm_config: Any) -> bool:
     )
 
 
+def _is_qwen2_rope_kv_fusion_config(vllm_config: Any) -> bool:
+    """Return whether the config is eligible for the exact MP31 Qwen2 fusion."""
+    from vllm_musa.utils.environ import envs as musa_envs
+
+    if not musa_envs.VLLM_MUSA_QWEN2_ROPE_KV_FUSION.get():
+        return False
+    model_config = getattr(vllm_config, "model_config", None)
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    if model_config is None or parallel_config is None:
+        return False
+
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    if hf_text_config is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        hf_text_config = getattr(hf_config, "text_config", hf_config)
+    single_gpu = all(
+        getattr(parallel_config, name, 1) == 1
+        for name in (
+            "tensor_parallel_size",
+            "pipeline_parallel_size",
+            "data_parallel_size",
+            "decode_context_parallel_size",
+        )
+    )
+    model_type = getattr(hf_text_config, "model_type", None)
+    # CosyVoice3 exposes its outer multimodal config here.  The actual talker
+    # attention layers are Qwen2-shaped and are checked again by the backend
+    # gate, so accept that wrapper without broadening the tensor-shape scope.
+    if model_type not in ("qwen2", "cosyvoice3"):
+        return False
+    num_key_value_heads = getattr(hf_text_config, "num_key_value_heads", None)
+    intermediate_size = getattr(hf_text_config, "intermediate_size", None)
+    cache_config = getattr(vllm_config, "cache_config", None)
+    cache_dtype = getattr(cache_config, "cache_dtype", "auto")
+    if model_type == "qwen2":
+        if num_key_value_heads != 2 or intermediate_size != 4864:
+            return False
+    elif num_key_value_heads not in (None, 2) or intermediate_size not in (None, 4864):
+        return False
+    return (
+        getattr(hf_text_config, "hidden_size", None) == 896
+        and getattr(hf_text_config, "num_hidden_layers", None) == 24
+        and getattr(hf_text_config, "num_attention_heads", None) == 14
+        and getattr(model_config, "dtype", None) == torch.bfloat16
+        and getattr(model_config, "quantization", None) in (None, "none")
+        and getattr(vllm_config, "quant_config", None) is None
+        and getattr(vllm_config, "speculative_config", None) is None
+        and cache_dtype in ("auto", torch.bfloat16)
+        and not getattr(model_config, "enforce_eager", False)
+        and single_gpu
+    )
+
+
 def _deepseek_v4_flashmla_sparse_block_size(model_config: Any | None) -> int:
     value = os.getenv(_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_ENV)
     if value is None or not _is_deepseek_v4_model(model_config):

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -231,6 +231,7 @@ def _is_qwen2_rope_kv_fusion_config(vllm_config: Any) -> bool:
     intermediate_size = getattr(hf_text_config, "intermediate_size", None)
     cache_config = getattr(vllm_config, "cache_config", None)
     cache_dtype = getattr(cache_config, "cache_dtype", "auto")
+    cache_block_size = getattr(cache_config, "block_size", None)
     if model_type == "qwen2":
         if num_key_value_heads != 2 or intermediate_size != 4864:
             return False
@@ -244,7 +245,13 @@ def _is_qwen2_rope_kv_fusion_config(vllm_config: Any) -> bool:
         and getattr(model_config, "quantization", None) in (None, "none")
         and getattr(vllm_config, "quant_config", None) is None
         and getattr(vllm_config, "speculative_config", None) is None
-        and cache_dtype in ("auto", torch.bfloat16)
+        # vLLM uses the string spelling for an explicit BF16 cache, while
+        # lightweight test/config objects may carry torch.bfloat16 directly.
+        and cache_dtype in ("auto", "bfloat16", torch.bfloat16)
+        # MUSA's fused kernel is specialized for the FA3 NHD block-64 cache.
+        # Keep None acceptable before cache initialization, but reject an
+        # explicitly incompatible block size before mutating the FX graph.
+        and cache_block_size in (None, 64)
         and not getattr(model_config, "enforce_eager", False)
         and single_gpu
     )

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -92,6 +92,10 @@ class Envs:
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SEEDED_MULTINOMIAL = EnvBool(True)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
+    # Exact-shape Qwen2 RoPE+NHD-cache fusion.  The model, graph, dtype, and
+    # tensor-layout gates fail closed; the environment switch is an A/B escape
+    # hatch rather than a required serving option.
+    VLLM_MUSA_QWEN2_ROPE_KV_FUSION = EnvBool(True)
 
 
 envs = Envs()

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -1382,6 +1382,74 @@ class FlashAttentionImpl(AttentionImpl):
         )
         return output
 
+    def fused_rope_kvcache_supported(self) -> bool:
+        """Whether this layer is inside the exact Qwen2 fusion envelope."""
+        from vllm_musa.utils.environ import envs as musa_envs
+
+        return (
+            musa_envs.VLLM_MUSA_QWEN2_ROPE_KV_FUSION.get()
+            and self.num_heads == 14
+            and self.num_kv_heads == 2
+            and self.head_size == 64
+            and self.attn_type == AttentionType.DECODER
+            and self.kv_cache_dtype in ("auto", "bfloat16")
+            and self.alibi_slopes is None
+            and self.sliding_window == (-1, -1)
+            and not self.logits_soft_cap
+            and self.sinks is None
+            and self.kv_sharing_target_layer_name is None
+        )
+
+    def do_rope_and_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        positions: torch.Tensor,
+        cos_sin_cache: torch.Tensor,
+        is_neox: bool,
+        kv_cache: torch.Tensor,
+        layer_slot_mapping: torch.Tensor,
+    ) -> None:
+        """Apply Qwen2 RoPE and populate its NHD cache in one MUSA launch."""
+        if query.shape[0] <= 1:
+            key_cache, value_cache = kv_cache.unbind(0)
+            from vllm_musa.kernels.qwen2_rope_kv import try_qwen2_rope_kv_cache
+
+            if try_qwen2_rope_kv_cache(
+                query,
+                key,
+                value,
+                positions,
+                cos_sin_cache,
+                is_neox,
+                key_cache,
+                value_cache,
+                layer_slot_mapping,
+            ):
+                return
+
+        # Keep the fused pass correctness-safe if a runtime tensor property
+        # falls outside the static model/layer gate.
+        from vllm_musa.jit_kernel.csrc.rope import rotary_embedding
+
+        rotary_embedding(
+            positions,
+            query,
+            key,
+            self.head_size,
+            cos_sin_cache,
+            is_neox,
+        )
+        self.do_kv_cache_update(
+            layer,
+            key,
+            value,
+            kv_cache,
+            layer_slot_mapping,
+        )
+
     def do_kv_cache_update(
         self,
         layer: torch.nn.Module,

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -1388,11 +1388,12 @@ class FlashAttentionImpl(AttentionImpl):
 
         return (
             musa_envs.VLLM_MUSA_QWEN2_ROPE_KV_FUSION.get()
+            and get_flash_attn_version() == 3
             and self.num_heads == 14
             and self.num_kv_heads == 2
             and self.head_size == 64
             and self.attn_type == AttentionType.DECODER
-            and self.kv_cache_dtype in ("auto", "bfloat16")
+            and self.kv_cache_dtype in ("auto", "bfloat16", torch.bfloat16)
             and self.alibi_slopes is None
             and self.sliding_window == (-1, -1)
             and not self.logits_soft_cap


### PR DESCRIPTION
## Summary

- tune the MP31 small-hidden add-RMSNorm launch used by the Qwen2 talker;
- fuse the exact Qwen2 BF16 RoPE + NHD KV-cache update chain into one MUSA
  Triton launch;
- apply the graph rewrite atomically before vLLM splitting so layer-name
  strings remain outside Inductor graphs and compiled pieces stay reusable;
- keep the upstream KV split and all unsupported model, graph, dtype, prefill,
  and tensor-layout paths on the existing implementation.

This PR changes vLLM-MUSA only. vLLM-Omni is an integration test path, not an
implementation dependency or patch target.

## Why the rewrite is pre-split

The first post-grad prototype fused correctly but caused about 95.6 seconds of
cold compilation because 24 layer-name strings produced non-reusable pieces.
The accepted raw-FX rewrite requires all 24 exact sites to match before any
mutation, adds the fused outer op as a split, and retains the original KV split
as a fail-closed fallback.

The accepted path restores compile plus initial warmup to 5.90 seconds on the
development container and produces only four reusable compile artifacts. It is
exact-gated and default-on; no serving flag is required. The environment switch
is retained only as an A/B and emergency-disable escape hatch.

## Performance

Single S5000, BF16, FlashAttention-3, normal vLLM compile/FULL graph capture,
357 input tokens, fixed 1024 output tokens (40.96-second audio proxy),
temperature 1.0, repetition penalty 1.0001. Two alternating same-host rounds,
three measured requests per cell after one warmup:

| Variant | Runs | Mean RTF | Median RTF |
|---|---:|---:|---:|
| RoPE+KV fusion | 6 | 0.141548 | 0.141559 |
| baseline on the same branch | 6 | 0.145836 | 0.145760 |

Combined mean gain: 2.94%; combined median gain: 2.88%. Both paired rounds are
positive. A deterministic token-identical A/B improves mean RTF from 0.077270
to 0.067954 (12.06%), isolating launch-heavy LLM decode from sampling cost.

A candidate MUPTI activity trace confirms the production path retains all
three native BF16 TCE GEMM families with the expected 2:1:1 call ratio. The
accepted fused kernel averages 4.445 us over the captured startup, graph,
warmup, and measured-request scope. Generated Inductor artifacts use external
addmm/mm kernels and do not Triton-lower the GEMMs.

## Validation

- focused FX/backend/config/real-S5000 kernel suite: 19 passed;
- default-on integration: matched 24/24 layers, exercised a 357-token prefill
  fallback, and completed 256 deterministic decode tokens with checksum
  953984;
- deterministic 1024-token candidate and baseline: identical checksum 15219200
  in all six measured requests;
- broader Python slice: 117 passed, 2 skipped, 3 failed; the same three
  unrelated FP8-MoE/format-patch failures reproduce from the pre-overlay source
  archive;
- formatting and lint pass for all new/changed files except three unchanged
  baseline findings in flash_attn.py.

## Not run / Draft status

- full synthesized-waveform listening and quality validation belongs to the
  downstream CosyVoice integration provider;
- project CI and maintainer review are still pending.

Keep this PR in Draft until those external gates complete.
