### PR TITLE
[MUSA-60042] Bypass FA3 scheduler for batch-one Qwen decode

### DIFF
--- a/tests/jit_kernel/test_fa3_metadata.py
+++ b/tests/jit_kernel/test_fa3_metadata.py
@@ -2,50 +2,93 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from vllm_musa.jit_kernel import fa3_metadata
 
 
-def test_qwen_fa3_scheduler_lookup_builder_direct_and_fallback(monkeypatch):
-    from types import SimpleNamespace
-
-    from vllm_musa.v1.attention.backends import flash_attn
-
+def _make_builder(flash_attn):
     builder = object.__new__(flash_attn.FlashAttentionMetadataBuilder)
+    builder.device = torch.device("cpu")
     builder.dcp_world_size = 1
     builder.dcp_rank = 0
     builder.cp_kv_cache_interleave_size = 1
     builder.reorder_batch_threshold = 1
     builder.use_full_cuda_graph = True
-    builder.max_cudagraph_size = 2
+    builder.max_cudagraph_size = 8
     builder.max_num_splits = 32
     builder.aot_schedule = True
     builder.aot_sliding_window = (-1, -1)
     builder._sm_count = 60
     builder._sm_count_query_succeeded = True
     builder._use_qwen_single_request_scheduler_lookup = True
-    builder._cu_seqlens_k_buffer = torch.zeros(2, dtype=torch.int32)
-    builder.scheduler_metadata = torch.full((17,), -1, dtype=torch.int32)
+    builder._cu_seqlens_k_buffer = torch.zeros(9, dtype=torch.int32)
+    builder.scheduler_metadata = torch.full((33,), -1, dtype=torch.int32)
     builder.num_heads_q = 16
     builder.num_heads_kv = 8
     builder.headdim = 128
     builder.block_size = 64
     builder.kv_cache_dtype = torch.bfloat16
     builder.cache_config = SimpleNamespace(cache_dtype="auto")
+    return builder
 
-    common_metadata = SimpleNamespace(
-        num_reqs=1,
-        num_actual_tokens=1,
-        max_query_len=1,
-        max_seq_len=128,
-        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
-        seq_lens=torch.tensor([128], dtype=torch.int32),
-        block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
-        slot_mapping=torch.zeros(1, dtype=torch.int64),
-        causal=True,
+
+def _make_common_metadata(
+    *,
+    num_reqs=1,
+    num_actual_tokens=1,
+    max_query_len=1,
+    max_seq_len=128,
+    causal=True,
+):
+    query_lens = [num_actual_tokens // num_reqs] * num_reqs
+    for index in range(num_actual_tokens % num_reqs):
+        query_lens[index] += 1
+    query_start_loc = [0]
+    for query_len in query_lens:
+        query_start_loc.append(query_start_loc[-1] + query_len)
+
+    return SimpleNamespace(
+        num_reqs=num_reqs,
+        num_actual_tokens=num_actual_tokens,
+        max_query_len=max_query_len,
+        max_seq_len=max_seq_len,
+        query_start_loc=torch.tensor(query_start_loc, dtype=torch.int32),
+        seq_lens=torch.full((num_reqs,), max_seq_len, dtype=torch.int32),
+        block_table_tensor=torch.zeros((num_reqs, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(num_actual_tokens, dtype=torch.int64),
+        causal=causal,
     )
+
+
+def _make_lookup_config(*, model_type="qwen3", tensor_parallel_size=1):
+    architecture = "Qwen3ForCausalLM" if model_type == "qwen3" else "LlamaForCausalLM"
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                model_type=model_type,
+                architectures=[architecture],
+            ),
+            architectures=[architecture],
+        ),
+        scheduler_config=SimpleNamespace(max_num_seqs=8),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=tensor_parallel_size,
+            decode_context_parallel_size=1,
+            pipeline_parallel_size=1,
+        ),
+        speculative_config=None,
+    )
+
+
+def test_qwen_fa3_scheduler_lookup_builder_direct_and_fallback(monkeypatch):
+    from vllm_musa.v1.attention.backends import flash_attn
+
+    builder = _make_builder(flash_attn)
+    common_metadata = _make_common_metadata()
     monkeypatch.setattr(
         flash_attn,
         "split_decodes_and_prefills",
@@ -123,6 +166,190 @@ def test_qwen_fa3_scheduler_lookup_builder_direct_and_fallback(monkeypatch):
     builder.build(0, common_metadata)
     assert not direct_calls
     assert len(mate_calls) == 1
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            {"builder": {"_use_qwen_single_request_scheduler_lookup": False}},
+            id="config-disabled",
+        ),
+        pytest.param({"lookup_config": {"model_type": "llama"}}, id="non-qwen-config"),
+        pytest.param(
+            {"lookup_config": {"tensor_parallel_size": 2}},
+            id="tensor-parallel-config",
+        ),
+        pytest.param({"builder": {"use_full_cuda_graph": False}}, id="no-full-graph"),
+        pytest.param(
+            {"builder": {"aot_schedule": False}, "mate_calls": 0},
+            id="aot-schedule-disabled",
+        ),
+        pytest.param({"fast_build": True, "mate_calls": 0}, id="fast-build"),
+        pytest.param(
+            {"builder": {"_cu_seqlens_k_buffer": None}},
+            id="missing-cu-seqlens-buffer",
+        ),
+        pytest.param(
+            {
+                "metadata": {"num_reqs": 2, "num_actual_tokens": 2},
+                "split": (2, 0, 2, 0),
+            },
+            id="multi-request",
+        ),
+        pytest.param({"split": (0, 1, 0, 1)}, id="prefill"),
+        pytest.param(
+            {
+                "metadata": {"num_actual_tokens": 2},
+                "split": (1, 0, 2, 0),
+            },
+            id="multi-token-decode",
+        ),
+        pytest.param(
+            {"metadata": {"max_query_len": 2}},
+            id="max-query-len",
+        ),
+        pytest.param(
+            {"metadata": {"max_seq_len": 0}},
+            id="zero-sequence-length",
+        ),
+        pytest.param(
+            {"metadata": {"max_seq_len": 4097}},
+            id="sequence-too-long",
+        ),
+        pytest.param({"metadata": {"causal": False}}, id="non-causal"),
+        pytest.param(
+            {"builder": {"aot_sliding_window": (127, 0)}},
+            id="sliding-window",
+        ),
+        pytest.param(
+            {"common_prefix_len": 64, "mate_calls": 2},
+            id="cascade",
+        ),
+        pytest.param(
+            {"builder": {"dcp_world_size": 2}},
+            id="decode-context-parallel",
+        ),
+        pytest.param(
+            {"builder": {"_sm_count_query_succeeded": False}},
+            id="mp-query-failed",
+        ),
+        pytest.param({"builder": {"_sm_count": 56}}, id="wrong-mp-count"),
+        pytest.param(
+            {"builder": {"max_cudagraph_size": 0}},
+            id="zero-split-budget",
+        ),
+        pytest.param(
+            {"builder": {"max_num_splits": 7}, "direct_calls": 1},
+            id="unsupported-exact-split-count",
+        ),
+        pytest.param({"builder": {"num_heads_kv": 33}}, id="too-many-kv-heads"),
+        pytest.param(
+            {"builder": {"num_heads_q": 15}},
+            id="non-integral-gqa-ratio",
+        ),
+        pytest.param({"builder": {"num_heads_q": 0}}, id="zero-gqa-ratio"),
+        pytest.param(
+            {"builder": {"num_heads_q": 64, "num_heads_kv": 1}},
+            id="gqa-ratio-too-large",
+        ),
+        pytest.param({"builder": {"headdim": 256}}, id="unsupported-head-dim"),
+        pytest.param({"builder": {"block_size": 128}}, id="unsupported-page-size"),
+        pytest.param(
+            {"builder": {"kv_cache_dtype": torch.float16}},
+            id="non-bf16-kv-cache",
+        ),
+        pytest.param(
+            {
+                "builder": {"num_heads_q": 24, "num_heads_kv": 4},
+                "direct_calls": 1,
+            },
+            id="unsupported-exact-geometry",
+        ),
+    ],
+)
+def test_qwen_fa3_scheduler_lookup_runtime_gate_fallback(monkeypatch, case):
+    from vllm_musa.v1.attention.backends import flash_attn
+
+    builder = _make_builder(flash_attn)
+    for name, value in case.get("builder", {}).items():
+        setattr(builder, name, value)
+
+    lookup_config = case.get("lookup_config")
+    if lookup_config is not None:
+        builder._use_qwen_single_request_scheduler_lookup = (
+            flash_attn._is_qwen_family_scheduler_lookup_base_config(
+                _make_lookup_config(**lookup_config)
+            )
+        )
+
+    common_metadata = _make_common_metadata(**case.get("metadata", {}))
+    split_result = case.get("split", (1, 0, 1, 0))
+    monkeypatch.setattr(
+        flash_attn,
+        "split_decodes_and_prefills",
+        lambda *_args, **_kwargs: split_result,
+    )
+    monkeypatch.setattr(
+        flash_attn,
+        "get_dcp_local_seq_lens",
+        lambda seq_lens, *_args, **_kwargs: seq_lens,
+    )
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "0")
+
+    direct_calls = []
+    mate_calls = []
+
+    def reject_direct_builder(
+        _seq_lens,
+        _cu_seqlens_k,
+        _scheduler_dst,
+        max_seq_len,
+        num_heads_q,
+        num_heads_kv,
+        head_dim,
+        max_num_splits,
+    ):
+        direct_calls.append(
+            (max_seq_len, num_heads_q, num_heads_kv, head_dim, max_num_splits)
+        )
+        assert not fa3_metadata._supports_qwen_fa3_scheduler_geometry(
+            max_seq_len,
+            num_heads_q,
+            num_heads_kv,
+            head_dim,
+            max_num_splits,
+        )
+        return False
+
+    def mate_builder(**kwargs):
+        mate_calls.append(kwargs)
+        return torch.arange(16, dtype=torch.int32)
+
+    monkeypatch.setattr(
+        fa3_metadata,
+        "try_build_qwen_single_request_fa3_metadata",
+        reject_direct_builder,
+    )
+    monkeypatch.setattr(
+        flash_attn,
+        "get_scheduler_metadata",
+        mate_builder,
+        raising=False,
+    )
+
+    result = builder.build(
+        case.get("common_prefix_len", 0),
+        common_metadata,
+        fast_build=case.get("fast_build", False),
+    )
+
+    assert len(direct_calls) == case.get("direct_calls", 0)
+    assert len(mate_calls) == case.get("mate_calls", 1)
+    if mate_calls:
+        assert result.scheduler_metadata.tolist() == list(range(16))
+    else:
+        assert result.scheduler_metadata is None
 
 
 def test_qwen_single_request_fa3_scheduler_lookup_support_gate():

--- a/tests/jit_kernel/test_fa3_metadata.py
+++ b/tests/jit_kernel/test_fa3_metadata.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm_musa.jit_kernel import fa3_metadata
+
+
+def test_qwen_fa3_scheduler_lookup_builder_direct_and_fallback(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_musa.v1.attention.backends import flash_attn
+
+    builder = object.__new__(flash_attn.FlashAttentionMetadataBuilder)
+    builder.dcp_world_size = 1
+    builder.dcp_rank = 0
+    builder.cp_kv_cache_interleave_size = 1
+    builder.reorder_batch_threshold = 1
+    builder.use_full_cuda_graph = True
+    builder.max_cudagraph_size = 2
+    builder.max_num_splits = 32
+    builder.aot_schedule = True
+    builder.aot_sliding_window = (-1, -1)
+    builder._sm_count = 60
+    builder._sm_count_query_succeeded = True
+    builder._use_qwen_single_request_scheduler_lookup = True
+    builder._cu_seqlens_k_buffer = torch.zeros(2, dtype=torch.int32)
+    builder.scheduler_metadata = torch.full((17,), -1, dtype=torch.int32)
+    builder.num_heads_q = 16
+    builder.num_heads_kv = 8
+    builder.headdim = 128
+    builder.block_size = 64
+    builder.kv_cache_dtype = torch.bfloat16
+    builder.cache_config = SimpleNamespace(cache_dtype="auto")
+
+    common_metadata = SimpleNamespace(
+        num_reqs=1,
+        num_actual_tokens=1,
+        max_query_len=1,
+        max_seq_len=128,
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([128], dtype=torch.int32),
+        block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(1, dtype=torch.int64),
+        causal=True,
+    )
+    monkeypatch.setattr(
+        flash_attn,
+        "split_decodes_and_prefills",
+        lambda *_args, **_kwargs: (1, 0, 1, 0),
+    )
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "0")
+
+    direct_enabled = True
+    direct_calls = []
+    mate_calls = []
+
+    def direct_builder(seq_lens, cu_seqlens_k, scheduler_dst, *args):
+        direct_calls.append((seq_lens.clone(), args))
+        if not direct_enabled:
+            return False
+        scheduler_dst.zero_()
+        scheduler_dst[0] = 2
+        scheduler_dst[8] = 1
+        scheduler_dst[12] = 8
+        cu_seqlens_k.copy_(torch.tensor([0, 128], dtype=torch.int32))
+        return True
+
+    def mate_builder(**_kwargs):
+        mate_calls.append(True)
+        return torch.arange(16, dtype=torch.int32)
+
+    monkeypatch.setattr(
+        fa3_metadata,
+        "try_build_qwen_single_request_fa3_metadata",
+        direct_builder,
+    )
+    monkeypatch.setattr(
+        flash_attn,
+        "get_scheduler_metadata",
+        mate_builder,
+        raising=False,
+    )
+
+    direct_result = builder.build(0, common_metadata)
+    assert len(direct_calls) == 1
+    assert direct_calls[0][1] == (128, 16, 8, 128, 8)
+    assert not mate_calls
+    assert direct_result.scheduler_metadata.tolist() == [
+        2,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        8,
+        0,
+        0,
+        0,
+    ]
+    assert direct_result.cu_seqlens_k.tolist() == [0, 128]
+
+    direct_enabled = False
+    direct_calls.clear()
+    fallback_result = builder.build(0, common_metadata)
+    assert len(direct_calls) == 1
+    assert len(mate_calls) == 1
+    assert fallback_result.scheduler_metadata.tolist() == list(range(16))
+    assert fallback_result.cu_seqlens_k.tolist() == [0, 128]
+    assert builder.scheduler_metadata[16].item() == 0
+
+    builder._sm_count = 56
+    direct_calls.clear()
+    mate_calls.clear()
+    builder.build(0, common_metadata)
+    assert not direct_calls
+    assert len(mate_calls) == 1
+
+
+def test_qwen_single_request_fa3_scheduler_lookup_support_gate():
+    seq_lens = torch.zeros(1, dtype=torch.int32)
+    cu_seqlens_k = torch.zeros(2, dtype=torch.int32)
+    scheduler_dst = torch.zeros(17, dtype=torch.int32)
+
+    assert fa3_metadata._supports_qwen_fa3_scheduler_geometry(4096, 16, 8, 128, 8)
+    assert not fa3_metadata._supports_qwen_fa3_scheduler_geometry(4097, 16, 8, 128, 8)
+    assert not fa3_metadata._supports_qwen_fa3_scheduler_geometry(128, 16, 8, 256, 8)
+    assert not fa3_metadata._supports_qwen_fa3_scheduler_geometry(128, 8, 2, 256, 30)
+    assert not fa3_metadata._supports_qwen_fa3_scheduler_geometry(128, 24, 25, 128, 3)
+    assert not fa3_metadata._supports_qwen_fa3_scheduler_geometry(128, 16, 8, 128, 7)
+
+    # Tensor support must fail closed away from a real MUSA device.
+    assert not fa3_metadata.supports_qwen_single_request_fa3_scheduler_lookup(
+        seq_lens, cu_seqlens_k, scheduler_dst, 128, 16, 8, 128, 8
+    )
+
+
+def test_qwen_single_request_fa3_scheduler_lookup_launches_once(monkeypatch):
+    launches = []
+
+    class FakeKernel:
+        def __getitem__(self, grid):
+            def launch(*args, **kwargs):
+                launches.append((grid, args, kwargs))
+
+            return launch
+
+    monkeypatch.setattr(
+        fa3_metadata,
+        "_build_qwen_single_request_fa3_metadata_kernel",
+        FakeKernel(),
+    )
+    monkeypatch.setattr(
+        fa3_metadata,
+        "supports_qwen_single_request_fa3_scheduler_lookup",
+        lambda *args: True,
+    )
+    seq_lens = torch.zeros(1, dtype=torch.int32)
+    cu_seqlens_k = torch.zeros(2, dtype=torch.int32)
+    scheduler_dst = torch.zeros(513, dtype=torch.int32)
+
+    assert fa3_metadata.try_build_qwen_single_request_fa3_metadata(
+        seq_lens, cu_seqlens_k, scheduler_dst, 128, 16, 8, 128, 8
+    )
+    assert len(launches) == 1
+    assert launches[0][0] == (3,)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch, "musa") and torch.musa.is_available()),
+    reason="requires a MUSA device",
+)
+@pytest.mark.parametrize(
+    ("num_heads_q", "num_heads_kv", "head_dim"),
+    [
+        (12, 2, 128),
+        (14, 2, 64),
+        (16, 2, 128),
+        (16, 8, 128),
+        (28, 4, 128),
+        (32, 4, 128),
+        (32, 8, 128),
+        (40, 8, 128),
+        (64, 4, 128),
+        (64, 8, 128),
+    ],
+)
+@pytest.mark.parametrize("seq_len", [1, 64, 65, 384, 385, 4096])
+def test_qwen_single_request_fa3_scheduler_lookup_values(
+    seq_len,
+    num_heads_q,
+    num_heads_kv,
+    head_dim,
+):
+    from vllm_musa.v1.attention.backends.fa_utils import get_scheduler_metadata
+
+    max_num_splits = (60 + num_heads_kv - 1) // num_heads_kv
+    seq_lens = torch.tensor([seq_len], dtype=torch.int32, device="musa")
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device="musa")
+    cu_seqlens_k = torch.full((2,), -1, dtype=torch.int32, device="musa")
+    scheduler_dst = torch.full((513,), -1, dtype=torch.int32, device="musa")
+    reference = get_scheduler_metadata(
+        batch_size=1,
+        max_seqlen_q=1,
+        max_seqlen_k=seq_len,
+        num_heads_q=num_heads_q,
+        num_heads_kv=num_heads_kv,
+        headdim=head_dim,
+        cache_seqlens=seq_lens,
+        qkv_dtype=torch.bfloat16,
+        cu_seqlens_q=cu_seqlens_q,
+        page_size=64,
+        causal=True,
+        window_size=(-1, -1),
+        num_splits=max_num_splits,
+    )
+
+    assert fa3_metadata.try_build_qwen_single_request_fa3_metadata(
+        seq_lens,
+        cu_seqlens_k,
+        scheduler_dst,
+        seq_len,
+        num_heads_q,
+        num_heads_kv,
+        head_dim,
+        max_num_splits,
+    )
+    torch.musa.synchronize()
+
+    semantic_indices = [0, 4, 8, 12]
+    candidate_values = scheduler_dst[:16].cpu().tolist()
+    reference_values = reference.cpu().tolist()
+    assert [candidate_values[index] for index in semantic_indices] == [
+        reference_values[index] for index in semantic_indices
+    ]
+    assert all(
+        value == 0
+        for index, value in enumerate(candidate_values)
+        if index not in semantic_indices
+    )
+    assert torch.count_nonzero(scheduler_dst[16:]).item() == 0
+    assert cu_seqlens_k.cpu().tolist() == [0, seq_len]

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -409,6 +409,10 @@ class TestMUSAPlatformBase:
         versions["mate"] = "0.2.5"
         assert not flash_attn._has_supported_fa3_scheduler_layout()
 
+        versions["mate"] = "0.2.4"
+        versions["flash_attn_3"] = "0.2.4+custom"
+        assert not flash_attn._has_supported_fa3_scheduler_layout()
+
         def missing_package(_package):
             raise PackageNotFoundError
 

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -391,11 +391,11 @@ class TestMUSAPlatformBase:
                 make_config("qwen3", "Qwen3ForCausalLM")
             )
 
-    def test_qwen_fa3_scheduler_lookup_default_off(self, monkeypatch):
+    def test_qwen_fa3_scheduler_lookup_default_on(self, monkeypatch):
         from vllm_musa.utils.environ import envs
 
         monkeypatch.delenv("VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP", raising=False)
-        assert envs.VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP.get() is False
+        assert envs.VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP.get() is True
 
     def test_qwen_fa3_scheduler_lookup_layout_version_gate(self, monkeypatch):
         from importlib.metadata import PackageNotFoundError

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -291,15 +291,129 @@ class TestMUSAPlatformBase:
             )
             config = make_config("qwen2", 2, 4864)
             assert _is_qwen2_rope_kv_fusion_config(config)
-            config.cache_config = SimpleNamespace(
-                cache_dtype="bfloat16", block_size=64
-            )
+            config.cache_config = SimpleNamespace(cache_dtype="bfloat16", block_size=64)
             assert _is_qwen2_rope_kv_fusion_config(config)
             config.cache_config.block_size = 128
             assert not _is_qwen2_rope_kv_fusion_config(config)
             config.cache_config.block_size = 64
             config.quant_config = object()
             assert not _is_qwen2_rope_kv_fusion_config(config)
+
+    def test_qwen_fa3_scheduler_lookup_config_gate(self):
+        from vllm_musa.utils.environ import envs
+        from vllm_musa.v1.attention.backends.flash_attn import (
+            _is_qwen_family_scheduler_lookup_config,
+        )
+
+        def make_config(
+            model_type: str,
+            architecture: str,
+            *,
+            max_num_seqs: int = 1,
+            speculative_config=None,
+            pipeline_parallel_size: int = 1,
+            decode_context_parallel_size: int = 1,
+            tensor_parallel_size: int = 1,
+        ):
+            return SimpleNamespace(
+                model_config=SimpleNamespace(
+                    hf_text_config=SimpleNamespace(
+                        model_type=model_type,
+                        architectures=[architecture],
+                    ),
+                    architectures=[architecture],
+                ),
+                scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
+                parallel_config=SimpleNamespace(
+                    tensor_parallel_size=tensor_parallel_size,
+                    pipeline_parallel_size=pipeline_parallel_size,
+                    decode_context_parallel_size=decode_context_parallel_size,
+                ),
+                speculative_config=speculative_config,
+            )
+
+        with envs.VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP.override(True):
+            assert _is_qwen_family_scheduler_lookup_config(
+                make_config("qwen3", "Qwen3ForCausalLM")
+            )
+            assert _is_qwen_family_scheduler_lookup_config(
+                make_config("qwen2", "Qwen2ForCausalLM")
+            )
+            assert _is_qwen_family_scheduler_lookup_config(
+                make_config("cosyvoice3", "CosyVoice3ForConditionalGeneration")
+            )
+            assert _is_qwen_family_scheduler_lookup_config(
+                make_config("qwen2", "Qwen2ForCausalLM", max_num_seqs=8)
+            )
+            assert not _is_qwen_family_scheduler_lookup_config(
+                make_config("llama", "LlamaForCausalLM")
+            )
+            assert not _is_qwen_family_scheduler_lookup_config(
+                make_config("deepseek_v3", "DeepseekV3ForCausalLM")
+            )
+            assert not _is_qwen_family_scheduler_lookup_config(
+                make_config("qwen3", "Qwen3ForCausalLM", max_num_seqs=0)
+            )
+            assert not _is_qwen_family_scheduler_lookup_config(
+                make_config(
+                    "qwen3",
+                    "Qwen3ForCausalLM",
+                    speculative_config=object(),
+                )
+            )
+            assert not _is_qwen_family_scheduler_lookup_config(
+                make_config(
+                    "qwen3",
+                    "Qwen3ForCausalLM",
+                    decode_context_parallel_size=2,
+                )
+            )
+            assert not _is_qwen_family_scheduler_lookup_config(
+                make_config(
+                    "qwen3",
+                    "Qwen3ForCausalLM",
+                    tensor_parallel_size=2,
+                )
+            )
+            incomplete_parallel_config = make_config("qwen3", "Qwen3ForCausalLM")
+            del incomplete_parallel_config.parallel_config.pipeline_parallel_size
+            assert not _is_qwen_family_scheduler_lookup_config(
+                incomplete_parallel_config
+            )
+            incomplete_scheduler_config = make_config("qwen3", "Qwen3ForCausalLM")
+            del incomplete_scheduler_config.scheduler_config.max_num_seqs
+            assert not _is_qwen_family_scheduler_lookup_config(
+                incomplete_scheduler_config
+            )
+
+        with envs.VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP.override(False):
+            assert not _is_qwen_family_scheduler_lookup_config(
+                make_config("qwen3", "Qwen3ForCausalLM")
+            )
+
+    def test_qwen_fa3_scheduler_lookup_default_off(self, monkeypatch):
+        from vllm_musa.utils.environ import envs
+
+        monkeypatch.delenv("VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP", raising=False)
+        assert envs.VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP.get() is False
+
+    def test_qwen_fa3_scheduler_lookup_layout_version_gate(self, monkeypatch):
+        from importlib.metadata import PackageNotFoundError
+
+        from vllm_musa.v1.attention.backends import flash_attn
+
+        versions = {"mate": "0.2.4", "flash_attn_3": "0.2.4+musa"}
+        monkeypatch.setattr(flash_attn, "version", versions.__getitem__)
+        assert flash_attn._has_supported_fa3_scheduler_layout()
+
+        versions["mate"] = "0.2.5"
+        assert not flash_attn._has_supported_fa3_scheduler_layout()
+
+        def missing_package(_package):
+            raise PackageNotFoundError
+
+        monkeypatch.setattr(flash_attn, "version", missing_package)
+        assert not flash_attn._has_supported_fa3_scheduler_layout()
 
     def test_supports_fp8_for_musa_3_1(self):
         """Test that FP8 is supported on MUSA capability 3.1."""

--- a/vllm_musa/jit_kernel/fa3_metadata.py
+++ b/vllm_musa/jit_kernel/fa3_metadata.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Direct single-request FA3 metadata preparation for MUSA."""
+
+from __future__ import annotations
+
+import torch
+from vllm.triton_utils import tl, triton
+
+_BLOCK_SIZE = 256
+_SINGLE_REQUEST_SCHEDULER_SIZE = 16
+_SUPPORTED_QWEN_GEOMETRIES = frozenset(
+    {
+        (12, 2, 128),
+        (14, 2, 64),
+        (16, 2, 128),
+        (16, 8, 128),
+        (28, 4, 128),
+        (32, 4, 128),
+        (32, 8, 128),
+        (40, 8, 128),
+        (64, 4, 128),
+        (64, 8, 128),
+    }
+)
+
+
+@triton.jit
+def _build_qwen_single_request_fa3_metadata_kernel(
+    seq_lens_ptr,
+    cu_seqlens_k_ptr,
+    scheduler_dst_ptr,
+    scheduler_dst_size,
+    NUM_HEADS_KV: tl.constexpr,
+    MAX_NUM_SPLITS: tl.constexpr,
+    MAX_KV_BLOCKS_IN_L2: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    seq_len = tl.load(seq_lens_ptr)
+    safe_seq_len = tl.where(seq_len > 0, seq_len, 1)
+
+    # Batch-one specialization of the MATE 0.2.4 metadata scheduler. Runtime
+    # gates fix BF16, causal decode, TileN/page size 64, pack-GQA and 60 active
+    # MPs. In this envelope num_m_blocks is one and global split-budget
+    # reduction is a no-op.
+    num_n_blocks = (safe_seq_len + 63) // 64
+    # MATE uses ceilf(n_blocks * 1.1f * nheads / 60). The host gate limits
+    # n_blocks to 64 and KV heads to 2/4/8, where this rational form is exactly
+    # equivalent and avoids backend-dependent float rounding in Triton.
+    blocks_per_mp = (num_n_blocks * 11 * NUM_HEADS_KV + 599) // 600
+    split_count = (num_n_blocks + blocks_per_mp - 1) // blocks_per_mp
+    split_count = tl.where(
+        split_count <= MAX_NUM_SPLITS,
+        split_count,
+        MAX_NUM_SPLITS,
+    )
+    split_n_blocks = (num_n_blocks + split_count - 1) // split_count
+    num_nheads_in_l2 = tl.where(
+        split_n_blocks * 16 <= MAX_KV_BLOCKS_IN_L2,
+        16,
+        tl.where(
+            split_n_blocks * 8 <= MAX_KV_BLOCKS_IN_L2,
+            8,
+            tl.where(
+                split_n_blocks * 4 <= MAX_KV_BLOCKS_IN_L2,
+                4,
+                tl.where(
+                    split_n_blocks * 2 <= MAX_KV_BLOCKS_IN_L2,
+                    2,
+                    1,
+                ),
+            ),
+        ),
+    )
+    num_nheads_in_l2 = tl.where(
+        num_nheads_in_l2 <= NUM_HEADS_KV,
+        num_nheads_in_l2,
+        NUM_HEADS_KV,
+    )
+    scheduler_values = tl.zeros((BLOCK_SIZE,), dtype=tl.int32)
+    scheduler_values = tl.where(offsets == 0, split_count, scheduler_values)
+    # The four batch-one fields start at 0, 4, 8 and 12 after b is rounded
+    # up to four. batch_table[0] is zero and is already covered by the fill.
+    scheduler_values = tl.where(offsets == 8, 1, scheduler_values)
+    scheduler_values = tl.where(
+        offsets == 12,
+        num_nheads_in_l2,
+        scheduler_values,
+    )
+    tl.store(
+        scheduler_dst_ptr + offsets,
+        scheduler_values,
+        mask=offsets < scheduler_dst_size,
+    )
+
+    cu_values = tl.where(offsets == 0, 0, safe_seq_len)
+    tl.store(
+        cu_seqlens_k_ptr + offsets,
+        cu_values,
+        mask=(tl.program_id(0) == 0) & (offsets < 2),
+    )
+
+
+def _supports_qwen_fa3_scheduler_geometry(
+    max_seq_len: int,
+    num_heads_q: int,
+    num_heads_kv: int,
+    head_dim: int,
+    max_num_splits: int,
+) -> bool:
+    return (
+        1 <= max_seq_len <= 4096
+        and (num_heads_q, num_heads_kv, head_dim) in _SUPPORTED_QWEN_GEOMETRIES
+        and max_num_splits == (60 + num_heads_kv - 1) // num_heads_kv
+    )
+
+
+def supports_qwen_single_request_fa3_scheduler_lookup(
+    seq_lens: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    scheduler_dst: torch.Tensor,
+    max_seq_len: int,
+    num_heads_q: int,
+    num_heads_kv: int,
+    head_dim: int,
+    max_num_splits: int,
+) -> bool:
+    tensors = (seq_lens, cu_seqlens_k, scheduler_dst)
+    return (
+        _supports_qwen_fa3_scheduler_geometry(
+            max_seq_len,
+            num_heads_q,
+            num_heads_kv,
+            head_dim,
+            max_num_splits,
+        )
+        and seq_lens.device.type == "musa"
+        and all(tensor.dtype == torch.int32 for tensor in tensors)
+        and all(tensor.device == seq_lens.device for tensor in tensors)
+        and all(tensor.is_contiguous() for tensor in tensors)
+        and seq_lens.numel() == 1
+        and cu_seqlens_k.numel() == 2
+        and scheduler_dst.numel() >= _SINGLE_REQUEST_SCHEDULER_SIZE
+    )
+
+
+def try_build_qwen_single_request_fa3_metadata(
+    seq_lens: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    scheduler_dst: torch.Tensor,
+    max_seq_len: int,
+    num_heads_q: int,
+    num_heads_kv: int,
+    head_dim: int,
+    max_num_splits: int,
+) -> bool:
+    """Build the exact-gated batch-one FA3 schedule and cu_seqlens_k."""
+    if not supports_qwen_single_request_fa3_scheduler_lookup(
+        seq_lens,
+        cu_seqlens_k,
+        scheduler_dst,
+        max_seq_len,
+        num_heads_q,
+        num_heads_kv,
+        head_dim,
+        max_num_splits,
+    ):
+        return False
+
+    grid = (triton.cdiv(scheduler_dst.numel(), _BLOCK_SIZE),)
+    _build_qwen_single_request_fa3_metadata_kernel[grid](
+        seq_lens,
+        cu_seqlens_k,
+        scheduler_dst,
+        scheduler_dst.numel(),
+        NUM_HEADS_KV=num_heads_kv,
+        MAX_NUM_SPLITS=max_num_splits,
+        MAX_KV_BLOCKS_IN_L2=96 if head_dim == 64 else 48,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return True
+
+
+__all__ = [
+    "supports_qwen_single_request_fa3_scheduler_lookup",
+    "try_build_qwen_single_request_fa3_metadata",
+]

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -96,6 +96,9 @@ class Envs:
     # tensor-layout gates fail closed; the environment switch is an A/B escape
     # hatch rather than a required serving option.
     VLLM_MUSA_QWEN2_ROPE_KV_FUSION = EnvBool(True)
+    # Direct batch-one Qwen FA3 scheduler metadata, with exact backend gates
+    # for the supported model geometry and decode shape.
+    VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP = EnvBool(False)
 
 
 envs = Envs()

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -97,8 +97,9 @@ class Envs:
     # hatch rather than a required serving option.
     VLLM_MUSA_QWEN2_ROPE_KV_FUSION = EnvBool(True)
     # Direct batch-one Qwen FA3 scheduler metadata, with exact backend gates
-    # for the supported model geometry and decode shape.
-    VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP = EnvBool(False)
+    # for the supported model geometry and decode shape.  Keep the environment
+    # switch as an explicit A/B and emergency-disable escape hatch.
+    VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP = EnvBool(True)
 
 
 envs = Envs()

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -5,6 +5,7 @@
 
 import copy
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
 from typing import ClassVar
 
 import numpy as np
@@ -65,6 +66,67 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 logger = init_logger(__name__)
 
 from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+
+
+def _is_qwen_family_scheduler_lookup_base_config(
+    vllm_config: VllmConfig,
+) -> bool:
+    """Check the Qwen FA3 scheduler configuration envelope."""
+    model_config = getattr(vllm_config, "model_config", None)
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    if model_config is None or scheduler_config is None or parallel_config is None:
+        return False
+
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    if hf_text_config is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        hf_text_config = getattr(hf_config, "text_config", hf_config)
+    model_type = str(getattr(hf_text_config, "model_type", "")).lower()
+    max_num_seqs = getattr(scheduler_config, "max_num_seqs", None)
+    architectures = getattr(model_config, "architectures", None)
+    if architectures is None:
+        architectures = getattr(hf_text_config, "architectures", None)
+    is_qwen_family = model_type.startswith("qwen") or model_type == "cosyvoice3"
+    is_qwen_family = is_qwen_family or any(
+        str(architecture).lower().startswith("qwen")
+        for architecture in architectures or ()
+    )
+
+    return (
+        is_qwen_family
+        and isinstance(max_num_seqs, int)
+        and max_num_seqs >= 1
+        and getattr(vllm_config, "speculative_config", None) is None
+        and all(
+            getattr(parallel_config, name, None) == 1
+            for name in (
+                "tensor_parallel_size",
+                "decode_context_parallel_size",
+                "pipeline_parallel_size",
+            )
+        )
+    )
+
+
+def _is_qwen_family_scheduler_lookup_config(vllm_config: VllmConfig) -> bool:
+    """Gate the direct FA3 scheduler path before runtime shape checks."""
+    from vllm_musa.utils.environ import envs as musa_envs
+
+    return (
+        musa_envs.VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP.get()
+        and _is_qwen_family_scheduler_lookup_base_config(vllm_config)
+    )
+
+
+def _has_supported_fa3_scheduler_layout() -> bool:
+    """The direct builder mirrors the pinned MATE 0.2.4 metadata layout."""
+    try:
+        mate_version = version("mate").split("+", 1)[0]
+        flash_attn_version = version("flash_attn_3").split("+", 1)[0]
+    except PackageNotFoundError:
+        return False
+    return mate_version == "0.2.4" and flash_attn_version == "0.2.4"
 
 
 def _torch_reduce_scatter_dim(
@@ -448,8 +510,13 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         self.max_cudagraph_size = self.compilation_config.max_cudagraph_capture_size
 
         self._sm_count = 60
+        self._sm_count_query_succeeded = False
         # ==================== MUSA ADAPTATION ====================
         self._cu_seqlens_k_buffer: torch.Tensor | None = None
+        self._use_qwen_single_request_scheduler_lookup = (
+            _is_qwen_family_scheduler_lookup_config(vllm_config)
+            and _has_supported_fa3_scheduler_layout()
+        )
         # ========================== END ==========================
 
         if self.use_full_cuda_graph and self.aot_schedule:
@@ -477,6 +544,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
                 self._sm_count = torch.musa.get_device_properties(
                     self.device
                 ).multi_processor_count
+                self._sm_count_query_succeeded = True
             except Exception:
                 self._sm_count = 60
 
@@ -643,6 +711,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         prefix_kv_lens = None
         suffix_kv_lens = None
         prefix_scheduler_metadata = None
+        direct_metadata_built = False
 
         if self.dcp_world_size > 1:
             query_kv_lens = query_start_loc[1:] - query_start_loc[:-1]
@@ -697,17 +766,64 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
                 causal=True,
             )
         else:
-            scheduler_metadata = schedule(
-                batch_size=num_reqs,
-                cu_query_lens=query_start_loc,
-                max_query_len=max_query_len,
-                seqlens=seq_lens,
-                max_seq_len=max_seq_len,
-                causal=causal,
+            scheduler_metadata = None
+
+            # The direct builder handles only supported Qwen batch-one decode
+            # inputs. All other inputs continue through schedule() below.
+            use_qwen_scheduler_lookup = (
+                self._use_qwen_single_request_scheduler_lookup
+                and self.use_full_cuda_graph
+                and aot_schedule
+                and self._cu_seqlens_k_buffer is not None
+                and num_reqs == 1
+                and num_decodes == 1
+                and num_decode_tokens == 1
+                and num_prefills == 0
+                and max_query_len == 1
+                and 1 <= max_seq_len <= 4096
+                and causal
+                and self.aot_sliding_window == (-1, -1)
+                and self._sm_count_query_succeeded
+                and self._sm_count == 60
+                and 1 <= max_num_splits <= 60
+                and 1 <= self.num_heads_kv <= 32
+                and self.num_heads_q % self.num_heads_kv == 0
+                and 1 <= self.num_heads_q // self.num_heads_kv <= 32
+                and self.headdim in (64, 128)
+                and self.block_size == 64
+                and self.kv_cache_dtype == torch.bfloat16
             )
+            if use_qwen_scheduler_lookup:
+                from vllm_musa.jit_kernel.fa3_metadata import (
+                    try_build_qwen_single_request_fa3_metadata,
+                )
+
+                buf = self._cu_seqlens_k_buffer
+                direct_metadata_built = try_build_qwen_single_request_fa3_metadata(
+                    seq_lens[:1],
+                    buf[:2],
+                    self.scheduler_metadata,
+                    max_seq_len,
+                    self.num_heads_q,
+                    self.num_heads_kv,
+                    self.headdim,
+                    max_num_splits,
+                )
+                if direct_metadata_built:
+                    cu_seqlens_k = buf[:2]
+                    scheduler_metadata = self.scheduler_metadata[:16]
+            if scheduler_metadata is None:
+                scheduler_metadata = schedule(
+                    batch_size=num_reqs,
+                    cu_query_lens=query_start_loc,
+                    max_query_len=max_query_len,
+                    seqlens=seq_lens,
+                    max_seq_len=max_seq_len,
+                    causal=causal,
+                )
 
             # ==================== MUSA ADAPTATION ====================
-            if self.use_full_cuda_graph:
+            if self.use_full_cuda_graph and not direct_metadata_built:
                 if self._cu_seqlens_k_buffer is not None:
                     n = num_reqs + 1
                     buf = self._cu_seqlens_k_buffer
@@ -726,12 +842,13 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         # For FA3 + full cudagraph
         if self.use_full_cuda_graph and scheduler_metadata is not None:
             n = scheduler_metadata.shape[0]
-            self.scheduler_metadata[:n] = scheduler_metadata
-            # NOTE(woosuk): We should zero out the rest of the scheduler
-            # metadata to guarantee the correctness. Otherwise, some thread
-            # blocks may use the invalid scheduler metadata and overwrite the
-            # output buffer.
-            self.scheduler_metadata[n:] = 0
+            if not direct_metadata_built:
+                self.scheduler_metadata[:n] = scheduler_metadata
+                # NOTE(woosuk): We should zero out the rest of the scheduler
+                # metadata to guarantee the correctness. Otherwise, some thread
+                # blocks may use the invalid scheduler metadata and overwrite the
+                # output buffer.
+                self.scheduler_metadata[n:] = 0
             scheduler_metadata = self.scheduler_metadata[:n]
 
         attn_metadata = FlashAttentionMetadata(

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -122,11 +122,14 @@ def _is_qwen_family_scheduler_lookup_config(vllm_config: VllmConfig) -> bool:
 def _has_supported_fa3_scheduler_layout() -> bool:
     """The direct builder mirrors the pinned MATE 0.2.4 metadata layout."""
     try:
-        mate_version = version("mate").split("+", 1)[0]
-        flash_attn_version = version("flash_attn_3").split("+", 1)[0]
+        mate_version = version("mate")
+        flash_attn_version = version("flash_attn_3")
     except PackageNotFoundError:
         return False
-    return mate_version == "0.2.4" and flash_attn_version == "0.2.4"
+    return mate_version == "0.2.4" and flash_attn_version in {
+        "0.2.4",
+        "0.2.4+musa",
+    }
 
 
 def _torch_reduce_scatter_dim(
@@ -176,7 +179,6 @@ def _musa_cp_lse_ag_out_rs(
     return_lse: bool = False,
     is_lse_base_on_e=True,
 ):
-
     safe_group = _DCPGroupWithTorchReduceScatter(cp_group)
     return cp_lse_ag_out_rs(
         cp_attn_out,


### PR DESCRIPTION
## Summary

- add a one-launch Triton fast path for the FA3 scheduler metadata and
  `cu_seqlens_k` used by single-request Qwen decode
- bypass the approximately 83 us MATE metadata scheduler that currently runs
  before each main decode graph replay
- keep the existing MATE scheduler as the unchanged fallback for every
  unsupported model, geometry, runtime state, or dependency version
- cover common Qwen2/Qwen2.5, Qwen3 dense, and Qwen3-MoE/VL-MoE head
  geometries; Qwen3.5/Qwen3.6 full-attention heads (`head_dim=256`)
  intentionally fall back

The optimization only changes vllm-musa. It does not import, patch, or
override vllm-omni; vllm-omni remains an integration validation path.

## Strict activation envelope

- Qwen-family text config
- exact MATE 0.2.4 and flash_attn_3 0.2.4/0.2.4+musa layout versions
- BF16 KV cache, page/block size 64, causal full-context attention
- TP/PP/DCP 1, no speculative decoding or cascade attention
- FULL CUDAGraph with the AOT FA3 scheduler buffer
- current step is exactly one request, one decode token, no prefill
- active MP query succeeded and returned exactly 60
- sequence length 1 through 4096
- exact allowlist of `(Q heads, KV heads, head dim)` geometries

Servers may have `max_num_seqs > 1`; the fast path is selected from the actual
step shape. A step with more than one request or token uses the original MATE
path.

## Clean-head S5000 evidence

The implementation gate was run from clean commit `cacc162fe` on one leased
S5000 (driver `3.3.5-server`, MUSA SDK 5.2, BF16, FlashAttention v3,
`FULL_AND_PIECEWISE` graph capture, async scheduling, `max_num_seqs=8`). Final
head `924d534e0` only changes the validated switch from default-off to
default-on and updates its test.

| Model / run | Baseline | Candidate | Change |
|---|---:|---:|---:|
| CosyVoice3 `CosyVoice-BlankEN`, 4 independent ABBA process pairs | 3.469014 ms/token | 3.354181 ms/token | +3.424% |

- per-pair gains: `+3.876%`, `+3.715%`, `+2.856%`, `+3.251%`
- independent-pair bootstrap 95% CI: `[+3.053%, +3.796%]`
- all token digests matched
- the MUPTI graph-child trace shows the five baseline metadata kernels per
  decode step (MATE metadata, scan, two fills, and identity) replaced by one
  `_build_qwen_single_request_fa3_metadata_kernel`
- the isolated metadata-chain saving is about `95.6 us/step`; the main FA3
  kernel count is unchanged

## Validation status

Completed on clean head `924d534e0`:

- `git diff --check`, targeted Ruff/format/compile checks, and commit hooks
- 95 targeted MUSA tests passed, including 29 table-driven fail-closed cases
  covering model/config, graph mode,
  multi-request/prefill, window/cascade, dtype/page size, MP/split, and exact
  geometry rejection
- arbitrary local dependency suffixes fail closed
- exhaustive reference parity passed for 10 Qwen geometries at every sequence
  length from 1 through 4096
- the default-on switch and explicit `=0` emergency/A-B override both passed
- final-head, environment-unset 2x128-token smoke passed at
  `3.441655 ms/token` with matching token digests
- regression controls passed: Qwen3-8B dense `FLASH_ATTN` semantic smoke and
  DeepSeek-V2-Lite `FLASH_MLA` semantic smoke
- Qwen3.5/Qwen3.6 configs all report text `head_dim=256` and the exact
  geometry gate returns false; a Qwen3.5-2B functional attempt reached FA3 but
  was not counted because an unrelated MATE JIT `.so` cache artifact was
  missing

Regression logs and the not-counted Qwen3.5 attempt are archived in
`MUSA-60042-regression.tar.gz` (SHA-256
`8d5cab0a4304c318ba5f37d115328072718cf34306730f0780712be4126a0e76`).

The hardware gate passed, so
`VLLM_MUSA_QWEN_FA3_SCHEDULER_LOOKUP` is now default-on. All unsupported
requests continue through the unchanged MATE fallback.

This is an LLM decode-path result, not a claim that the end-to-end 50-second
vLLM-Omni streaming RTF target has already been met; that integration gate is
tracked separately.
