### PR TITLE
[MUSA-60038] Fuse Qwen3 QK norm, RoPE and KV cache update

### DIFF
--- a/tests/jit_kernel/test_qk_mrope_negative_slots.py
+++ b/tests/jit_kernel/test_qk_mrope_negative_slots.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA checks for negative qk_mrope cache slots."""
+
+import os
+from dataclasses import dataclass
+
+import pytest
+
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
+os.environ.setdefault("VLLM_MUSA_JIT_CACHE_DIR", "/tmp/vllm_musa_pytest_jit_cache")
+os.environ.setdefault("VLLM_MUSA_ARCH_LIST", "31")
+
+pytest.importorskip("torchada")
+torch = pytest.importorskip("torch")
+
+
+@dataclass(frozen=True)
+class QkMropeCase:
+    label: str
+    q_heads: int
+    kv_heads: int
+    head_dim: int
+    rotary_dim: int
+    mrope_sections: tuple[int, int, int]
+    is_interleaved: bool
+    gemma: bool
+
+
+QK_MROPE_CASES = (
+    QkMropeCase("qwen3_06b", 16, 8, 128, 128, (64, 0, 0), False, False),
+    QkMropeCase("qwen3_8b", 32, 8, 128, 128, (64, 0, 0), False, False),
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _musa_device() -> None:
+    pytest.importorskip("torch_musa")
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+    torch.musa.set_device(0)
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    torch.musa.synchronize()
+    torch.testing.assert_close(actual.float(), expected.float(), atol=2e-2, rtol=2e-2)
+
+
+def _qwen3_rmsnorm_rope_reference(
+    tensor: torch.Tensor,
+    weight: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    variance = tensor.float().square().mean(dim=-1, keepdim=True)
+    normalized = tensor.float() * torch.rsqrt(variance + eps)
+    normalized = (normalized * weight.float()).to(tensor.dtype)
+
+    cos_sin = cos_sin_cache.index_select(0, positions[0])
+    rotary_dim = cos_sin.shape[-1]
+    half_dim = rotary_dim // 2
+    cos = cos_sin[:, None, :half_dim].float()
+    sin = cos_sin[:, None, half_dim:].float()
+    x = normalized[..., :rotary_dim].float()
+    x1, x2 = x[..., :half_dim], x[..., half_dim:]
+    rotated = torch.cat((x1 * cos - x2 * sin, x2 * cos + x1 * sin), dim=-1)
+    if rotary_dim == tensor.shape[-1]:
+        return rotated.to(tensor.dtype)
+    return torch.cat((rotated.to(tensor.dtype), normalized[..., rotary_dim:]), dim=-1)
+
+
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+@pytest.mark.parametrize("case", QK_MROPE_CASES, ids=lambda case: case.label)
+def test_qk_mrope_negative_slot_skips_cache_but_preserves_outputs(
+    index_dtype: torch.dtype,
+    case: QkMropeCase,
+) -> None:
+    from vllm_musa.jit_kernel.csrc.norm import _qk_mrope_module
+
+    torch.manual_seed(123)
+    device = torch.device("musa")
+    tokens = 2
+    kv_heads = case.kv_heads
+    cache_rows = 4
+    sentinel = -7.0
+    mrope_section_t, mrope_section_h, mrope_section_w = case.mrope_sections
+
+    q = torch.randn(
+        (tokens, case.q_heads, case.head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k = torch.randn(
+        (tokens, kv_heads, case.head_dim), device=device, dtype=torch.bfloat16
+    )
+    v = torch.randn(
+        (tokens, kv_heads, case.head_dim), device=device, dtype=torch.bfloat16
+    )
+    q_weight = torch.randn((case.head_dim,), device=device, dtype=torch.bfloat16)
+    k_weight = torch.randn((case.head_dim,), device=device, dtype=torch.bfloat16)
+    positions = torch.arange(tokens, device=device, dtype=torch.int64).repeat(3, 1)
+    angles = torch.randn((8, case.rotary_dim // 2), device=device, dtype=torch.float32)
+    cos_sin_cache = torch.cat((angles.cos(), angles.sin()), dim=-1).to(torch.bfloat16)
+    indices = torch.tensor([0, -1], device=device, dtype=index_dtype)
+
+    module = _qk_mrope_module()
+    q_ref = _qwen3_rmsnorm_rope_reference(
+        q,
+        q_weight,
+        positions,
+        cos_sin_cache,
+        1e-6,
+    )
+    k_ref = _qwen3_rmsnorm_rope_reference(
+        k,
+        k_weight,
+        positions,
+        cos_sin_cache,
+        1e-6,
+    )
+
+    q_out = torch.empty_like(q)
+    k_out = torch.empty_like(k)
+    k_cache = torch.full(
+        (cache_rows, kv_heads * case.head_dim),
+        sentinel,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v_cache = torch.full_like(k_cache, sentinel)
+    module.sgl_musa_fused_qk_rmsnorm_mrope_cache_out(
+        q,
+        k,
+        v,
+        q_weight,
+        k_weight,
+        positions,
+        cos_sin_cache,
+        q_out,
+        k_out,
+        k_cache,
+        v_cache,
+        indices,
+        True,
+        mrope_section_t,
+        mrope_section_h,
+        mrope_section_w,
+        case.is_interleaved,
+        1e-6,
+        case.gemma,
+    )
+
+    _assert_close(q_out, q_ref)
+    _assert_close(k_out, k_ref)
+    _assert_close(k_cache[0], k_out[0].reshape(-1))
+    assert torch.equal(v_cache[0], v[0].reshape(-1))
+    assert torch.equal(k_cache[1:], torch.full_like(k_cache[1:], sentinel))
+    assert torch.equal(v_cache[1:], torch.full_like(v_cache[1:], sentinel))
+
+    q_cache_only = torch.empty_like(q)
+    k_cache_only = torch.full_like(k_cache, sentinel)
+    v_cache_only = torch.full_like(v_cache, sentinel)
+    module.sgl_musa_fused_qk_rmsnorm_mrope_cache(
+        q,
+        k,
+        v,
+        q_weight,
+        k_weight,
+        positions,
+        cos_sin_cache,
+        q_cache_only,
+        k_cache_only,
+        v_cache_only,
+        indices,
+        True,
+        mrope_section_t,
+        mrope_section_h,
+        mrope_section_w,
+        case.is_interleaved,
+        1e-6,
+        case.gemma,
+    )
+
+    _assert_close(q_cache_only, q_ref)
+    _assert_close(k_cache_only[0], k_ref[0].reshape(-1))
+    assert torch.equal(v_cache_only[0], v[0].reshape(-1))
+    assert torch.equal(k_cache_only[1:], torch.full_like(k_cache_only[1:], sentinel))
+    assert torch.equal(v_cache_only[1:], torch.full_like(v_cache_only[1:], sentinel))

--- a/tests/jit_kernel/test_qwen3_qk_cache_out_wrapper.py
+++ b/tests/jit_kernel/test_qwen3_qk_cache_out_wrapper.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA wrapper-level checks for the dense Qwen3 cache-out provider."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
+os.environ.setdefault("VLLM_MUSA_JIT_CACHE_DIR", "/tmp/vllm_musa_pytest_jit_cache")
+os.environ.setdefault("VLLM_MUSA_ARCH_LIST", "31")
+
+pytest.importorskip("torchada")
+torch = pytest.importorskip("torch")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _musa_device() -> None:
+    pytest.importorskip("torch_musa")
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+    torch.musa.set_device(0)
+
+
+def _reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+) -> torch.Tensor:
+    variance = x.float().square().mean(dim=-1, keepdim=True)
+    normed = (x.float() * torch.rsqrt(variance + 1e-6) * weight.float()).to(x.dtype)
+    cos_sin = cos_sin_cache.index_select(0, positions[0])
+    half = cos_sin.shape[-1] // 2
+    cos = cos_sin[:, None, :half].float()
+    sin = cos_sin[:, None, half:].float()
+    x1, x2 = normed[..., :half].float(), normed[..., half:].float()
+    return torch.cat((x1 * cos - x2 * sin, x2 * cos + x1 * sin), dim=-1).to(x.dtype)
+
+
+@pytest.mark.parametrize("q_heads", [16, 32])
+def test_qwen3_cache_out_wrapper_registers_and_preserves_padding(q_heads: int) -> None:
+    from vllm_musa.jit_kernel.csrc.norm import fused_qk_rmsnorm_mrope_cache_out
+
+    device = torch.device("musa")
+    tokens, kv_heads, head_dim = 2, 8, 128
+    qkv = torch.randn(
+        (tokens, (q_heads + 2 * kv_heads) * head_dim),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    q_flat, k_flat, v_flat = qkv.split(
+        [q_heads * head_dim, kv_heads * head_dim, kv_heads * head_dim], dim=-1
+    )
+    q = q_flat.view(tokens, q_heads, head_dim)
+    k = k_flat.view(tokens, kv_heads, head_dim)
+    v = v_flat.view(tokens, kv_heads, head_dim)
+    q_weight = torch.randn((head_dim,), device=device, dtype=torch.bfloat16)
+    k_weight = torch.randn((head_dim,), device=device, dtype=torch.bfloat16)
+    positions = torch.arange(tokens, device=device, dtype=torch.int64).repeat(3, 1)
+    angles = torch.randn((8, head_dim // 2), device=device, dtype=torch.float32)
+    cos_sin_cache = torch.cat((angles.cos(), angles.sin()), dim=-1).to(torch.bfloat16)
+    slot_mapping = torch.tensor([0, -1], device=device, dtype=torch.int32)
+    sentinel = -9.0
+    q_out = torch.empty_like(q)
+    k_out = torch.empty_like(k)
+    key_cache = torch.full(
+        (4, kv_heads * head_dim), sentinel, device=device, dtype=torch.bfloat16
+    )
+    value_cache = torch.full_like(key_cache, sentinel)
+
+    fused_qk_rmsnorm_mrope_cache_out(
+        q,
+        k,
+        v,
+        q_weight,
+        k_weight,
+        positions,
+        cos_sin_cache,
+        q_out,
+        k_out,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        True,
+        64,
+        0,
+        0,
+        False,
+    )
+    torch.musa.synchronize()
+
+    torch.testing.assert_close(
+        q_out.float(),
+        _reference(q, q_weight, positions, cos_sin_cache).float(),
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    torch.testing.assert_close(
+        k_out.float(),
+        _reference(k, k_weight, positions, cos_sin_cache).float(),
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    torch.testing.assert_close(key_cache[0], k_out[0].reshape(-1))
+    torch.testing.assert_close(value_cache[0], v[0].reshape(-1))
+    assert torch.equal(key_cache[1:], torch.full_like(key_cache[1:], sentinel))
+    assert torch.equal(value_cache[1:], torch.full_like(value_cache[1:], sentinel))
+
+
+def test_qwen3_hnd_runtime_falls_back_before_cache_view(monkeypatch) -> None:
+    from vllm_musa.jit_kernel.csrc import norm
+    from vllm_musa.v1.attention.backends import flash_attn
+
+    def fail_if_cache_out(*args, **kwargs):
+        raise AssertionError("HND must not enter the flat-NHD cache-out provider")
+
+    monkeypatch.setattr(norm, "fused_qk_rmsnorm_mrope_cache_out", fail_if_cache_out)
+    monkeypatch.setattr(flash_attn, "get_kv_cache_layout", lambda: "HND")
+
+    updates: list[tuple[torch.Tensor, torch.Tensor]] = []
+
+    def record_update(layer, key, value, kv_cache, slot_mapping) -> None:
+        del layer, kv_cache, slot_mapping
+        updates.append((key, value))
+
+    impl = SimpleNamespace(
+        num_kv_heads=8,
+        head_size=128,
+        do_kv_cache_update=record_update,
+    )
+    device = torch.device("musa")
+    q = torch.randn((2, 16, 128), device=device, dtype=torch.bfloat16)
+    k = torch.randn((2, 8, 128), device=device, dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    q_weight = torch.randn((128,), device=device, dtype=torch.bfloat16)
+    k_weight = torch.randn((128,), device=device, dtype=torch.bfloat16)
+    positions = torch.arange(2, device=device, dtype=torch.int64)
+    angles = torch.randn((8, 64), device=device, dtype=torch.float32)
+    cos_sin_cache = torch.cat((angles.cos(), angles.sin()), dim=-1).to(torch.bfloat16)
+    q_out = torch.empty_like(q)
+    k_out = torch.empty_like(k)
+    kv_cache = torch.empty((2, 4, 8, 64, 128), device=device, dtype=torch.bfloat16)
+    slot_mapping = torch.tensor([0, -1], device=device, dtype=torch.int32)
+
+    flash_attn.FlashAttentionImpl.do_qwen3_qk_rope_and_kv_cache_update(
+        impl,
+        object(),
+        q,
+        k,
+        v,
+        q_weight,
+        k_weight,
+        positions,
+        cos_sin_cache,
+        q_out,
+        k_out,
+        kv_cache,
+        slot_mapping,
+    )
+    torch.musa.synchronize()
+
+    assert len(updates) == 1
+    assert updates[0][0] is k_out
+    assert updates[0][1] is v
+    torch.testing.assert_close(
+        q_out.float(),
+        _reference(q, q_weight, positions.repeat(3, 1), cos_sin_cache).float(),
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    torch.testing.assert_close(
+        k_out.float(),
+        _reference(k, k_weight, positions.repeat(3, 1), cos_sin_cache).float(),
+        atol=2e-2,
+        rtol=2e-2,
+    )

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -291,15 +291,179 @@ class TestMUSAPlatformBase:
             )
             config = make_config("qwen2", 2, 4864)
             assert _is_qwen2_rope_kv_fusion_config(config)
-            config.cache_config = SimpleNamespace(
-                cache_dtype="bfloat16", block_size=64
-            )
+            config.cache_config = SimpleNamespace(cache_dtype="bfloat16", block_size=64)
             assert _is_qwen2_rope_kv_fusion_config(config)
             config.cache_config.block_size = 128
             assert not _is_qwen2_rope_kv_fusion_config(config)
             config.cache_config.block_size = 64
             config.quant_config = object()
             assert not _is_qwen2_rope_kv_fusion_config(config)
+
+    def test_qwen3_qk_rope_kv_fusion_exact_config_gate(self):
+        import torch
+
+        from vllm_musa.platform import _is_qwen3_qk_rope_kv_fusion_config
+        from vllm_musa.utils.environ import envs
+
+        def make_config(
+            *,
+            hidden_size: int,
+            intermediate_size: int,
+            num_hidden_layers: int,
+            num_attention_heads: int,
+            num_key_value_heads: int = 8,
+            head_dim: int = 128,
+            model_type: str = "qwen3",
+            architecture: str = "Qwen3ForCausalLM",
+            tensor_parallel_size: int = 1,
+            quantization=None,
+            quant_config=None,
+            block_size: int = 64,
+        ):
+            return SimpleNamespace(
+                model_config=SimpleNamespace(
+                    hf_text_config=SimpleNamespace(
+                        model_type=model_type,
+                        hidden_size=hidden_size,
+                        intermediate_size=intermediate_size,
+                        num_hidden_layers=num_hidden_layers,
+                        num_attention_heads=num_attention_heads,
+                        num_key_value_heads=num_key_value_heads,
+                        head_dim=head_dim,
+                    ),
+                    architectures=(architecture,),
+                    dtype=torch.bfloat16,
+                    quantization=quantization,
+                    enforce_eager=False,
+                ),
+                parallel_config=SimpleNamespace(
+                    tensor_parallel_size=tensor_parallel_size,
+                    pipeline_parallel_size=1,
+                    data_parallel_size=1,
+                    decode_context_parallel_size=1,
+                ),
+                cache_config=SimpleNamespace(
+                    cache_dtype="bfloat16", block_size=block_size
+                ),
+                quant_config=quant_config,
+                speculative_config=None,
+            )
+
+        qwen3_0_6b = make_config(
+            hidden_size=1024,
+            intermediate_size=3072,
+            num_hidden_layers=28,
+            num_attention_heads=16,
+        )
+        qwen3_8b = make_config(
+            hidden_size=4096,
+            intermediate_size=12288,
+            num_hidden_layers=36,
+            num_attention_heads=32,
+        )
+
+        with envs.VLLM_MUSA_QWEN3_QK_ROPE_KV_FUSION.override(True):
+            assert _is_qwen3_qk_rope_kv_fusion_config(qwen3_0_6b)
+            assert _is_qwen3_qk_rope_kv_fusion_config(qwen3_8b)
+
+            assert not _is_qwen3_qk_rope_kv_fusion_config(
+                make_config(
+                    hidden_size=1024,
+                    intermediate_size=3072,
+                    num_hidden_layers=28,
+                    num_attention_heads=16,
+                    model_type="qwen2",
+                    architecture="Qwen2ForCausalLM",
+                )
+            )
+            assert not _is_qwen3_qk_rope_kv_fusion_config(
+                make_config(
+                    hidden_size=2048,
+                    intermediate_size=6144,
+                    num_hidden_layers=24,
+                    num_attention_heads=8,
+                    num_key_value_heads=2,
+                    head_dim=256,
+                    model_type="qwen3_5",
+                    architecture="Qwen3_5ForCausalLM",
+                )
+            )
+            assert not _is_qwen3_qk_rope_kv_fusion_config(
+                make_config(
+                    hidden_size=4096,
+                    intermediate_size=12288,
+                    num_hidden_layers=36,
+                    num_attention_heads=32,
+                    tensor_parallel_size=2,
+                )
+            )
+            assert not _is_qwen3_qk_rope_kv_fusion_config(
+                make_config(
+                    hidden_size=4096,
+                    intermediate_size=12288,
+                    num_hidden_layers=36,
+                    num_attention_heads=32,
+                    quantization="fp8",
+                )
+            )
+            assert not _is_qwen3_qk_rope_kv_fusion_config(
+                make_config(
+                    hidden_size=4096,
+                    intermediate_size=12288,
+                    num_hidden_layers=36,
+                    num_attention_heads=32,
+                    quant_config=object(),
+                )
+            )
+            assert not _is_qwen3_qk_rope_kv_fusion_config(
+                make_config(
+                    hidden_size=4096,
+                    intermediate_size=12288,
+                    num_hidden_layers=36,
+                    num_attention_heads=32,
+                    block_size=128,
+                )
+            )
+
+        with envs.VLLM_MUSA_QWEN3_QK_ROPE_KV_FUSION.override(False):
+            assert not _is_qwen3_qk_rope_kv_fusion_config(qwen3_0_6b)
+            assert not _is_qwen3_qk_rope_kv_fusion_config(qwen3_8b)
+
+    def test_qwen3_qk_rope_kv_fusion_defaults_on(self, monkeypatch):
+        from vllm_musa.utils.environ import envs
+
+        monkeypatch.delenv("VLLM_MUSA_QWEN3_QK_ROPE_KV_FUSION", raising=False)
+        assert envs.VLLM_MUSA_QWEN3_QK_ROPE_KV_FUSION.get() is True
+
+    @pytest.mark.parametrize(("layout", "expected"), [("NHD", True), ("HND", False)])
+    def test_qwen3_qk_rope_kv_provider_layout_gate(
+        self,
+        monkeypatch,
+        layout: str,
+        expected: bool,
+    ) -> None:
+        from vllm_musa.utils.environ import envs
+        from vllm_musa.v1.attention.backends import flash_attn
+
+        impl = SimpleNamespace(
+            num_heads=16,
+            num_kv_heads=8,
+            head_size=128,
+            attn_type=flash_attn.AttentionType.DECODER,
+            kv_cache_dtype="auto",
+            alibi_slopes=None,
+            sliding_window=(-1, -1),
+            logits_soft_cap=0.0,
+            sinks=None,
+            kv_sharing_target_layer_name=None,
+        )
+        monkeypatch.setattr(flash_attn, "get_flash_attn_version", lambda: 3)
+        monkeypatch.setattr(flash_attn, "get_kv_cache_layout", lambda: layout)
+        with envs.VLLM_MUSA_QWEN3_QK_ROPE_KV_FUSION.override(True):
+            assert (
+                flash_attn.FlashAttentionImpl.qwen3_qk_rope_kvcache_supported(impl)
+                is expected
+            )
 
     def test_supports_fp8_for_musa_3_1(self):
         """Test that FP8 is supported on MUSA capability 3.1."""

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -189,6 +189,192 @@ class TestCompilationBackendPatch:
         assert compilation_config.splitting_ops is splitting_ops
         assert compilation_config.traced_files == set()
 
+    @pytest.mark.parametrize("text_config_source", ["hf_text_config", "hf_config"])
+    def test_qwen3_presplit_fuses_all_sites_and_hashes_helper(
+        self,
+        monkeypatch,
+        text_config_source: str,
+    ):
+        from vllm_musa import platform
+        from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_file = next(
+            f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
+        )
+        patch_module = _load_patch_module(patch_file)
+        monkeypatch.setattr(
+            platform, "_is_qwen3_qk_rope_kv_fusion_config", lambda _config: True
+        )
+        monkeypatch.setattr(
+            presplit,
+            "qwen3_qk_rope_kv_backend_supported",
+            lambda _config, expected_sites: expected_sites == 28,
+        )
+        monkeypatch.setattr(
+            presplit,
+            "plan_qwen3_qk_rope_kv_presplit",
+            lambda _graph, expected_sites: tuple(range(expected_sites)),
+        )
+        monkeypatch.setattr(
+            presplit,
+            "apply_qwen3_qk_rope_kv_presplit",
+            lambda _graph, candidates: len(candidates),
+        )
+        compilation_config = SimpleNamespace(
+            use_inductor_graph_partition=False,
+            splitting_ops=["vllm::unified_kv_cache_update", "vllm::attention"],
+            traced_files=set(),
+        )
+        text_config = SimpleNamespace(num_hidden_layers=28)
+        model_config = (
+            SimpleNamespace(hf_text_config=text_config)
+            if text_config_source == "hf_text_config"
+            else SimpleNamespace(hf_config=SimpleNamespace(text_config=text_config))
+        )
+        backend = SimpleNamespace(
+            vllm_config=SimpleNamespace(model_config=model_config),
+            compilation_config=compilation_config,
+        )
+
+        assert patch_module._try_qwen3_qk_rope_kv_presplit(backend, object()) == 28
+        assert compilation_config.splitting_ops == [
+            "vllm::unified_kv_cache_update",
+            "vllm::attention",
+            "vllm::musa_qwen3_qk_rope_and_unified_kv_cache_update",
+        ]
+        assert str(Path(presplit.__file__).resolve()) in compilation_config.traced_files
+        assert str(Path(patch_module.__file__).resolve()) in (
+            compilation_config.traced_files
+        )
+
+    def test_qwen3_presplit_missing_layer_count_is_fail_closed(self, monkeypatch):
+        from vllm_musa import platform
+        from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_file = next(
+            f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
+        )
+        patch_module = _load_patch_module(patch_file)
+        monkeypatch.setattr(
+            platform, "_is_qwen3_qk_rope_kv_fusion_config", lambda _config: True
+        )
+
+        def unexpected_backend_check(*_args, **_kwargs):
+            pytest.fail("backend support must not run without a layer count")
+
+        monkeypatch.setattr(
+            presplit,
+            "qwen3_qk_rope_kv_backend_supported",
+            unexpected_backend_check,
+        )
+        splitting_ops = ["vllm::unified_kv_cache_update", "vllm::attention"]
+        compilation_config = SimpleNamespace(
+            use_inductor_graph_partition=False,
+            splitting_ops=splitting_ops,
+            traced_files=set(),
+        )
+        backend = SimpleNamespace(
+            vllm_config=SimpleNamespace(
+                model_config=SimpleNamespace(hf_config=SimpleNamespace())
+            ),
+            compilation_config=compilation_config,
+        )
+
+        assert patch_module._try_qwen3_qk_rope_kv_presplit(backend, object()) == 0
+        assert compilation_config.splitting_ops is splitting_ops
+        assert compilation_config.traced_files == set()
+
+    def test_qwen3_presplit_site_mismatch_is_atomic(self, monkeypatch):
+        from vllm_musa import platform
+        from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_file = next(
+            f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
+        )
+        patch_module = _load_patch_module(patch_file)
+        monkeypatch.setattr(
+            platform, "_is_qwen3_qk_rope_kv_fusion_config", lambda _config: True
+        )
+        monkeypatch.setattr(
+            presplit,
+            "qwen3_qk_rope_kv_backend_supported",
+            lambda _config, expected_sites: expected_sites == 36,
+        )
+        monkeypatch.setattr(
+            presplit,
+            "plan_qwen3_qk_rope_kv_presplit",
+            lambda _graph, _expected_sites: None,
+        )
+
+        def fail_if_applied(_graph, _candidates):
+            raise AssertionError("an incomplete Qwen3 plan must not be applied")
+
+        monkeypatch.setattr(
+            presplit, "apply_qwen3_qk_rope_kv_presplit", fail_if_applied
+        )
+        splitting_ops = ["vllm::unified_kv_cache_update", "vllm::attention"]
+        compilation_config = SimpleNamespace(
+            use_inductor_graph_partition=False,
+            splitting_ops=splitting_ops,
+            traced_files=set(),
+        )
+        backend = SimpleNamespace(
+            vllm_config=SimpleNamespace(
+                model_config=SimpleNamespace(
+                    hf_text_config=SimpleNamespace(num_hidden_layers=36)
+                )
+            ),
+            compilation_config=compilation_config,
+        )
+
+        assert patch_module._try_qwen3_qk_rope_kv_presplit(backend, object()) == 0
+        assert compilation_config.splitting_ops is splitting_ops
+        assert compilation_config.traced_files == set()
+
+    def test_qwen3_presplit_rejects_unsupported_attention_backend(self, monkeypatch):
+        from vllm_musa import platform
+        from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        patch_file = next(
+            f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
+        )
+        patch_module = _load_patch_module(patch_file)
+        monkeypatch.setattr(
+            platform, "_is_qwen3_qk_rope_kv_fusion_config", lambda _config: True
+        )
+        monkeypatch.setattr(
+            presplit,
+            "qwen3_qk_rope_kv_backend_supported",
+            lambda _config, _expected_sites: False,
+        )
+
+        def fail_if_planned(_graph, _expected_sites):
+            raise AssertionError("unsupported backends must not plan a Qwen3 rewrite")
+
+        monkeypatch.setattr(presplit, "plan_qwen3_qk_rope_kv_presplit", fail_if_planned)
+        splitting_ops = ["vllm::unified_kv_cache_update", "vllm::attention"]
+        compilation_config = SimpleNamespace(
+            use_inductor_graph_partition=False,
+            splitting_ops=splitting_ops,
+            traced_files=set(),
+        )
+        backend = SimpleNamespace(
+            vllm_config=SimpleNamespace(
+                model_config=SimpleNamespace(
+                    hf_text_config=SimpleNamespace(num_hidden_layers=28)
+                )
+            ),
+            compilation_config=compilation_config,
+        )
+
+        assert patch_module._try_qwen3_qk_rope_kv_presplit(backend, object()) == 0
+        assert compilation_config.splitting_ops is splitting_ops
+        assert compilation_config.traced_files == set()
+
     def test_live_functorch_config_patch_skips_missing_keys(self):
         from contextlib import nullcontext
 

--- a/tests/test_qk_mrope_negative_slots_source.py
+++ b/tests/test_qk_mrope_negative_slots_source.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source contracts for negative qk_mrope cache slots."""
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = (ROOT / "vllm_musa/jit_kernel/csrc/norm/qk_mrope.mu").read_text(
+    encoding="utf-8"
+)
+
+SPECIALIZED_CACHE_KERNELS = (
+    "fused_qk_rmsnorm_mrope_cache_32q4kv_h128_bf16_kernel",
+    "fused_qk_rmsnorm_mrope_cache_h128_full_bf16_kernel",
+    "fused_qk_rmsnorm_rope_cache_h128_full_bf16_kernel",
+    "fused_qk_rmsnorm_rope_cache_h128r64_bf16_kernel",
+    "fused_qk_rmsnorm_mrope_cache_h256r64_bf16_kernel",
+)
+
+
+def _braced_body(source: str, marker: str, start: int = 0) -> str:
+    marker_offset = source.index(marker, start)
+    body_start = source.index("{", marker_offset)
+    depth = 0
+    for offset in range(body_start, len(source)):
+        if source[offset] == "{":
+            depth += 1
+        elif source[offset] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[body_start + 1 : offset]
+    raise AssertionError(f"unclosed source block after {marker!r}")
+
+
+def _all_braced_bodies(source: str, marker: str) -> list[str]:
+    bodies = []
+    offset = 0
+    while marker in source[offset:]:
+        marker_offset = source.index(marker, offset)
+        body = _braced_body(source, marker, marker_offset)
+        bodies.append(body)
+        body_start = source.index("{", marker_offset)
+        offset = body_start + len(body) + 2
+    return bodies
+
+
+@pytest.mark.parametrize("kernel_name", SPECIALIZED_CACHE_KERNELS)
+def test_specialized_cache_kernel_guards_negative_slots(kernel_name: str) -> None:
+    body = _braced_body(SOURCE, f"__global__ void {kernel_name}(")
+
+    assert "const bool write_cache = cache_idx >= 0;" in body
+    assert "if (group == 0 && write_cache)" in body
+    assert "if (group == 0)" not in body
+
+    value_cache_block = _braced_body(body, "if (group == 0 && write_cache)")
+    assert "v_cache" in value_cache_block
+    assert body.count("v_cache") == value_cache_block.count("v_cache")
+
+    cache_write_blocks = _all_braced_bodies(body, "if (write_cache)")
+    assert cache_write_blocks
+    assert any("k_cache" in block for block in cache_write_blocks)
+    assert body.count("k_cache") == sum(
+        block.count("k_cache") for block in cache_write_blocks
+    )
+    assert all("k_out" not in block for block in cache_write_blocks)
+    assert "if constexpr (STORE_K_OUT)" in body
+
+
+def test_generic_cache_kernel_guards_negative_slots_but_keeps_k_out() -> None:
+    body = _braced_body(
+        SOURCE, "__global__ void fused_qk_rmsnorm_mrope_generic_bf16_kernel("
+    )
+
+    assert "write_cache = cache_idx >= 0;" in body
+    assert "if (group == 0 && write_cache)" in body
+    assert "if (group == 0)" not in body
+
+    value_cache_block = _braced_body(body, "if (group == 0 && write_cache)")
+    assert "v_cache" in value_cache_block
+    assert body.count("v_cache") == value_cache_block.count("v_cache")
+
+    cache_write_blocks = _all_braced_bodies(body, "if (write_cache)")
+    assert len(cache_write_blocks) == 2
+    assert all("k_cache" in block for block in cache_write_blocks)
+    assert body.count("k_cache") == sum(
+        block.count("k_cache") for block in cache_write_blocks
+    )
+    assert all("k_out" not in block for block in cache_write_blocks)
+    assert body.count("if (k_out != nullptr)") == 2

--- a/tests/test_qwen3_qk_rope_kv_presplit.py
+++ b/tests/test_qwen3_qk_rope_kv_presplit.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import gc
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("torchada")
+torch = pytest.importorskip("torch")
+from torch import fx  # noqa: E402
+
+from vllm_musa.compilation.qwen3_qk_rope_kv_presplit import (  # noqa: E402
+    apply_qwen3_qk_rope_kv_presplit,
+    plan_qwen3_qk_rope_kv_presplit,
+)
+
+_FUSED_OP_NAME = "musa_qwen3_qk_rope_and_unified_kv_cache_update"
+_FUSED_OP_SCHEMA = (
+    "musa_qwen3_qk_rope_and_unified_kv_cache_update(Tensor q, Tensor k, "
+    "Tensor v, Tensor q_weight, Tensor k_weight, Tensor positions, "
+    "Tensor cos_sin_cache, Tensor(a!) q_out, Tensor(b!) k_out, "
+    "str layer_name) -> Tensor"
+)
+_GRAPH_OP_SCHEMAS = (
+    (
+        "musa_rotary_embedding",
+        "musa_rotary_embedding(Tensor positions, Tensor(a!) query, Tensor(b!) key, "
+        "int head_size, Tensor cos_sin_cache, bool is_neox) -> ()",
+    ),
+    (
+        "unified_kv_cache_update",
+        "unified_kv_cache_update(Tensor key, Tensor value, str layer_name) -> Tensor",
+    ),
+    (
+        "unified_attention_with_output",
+        "unified_attention_with_output(Tensor query, Tensor key, Tensor value, "
+        "Tensor(a!) output, str layer_name, float scale, float output_scale, "
+        "Tensor? kv_cache_dummy_dep) -> Tensor",
+    ),
+)
+
+
+def _dispatch_has_schema(name: str) -> bool:
+    try:
+        torch._C._dispatch_find_schema_or_throw(f"vllm::{name}", "")
+    except RuntimeError:
+        return False
+    return True
+
+
+@contextmanager
+def _temporary_schema(name: str, schema: str):
+    library = None
+    if not _dispatch_has_schema(name):
+        library = torch.library.Library("vllm", "FRAGMENT")
+        library.define(schema)
+    try:
+        yield
+    finally:
+        if library is not None:
+            library._destroy()
+
+
+@pytest.fixture(autouse=True)
+def _graph_op_schemas():
+    initial = {name: _dispatch_has_schema(name) for name, _ in _GRAPH_OP_SCHEMAS}
+    libraries = []
+    for name, schema in _GRAPH_OP_SCHEMAS:
+        if not initial[name]:
+            library = torch.library.Library("vllm", "FRAGMENT")
+            library.define(schema)
+            libraries.append(library)
+    yield
+    for library in reversed(libraries):
+        library._destroy()
+    gc.collect()
+    assert {
+        name: _dispatch_has_schema(name) for name, _ in _GRAPH_OP_SCHEMAS
+    } == initial
+
+
+def _meta(node: fx.Node, shape: tuple[int, ...], dtype=torch.bfloat16) -> fx.Node:
+    node.meta["example_value"] = SimpleNamespace(shape=shape, dtype=dtype)
+    return node
+
+
+def _make_graph(*, q_heads: int = 16, extra_q_user: bool = False):
+    kv_heads = 8
+    q_width = q_heads * 128
+    kv_width = kv_heads * 128
+    graph = fx.Graph()
+    qkv = _meta(graph.placeholder("qkv"), (1, q_width + 2 * kv_width))
+    q_weight = _meta(graph.placeholder("q_weight"), (128,))
+    k_weight = _meta(graph.placeholder("k_weight"), (128,))
+    positions = _meta(graph.placeholder("positions"), (1,), torch.int64)
+    cos = _meta(graph.placeholder("cos"), (32, 128))
+    output = _meta(graph.placeholder("output"), (1, q_heads, 128))
+    split = graph.call_method(
+        "split",
+        args=(qkv, [q_width, kv_width, kv_width]),
+        kwargs={"dim": -1},
+    )
+    q_item = graph.call_function(__import__("operator").getitem, args=(split, 0))
+    k_item = graph.call_function(__import__("operator").getitem, args=(split, 1))
+    v_item = graph.call_function(__import__("operator").getitem, args=(split, 2))
+    q_head = _meta(
+        graph.call_method("view", args=(q_item, 1, q_heads, 128)),
+        (1, q_heads, 128),
+    )
+    k_head = _meta(
+        graph.call_method("view", args=(k_item, 1, kv_heads, 128)),
+        (1, kv_heads, 128),
+    )
+    value = _meta(
+        graph.call_method("view", args=(v_item, 1, kv_heads, 128)),
+        (1, kv_heads, 128),
+    )
+    q_norm = _meta(
+        graph.call_function(torch.rms_norm, args=(q_head, [128], q_weight, 1e-6)),
+        (1, q_heads, 128),
+    )
+    k_norm = _meta(
+        graph.call_function(torch.rms_norm, args=(k_head, [128], k_weight, 1e-6)),
+        (1, kv_heads, 128),
+    )
+    q_flat = _meta(
+        graph.call_method("view", args=(q_norm, 1, q_width)),
+        (1, q_width),
+    )
+    k_flat = _meta(
+        graph.call_method("view", args=(k_norm, 1, kv_width)),
+        (1, kv_width),
+    )
+    graph.call_function(
+        torch.ops.vllm.musa_rotary_embedding,
+        args=(positions, q_flat, k_flat, 128, cos, True),
+    )
+    query = _meta(
+        graph.call_method("view", args=(q_flat, 1, q_heads, 128)),
+        (1, q_heads, 128),
+    )
+    key = _meta(
+        graph.call_method("view", args=(k_flat, 1, kv_heads, 128)),
+        (1, kv_heads, 128),
+    )
+    if extra_q_user:
+        graph.call_function(torch.ops.aten.clone.default, args=(q_flat,))
+    kv_update = graph.call_function(
+        torch.ops.vllm.unified_kv_cache_update,
+        kwargs={"key": key, "value": value, "layer_name": "model.layers.0.self_attn"},
+    )
+    attention = graph.call_function(
+        torch.ops.vllm.unified_attention_with_output,
+        kwargs={
+            "query": query,
+            "key": key,
+            "value": value,
+            "output": output,
+            "layer_name": "model.layers.0.self_attn",
+            "scale": 0.08838834764831845,
+            "output_scale": 1.0,
+            "kv_cache_dummy_dep": kv_update,
+        },
+    )
+    graph.output(attention)
+    return fx.GraphModule({}, graph)
+
+
+def test_plan_matches_qwen3_06b_and_8b_shapes():
+    for q_heads in (16, 32):
+        graph_module = _make_graph(q_heads=q_heads)
+        candidates = plan_qwen3_qk_rope_kv_presplit(graph_module, 1)
+        assert candidates is not None
+        assert len(candidates) == 1
+
+
+def test_plan_is_atomic_on_extra_q_user():
+    graph_module = _make_graph(extra_q_user=True)
+    before = str(graph_module.graph)
+    assert plan_qwen3_qk_rope_kv_presplit(graph_module, 1) is None
+    assert str(graph_module.graph) == before
+
+
+def test_temporary_schema_is_order_isolated():
+    unique_name = "musa_qwen3_qk_rope_presplit_test_isolation"
+    cases = (
+        (unique_name, f"{unique_name}() -> ()"),
+        (_FUSED_OP_NAME, _FUSED_OP_SCHEMA),
+    )
+    for name, schema in cases:
+        registered_before = _dispatch_has_schema(name)
+        with _temporary_schema(name, schema):
+            assert _dispatch_has_schema(name)
+        assert _dispatch_has_schema(name) is registered_before
+
+
+def test_apply_replaces_norm_rope_and_cache(monkeypatch):
+    module_name = "vllm_musa.kernels.qwen3_qk_rope_kv"
+    if module_name not in sys.modules:
+        kernels_package = sys.modules.get("vllm_musa.kernels")
+        if kernels_package is None:
+            kernels_package = types.ModuleType("vllm_musa.kernels")
+            kernels_package.__path__ = [
+                str(Path(__file__).parents[1] / "vllm_musa" / "kernels")
+            ]
+            monkeypatch.setitem(sys.modules, "vllm_musa.kernels", kernels_package)
+        fake_module = types.ModuleType(module_name)
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
+        monkeypatch.setattr(
+            kernels_package,
+            "qwen3_qk_rope_kv",
+            fake_module,
+            raising=False,
+        )
+
+    with _temporary_schema(_FUSED_OP_NAME, _FUSED_OP_SCHEMA):
+        graph_module = _make_graph()
+        candidates = plan_qwen3_qk_rope_kv_presplit(graph_module, 1)
+        assert candidates is not None
+        assert apply_qwen3_qk_rope_kv_presplit(graph_module, candidates) == 1
+        targets = [str(node.target) for node in graph_module.graph.nodes]
+        assert (
+            sum(
+                "musa_qwen3_qk_rope_and_unified_kv_cache_update" in target
+                for target in targets
+            )
+            == 1
+        )
+        assert not any("musa_rotary_embedding" in target for target in targets)
+        assert "vllm.unified_kv_cache_update.default" not in targets
+        assert not any("rms_norm" in target for target in targets)
+        attention_nodes = [
+            node
+            for node in graph_module.graph.nodes
+            if str(node.target) == "vllm.unified_attention_with_output"
+        ]
+        fused_nodes = [
+            node
+            for node in graph_module.graph.nodes
+            if "musa_qwen3_qk_rope_and_unified_kv_cache_update" in str(node.target)
+        ]
+        assert len(attention_nodes) == 1
+        assert len(fused_nodes) == 1
+        assert fused_nodes[0] in attention_nodes[0].all_input_nodes

--- a/vllm_musa/compilation/qwen3_qk_rope_kv_presplit.py
+++ b/vllm_musa/compilation/qwen3_qk_rope_kv_presplit.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed pre-split fusion for dense Qwen3 QK norm/RoPE/KV update."""
+
+from __future__ import annotations
+
+import operator
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torch import fx
+
+KV_UPDATE_SPLITTING_OP = "vllm::unified_kv_cache_update"
+FUSED_SPLITTING_OP = "vllm::musa_qwen3_qk_rope_and_unified_kv_cache_update"
+_MISSING = object()
+
+_SUPPORTED_SPLITS = {
+    (2048, 1024, 1024): (16, 8),
+    (4096, 1024, 1024): (32, 8),
+}
+
+
+def qwen3_qk_rope_kv_backend_supported(
+    vllm_config: Any,
+    expected_sites: int,
+) -> bool:
+    try:
+        from vllm.config import get_layers_from_vllm_config
+        from vllm.model_executor.layers.attention.attention import Attention
+
+        layers = get_layers_from_vllm_config(vllm_config, Attention)
+    except Exception:
+        return False
+    if len(layers) != expected_sites:
+        return False
+    try:
+        return all(
+            getattr(
+                layer.impl,
+                "qwen3_qk_rope_kvcache_supported",
+                lambda: False,
+            )()
+            for layer in layers.values()
+        )
+    except Exception:
+        return False
+
+
+@dataclass(frozen=True)
+class Qwen3QKRoPEKVCandidate:
+    rope: fx.Node
+    kv_update: fx.Node
+    attention: fx.Node
+    q_head: fx.Node
+    k_head: fx.Node
+    value: fx.Node
+    q_weight: fx.Node
+    k_weight: fx.Node
+    positions: fx.Node
+    cos_sin_cache: fx.Node
+    layer_name: str
+
+
+def _is_call(node: fx.Node, qualified_name: str) -> bool:
+    if node.op != "call_function":
+        return False
+    target = str(node.target)
+    expected = qualified_name.replace("::", ".")
+    if target == expected or target == f"{expected}.default":
+        return True
+    module = getattr(node.target, "__module__", None)
+    name = getattr(node.target, "__name__", None)
+    return (
+        isinstance(module, str)
+        and isinstance(name, str)
+        and (f"{module}.{name}" == expected)
+    )
+
+
+def _arg(
+    node: fx.Node,
+    index: int,
+    name: str,
+    default: Any = _MISSING,
+) -> Any:
+    if name in node.kwargs:
+        return node.kwargs[name]
+    if len(node.args) > index:
+        return node.args[index]
+    if default is not _MISSING:
+        return default
+    return _MISSING
+
+
+def _tensor_value(node: fx.Node) -> Any:
+    for key in ("val", "example_value"):
+        value = node.meta.get(key)
+        if value is not None:
+            return value
+    return node.meta.get("tensor_meta")
+
+
+def _shape(node: fx.Node) -> tuple[Any, ...] | None:
+    shape = getattr(_tensor_value(node), "shape", None)
+    return tuple(shape) if shape is not None else None
+
+
+def _shape_tail(node: fx.Node) -> tuple[Any, Any] | None:
+    shape = _shape(node)
+    return None if shape is None or len(shape) < 2 else (shape[-2], shape[-1])
+
+
+def _dtype(node: fx.Node) -> torch.dtype | None:
+    return getattr(_tensor_value(node), "dtype", None)
+
+
+def _view_base(node: fx.Node) -> fx.Node | None:
+    is_view = node.op == "call_method" and node.target in {"view", "reshape"}
+    is_view = is_view or any(
+        _is_call(node, target)
+        for target in ("aten::view", "aten::reshape", "aten::_unsafe_view")
+    )
+    if not is_view or not node.args or not isinstance(node.args[0], fx.Node):
+        return None
+    return node.args[0]
+
+
+def _split_getitem(node: fx.Node, index: int) -> fx.Node | None:
+    if (
+        node.op != "call_function"
+        or node.target is not operator.getitem
+        or len(node.args) != 2
+        or node.args[1] != index
+        or not isinstance(node.args[0], fx.Node)
+    ):
+        return None
+    return node.args[0]
+
+
+def _split_sizes(node: fx.Node) -> tuple[int, ...] | None:
+    if node.op == "call_method" and node.target == "split":
+        sizes = _arg(node, 1, "split_size")
+        dim = _arg(node, 2, "dim", 0)
+    elif _is_call(node, "aten::split_with_sizes"):
+        sizes = _arg(node, 1, "split_sizes")
+        dim = _arg(node, 2, "dim", 0)
+    else:
+        return None
+    if not isinstance(sizes, (list, tuple)) or dim not in (-1, 1):
+        return None
+    return tuple(int(size) for size in sizes)
+
+
+def _rms_norm_parts(node: fx.Node) -> tuple[fx.Node, fx.Node] | None:
+    if not (_is_call(node, "aten::rms_norm") or _is_call(node, "torch::rms_norm")):
+        return None
+    tensor = _arg(node, 0, "input")
+    normalized_shape = _arg(node, 1, "normalized_shape")
+    weight = _arg(node, 2, "weight")
+    eps = _arg(node, 3, "eps", None)
+    if (
+        not isinstance(tensor, fx.Node)
+        or not isinstance(weight, fx.Node)
+        or not isinstance(normalized_shape, (list, tuple))
+        or tuple(normalized_shape) != (128,)
+        or eps is None
+        or float(eps) != 1e-6
+    ):
+        return None
+    return tensor, weight
+
+
+def _only_users(node: fx.Node, expected: set[fx.Node]) -> bool:
+    return set(node.users) == expected
+
+
+def plan_qwen3_qk_rope_kv_presplit(
+    graph_module: fx.GraphModule,
+    expected_sites: int,
+) -> tuple[Qwen3QKRoPEKVCandidate, ...] | None:
+    nodes = tuple(graph_module.graph.nodes)
+    all_rope = [node for node in nodes if _is_call(node, "vllm::musa_rotary_embedding")]
+    all_kv = [node for node in nodes if _is_call(node, KV_UPDATE_SPLITTING_OP)]
+    if len(all_rope) != expected_sites or len(all_kv) != expected_sites:
+        return None
+
+    candidates: list[Qwen3QKRoPEKVCandidate] = []
+    seen_rope: set[fx.Node] = set()
+    seen_layer_names: set[str] = set()
+    for kv_update in all_kv:
+        if len(kv_update.users) != 1:
+            return None
+        attention = next(iter(kv_update.users))
+        if not _is_call(attention, "vllm::unified_attention_with_output"):
+            return None
+        query = _arg(attention, 0, "query")
+        key = _arg(attention, 1, "key")
+        value = _arg(attention, 2, "value")
+        layer_name = _arg(attention, 4, "layer_name")
+        dummy = _arg(attention, 7, "kv_cache_dummy_dep", None)
+        if (
+            not all(isinstance(node, fx.Node) for node in (query, key, value))
+            or dummy is not kv_update
+            or not isinstance(layer_name, str)
+            or _arg(kv_update, 0, "key") is not key
+            or _arg(kv_update, 1, "value") is not value
+            or _arg(kv_update, 2, "layer_name") != layer_name
+            or layer_name in seen_layer_names
+        ):
+            return None
+
+        q_flat = _view_base(query)
+        k_flat = _view_base(key)
+        if q_flat is None or k_flat is None:
+            return None
+        q_norm = _view_base(q_flat)
+        k_norm = _view_base(k_flat)
+        if q_norm is None or k_norm is None:
+            return None
+        q_parts = _rms_norm_parts(q_norm)
+        k_parts = _rms_norm_parts(k_norm)
+        if q_parts is None or k_parts is None:
+            return None
+        q_head, q_weight = q_parts
+        k_head, k_weight = k_parts
+        q_base = _view_base(q_head)
+        k_base = _view_base(k_head)
+        value_base = _view_base(value)
+        if q_base is None or k_base is None or value_base is None:
+            return None
+        q_split = _split_getitem(q_base, 0)
+        k_split = _split_getitem(k_base, 1)
+        v_split = _split_getitem(value_base, 2)
+        if q_split is None or q_split is not k_split or q_split is not v_split:
+            return None
+        split_sizes = _split_sizes(q_split)
+        expected_heads = _SUPPORTED_SPLITS.get(split_sizes or ())
+        if expected_heads is None:
+            return None
+        q_heads, kv_heads = expected_heads
+        if (
+            _shape_tail(q_head) != (q_heads, 128)
+            or _shape_tail(k_head) != (kv_heads, 128)
+            or _shape_tail(value) != (kv_heads, 128)
+            or _shape(q_weight) != (128,)
+            or _shape(k_weight) != (128,)
+            or any(
+                _dtype(node) != torch.bfloat16
+                for node in (q_head, k_head, value, q_weight, k_weight)
+            )
+        ):
+            return None
+
+        rope_candidates = {
+            user
+            for user in q_flat.users
+            if _is_call(user, "vllm::musa_rotary_embedding")
+        } & {
+            user
+            for user in k_flat.users
+            if _is_call(user, "vllm::musa_rotary_embedding")
+        }
+        if len(rope_candidates) != 1:
+            return None
+        rope = rope_candidates.pop()
+        positions = _arg(rope, 0, "positions")
+        cos_sin_cache = _arg(rope, 4, "cos_sin_cache")
+        if (
+            rope in seen_rope
+            or rope.users
+            or not isinstance(positions, fx.Node)
+            or not isinstance(cos_sin_cache, fx.Node)
+            or _arg(rope, 1, "query") is not q_flat
+            or _arg(rope, 2, "key") is not k_flat
+            or _arg(rope, 3, "head_size") != 128
+            or _arg(rope, 5, "is_neox") is not True
+            or _dtype(cos_sin_cache) != torch.bfloat16
+            or not _only_users(q_flat, {query, rope})
+            or not _only_users(k_flat, {key, rope})
+            or not _only_users(q_norm, {q_flat})
+            or not _only_users(k_norm, {k_flat})
+            or not _only_users(q_head, {q_norm})
+            or not _only_users(k_head, {k_norm})
+            or not _only_users(query, {attention})
+            or not _only_users(key, {kv_update, attention})
+            or not _only_users(value, {kv_update, attention})
+        ):
+            return None
+
+        candidates.append(
+            Qwen3QKRoPEKVCandidate(
+                rope=rope,
+                kv_update=kv_update,
+                attention=attention,
+                q_head=q_head,
+                k_head=k_head,
+                value=value,
+                q_weight=q_weight,
+                k_weight=k_weight,
+                positions=positions,
+                cos_sin_cache=cos_sin_cache,
+                layer_name=layer_name,
+            )
+        )
+        seen_rope.add(rope)
+        seen_layer_names.add(layer_name)
+
+    if len(candidates) != expected_sites or seen_rope != set(all_rope):
+        return None
+    return tuple(candidates)
+
+
+def _replace_arg(node: fx.Node, index: int, name: str, value: Any) -> None:
+    if name in node.kwargs:
+        kwargs = dict(node.kwargs)
+        kwargs[name] = value
+        node.kwargs = kwargs
+        return
+    args = list(node.args)
+    args[index] = value
+    node.args = tuple(args)
+
+
+def apply_qwen3_qk_rope_kv_presplit(
+    graph_module: fx.GraphModule,
+    candidates: tuple[Qwen3QKRoPEKVCandidate, ...],
+) -> int:
+    from vllm_musa.kernels import qwen3_qk_rope_kv  # noqa: F401
+
+    fused_op = torch.ops.vllm.musa_qwen3_qk_rope_and_unified_kv_cache_update.default
+    empty_like = torch.ops.aten.empty_like.default
+    graph = graph_module.graph
+    for candidate in candidates:
+        old_query = _arg(candidate.attention, 0, "query")
+        old_key = _arg(candidate.attention, 1, "key")
+        old_q_flat = _view_base(old_query) if isinstance(old_query, fx.Node) else None
+        old_k_flat = _view_base(old_key) if isinstance(old_key, fx.Node) else None
+        old_q_norm = _view_base(old_q_flat) if isinstance(old_q_flat, fx.Node) else None
+        old_k_norm = _view_base(old_k_flat) if isinstance(old_k_flat, fx.Node) else None
+        with graph.inserting_before(candidate.kv_update):
+            q_out = graph.call_function(empty_like, args=(candidate.q_head,))
+            k_out = graph.call_function(empty_like, args=(candidate.k_head,))
+            fused = graph.call_function(
+                fused_op,
+                kwargs={
+                    "q": candidate.q_head,
+                    "k": candidate.k_head,
+                    "v": candidate.value,
+                    "q_weight": candidate.q_weight,
+                    "k_weight": candidate.k_weight,
+                    "positions": candidate.positions,
+                    "cos_sin_cache": candidate.cos_sin_cache,
+                    "q_out": q_out,
+                    "k_out": k_out,
+                    "layer_name": candidate.layer_name,
+                },
+            )
+        q_out.meta = dict(candidate.q_head.meta)
+        k_out.meta = dict(candidate.k_head.meta)
+        fused.meta = dict(candidate.kv_update.meta)
+        _replace_arg(candidate.attention, 0, "query", q_out)
+        _replace_arg(candidate.attention, 1, "key", k_out)
+        candidate.kv_update.replace_all_uses_with(fused)
+        graph.erase_node(candidate.kv_update)
+        if candidate.rope.users:
+            raise RuntimeError("MUSA Qwen3 RoPE node gained an unexpected user")
+        graph.erase_node(candidate.rope)
+
+        seen: set[fx.Node] = set()
+        for dead_node in (
+            old_query,
+            old_key,
+            old_q_flat,
+            old_k_flat,
+            old_q_norm,
+            old_k_norm,
+        ):
+            if (
+                isinstance(dead_node, fx.Node)
+                and dead_node not in seen
+                and not dead_node.users
+            ):
+                graph.erase_node(dead_node)
+                seen.add(dead_node)
+
+    graph.lint()
+    graph_module.recompile()
+    return len(candidates)
+
+
+__all__ = [
+    "FUSED_SPLITTING_OP",
+    "KV_UPDATE_SPLITTING_OP",
+    "Qwen3QKRoPEKVCandidate",
+    "apply_qwen3_qk_rope_kv_presplit",
+    "plan_qwen3_qk_rope_kv_presplit",
+    "qwen3_qk_rope_kv_backend_supported",
+]

--- a/vllm_musa/jit_kernel/csrc/norm.py
+++ b/vllm_musa/jit_kernel/csrc/norm.py
@@ -223,6 +223,51 @@ def fused_qk_rmsnorm_mrope(
     return q_out, k_out
 
 
+def fused_qk_rmsnorm_mrope_cache_out(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_out: torch.Tensor,
+    k_out: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    is_neox: bool,
+    mrope_section_t: int,
+    mrope_section_h: int,
+    mrope_section_w: int,
+    is_interleaved: bool,
+    eps: float = 1e-6,
+    gemma: bool = False,
+) -> None:
+    """Fuse Q/K RMSNorm, RoPE, and a flat-NHD K/V cache update."""
+    torch.ops.vllm.musa_csrc_fused_qk_rmsnorm_mrope_cache_out(
+        q,
+        k,
+        v,
+        q_weight,
+        k_weight,
+        positions,
+        cos_sin_cache,
+        q_out,
+        k_out,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        bool(is_neox),
+        int(mrope_section_t),
+        int(mrope_section_h),
+        int(mrope_section_w),
+        bool(is_interleaved),
+        float(eps),
+        bool(gemma),
+    )
+
+
 def _fused_qk_rmsnorm_mrope_custom(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -284,4 +329,80 @@ direct_register_custom_op(
     op_func=_fused_qk_rmsnorm_mrope_custom,
     mutates_args=["q_out", "k_out"],
     fake_impl=_fused_qk_rmsnorm_mrope_custom_fake,
+)
+
+
+def _fused_qk_rmsnorm_mrope_cache_out_custom(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_out: torch.Tensor,
+    k_out: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    is_neox: bool,
+    mrope_section_t: int,
+    mrope_section_h: int,
+    mrope_section_w: int,
+    is_interleaved: bool,
+    eps: float,
+    gemma: bool,
+) -> None:
+    _qk_mrope_module().sgl_musa_fused_qk_rmsnorm_mrope_cache_out(
+        q,
+        k,
+        v,
+        q_weight,
+        k_weight,
+        positions,
+        cos_sin_cache,
+        q_out,
+        k_out,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        bool(is_neox),
+        int(mrope_section_t),
+        int(mrope_section_h),
+        int(mrope_section_w),
+        bool(is_interleaved),
+        float(eps),
+        bool(gemma),
+    )
+
+
+def _fused_qk_rmsnorm_mrope_cache_out_custom_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_out: torch.Tensor,
+    k_out: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    is_neox: bool,
+    mrope_section_t: int,
+    mrope_section_h: int,
+    mrope_section_w: int,
+    is_interleaved: bool,
+    eps: float,
+    gemma: bool,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="musa_csrc_fused_qk_rmsnorm_mrope_cache_out",
+    op_func=_fused_qk_rmsnorm_mrope_cache_out_custom,
+    mutates_args=["q_out", "k_out", "key_cache", "value_cache"],
+    fake_impl=_fused_qk_rmsnorm_mrope_cache_out_custom_fake,
 )

--- a/vllm_musa/jit_kernel/csrc/norm/qk_mrope.mu
+++ b/vllm_musa/jit_kernel/csrc/norm/qk_mrope.mu
@@ -282,8 +282,9 @@ __global__ void fused_qk_rmsnorm_mrope_cache_32q4kv_h128_bf16_kernel(
 
   const int64_t cache_idx =
       static_cast<int64_t>(indices[(int64_t)token * indices_stride]);
+  const bool write_cache = cache_idx >= 0;
 
-  if (group == 0) {
+  if (group == 0 && write_cache) {
     constexpr int kVec = 8;
     constexpr int row_dim = k_heads * hidden;
     constexpr int vec_count = row_dim / kVec;
@@ -315,8 +316,6 @@ __global__ void fused_qk_rmsnorm_mrope_cache_32q4kv_h128_bf16_kernel(
       (int64_t)token * q_out_batch_stride + (int64_t)head * q_out_head_stride;
   const int64_t k_out_base =
       (int64_t)token * k_out_batch_stride + (int64_t)head * k_out_head_stride;
-  const int64_t k_cache_base =
-      cache_idx * k_cache_row_stride + (int64_t)head * hidden;
 
   const float data_0 = __bfloat162float(data[base + lane]);
   const float data_1 = __bfloat162float(data[base + lane + 32]);
@@ -352,8 +351,12 @@ __global__ void fused_qk_rmsnorm_mrope_cache_32q4kv_h128_bf16_kernel(
     q_out[q_out_base + x_index0] = x_rot0;
     q_out[q_out_base + y_index0] = y_rot0;
   } else {
-    k_cache[k_cache_base + x_index0] = x_rot0;
-    k_cache[k_cache_base + y_index0] = y_rot0;
+    if (write_cache) {
+      const int64_t k_cache_base =
+          cache_idx * k_cache_row_stride + (int64_t)head * hidden;
+      k_cache[k_cache_base + x_index0] = x_rot0;
+      k_cache[k_cache_base + y_index0] = y_rot0;
+    }
     if constexpr (STORE_K_OUT) {
       k_out[k_out_base + x_index0] = x_rot0;
       k_out[k_out_base + y_index0] = y_rot0;
@@ -382,8 +385,12 @@ __global__ void fused_qk_rmsnorm_mrope_cache_32q4kv_h128_bf16_kernel(
     q_out[q_out_base + x_index1] = x_rot1;
     q_out[q_out_base + y_index1] = y_rot1;
   } else {
-    k_cache[k_cache_base + x_index1] = x_rot1;
-    k_cache[k_cache_base + y_index1] = y_rot1;
+    if (write_cache) {
+      const int64_t k_cache_base =
+          cache_idx * k_cache_row_stride + (int64_t)head * hidden;
+      k_cache[k_cache_base + x_index1] = x_rot1;
+      k_cache[k_cache_base + y_index1] = y_rot1;
+    }
     if constexpr (STORE_K_OUT) {
       k_out[k_out_base + x_index1] = x_rot1;
       k_out[k_out_base + y_index1] = y_rot1;
@@ -428,8 +435,9 @@ __global__ void fused_qk_rmsnorm_mrope_cache_h128_full_bf16_kernel(
 
   const int64_t cache_idx =
       static_cast<int64_t>(indices[(int64_t)token * indices_stride]);
+  const bool write_cache = cache_idx >= 0;
 
-  if (group == 0) {
+  if (group == 0 && write_cache) {
     constexpr int kVec = 8;
     constexpr int row_dim = K_HEADS * hidden;
     constexpr int vec_count = row_dim / kVec;
@@ -526,12 +534,14 @@ __global__ void fused_qk_rmsnorm_mrope_cache_h128_full_bf16_kernel(
     q_out[q_out_base + rot_offset1] = x_rot1;
     q_out[q_out_base + embed_dim + rot_offset1] = y_rot1;
   } else {
-    const int64_t k_cache_base =
-        cache_idx * k_cache_row_stride + (int64_t)head * hidden;
-    k_cache[k_cache_base + rot_offset0] = x_rot0;
-    k_cache[k_cache_base + embed_dim + rot_offset0] = y_rot0;
-    k_cache[k_cache_base + rot_offset1] = x_rot1;
-    k_cache[k_cache_base + embed_dim + rot_offset1] = y_rot1;
+    if (write_cache) {
+      const int64_t k_cache_base =
+          cache_idx * k_cache_row_stride + (int64_t)head * hidden;
+      k_cache[k_cache_base + rot_offset0] = x_rot0;
+      k_cache[k_cache_base + embed_dim + rot_offset0] = y_rot0;
+      k_cache[k_cache_base + rot_offset1] = x_rot1;
+      k_cache[k_cache_base + embed_dim + rot_offset1] = y_rot1;
+    }
     if constexpr (STORE_K_OUT) {
       const int64_t k_out_base = (int64_t)token * k_out_batch_stride +
                                  (int64_t)head * k_out_head_stride;
@@ -579,8 +589,9 @@ __global__ void fused_qk_rmsnorm_rope_cache_h128_full_bf16_kernel(
 
   const int64_t cache_idx =
       static_cast<int64_t>(indices[(int64_t)token * indices_stride]);
+  const bool write_cache = cache_idx >= 0;
 
-  if (group == 0) {
+  if (group == 0 && write_cache) {
     constexpr int kVec = 8;
     constexpr int row_dim = K_HEADS * hidden;
     constexpr int vec_count = row_dim / kVec;
@@ -656,12 +667,14 @@ __global__ void fused_qk_rmsnorm_rope_cache_h128_full_bf16_kernel(
     q_out[q_out_base + rot_offset1] = x_rot1;
     q_out[q_out_base + embed_dim + rot_offset1] = y_rot1;
   } else {
-    const int64_t k_cache_base =
-        cache_idx * k_cache_row_stride + (int64_t)head * hidden;
-    k_cache[k_cache_base + lane] = x_rot0;
-    k_cache[k_cache_base + embed_dim + lane] = y_rot0;
-    k_cache[k_cache_base + rot_offset1] = x_rot1;
-    k_cache[k_cache_base + embed_dim + rot_offset1] = y_rot1;
+    if (write_cache) {
+      const int64_t k_cache_base =
+          cache_idx * k_cache_row_stride + (int64_t)head * hidden;
+      k_cache[k_cache_base + lane] = x_rot0;
+      k_cache[k_cache_base + embed_dim + lane] = y_rot0;
+      k_cache[k_cache_base + rot_offset1] = x_rot1;
+      k_cache[k_cache_base + embed_dim + rot_offset1] = y_rot1;
+    }
     if constexpr (STORE_K_OUT) {
       const int64_t k_out_base = (int64_t)token * k_out_batch_stride +
                                  (int64_t)head * k_out_head_stride;
@@ -713,8 +726,9 @@ __global__ void fused_qk_rmsnorm_rope_cache_h128r64_bf16_kernel(
 
   const int64_t cache_idx =
       static_cast<int64_t>(indices[(int64_t)token * indices_stride]);
+  const bool write_cache = cache_idx >= 0;
 
-  if (group == 0) {
+  if (group == 0 && write_cache) {
     constexpr int kVec = 8;
     constexpr int row_dim = K_HEADS * hidden;
     constexpr int vec_count = row_dim / kVec;
@@ -814,16 +828,18 @@ __global__ void fused_qk_rmsnorm_rope_cache_h128r64_bf16_kernel(
     *reinterpret_cast<__mt_bfloat162 *>(q_out + q_out_base + 96 + pair_col) =
         pass1;
   } else {
-    const int64_t k_cache_base =
-        cache_idx * k_cache_row_stride + (int64_t)head * hidden;
-    *reinterpret_cast<__mt_bfloat162 *>(k_cache + k_cache_base + pair_col) =
-        x_rot;
-    *reinterpret_cast<__mt_bfloat162 *>(k_cache + k_cache_base + embed_dim +
-                                        pair_col) = y_rot;
-    *reinterpret_cast<__mt_bfloat162 *>(k_cache + k_cache_base + 64 + pair_col) =
-        pass0;
-    *reinterpret_cast<__mt_bfloat162 *>(k_cache + k_cache_base + 96 + pair_col) =
-        pass1;
+    if (write_cache) {
+      const int64_t k_cache_base =
+          cache_idx * k_cache_row_stride + (int64_t)head * hidden;
+      *reinterpret_cast<__mt_bfloat162 *>(k_cache + k_cache_base + pair_col) =
+          x_rot;
+      *reinterpret_cast<__mt_bfloat162 *>(k_cache + k_cache_base + embed_dim +
+                                          pair_col) = y_rot;
+      *reinterpret_cast<__mt_bfloat162 *>(k_cache + k_cache_base + 64 + pair_col) =
+          pass0;
+      *reinterpret_cast<__mt_bfloat162 *>(k_cache + k_cache_base + 96 + pair_col) =
+          pass1;
+    }
     if constexpr (STORE_K_OUT) {
       const int64_t k_out_base = (int64_t)token * k_out_batch_stride +
                                  (int64_t)head * k_out_head_stride;
@@ -875,8 +891,9 @@ __global__ void fused_qk_rmsnorm_mrope_cache_h256r64_bf16_kernel(
 
   const int64_t cache_idx =
       static_cast<int64_t>(indices[(int64_t)token * indices_stride]);
+  const bool write_cache = cache_idx >= 0;
 
-  if (group == 0) {
+  if (group == 0 && write_cache) {
     constexpr int kVec = 8;
     constexpr int row_dim = K_HEADS * hidden;
     constexpr int vec_count = row_dim / kVec;
@@ -960,16 +977,18 @@ __global__ void fused_qk_rmsnorm_mrope_cache_h256r64_bf16_kernel(
     q_out[q_out_base + lane + 192] = out_6;
     q_out[q_out_base + lane + 224] = out_7;
   } else {
-    const int64_t k_cache_base =
-        cache_idx * k_cache_row_stride + (int64_t)head * hidden;
-    k_cache[k_cache_base + lane] = x_rot;
-    k_cache[k_cache_base + lane + 32] = y_rot;
-    k_cache[k_cache_base + lane + 64] = out_2;
-    k_cache[k_cache_base + lane + 96] = out_3;
-    k_cache[k_cache_base + lane + 128] = out_4;
-    k_cache[k_cache_base + lane + 160] = out_5;
-    k_cache[k_cache_base + lane + 192] = out_6;
-    k_cache[k_cache_base + lane + 224] = out_7;
+    if (write_cache) {
+      const int64_t k_cache_base =
+          cache_idx * k_cache_row_stride + (int64_t)head * hidden;
+      k_cache[k_cache_base + lane] = x_rot;
+      k_cache[k_cache_base + lane + 32] = y_rot;
+      k_cache[k_cache_base + lane + 64] = out_2;
+      k_cache[k_cache_base + lane + 96] = out_3;
+      k_cache[k_cache_base + lane + 128] = out_4;
+      k_cache[k_cache_base + lane + 160] = out_5;
+      k_cache[k_cache_base + lane + 192] = out_6;
+      k_cache[k_cache_base + lane + 224] = out_7;
+    }
     if constexpr (STORE_K_OUT) {
       const int64_t k_out_base = (int64_t)token * k_out_batch_stride +
                                  (int64_t)head * k_out_head_stride;
@@ -1293,9 +1312,11 @@ __global__ void fused_qk_rmsnorm_mrope_generic_bf16_kernel(
   }
 
   int64_t cache_idx = 0;
+  bool write_cache = false;
   if constexpr (WITH_CACHE) {
     cache_idx = static_cast<int64_t>(indices[(int64_t)token * indices_stride]);
-    if (group == 0) {
+    write_cache = cache_idx >= 0;
+    if (group == 0 && write_cache) {
       const int row_dim = k_heads * hidden;
       const int64_t v_base = (int64_t)token * v_batch_stride;
       const int64_t v_dst = cache_idx * v_cache_row_stride;
@@ -1366,10 +1387,12 @@ __global__ void fused_qk_rmsnorm_mrope_generic_bf16_kernel(
       q_out[out_base + x_index] = x_rot;
       q_out[out_base + y_index] = y_rot;
     } else if constexpr (WITH_CACHE) {
-      const int64_t cache_base =
-          cache_idx * k_cache_row_stride + (int64_t)head * hidden;
-      k_cache[cache_base + x_index] = x_rot;
-      k_cache[cache_base + y_index] = y_rot;
+      if (write_cache) {
+        const int64_t cache_base =
+            cache_idx * k_cache_row_stride + (int64_t)head * hidden;
+        k_cache[cache_base + x_index] = x_rot;
+        k_cache[cache_base + y_index] = y_rot;
+      }
       if (k_out != nullptr) {
         const int64_t out_base =
             (int64_t)token * k_out_batch_stride +
@@ -1397,9 +1420,11 @@ __global__ void fused_qk_rmsnorm_mrope_generic_bf16_kernel(
           (int64_t)head * q_out_head_stride;
       q_out[out_base + col] = out_value;
     } else if constexpr (WITH_CACHE) {
-      const int64_t cache_base =
-          cache_idx * k_cache_row_stride + (int64_t)head * hidden;
-      k_cache[cache_base + col] = out_value;
+      if (write_cache) {
+        const int64_t cache_base =
+            cache_idx * k_cache_row_stride + (int64_t)head * hidden;
+        k_cache[cache_base + col] = out_value;
+      }
       if (k_out != nullptr) {
         const int64_t out_base =
             (int64_t)token * k_out_batch_stride +

--- a/vllm_musa/kernels/qwen3_qk_rope_kv.py
+++ b/vllm_musa/kernels/qwen3_qk_rope_kv.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3 QK RMSNorm + full RoPE + KV-cache side-effect custom op."""
+
+from __future__ import annotations
+
+import torch
+from vllm.model_executor.layers.attention.attention import get_attention_context
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _resolve_layer_name,
+    direct_register_custom_op,
+)
+
+
+def qwen3_qk_rope_and_unified_kv_cache_update_impl(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_out: torch.Tensor,
+    k_out: torch.Tensor,
+    layer_name: LayerNameType,
+) -> torch.Tensor:
+    """Populate Q/K outputs and the current layer's paged KV cache."""
+    layer_name = _resolve_layer_name(layer_name)
+    _, attn_layer, kv_cache, layer_slot_mapping = get_attention_context(layer_name)
+    attn_layer.impl.do_qwen3_qk_rope_and_kv_cache_update(
+        attn_layer,
+        q,
+        k,
+        v,
+        q_weight,
+        k_weight,
+        positions,
+        cos_sin_cache,
+        q_out,
+        k_out,
+        kv_cache,
+        layer_slot_mapping,
+    )
+    return torch.empty(0, device=kv_cache.device, dtype=kv_cache.dtype)
+
+
+def qwen3_qk_rope_and_unified_kv_cache_update_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_out: torch.Tensor,
+    k_out: torch.Tensor,
+    layer_name: LayerNameType,
+) -> torch.Tensor:
+    return torch.empty(0, device=q.device, dtype=q.dtype)
+
+
+direct_register_custom_op(
+    op_name="musa_qwen3_qk_rope_and_unified_kv_cache_update",
+    op_func=qwen3_qk_rope_and_unified_kv_cache_update_impl,
+    mutates_args=["q_out", "k_out"],
+    fake_impl=qwen3_qk_rope_and_unified_kv_cache_update_fake,
+)
+
+
+FUSED_QWEN3_QK_ROPE_KV_OP = (
+    torch.ops.vllm.musa_qwen3_qk_rope_and_unified_kv_cache_update.default
+)
+
+
+__all__ = ["FUSED_QWEN3_QK_ROPE_KV_OP"]

--- a/vllm_musa/patches/vllm__compilation__backends.patch.py
+++ b/vllm_musa/patches/vllm__compilation__backends.patch.py
@@ -2,7 +2,7 @@
 """MUSA cat-6 object patch for the vLLM compilation backend.
 
 Accept torch.compile backend keyword options on this vLLM snapshot and apply
-the exact Qwen2 RoPE+KV-cache rewrite before vLLM splits the raw FX graph.
+the exact Qwen-family rewrites before vLLM splits the raw FX graph.
 """
 
 from functools import wraps
@@ -74,6 +74,74 @@ def _try_qwen2_rope_kv_presplit(backend, graph) -> int:
     return matched
 
 
+def _try_qwen3_qk_rope_kv_presplit(backend, graph) -> int:
+    vllm_config = getattr(backend, "vllm_config", None)
+    compilation_config = getattr(backend, "compilation_config", None)
+    if vllm_config is None or compilation_config is None:
+        return 0
+
+    from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
+    from vllm_musa.platform import _is_qwen3_qk_rope_kv_fusion_config
+
+    if not _is_qwen3_qk_rope_kv_fusion_config(vllm_config):
+        return 0
+    model_config = getattr(vllm_config, "model_config", None)
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    if hf_text_config is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        hf_text_config = getattr(hf_config, "text_config", hf_config)
+    expected_sites = getattr(hf_text_config, "num_hidden_layers", None)
+    if not isinstance(expected_sites, int) or expected_sites <= 0:
+        logger.warning_once(
+            "MUSA Qwen3 QK-RoPE-KV fusion skipped: missing layer count."
+        )
+        return 0
+    if not presplit.qwen3_qk_rope_kv_backend_supported(vllm_config, expected_sites):
+        logger.warning_once(
+            "MUSA Qwen3 QK-RoPE-KV fusion requires every attention layer "
+            "to use the exact FlashAttention3 BF16/NHD implementation; "
+            "keeping the baseline split graph."
+        )
+        return 0
+
+    splitting_ops = compilation_config.splitting_ops
+    if (
+        compilation_config.use_inductor_graph_partition
+        or splitting_ops is None
+        or presplit.KV_UPDATE_SPLITTING_OP not in splitting_ops
+    ):
+        logger.warning_once(
+            "MUSA Qwen3 QK-RoPE-KV fusion requires the baseline Dynamo "
+            "KV-cache split; keeping the unfused graph."
+        )
+        return 0
+
+    candidates = presplit.plan_qwen3_qk_rope_kv_presplit(graph, expected_sites)
+    if candidates is None:
+        logger.warning_once(
+            "MUSA Qwen3 QK-RoPE-KV fusion did not find the exact all-layer "
+            "raw FX graph; keeping the baseline split graph."
+        )
+        return 0
+    matched = presplit.apply_qwen3_qk_rope_kv_presplit(graph, candidates)
+    if presplit.FUSED_SPLITTING_OP not in splitting_ops:
+        compilation_config.splitting_ops = [
+            *splitting_ops,
+            presplit.FUSED_SPLITTING_OP,
+        ]
+    compilation_config.traced_files.update(
+        {
+            str(Path(__file__).resolve()),
+            str(Path(presplit.__file__).resolve()),
+        }
+    )
+    logger.info_once(
+        "Applied the MUSA Qwen3 QK-RoPE-KV pre-split fusion to %d layers.",
+        matched,
+    )
+    return matched
+
+
 def apply() -> None:
     try:
         from vllm.compilation.backends import VllmBackend
@@ -88,6 +156,7 @@ def apply() -> None:
     @wraps(original_call)
     def call_with_ignored_options(self, graph, example_inputs, **kwargs):
         _try_qwen2_rope_kv_presplit(self, graph)
+        _try_qwen3_qk_rope_kv_presplit(self, graph)
         return original_call(self, graph, example_inputs)
 
     call_with_ignored_options._musa_accepts_backend_options = True

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -257,6 +257,63 @@ def _is_qwen2_rope_kv_fusion_config(vllm_config: Any) -> bool:
     )
 
 
+def _is_qwen3_qk_rope_kv_fusion_config(vllm_config: Any) -> bool:
+    """Return whether config is in the validated dense Qwen3 TP1 scope."""
+    from vllm_musa.utils.environ import envs as musa_envs
+
+    if not musa_envs.VLLM_MUSA_QWEN3_QK_ROPE_KV_FUSION.get():
+        return False
+    model_config = getattr(vllm_config, "model_config", None)
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    if model_config is None or parallel_config is None:
+        return False
+
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    if hf_text_config is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        hf_text_config = getattr(hf_config, "text_config", hf_config)
+    architectures = getattr(model_config, "architectures", None)
+    if architectures is None:
+        architectures = getattr(hf_text_config, "architectures", None)
+
+    cache_config = getattr(vllm_config, "cache_config", None)
+    cache_dtype = getattr(cache_config, "cache_dtype", "auto")
+    cache_block_size = getattr(cache_config, "block_size", None)
+    single_gpu = all(
+        getattr(parallel_config, name, 1) == 1
+        for name in (
+            "tensor_parallel_size",
+            "pipeline_parallel_size",
+            "data_parallel_size",
+            "decode_context_parallel_size",
+        )
+    )
+    exact_geometry = (
+        getattr(hf_text_config, "hidden_size", None),
+        getattr(hf_text_config, "intermediate_size", None),
+        getattr(hf_text_config, "num_hidden_layers", None),
+        getattr(hf_text_config, "num_attention_heads", None),
+        getattr(hf_text_config, "num_key_value_heads", None),
+        getattr(hf_text_config, "head_dim", None),
+    ) in (
+        (1024, 3072, 28, 16, 8, 128),
+        (4096, 12288, 36, 32, 8, 128),
+    )
+    return (
+        tuple(architectures or ()) == ("Qwen3ForCausalLM",)
+        and getattr(hf_text_config, "model_type", None) == "qwen3"
+        and exact_geometry
+        and getattr(model_config, "dtype", None) == torch.bfloat16
+        and getattr(model_config, "quantization", None) in (None, "none")
+        and getattr(vllm_config, "quant_config", None) is None
+        and getattr(vllm_config, "speculative_config", None) is None
+        and cache_dtype in ("auto", "bfloat16", torch.bfloat16)
+        and cache_block_size in (None, 64)
+        and not getattr(model_config, "enforce_eager", False)
+        and single_gpu
+    )
+
+
 def _deepseek_v4_flashmla_sparse_block_size(model_config: Any | None) -> int:
     value = os.getenv(_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_ENV)
     if value is None or not _is_deepseek_v4_model(model_config):

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -96,6 +96,9 @@ class Envs:
     # tensor-layout gates fail closed; the environment switch is an A/B escape
     # hatch rather than a required serving option.
     VLLM_MUSA_QWEN2_ROPE_KV_FUSION = EnvBool(True)
+    # Independent Qwen3 QK-norm + full-RoPE + NHD-cache fusion. Platform and
+    # backend gates restrict it to validated dense Qwen3 configurations.
+    VLLM_MUSA_QWEN3_QK_ROPE_KV_FUSION = EnvBool(True)
 
 
 envs = Envs()

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -1401,6 +1401,114 @@ class FlashAttentionImpl(AttentionImpl):
             and self.kv_sharing_target_layer_name is None
         )
 
+    def qwen3_qk_rope_kvcache_supported(self) -> bool:
+        """Whether this layer is inside the initial dense Qwen3 envelope."""
+        from vllm_musa.utils.environ import envs as musa_envs
+
+        return (
+            musa_envs.VLLM_MUSA_QWEN3_QK_ROPE_KV_FUSION.get()
+            and get_flash_attn_version() == 3
+            and get_kv_cache_layout() == "NHD"
+            and (self.num_heads, self.num_kv_heads) in ((16, 8), (32, 8))
+            and self.head_size == 128
+            and self.attn_type == AttentionType.DECODER
+            and self.kv_cache_dtype in ("auto", "bfloat16", torch.bfloat16)
+            and self.alibi_slopes is None
+            and self.sliding_window == (-1, -1)
+            and not self.logits_soft_cap
+            and self.sinks is None
+            and self.kv_sharing_target_layer_name is None
+        )
+
+    def do_qwen3_qk_rope_and_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        q_weight: torch.Tensor,
+        k_weight: torch.Tensor,
+        positions: torch.Tensor,
+        cos_sin_cache: torch.Tensor,
+        q_out: torch.Tensor,
+        k_out: torch.Tensor,
+        kv_cache: torch.Tensor,
+        layer_slot_mapping: torch.Tensor | None,
+    ) -> None:
+        """Run the exact Qwen3 provider, falling back before cache fusion."""
+        from vllm_musa.jit_kernel.csrc.norm import (
+            fused_qk_rmsnorm_mrope_cache_out,
+        )
+
+        positions_3d = (
+            positions
+            if positions.dim() == 2
+            else positions.unsqueeze(0).expand(3, -1)
+        )
+        can_fuse_cache = (
+            layer_slot_mapping is not None
+            and layer_slot_mapping.shape[0] == q.shape[0]
+            and get_kv_cache_layout() == "NHD"
+        )
+        if can_fuse_cache:
+            key_cache, value_cache = kv_cache.unbind(0)
+            expected_tail = (self.num_kv_heads, self.head_size)
+            flat_cache_supported = (
+                key_cache.is_contiguous()
+                and value_cache.is_contiguous()
+                and tuple(key_cache.shape[-2:]) == expected_tail
+                and tuple(value_cache.shape[-2:]) == expected_tail
+            )
+            if flat_cache_supported:
+                fused_qk_rmsnorm_mrope_cache_out(
+                    q,
+                    k,
+                    v,
+                    q_weight,
+                    k_weight,
+                    positions_3d,
+                    cos_sin_cache,
+                    q_out,
+                    k_out,
+                    key_cache.view(-1, self.num_kv_heads * self.head_size),
+                    value_cache.view(-1, self.num_kv_heads * self.head_size),
+                    layer_slot_mapping,
+                    True,
+                    64,
+                    0,
+                    0,
+                    False,
+                    1e-6,
+                    False,
+                )
+                return
+
+        torch.ops.vllm.musa_csrc_fused_qk_rmsnorm_mrope(
+            q,
+            k,
+            q_weight,
+            k_weight,
+            positions_3d,
+            cos_sin_cache,
+            q_out,
+            k_out,
+            True,
+            64,
+            0,
+            0,
+            False,
+            1e-6,
+            False,
+        )
+        if layer_slot_mapping is not None:
+            self.do_kv_cache_update(
+                layer,
+                k_out,
+                v,
+                kv_cache,
+                layer_slot_mapping,
+            )
+
     def do_rope_and_kv_cache_update(
         self,
         layer: torch.nn.Module,


### PR DESCRIPTION
## Summary

- add an exact-gated Qwen3 fusion for 2x RMSNorm + full NeoX RoPE + NHD KV-cache update
- rewrite the four-op region to one custom op before graph splitting and keep attention ordering through the existing dummy dependency
- support the validated dense BF16 Qwen3-0.6B and Qwen3-8B shapes on S5000/FA3; the feature is enabled by default with an environment escape hatch
- fail closed for other architectures, shapes, dtypes, cache layouts, eager mode, quantization, speculative decoding, TP > 1, and incomplete graph matches
- guard all cache writes for negative slot mappings while still producing Q/K outputs for padded graph slots

Qwen3.5/Qwen3.6 are intentionally not attached here. Their current path already fuses QK norm with MRoPE, and the tested cache-out extension was neutral or regressive at decode T=1.

## S5000 performance

Single isolated S5000, BF16, FA3, VLLM_COMPILE, FULL_AND_PIECEWISE, FULL CUDAGraph, batch 1, input 32, output 128, 5 warmups + 20 measured iterations per run, A/B/A/B:

| Model | Fusion off mean | Fusion on mean | End-to-end latency |
|---|---:|---:|---:|
| Qwen3-0.6B | 0.642264 s | 0.608957 s | -5.19% |
| Qwen3-8B | 1.982800 s | 1.933795 s | -2.47% |

The pass matched all expected sites: 28/28 for Qwen3-0.6B and 36/36 for Qwen3-8B.

## Validation

- focused platform/backend/FX/source/kernel/wrapper tests: 4 + 5 + 17 passed
- mixed pytest collection order regression: 8 passed
- Qwen3-0.6B and Qwen3-8B default-on semantic smokes returned Paris
- both semantic smokes selected FA3 and completed VLLM_COMPILE + FULL CUDAGraph capture
- Qwen3.5-2B negative control completed compiled capture and semantic generation without the Qwen3 fusion in its splitting/apply logs
- DeepSeek-V2-Lite negative control completed semantic generation on FlashMLA with the Qwen3 gate inactive
- negative-slot hardware coverage: Q16/KV8 and Q32/KV8, int32/int64 slot mappings, mixed valid and -1 entries
- local diff check, Ruff, format check for new/touched standalone files, and Python compile checks passed

## Notes

- The fusion only changes vllm-musa. vllm-omni remains an integration validation path and is not imported or overridden.
- A broader touched-file test run had 136 passes, 2 skips, and 3 unrelated existing failures in FP8 fallback and patch-payload checks; this PR does not claim a full-suite pass.
- The full model regression matrix is not claimed in this draft: dense Qwen3 and DeepSeek Lite/FlashMLA controls pass, while the Qwen MoE row was not run because no small one-card checkpoint was staged in the isolated container.
