### PR TITLE
perf(musa): gated Qwen-family sampling and GDN decode

### DIFF
--- a/tests/test_qwen_gdn_decode_output.py
+++ b/tests/test_qwen_gdn_decode_output.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: I001
+"""Focused caller-output contract for the MUSA Qwen GDN decode path."""
+
+from types import SimpleNamespace
+
+import torchada  # noqa: F401
+import torch
+
+from vllm_musa.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+
+
+def _fake_attention() -> gdn.MusaQwenGatedDeltaNetAttention:
+    attention = object.__new__(gdn.MusaQwenGatedDeltaNetAttention)
+    attention.key_dim = 4
+    attention.value_dim = 4
+    attention.head_k_dim = 2
+    attention.head_v_dim = 2
+    attention.num_v_heads = 2
+    attention.tp_size = 1
+    attention.activation = "silu"
+    attention.A_log = torch.ones(2)
+    attention.dt_bias = torch.ones(2)
+    attention.conv1d = SimpleNamespace(weight=torch.ones(4, 1, 1), bias=torch.zeros(4))
+    attention.kv_cache = (
+        torch.zeros(2, 4, 1),
+        torch.zeros(4, 2, 2, 2, dtype=torch.float32),
+    )
+    return attention
+
+
+def _patch_decode_prerequisites(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.mamba.mamba_utils.is_conv_state_dim_first",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.mamba.ops.causal_conv1d.causal_conv1d_update",
+        lambda x, *_args, **_kwargs: x,
+    )
+
+
+def _metadata(num_decode_tokens: int, state_indices: list[int]) -> SimpleNamespace:
+    return SimpleNamespace(
+        spec_sequence_masks=None,
+        num_decodes=num_decode_tokens,
+        num_decode_tokens=num_decode_tokens,
+        non_spec_query_start_loc=torch.arange(num_decode_tokens + 1, dtype=torch.int32),
+        non_spec_state_indices_tensor=torch.tensor(state_indices, dtype=torch.int64),
+    )
+
+
+def test_mate_decode_writes_caller_output_and_ignores_decoy(monkeypatch) -> None:
+    attention = _fake_attention()
+    num_tokens = 2
+    mixed_qkv = torch.randn(num_tokens, 12)
+    a = torch.ones(num_tokens, 2)
+    b = torch.ones(num_tokens, 2)
+    core_attn_out = torch.zeros(num_tokens, 2, 2)
+    metadata = _metadata(num_tokens, [0, 1])
+    captured = {}
+
+    _patch_decode_prerequisites(monkeypatch)
+
+    def fake_decode(**kwargs):
+        captured.update(kwargs)
+        kwargs["output"].fill_(7)
+        return torch.full_like(kwargs["output"], 99), None
+
+    monkeypatch.setattr(gdn, "gated_delta_rule_decode", fake_decode)
+    monkeypatch.setattr(gdn, "_MATE_GDN_DECODE_HAS_OUTPUT", True)
+    monkeypatch.setenv("VLLM_MUSA_MAMBA_SEPARATE_POOL", "1")
+
+    assert attention._try_mate_decode(mixed_qkv, b, a, core_attn_out, metadata)
+
+    assert captured["output"].shape == (num_tokens, 1, 2, 2)
+    assert captured["output"].data_ptr() == core_attn_out.data_ptr()
+    assert torch.equal(core_attn_out, torch.full_like(core_attn_out, 7))
+    assert not torch.any(core_attn_out == 99)
+
+
+def test_mate_decode_legacy_api_copies_returned_output(monkeypatch) -> None:
+    attention = _fake_attention()
+    num_tokens = 2
+    mixed_qkv = torch.randn(num_tokens, 12)
+    a = torch.ones(num_tokens, 2)
+    b = torch.ones(num_tokens, 2)
+    core_attn_out = torch.zeros(num_tokens, 2, 2)
+    metadata = _metadata(num_tokens, [0, 1])
+    captured = {}
+
+    _patch_decode_prerequisites(monkeypatch)
+
+    def fake_decode(**kwargs):
+        captured.update(kwargs)
+        return torch.full((num_tokens, 1, 2, 2), 9.0), None
+
+    monkeypatch.setattr(gdn, "gated_delta_rule_decode", fake_decode)
+    monkeypatch.setattr(gdn, "_MATE_GDN_DECODE_HAS_OUTPUT", False)
+    monkeypatch.setenv("VLLM_MUSA_MAMBA_SEPARATE_POOL", "1")
+
+    assert attention._try_mate_decode(mixed_qkv, b, a, core_attn_out, metadata)
+
+    assert "output" not in captured
+    assert torch.equal(core_attn_out, torch.full_like(core_attn_out, 9))
+
+
+def test_mate_decode_gather_scatter_reuses_output_and_updates_active_state(
+    monkeypatch,
+) -> None:
+    attention = _fake_attention()
+    num_tokens = 2
+    mixed_qkv = torch.randn(num_tokens, 12)
+    a = torch.ones(num_tokens, 2)
+    b = torch.ones(num_tokens, 2)
+    core_attn_out = torch.zeros(num_tokens, 2, 2)
+    metadata = _metadata(num_tokens, [1, 3])
+    original_state = attention.kv_cache[1].clone()
+
+    _patch_decode_prerequisites(monkeypatch)
+
+    def fake_decode(**kwargs):
+        kwargs["output"].fill_(7)
+        return kwargs["output"], torch.full_like(kwargs["state"], 5)
+
+    monkeypatch.setattr(gdn, "gated_delta_rule_decode", fake_decode)
+    monkeypatch.setattr(gdn, "_MATE_GDN_DECODE_HAS_OUTPUT", True)
+    monkeypatch.setenv("VLLM_MUSA_MAMBA_SEPARATE_POOL", "0")
+
+    assert attention._try_mate_decode(mixed_qkv, b, a, core_attn_out, metadata)
+
+    assert torch.equal(core_attn_out, torch.full_like(core_attn_out, 7))
+    assert torch.equal(attention.kv_cache[1][[1, 3]], torch.full((2, 2, 2, 2), 5.0))
+    assert torch.equal(attention.kv_cache[1][[0, 2]], original_state[[0, 2]])
+
+
+def test_mate_decode_output_reuse_only_writes_decode_prefix(monkeypatch) -> None:
+    attention = _fake_attention()
+    num_tokens = 3
+    num_decode_tokens = 2
+    mixed_qkv = torch.randn(num_tokens, 12)
+    a = torch.ones(num_tokens, 2)
+    b = torch.ones(num_tokens, 2)
+    core_attn_out = torch.full((num_tokens, 2, 2), -3.0)
+    metadata = _metadata(num_decode_tokens, [0, 1])
+
+    _patch_decode_prerequisites(monkeypatch)
+
+    def fake_decode(**kwargs):
+        kwargs["output"].fill_(7)
+        return kwargs["output"], None
+
+    monkeypatch.setattr(gdn, "gated_delta_rule_decode", fake_decode)
+    monkeypatch.setattr(gdn, "_MATE_GDN_DECODE_HAS_OUTPUT", True)
+    monkeypatch.setenv("VLLM_MUSA_MAMBA_SEPARATE_POOL", "1")
+
+    assert attention._try_mate_decode(mixed_qkv, b, a, core_attn_out, metadata)
+
+    assert torch.equal(core_attn_out[:num_decode_tokens], torch.full((2, 2, 2), 7.0))
+    assert torch.equal(core_attn_out[num_decode_tokens:], torch.full((1, 2, 2), -3.0))

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -1,0 +1,677 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: I001
+"""CPU-state contracts for MUSA V2 sampling fast paths."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torchada  # noqa: F401
+import torch
+
+from vllm_musa.v1.sample import topk_topp_sampler as sampler
+
+
+requires_musa = pytest.mark.skipif(
+    not hasattr(torch, "musa") or not torch.musa.is_available(),
+    reason="requires a MUSA device",
+)
+
+
+def _state_array(
+    values: list[int] | list[float], dtype: torch.dtype
+) -> SimpleNamespace:
+    numpy_dtype = np.int32 if dtype == torch.int32 else np.float32
+    return SimpleNamespace(
+        np=np.asarray(values, dtype=numpy_dtype),
+        gpu=torch.tensor(values, dtype=dtype),
+    )
+
+
+def _gumbel_gate_sampler(
+    rows: int,
+    *,
+    temperature: float = 1.0,
+    top_k: int = 50,
+    top_p: float = 1.0,
+    min_p: float = 0.05,
+    all_seeded: bool = True,
+    num_speculative_tokens: int = 1,
+    use_fp64_gumbel: bool = False,
+    logprobs_mode: str = "raw_logprobs",
+) -> SimpleNamespace:
+    states = SimpleNamespace(
+        temperature=_state_array([temperature] * rows, torch.float32),
+        top_k=_state_array([top_k] * rows, torch.int32),
+        top_p=_state_array([top_p] * rows, torch.float32),
+        min_p=_state_array([min_p] * rows, torch.float32),
+        has_user_seed=np.full(rows, all_seeded, dtype=np.bool_),
+    )
+    return SimpleNamespace(
+        sampling_states=states,
+        num_speculative_tokens=num_speculative_tokens,
+        use_fp64_gumbel=use_fp64_gumbel,
+        logprobs_mode=logprobs_mode,
+    )
+
+
+class _FakeGenerator:
+    def __init__(
+        self,
+        seed: int,
+        offset: int = 0,
+        device: torch.device | None = None,
+        fail_offset: int | None = None,
+    ) -> None:
+        self.seed = seed
+        self.offset = offset
+        self.device = device or torch.device("cpu")
+        self.fail_offset = fail_offset
+
+    def initial_seed(self) -> int:
+        return self.seed
+
+    def get_offset(self) -> int:
+        return self.offset
+
+    def set_offset(self, offset: int) -> None:
+        if offset == self.fail_offset:
+            raise RuntimeError("injected set_offset failure")
+        self.offset = offset
+
+
+def _legacy_gumbel_metadata(rows: int, **kwargs) -> SimpleNamespace:
+    return SimpleNamespace(
+        max_num_logprobs=kwargs.get("max_num_logprobs"),
+        logprob_token_ids=kwargs.get("logprob_token_ids"),
+        all_random=kwargs.get("all_random", True),
+        top_k=kwargs.get("top_k", torch.full((rows,), 50, dtype=torch.int32)),
+        top_p=kwargs.get("top_p"),
+        spec_token_ids=kwargs.get("spec_token_ids", [[] for _ in range(rows)]),
+        generators=kwargs.get(
+            "generators", {row: _FakeGenerator(60043 + row) for row in range(rows)}
+        ),
+    )
+
+
+def test_qwen_legacy_gumbel_gate_and_generator_handoff(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_MUSA_QWEN_LEGACY_GUMBEL", "1")
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    rows = 4
+    logits = torch.randn((rows, 248320))
+    metadata = _legacy_gumbel_metadata(rows)
+
+    assert sampler.can_use_qwen_legacy_gumbel(
+        logits, metadata, "raw_logprobs", None, False
+    )
+    metadata.generators = dict(reversed(tuple(metadata.generators.items())))
+    assert sampler.can_use_qwen_legacy_gumbel(
+        logits, metadata, "raw_logprobs", None, False
+    )
+    state = sampler.get_qwen_legacy_generator_state(metadata.generators, rows)
+    assert state == ([60043, 60044, 60045, 60046], [0, 0, 0, 0])
+
+    captured = {}
+
+    def fake_gumbel_sample(
+        processed_logits,
+        mapping,
+        temperature,
+        seeds,
+        positions,
+        **kwargs,
+    ):
+        captured.update(
+            processed_logits=processed_logits,
+            mapping=mapping,
+            temperature=temperature,
+            seeds=seeds,
+            positions=positions,
+            kwargs=kwargs,
+        )
+        return torch.arange(rows, dtype=torch.int64)
+
+    monkeypatch.setattr(sampler, "_apply_top_k_top_p", lambda tensor, *_args: tensor)
+    monkeypatch.setattr(
+        sampler.vllm_worker_sampler, "gumbel_sample", fake_gumbel_sample
+    )
+    sampled = sampler.sample_qwen_legacy_gumbel(
+        logits, metadata.generators, metadata.top_k, state
+    )
+
+    assert sampled.tolist() == [0, 1, 2, 3]
+    assert captured["mapping"].tolist() == [0, 1, 2, 3]
+    assert captured["temperature"].tolist() == [1.0] * rows
+    assert captured["seeds"].tolist() == [60043, 60044, 60045, 60046]
+    assert captured["positions"].tolist() == [0] * rows
+    assert captured["kwargs"] == {"apply_temperature": False, "use_fp64": False}
+    assert [generator.get_offset() for generator in metadata.generators.values()] == [
+        4
+    ] * rows
+
+
+def test_qwen_legacy_gumbel_gate_fails_closed(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_MUSA_QWEN_LEGACY_GUMBEL", "1")
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    logits = torch.randn((4, 248320))
+
+    assert sampler.can_use_qwen_legacy_gumbel(
+        torch.randn((1, 248320)),
+        _legacy_gumbel_metadata(1),
+        "raw_logprobs",
+        None,
+        False,
+    )
+    assert not sampler.can_use_qwen_legacy_gumbel(
+        torch.randn((4, 151936)),
+        _legacy_gumbel_metadata(4),
+        "raw_logprobs",
+        None,
+        False,
+    )
+    assert not sampler.can_use_qwen_legacy_gumbel(
+        logits,
+        _legacy_gumbel_metadata(4, max_num_logprobs=0),
+        "raw_logprobs",
+        None,
+        False,
+    )
+    assert not sampler.can_use_qwen_legacy_gumbel(
+        logits,
+        _legacy_gumbel_metadata(4, generators={0: _FakeGenerator(1)}),
+        "raw_logprobs",
+        None,
+        False,
+    )
+    assert not sampler.can_use_qwen_legacy_gumbel(
+        logits,
+        _legacy_gumbel_metadata(4, spec_token_ids=[[1], [], [], []]),
+        "raw_logprobs",
+        None,
+        False,
+    )
+    assert not sampler.can_use_qwen_legacy_gumbel(
+        logits, _legacy_gumbel_metadata(4), "raw_logprobs", None, True
+    )
+    invalid = _legacy_gumbel_metadata(4)
+    invalid.generators[0].offset = 2
+    assert sampler.get_qwen_legacy_generator_state(invalid.generators, 4) is None
+
+
+def test_qwen_legacy_gumbel_rolls_back_partial_generator_advance(
+    monkeypatch,
+) -> None:
+    rows = 4
+    logits = torch.randn((rows, 248320))
+    generators = {
+        row: _FakeGenerator(
+            60043 + row,
+            device=logits.device,
+            fail_offset=4 if row == 1 else None,
+        )
+        for row in range(rows)
+    }
+    state = sampler.get_qwen_legacy_generator_state(generators, rows)
+    monkeypatch.setattr(sampler, "_apply_top_k_top_p", lambda tensor, *_args: tensor)
+    monkeypatch.setattr(
+        sampler.vllm_worker_sampler,
+        "gumbel_sample",
+        lambda *_args, **_kwargs: torch.arange(rows, dtype=torch.int64),
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to advance legacy MUSA generators"):
+        sampler.sample_qwen_legacy_gumbel(
+            logits,
+            generators,
+            torch.full((rows,), 50, dtype=torch.int32),
+            state,
+        )
+
+    assert [generator.get_offset() for generator in generators.values()] == [0] * rows
+
+
+def test_qwen_legacy_gumbel_gate_is_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_MUSA_QWEN_LEGACY_GUMBEL", raising=False)
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+
+    assert not sampler.can_use_qwen_legacy_gumbel(
+        torch.randn((4, 248320)),
+        _legacy_gumbel_metadata(4),
+        "raw_logprobs",
+        None,
+        False,
+    )
+
+
+def test_qwen_v2_gumbel_gate_accepts_only_exact_contract(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_MUSA_QWEN_V2_GUMBEL", "1")
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    rows = 4
+    logits = torch.randn((rows, 151936))
+    mapping = torch.arange(rows, dtype=torch.int64)
+    mapping_np = np.arange(rows, dtype=np.int64)
+    pos = mapping.clone()
+
+    assert sampler.can_use_qwen_v2_gumbel(
+        _gumbel_gate_sampler(rows), logits, mapping, mapping_np, pos, False
+    )
+    assert not sampler.can_use_qwen_v2_gumbel(
+        _gumbel_gate_sampler(rows, top_p=0.9),
+        logits,
+        mapping,
+        mapping_np,
+        pos,
+        False,
+    )
+    assert not sampler.can_use_qwen_v2_gumbel(
+        _gumbel_gate_sampler(rows, all_seeded=False),
+        logits,
+        mapping,
+        mapping_np,
+        pos,
+        False,
+    )
+    assert not sampler.can_use_qwen_v2_gumbel(
+        _gumbel_gate_sampler(rows, num_speculative_tokens=2),
+        logits,
+        mapping,
+        mapping_np,
+        pos,
+        False,
+    )
+    assert not sampler.can_use_qwen_v2_gumbel(
+        _gumbel_gate_sampler(rows), logits, mapping, mapping_np, pos, True
+    )
+
+
+def test_qwen_v2_gumbel_gate_rejects_non_qwen_vocab(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_MUSA_QWEN_V2_GUMBEL", "1")
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    rows = 4
+    mapping = torch.arange(rows, dtype=torch.int64)
+
+    assert not sampler.can_use_qwen_v2_gumbel(
+        _gumbel_gate_sampler(rows),
+        torch.randn((rows, 131072)),
+        mapping,
+        np.arange(rows, dtype=np.int64),
+        mapping,
+        False,
+    )
+
+
+def test_qwen_v2_gumbel_gate_is_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_MUSA_QWEN_V2_GUMBEL", raising=False)
+    rows = 1
+    mapping = torch.zeros(rows, dtype=torch.int64)
+
+    assert not sampler.can_use_qwen_v2_gumbel(
+        _gumbel_gate_sampler(rows),
+        torch.randn((rows, 151936)),
+        mapping,
+        np.zeros(rows, dtype=np.int64),
+        mapping,
+        False,
+    )
+
+
+def test_uniform_active_min_p_uses_cpu_state() -> None:
+    assert sampler._uniform_active_min_p(
+        np.asarray([0.05], dtype=np.float32)
+    ) == pytest.approx(0.05)
+    assert sampler._uniform_active_min_p(
+        np.asarray([0.05, 0.05], dtype=np.float32)
+    ) == pytest.approx(0.05)
+    assert sampler._uniform_active_min_p(np.asarray([], dtype=np.float32)) is None
+    assert (
+        sampler._uniform_active_min_p(np.asarray([0.0, 0.0], dtype=np.float32)) is None
+    )
+    assert (
+        sampler._uniform_active_min_p(np.asarray([0.05, 0.1], dtype=np.float32)) is None
+    )
+
+
+def test_uniform_top_k_threshold_preserves_ties() -> None:
+    logits = torch.arange(64, dtype=torch.float32).repeat(2, 1)
+    logits[:, 12:17] = 14.0
+    expected = sampler.vllm_topk_topp_sampler.apply_top_k_only(
+        logits.clone(), torch.full((2,), 50, dtype=torch.int32)
+    )
+
+    actual = sampler._apply_top_k_top_p(logits.clone(), 50, None)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert torch.equal(actual.isfinite(), expected.isfinite())
+    assert actual.isfinite().sum(dim=1).tolist() == [52, 52]
+
+
+def test_tensor_top_k_top_p_prefilter_matches_upstream() -> None:
+    torch.manual_seed(60046)
+    logits = torch.randn((4, 256), dtype=torch.float32)
+    top_k = torch.tensor([20, 50, 7, 49], dtype=torch.int32)
+    top_p = torch.tensor([0.75, 0.8, 0.9, 0.95], dtype=torch.float32)
+    expected = sampler.vllm_topk_topp_sampler.apply_top_k_top_p_pytorch(
+        logits.clone(), top_k, top_p
+    )
+
+    actual_input = logits.clone()
+    actual = sampler._apply_top_k_top_p_musa_topk_prefilter(actual_input, top_k, top_p)
+
+    assert actual.data_ptr() == actual_input.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert torch.equal(actual.isfinite(), expected.isfinite())
+
+
+def test_seeded_filters_reuse_processed_logits_only_when_allowed() -> None:
+    sampling_states = SimpleNamespace(
+        vocab_size=64,
+        top_k=_state_array([50, 50], torch.int32),
+        top_p=_state_array([1.0, 1.0], torch.float32),
+        min_p=_state_array([0.0, 0.0], torch.float32),
+        apply_min_p=lambda *_args: None,
+    )
+    fake_sampler = SimpleNamespace(sampling_states=sampling_states)
+    mapping = torch.tensor([0, 1], dtype=torch.int64)
+    mapping_np = np.asarray([0, 1], dtype=np.int64)
+    processed = torch.randn((2, 64), dtype=torch.float32)
+    original = processed.clone()
+
+    reused = sampler._apply_worker_sampling_filters_for_seeded_multinomial(
+        fake_sampler,
+        processed,
+        mapping,
+        mapping_np,
+        preserve_processed_logits=False,
+    )
+    assert reused.data_ptr() == processed.data_ptr()
+    assert not torch.equal(processed, original)
+
+    preserved_input = original.clone()
+    copied = sampler._apply_worker_sampling_filters_for_seeded_multinomial(
+        fake_sampler,
+        preserved_input,
+        mapping,
+        mapping_np,
+        preserve_processed_logits=True,
+    )
+    assert copied.data_ptr() != preserved_input.data_ptr()
+    torch.testing.assert_close(preserved_input, original, rtol=0, atol=0)
+    torch.testing.assert_close(copied, reused, rtol=0, atol=0)
+
+
+def test_seeded_top_p_keeps_tensor_top_k_fallback(monkeypatch) -> None:
+    captured = {}
+
+    def fake_apply_top_k_top_p(logits, top_k, top_p):
+        captured.update(top_k=top_k, top_p=top_p)
+        return logits
+
+    monkeypatch.setattr(sampler, "_apply_top_k_top_p", fake_apply_top_k_top_p)
+    sampling_states = SimpleNamespace(
+        vocab_size=64,
+        top_k=_state_array([50, 50], torch.int32),
+        top_p=_state_array([0.9, 0.9], torch.float32),
+        min_p=_state_array([0.0, 0.0], torch.float32),
+        apply_min_p=lambda *_args: None,
+    )
+    fake_sampler = SimpleNamespace(sampling_states=sampling_states)
+    mapping = torch.tensor([0, 1], dtype=torch.int64)
+    mapping_np = np.asarray([0, 1], dtype=np.int64)
+
+    sampler._apply_worker_sampling_filters_for_seeded_multinomial(
+        fake_sampler,
+        torch.randn((2, 64)),
+        mapping,
+        mapping_np,
+        preserve_processed_logits=False,
+    )
+
+    assert isinstance(captured["top_k"], torch.Tensor)
+    assert isinstance(captured["top_p"], torch.Tensor)
+
+
+def test_seeded_large_uniform_top_k_top_p_uses_cpu_scalar(monkeypatch) -> None:
+    captured = {}
+
+    def fake_apply_top_k_top_p(logits, top_k, top_p):
+        captured.update(top_k=top_k, top_p=top_p)
+        return logits
+
+    monkeypatch.setattr(sampler, "_apply_top_k_top_p", fake_apply_top_k_top_p)
+    rows = 16
+    vocab_size = 248320
+    sampling_states = SimpleNamespace(
+        vocab_size=vocab_size,
+        top_k=_state_array([50] * rows, torch.int32),
+        top_p=_state_array([0.9] * rows, torch.float32),
+        min_p=_state_array([0.0] * rows, torch.float32),
+        apply_min_p=lambda *_args: None,
+    )
+    fake_sampler = SimpleNamespace(sampling_states=sampling_states)
+    mapping = torch.arange(rows, dtype=torch.int64)
+    mapping_np = np.arange(rows, dtype=np.int64)
+
+    sampler._apply_worker_sampling_filters_for_seeded_multinomial(
+        fake_sampler,
+        torch.randn((rows, vocab_size)),
+        mapping,
+        mapping_np,
+        preserve_processed_logits=False,
+    )
+
+    assert captured["top_k"] == 50
+    assert isinstance(captured["top_p"], torch.Tensor)
+
+
+def test_seeded_small_batch_qwen_vocab_uses_cpu_scalar(monkeypatch) -> None:
+    captured = {}
+
+    def fake_apply_top_k_top_p(logits, top_k, top_p):
+        captured.update(top_k=top_k, top_p=top_p)
+        return logits
+
+    monkeypatch.setattr(sampler, "_apply_top_k_top_p", fake_apply_top_k_top_p)
+    rows = 4
+    vocab_size = 151936
+    sampling_states = SimpleNamespace(
+        vocab_size=vocab_size,
+        top_k=_state_array([50] * rows, torch.int32),
+        top_p=_state_array([1.0] * rows, torch.float32),
+        min_p=_state_array([0.0] * rows, torch.float32),
+        apply_min_p=lambda *_args: None,
+    )
+    fake_sampler = SimpleNamespace(sampling_states=sampling_states)
+    mapping = torch.arange(rows, dtype=torch.int64)
+    mapping_np = np.arange(rows, dtype=np.int64)
+
+    sampler._apply_worker_sampling_filters_for_seeded_multinomial(
+        fake_sampler,
+        torch.randn((rows, vocab_size)),
+        mapping,
+        mapping_np,
+        preserve_processed_logits=False,
+    )
+
+    assert captured == {"top_k": 50, "top_p": None}
+
+
+def test_non_qwen_vocab_keeps_tensor_top_k_path(monkeypatch) -> None:
+    captured = {}
+
+    def fake_apply_top_k_top_p(logits, top_k, top_p):
+        captured.update(top_k=top_k, top_p=top_p)
+        return logits
+
+    monkeypatch.setattr(sampler, "_apply_top_k_top_p", fake_apply_top_k_top_p)
+    rows = 4
+    vocab_size = 131072
+    sampling_states = SimpleNamespace(
+        vocab_size=vocab_size,
+        top_k=_state_array([50] * rows, torch.int32),
+        top_p=_state_array([1.0] * rows, torch.float32),
+        min_p=_state_array([0.0] * rows, torch.float32),
+        apply_min_p=lambda *_args: None,
+    )
+    fake_sampler = SimpleNamespace(sampling_states=sampling_states)
+    mapping = torch.arange(rows, dtype=torch.int64)
+    mapping_np = np.arange(rows, dtype=np.int64)
+
+    sampler._apply_worker_sampling_filters_for_seeded_multinomial(
+        fake_sampler,
+        torch.randn((rows, vocab_size)),
+        mapping,
+        mapping_np,
+        preserve_processed_logits=False,
+    )
+
+    assert isinstance(captured["top_k"], torch.Tensor)
+
+
+def test_seeded_bs1_active_top_p_keeps_tensor_path(monkeypatch) -> None:
+    captured = {}
+
+    def fake_apply_top_k_top_p(logits, top_k, top_p):
+        captured.update(top_k=top_k, top_p=top_p)
+        return logits
+
+    monkeypatch.setattr(sampler, "_apply_top_k_top_p", fake_apply_top_k_top_p)
+    vocab_size = 151936
+    sampling_states = SimpleNamespace(
+        vocab_size=vocab_size,
+        top_k=_state_array([50], torch.int32),
+        top_p=_state_array([0.9], torch.float32),
+        min_p=_state_array([0.0], torch.float32),
+        apply_min_p=lambda *_args: None,
+    )
+    fake_sampler = SimpleNamespace(sampling_states=sampling_states)
+    mapping = torch.zeros(1, dtype=torch.int64)
+    mapping_np = np.zeros(1, dtype=np.int64)
+
+    sampler._apply_worker_sampling_filters_for_seeded_multinomial(
+        fake_sampler,
+        torch.randn((1, vocab_size)),
+        mapping,
+        mapping_np,
+        preserve_processed_logits=False,
+    )
+
+    assert isinstance(captured["top_k"], torch.Tensor)
+    assert isinstance(captured["top_p"], torch.Tensor)
+
+
+def test_uniform_top_k_top_p_prefilter_matches_upstream() -> None:
+    torch.manual_seed(60043)
+    logits = torch.randn((4, 256), dtype=torch.float32)
+    top_p = torch.tensor([0.75, 0.8, 0.9, 0.95], dtype=torch.float32)
+    expected = sampler.vllm_topk_topp_sampler.apply_top_k_top_p_pytorch(
+        logits.clone(), torch.full((4,), 50, dtype=torch.int32), top_p
+    )
+
+    actual_input = logits.clone()
+    actual = sampler._apply_top_k_top_p_musa_uniform_k_prefilter(
+        actual_input, 50, top_p
+    )
+
+    assert actual.data_ptr() == actual_input.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert torch.equal(actual.isfinite(), expected.isfinite())
+
+
+def test_uniform_top_k_top_p_prefilter_falls_back_for_boundary_ties() -> None:
+    logits = torch.arange(64, dtype=torch.float32).repeat(2, 1)
+    logits[:, 12:17] = 14.0
+    top_p = torch.tensor([0.9, 0.95], dtype=torch.float32)
+    expected = sampler.vllm_topk_topp_sampler.apply_top_k_top_p_pytorch(
+        logits.clone(), torch.full((2,), 50, dtype=torch.int32), top_p
+    )
+
+    actual = sampler._apply_top_k_top_p_musa_uniform_k_prefilter(
+        logits.clone(), 50, top_p
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert torch.equal(actual.isfinite(), expected.isfinite())
+
+
+def test_unseeded_uniform_min_p_reaches_sampler_as_scalar(monkeypatch) -> None:
+    captured = {}
+
+    def fake_sample_from_logits(logits, top_k, top_p, min_p):
+        captured.update(top_k=top_k, top_p=top_p, min_p=min_p)
+        return torch.zeros(logits.shape[0], dtype=torch.int64)
+
+    monkeypatch.setattr(sampler, "sample_from_logits", fake_sample_from_logits)
+    sampling_states = SimpleNamespace(
+        vocab_size=128,
+        top_k=_state_array([128, 128], torch.int32),
+        top_p=_state_array([1.0, 1.0], torch.float32),
+        min_p=_state_array([0.05, 0.05], torch.float32),
+    )
+    mapping = torch.tensor([0, 1], dtype=torch.int64)
+    mapping_np = np.asarray([0, 1], dtype=np.int64)
+
+    sampler.sample_worker_logits(
+        torch.randn((2, 128)), sampling_states, mapping, mapping_np
+    )
+
+    assert captured == {"top_k": None, "top_p": None, "min_p": pytest.approx(0.05)}
+
+
+def test_unseeded_mixed_min_p_keeps_tensor_fallback(monkeypatch) -> None:
+    captured = {}
+
+    def fake_sample_from_logits(logits, top_k, top_p, min_p):
+        captured["min_p"] = min_p
+        return torch.zeros(logits.shape[0], dtype=torch.int64)
+
+    monkeypatch.setattr(sampler, "sample_from_logits", fake_sample_from_logits)
+    sampling_states = SimpleNamespace(
+        vocab_size=128,
+        top_k=_state_array([128, 128], torch.int32),
+        top_p=_state_array([1.0, 1.0], torch.float32),
+        min_p=_state_array([0.05, 0.1], torch.float32),
+    )
+    mapping = torch.tensor([0, 1], dtype=torch.int64)
+    mapping_np = np.asarray([0, 1], dtype=np.int64)
+
+    sampler.sample_worker_logits(
+        torch.randn((2, 128)), sampling_states, mapping, mapping_np
+    )
+
+    assert isinstance(captured["min_p"], torch.Tensor)
+    torch.testing.assert_close(
+        captured["min_p"], torch.tensor([0.05, 0.1]), rtol=0, atol=0
+    )
+
+
+@requires_musa
+@pytest.mark.parametrize("vocab_size", [151936, 248320])
+@pytest.mark.parametrize("rows", [1, 4, 16, 64])
+def test_uniform_min_p_scalar_preserves_tokens_and_generator_state(
+    vocab_size: int, rows: int
+) -> None:
+    torch.manual_seed(60043 + rows)
+    probs = torch.softmax(
+        torch.randn((rows, vocab_size), device="musa", dtype=torch.float32), dim=-1
+    )
+    probs = sampler._ops.top_k_renorm_probs(probs, 50)
+    scalar_generator = torch.Generator(device="musa").manual_seed(5678)
+    tensor_generator = torch.Generator(device="musa").manual_seed(5678)
+
+    scalar_tokens = sampler._ops.min_p_sampling_from_probs(
+        probs, 0.05, generator=scalar_generator
+    )
+    tensor_tokens = sampler._ops.min_p_sampling_from_probs(
+        probs,
+        torch.full((rows,), 0.05, device="musa", dtype=torch.float32),
+        generator=tensor_generator,
+    )
+    torch.musa.synchronize()
+
+    assert torch.equal(scalar_tokens, tensor_tokens)
+    assert torch.equal(scalar_generator.get_state(), tensor_generator.get_state())

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -21,6 +21,9 @@ _MATE_GDN_PREFILL_HAS_OUTPUT = (
 _MATE_GDN_PREFILL_HAS_IS_LOG_SPACE = (
     "is_log_space" in inspect.signature(chunk_gated_delta_rule).parameters
 )
+_MATE_GDN_DECODE_HAS_OUTPUT = (
+    "output" in inspect.signature(gated_delta_rule_decode).parameters
+)
 
 
 def _log_once(method_name: str, message: str, *args) -> None:
@@ -215,47 +218,64 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
                 if _musa_sep and ssm_state.is_contiguous():
                     # MUSA: separate contiguous mamba pool -> mate decodes in
                     # place (block b at b*state_numel); no gather/scatter copy.
-                    output, _ = gated_delta_rule_decode(
-                        q=query,
-                        k=key,
-                        v=value,
-                        state=ssm_state,
-                        state_layout="VK",
-                        state_indices=state_indices,
-                        scale=self.head_k_dim**-0.5,
-                        A_log=self.A_log.detach().float(),
-                        a=a.view(num_decode_tokens, 1, -1),
-                        dt_bias=self.dt_bias.detach().float(),
-                        b=b.view(num_decode_tokens, 1, -1),
-                        disable_state_update=False,
-                        use_qk_l2norm=True,
-                    )
+                    mate_kwargs = {
+                        "q": query,
+                        "k": key,
+                        "v": value,
+                        "state": ssm_state,
+                        "state_layout": "VK",
+                        "state_indices": state_indices,
+                        "scale": self.head_k_dim**-0.5,
+                        "A_log": self.A_log.detach().float(),
+                        "a": a.view(num_decode_tokens, 1, -1),
+                        "dt_bias": self.dt_bias.detach().float(),
+                        "b": b.view(num_decode_tokens, 1, -1),
+                        "disable_state_update": False,
+                        "use_qk_l2norm": True,
+                    }
+                    if _MATE_GDN_DECODE_HAS_OUTPUT:
+                        mate_kwargs["output"] = core_attn_out[:num_decode_tokens].view(
+                            num_decode_tokens,
+                            1,
+                            self.num_v_heads // self.tp_size,
+                            self.head_v_dim,
+                        )
+                    output, _ = gated_delta_rule_decode(**mate_kwargs)
                     _log_once(
                         "info",
                         "MUSA GDN mate in-place decode active (separate pool)",
                     )
                 else:
                     active_state = ssm_state[state_indices]
-                    output, updated_state = gated_delta_rule_decode(
-                        q=query,
-                        k=key,
-                        v=value,
-                        state=active_state,
-                        state_layout="VK",
-                        scale=self.head_k_dim**-0.5,
-                        A_log=self.A_log.detach().float(),
-                        a=a.view(num_decode_tokens, 1, -1),
-                        dt_bias=self.dt_bias.detach().float(),
-                        b=b.view(num_decode_tokens, 1, -1),
-                        disable_state_update=False,
-                        use_qk_l2norm=True,
-                    )
+                    mate_kwargs = {
+                        "q": query,
+                        "k": key,
+                        "v": value,
+                        "state": active_state,
+                        "state_layout": "VK",
+                        "scale": self.head_k_dim**-0.5,
+                        "A_log": self.A_log.detach().float(),
+                        "a": a.view(num_decode_tokens, 1, -1),
+                        "dt_bias": self.dt_bias.detach().float(),
+                        "b": b.view(num_decode_tokens, 1, -1),
+                        "disable_state_update": False,
+                        "use_qk_l2norm": True,
+                    }
+                    if _MATE_GDN_DECODE_HAS_OUTPUT:
+                        mate_kwargs["output"] = core_attn_out[:num_decode_tokens].view(
+                            num_decode_tokens,
+                            1,
+                            self.num_v_heads // self.tp_size,
+                            self.head_v_dim,
+                        )
+                    output, updated_state = gated_delta_rule_decode(**mate_kwargs)
                     ssm_state[state_indices] = updated_state
-                core_attn_out[:num_decode_tokens] = output.view(
-                    num_decode_tokens,
-                    self.num_v_heads // self.tp_size,
-                    self.head_v_dim,
-                )
+                if not _MATE_GDN_DECODE_HAS_OUTPUT:
+                    core_attn_out[:num_decode_tokens] = output.view(
+                        num_decode_tokens,
+                        self.num_v_heads // self.tp_size,
+                        self.head_v_dim,
+                    )
                 return True
             except Exception as e:
                 _log_once(

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -91,6 +91,8 @@ class Envs:
     VLLM_MUSA_FUSED_ADD_RMSNORM = EnvBool(True)
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SEEDED_MULTINOMIAL = EnvBool(True)
+    VLLM_MUSA_QWEN_V2_GUMBEL = EnvBool(False)
+    VLLM_MUSA_QWEN_LEGACY_GUMBEL = EnvBool(False)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
     # Exact-shape Qwen2 RoPE+NHD-cache fusion.  The model, graph, dtype, and
     # tensor-layout gates fail closed; the environment switch is an A/B escape

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -19,6 +19,12 @@ from vllm_musa.utils.environ import envs
 logger = logging.getLogger(__name__)
 
 _SAMPLING_EPS = 1e-5
+_MUSA_QWEN_SAMPLER_VOCAB_SIZES = frozenset((151936, 248320))
+
+
+def _is_qwen_sampler_vocab(logits: torch.Tensor) -> bool:
+    """Limit scalar sampler specializations to validated Qwen vocabularies."""
+    return logits.ndim == 2 and logits.shape[1] in _MUSA_QWEN_SAMPLER_VOCAB_SIZES
 
 
 def _is_uniform_top_k_50(top_k: np.ndarray) -> bool:
@@ -26,8 +32,24 @@ def _is_uniform_top_k_50(top_k: np.ndarray) -> bool:
     return top_k.size > 0 and bool(np.all(top_k == 50))
 
 
+def _uniform_active_min_p(min_p: np.ndarray) -> float | None:
+    """Return a uniform active min-p value from the existing CPU state."""
+    if min_p.size == 0 or not bool(np.all(min_p == min_p[0])):
+        return None
+    value = float(min_p[0])
+    return value if value != 0.0 else None
+
+
 def musa_seeded_multinomial_enabled() -> bool:
     return envs.VLLM_MUSA_SEEDED_MULTINOMIAL.get()
+
+
+def musa_qwen_v2_gumbel_enabled() -> bool:
+    return envs.VLLM_MUSA_QWEN_V2_GUMBEL.get()
+
+
+def musa_qwen_legacy_gumbel_enabled() -> bool:
+    return envs.VLLM_MUSA_QWEN_LEGACY_GUMBEL.get()
 
 
 def is_musa_tensor(tensor: torch.Tensor) -> bool:
@@ -184,20 +206,64 @@ def _apply_top_k_top_p_musa_topk_prefilter(
     top_p_mask[:, -1] = False
     logits_sort.masked_fill_(top_p_mask, -float("inf"))
 
-    output = logits.new_full(logits.shape, -float("inf"))
-    output.scatter_(dim=-1, index=logits_idx, src=logits_sort)
-    logits.copy_(output)
-    return logits
+    # ``values`` and ``indices`` do not alias ``logits``. Reuse the input
+    # buffer instead of allocating a full-vocabulary output and copying it
+    # back after the scatter.
+    logits.fill_(-float("inf"))
+    return logits.scatter_(dim=-1, index=logits_idx, src=logits_sort)
+
+
+def _apply_top_k_top_p_musa_uniform_k_prefilter(
+    logits: torch.Tensor, k: int, p: torch.Tensor
+) -> torch.Tensor:
+    """Apply uniform top-k/top-p without reading sampling state from MUSA.
+
+    The CPU sampling state has already proved that every active row uses the
+    same ``k``. The only host read is the post-topk tie check: it preserves the
+    upstream rule that all values tied at the kth boundary remain eligible.
+    """
+    values, indices = logits.topk(k, dim=-1, largest=True, sorted=True)
+    threshold = values[:, -1:]
+    num_ge = (logits >= threshold).sum(dim=-1)
+    if bool((num_ge != k).any().item()):
+        k_tensor = torch.full(
+            (logits.shape[0],), k, dtype=torch.int32, device=logits.device
+        )
+        return vllm_topk_topp_sampler.apply_top_k_top_p_pytorch(logits, k_tensor, p)
+
+    logits_sort = values.flip(dims=(-1,))
+    logits_idx = indices.flip(dims=(-1,))
+    probs_sort = logits_sort.softmax(dim=-1)
+    probs_sum = torch.cumsum(probs_sort, dim=-1, out=probs_sort)
+    top_p_mask = probs_sum <= 1 - p.unsqueeze(dim=1)
+    top_p_mask[:, -1] = False
+    logits_sort.masked_fill_(top_p_mask, -float("inf"))
+
+    logits.fill_(-float("inf"))
+    return logits.scatter_(dim=-1, index=logits_idx, src=logits_sort)
 
 
 def _apply_top_k_top_p(
-    logits: torch.Tensor, k: torch.Tensor | None, p: torch.Tensor | None
+    logits: torch.Tensor,
+    k: torch.Tensor | int | None,
+    p: torch.Tensor | None,
 ) -> torch.Tensor:
     if p is None and k is None:
         return logits
 
+    # Uniform k=50 is already known from CPU sampling state. Keep the exact
+    # upstream threshold/tie semantics without materializing a device k tensor
+    # or synchronizing it back to the CPU before submitting topk.
+    if isinstance(k, int):
+        if k <= 0 or k >= logits.shape[1]:
+            return logits
+        if p is None:
+            threshold = logits.topk(k, dim=1).values[:, -1:]
+            return logits.masked_fill_(logits < threshold, -float("inf"))
+        return _apply_top_k_top_p_musa_uniform_k_prefilter(logits, k, p)
+
     if current_platform.is_musa():
-        if k is not None and logits.shape[0] >= 16:
+        if isinstance(k, torch.Tensor) and logits.shape[0] >= 16:
             if p is None and logits.shape[1] >= 65536:
                 max_top_k = int(k.to(torch.long).max().item())
                 if 0 < max_top_k <= 1024:
@@ -310,6 +376,128 @@ def _call_topk_topp_sampler(
         sampler.logprobs_mode = original_logprobs_mode
 
 
+def can_use_qwen_legacy_gumbel(
+    logits: torch.Tensor,
+    sampling_metadata: Any,
+    logprobs_mode: LogprobsMode,
+    deferred_min_p: torch.Tensor | None,
+    use_fp64_gumbel: bool,
+) -> bool:
+    """Gate MRV1 Qwen sampling to a batched stateless Gumbel handoff."""
+    if not musa_qwen_legacy_gumbel_enabled():
+        return False
+    if not current_platform.is_musa() or not is_musa_tensor(logits):
+        return False
+    if (
+        logits.ndim != 2
+        or logits.shape[0] == 0
+        or logits.shape[1] != 248320
+        or logits.stride(-1) != 1
+    ):
+        return False
+    if logprobs_mode != "raw_logprobs" or deferred_min_p is not None or use_fp64_gumbel:
+        return False
+    if (
+        sampling_metadata.max_num_logprobs is not None
+        or sampling_metadata.logprob_token_ids
+        or not sampling_metadata.all_random
+    ):
+        return False
+    top_k = sampling_metadata.top_k
+    if (
+        top_k is None
+        or top_k.ndim != 1
+        or top_k.numel() != logits.shape[0]
+        or sampling_metadata.top_p is not None
+    ):
+        return False
+
+    spec_token_ids = getattr(sampling_metadata, "spec_token_ids", None)
+    if spec_token_ids and any(spec_token_ids):
+        return False
+
+    generators = sampling_metadata.generators
+    rows = logits.shape[0]
+    if len(generators) != rows or not all(row in generators for row in range(rows)):
+        return False
+    return all(
+        hasattr(generator, "initial_seed")
+        and hasattr(generator, "get_offset")
+        and hasattr(generator, "set_offset")
+        and getattr(getattr(generator, "device", None), "type", None)
+        == logits.device.type
+        for generator in generators.values()
+    )
+
+
+def get_qwen_legacy_generator_state(
+    generators: dict[int, torch.Generator], rows: int
+) -> tuple[list[int], list[int]] | None:
+    """Read a valid per-row seed/Philox-offset snapshot without mutation."""
+    seeds = []
+    offsets = []
+    int64_max = np.iinfo(np.int64).max
+    try:
+        for row in range(rows):
+            generator = generators[row]
+            seed = int(generator.initial_seed())
+            offset = int(generator.get_offset())
+            if seed < 0 or seed > int64_max or offset < 0 or offset % 4:
+                return None
+            seeds.append(seed)
+            offsets.append(offset)
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return None
+    return seeds, offsets
+
+
+def sample_qwen_legacy_gumbel(
+    logits: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    top_k: torch.Tensor,
+    generator_state: tuple[list[int], list[int]],
+) -> torch.Tensor:
+    """Batch MRV1 seeded rows and preserve one-call generator offsets."""
+    logits = _apply_top_k_top_p(logits, top_k, None)
+    seeds_cpu, offsets_cpu = generator_state
+    rows = logits.shape[0]
+    mapping = torch.arange(rows, dtype=torch.int32, device=logits.device)
+    temperature = torch.ones(rows, dtype=torch.float32, device=logits.device)
+    seeds = torch.tensor(seeds_cpu, dtype=torch.int64, device=logits.device)
+    positions = torch.tensor(
+        [offset // 4 for offset in offsets_cpu],
+        dtype=torch.int64,
+        device=logits.device,
+    )
+    sampled = vllm_worker_sampler.gumbel_sample(
+        logits,
+        mapping,
+        temperature,
+        seeds,
+        positions,
+        apply_temperature=False,
+        use_fp64=False,
+    )
+    advanced_rows = []
+    try:
+        for row, offset in enumerate(offsets_cpu):
+            generators[row].set_offset(offset + 4)
+            advanced_rows.append(row)
+    except (RuntimeError, TypeError, ValueError) as error:
+        rollback_errors = []
+        for row in reversed(advanced_rows):
+            try:
+                generators[row].set_offset(offsets_cpu[row])
+            except (RuntimeError, TypeError, ValueError) as rollback_error:
+                rollback_errors.append(rollback_error)
+        if rollback_errors:
+            raise RuntimeError(
+                "Failed to advance and fully roll back legacy MUSA generators"
+            ) from error
+        raise RuntimeError("Failed to advance legacy MUSA generators") from error
+    return sampled
+
+
 def _sample(
     self: Any,
     logits: torch.Tensor,
@@ -348,7 +536,31 @@ def _sample(
             continue
         logits = processor.apply(logits)
 
-    if musa_min_p is None:
+    use_legacy_gumbel = can_use_qwen_legacy_gumbel(
+        logits,
+        sampling_metadata,
+        logprobs_mode,
+        musa_min_p,
+        self.use_fp64_gumbel,
+    )
+    legacy_generator_state = (
+        get_qwen_legacy_generator_state(sampling_metadata.generators, logits.shape[0])
+        if use_legacy_gumbel
+        else None
+    )
+    if legacy_generator_state is not None:
+        vllm_topk_topp_sampler.logger.info_once(
+            "Using the gated MUSA legacy Gumbel sampler for Qwen requests.",
+            scope="global",
+        )
+        random_sampled = sample_qwen_legacy_gumbel(
+            logits,
+            sampling_metadata.generators,
+            sampling_metadata.top_k,
+            legacy_generator_state,
+        )
+        processed_logprobs = None
+    elif musa_min_p is None:
         random_sampled, processed_logprobs = _call_topk_topp_sampler(
             self.topk_topp_sampler,
             logprobs_mode,
@@ -410,6 +622,56 @@ def has_worker_user_seed(sampling_states: Any, idx_mapping_np: np.ndarray) -> bo
     return bool(np.any(has_user_seed[idx_mapping_np]))
 
 
+def has_worker_all_user_seeds(sampling_states: Any, idx_mapping_np: np.ndarray) -> bool:
+    has_user_seed = getattr(sampling_states, "has_user_seed", None)
+    if has_user_seed is None or idx_mapping_np.size == 0:
+        return False
+    return bool(np.all(has_user_seed[idx_mapping_np]))
+
+
+def can_use_qwen_v2_gumbel(
+    sampler: Any,
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    idx_mapping_np: np.ndarray,
+    pos: torch.Tensor,
+    return_logprobs: bool,
+) -> bool:
+    """Gate the pinned V2 Gumbel sampler to one validated Qwen contract."""
+    if not musa_qwen_v2_gumbel_enabled():
+        return False
+    if not current_platform.is_musa() or not is_musa_tensor(logits):
+        return False
+    if not _is_qwen_sampler_vocab(logits) or logits.stride(-1) != 1:
+        return False
+    if idx_mapping_np.ndim != 1 or logits.shape[0] != idx_mapping_np.size:
+        return False
+    if (
+        expanded_idx_mapping.ndim != 1
+        or expanded_idx_mapping.numel() != logits.shape[0]
+    ):
+        return False
+    if pos.ndim != 1 or pos.numel() != logits.shape[0]:
+        return False
+    if getattr(sampler, "num_speculative_tokens", 1) != 1:
+        return False
+    if sampler.use_fp64_gumbel or sampler.logprobs_mode != "raw_logprobs":
+        return False
+    if return_logprobs or not has_worker_all_user_seeds(
+        sampler.sampling_states, idx_mapping_np
+    ):
+        return False
+
+    states = sampler.sampling_states
+    if not np.all(states.temperature.np[idx_mapping_np] == np.float32(1.0)):
+        return False
+    if not np.all(states.top_k.np[idx_mapping_np] == 50):
+        return False
+    if not np.all(states.top_p.np[idx_mapping_np] == np.float32(1.0)):
+        return False
+    return bool(np.all(states.min_p.np[idx_mapping_np] == np.float32(0.05)))
+
+
 def can_use_worker_seeded_multinomial(
     logits: torch.Tensor,
     logprobs_mode: LogprobsMode,
@@ -456,18 +718,28 @@ def sample_worker_logits(
 ) -> torch.Tensor:
     vocab_size = sampling_states.vocab_size
     top_k_np = sampling_states.top_k.np[idx_mapping_np]
+    min_p_np = sampling_states.min_p.np[idx_mapping_np]
     use_top_k = np.any(top_k_np != vocab_size)
     use_top_p = np.any(sampling_states.top_p.np[idx_mapping_np] != 1.0)
-    use_min_p = np.any(sampling_states.min_p.np[idx_mapping_np] != 0.0)
+    use_min_p = np.any(min_p_np != 0.0)
 
     # Select the scalar from existing CPU sampling state so the decode path
     # never copies a device tensor to the host merely to choose a kernel.
-    if use_top_k and _is_uniform_top_k_50(top_k_np):
+    if (
+        use_top_k
+        and _is_uniform_top_k_50(top_k_np)
+        and _is_qwen_sampler_vocab(logits)
+        and (not use_top_p or logits.shape[0] >= 4)
+    ):
         top_k = 50
     else:
         top_k = sampling_states.top_k.gpu[expanded_idx_mapping] if use_top_k else None
     top_p = sampling_states.top_p.gpu[expanded_idx_mapping] if use_top_p else None
-    min_p = sampling_states.min_p.gpu[expanded_idx_mapping] if use_min_p else None
+    uniform_min_p = _uniform_active_min_p(min_p_np)
+    if uniform_min_p is not None:
+        min_p = uniform_min_p
+    else:
+        min_p = sampling_states.min_p.gpu[expanded_idx_mapping] if use_min_p else None
     return sample_from_logits(logits, top_k, top_p, min_p)
 
 
@@ -482,6 +754,38 @@ def sample_worker_logits_seeded_multinomial(
         for row_idx, req_idx in enumerate(idx_mapping_np)
     }
     return sample_probs_seeded_multinomial(probs, generators)
+
+
+def sample_worker_logits_qwen_v2_gumbel(
+    sampler: Any,
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    idx_mapping_np: np.ndarray,
+    pos: torch.Tensor,
+    input_ids: torch.Tensor,
+    expanded_local_pos: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run pinned V2 Gumbel with CPU-proven uniform Qwen top-k state."""
+    processed_logits = sampler.apply_sampling_params(
+        logits,
+        expanded_idx_mapping,
+        idx_mapping_np,
+        pos,
+        input_ids,
+        expanded_local_pos,
+        skip_top_k_top_p=True,
+    )
+    processed_logits = _apply_top_k_top_p(processed_logits, 50, None)
+    sampled = vllm_worker_sampler.gumbel_sample(
+        processed_logits,
+        expanded_idx_mapping,
+        sampler.sampling_states.temperature.gpu,
+        sampler.sampling_states.seeds.gpu,
+        pos,
+        apply_temperature=False,
+        use_fp64=False,
+    )
+    return sampled, processed_logits
 
 
 def _sampling_states_init(self: Any, max_num_reqs: int, vocab_size: int):
@@ -542,16 +846,29 @@ def _apply_worker_sampling_filters_for_seeded_multinomial(
     logits: torch.Tensor,
     expanded_idx_mapping: torch.Tensor,
     idx_mapping_np: np.ndarray,
+    preserve_processed_logits: bool = True,
 ) -> torch.Tensor:
-    logits = torch.empty_like(logits, dtype=torch.float32).copy_(logits)
+    if preserve_processed_logits:
+        logits = torch.empty_like(logits, dtype=torch.float32).copy_(logits)
 
     vocab_size = sampler.sampling_states.vocab_size
-    use_top_k = np.any(sampler.sampling_states.top_k.np[idx_mapping_np] != vocab_size)
+    top_k_np = sampler.sampling_states.top_k.np[idx_mapping_np]
+    use_top_k = np.any(top_k_np != vocab_size)
     use_top_p = np.any(sampler.sampling_states.top_p.np[idx_mapping_np] != 1.0)
     use_min_p = np.any(sampler.sampling_states.min_p.np[idx_mapping_np] != 0.0)
-    top_k = (
-        sampler.sampling_states.top_k.gpu[expanded_idx_mapping] if use_top_k else None
-    )
+    if (
+        use_top_k
+        and _is_uniform_top_k_50(top_k_np)
+        and _is_qwen_sampler_vocab(logits)
+        and (not use_top_p or logits.shape[0] >= 4)
+    ):
+        top_k = 50
+    else:
+        top_k = (
+            sampler.sampling_states.top_k.gpu[expanded_idx_mapping]
+            if use_top_k
+            else None
+        )
     top_p = (
         sampler.sampling_states.top_p.gpu[expanded_idx_mapping] if use_top_p else None
     )
@@ -573,6 +890,28 @@ def _worker_sample(
     expanded_local_pos: torch.Tensor,
     return_logprobs: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if can_use_qwen_v2_gumbel(
+        self,
+        logits,
+        expanded_idx_mapping,
+        idx_mapping_np,
+        pos,
+        return_logprobs,
+    ):
+        vllm_topk_topp_sampler.logger.info_once(
+            "Using the gated MUSA V2 Gumbel sampler for Qwen requests.",
+            scope="global",
+        )
+        return sample_worker_logits_qwen_v2_gumbel(
+            self,
+            logits,
+            expanded_idx_mapping,
+            idx_mapping_np,
+            pos,
+            input_ids,
+            expanded_local_pos,
+        )
+
     if logits.shape[0] == idx_mapping_np.shape[0] and can_use_worker_seeded_multinomial(
         logits, self.logprobs_mode, self.sampling_states, idx_mapping_np
     ):
@@ -594,6 +933,7 @@ def _worker_sample(
             processed_logits,
             expanded_idx_mapping,
             idx_mapping_np,
+            preserve_processed_logits=return_logprobs,
         )
         sampled = sample_worker_logits_seeded_multinomial(
             sampling_logits, self.sampling_states, idx_mapping_np


### PR DESCRIPTION
## Summary

This draft adds two narrowly gated vLLM-MUSA optimizations for the Qwen family:

- Reuse the caller-owned output buffer for the pinned MATE GDN decode API.
- Add an experimental legacy (MRV1) Qwen3.5/Qwen3.6 seeded sampler path that
  batches per-row stateless Gumbel sampling and preserves the MUSA generator
  Philox offset contract.

The patch changes vLLM-MUSA only. It does not override or modify vLLM,
vLLM-Omni, or any upstream model code.

## Runtime gates

- `VLLM_MUSA_QWEN_LEGACY_GUMBEL=0` by default.
- The legacy path is selected only for MUSA, vocabulary size 248320,
  contiguous 2-D logits, raw/no-logprobs, all-random requests, no speculative
  tokens, no deferred min-p, valid per-request MUSA generators, and the
  validated top-k=50/top-p=1/min-p=.05 contract.
- Unsupported MATE APIs, shapes, generator state, mixed filters, and mixed
  seeded/unseeded batches fall back without changing the existing path.

## Formal Qwen3.5 result

Qwen3.5-27B BF16, TP2, one isolated S5000 node, exact 4096-input/1024-output
contract, fresh-server A-B-B-A, normal compile and `FULL_AND_PIECEWISE` graph
capture:

| Batch size | TPOT delta | Output throughput delta | TTFT delta |
|---:|---:|---:|---:|
| 1 | -2.248537% | +2.276222% | -0.900799% |
| 4 | -1.907582% | +1.858335% | -0.036928% |
| 16 | -5.724640% | +5.468920% | -0.234500% |
| 64 | -21.353237% | +22.057325% | -0.351893% |

All 340 measured requests completed with zero failures and exact output
lengths. The environment switch remains disabled by default because random
completion hashes drift across fresh servers in both control and candidate,
and mixed seeded/unseeded partitioning still needs a dedicated implementation.

## Sibling path smoke

The same source and image hit the legacy Gumbel marker and passed FA3,
GDN/MATE, compile, and graph checks on:

- Qwen3.5-35B-A3B BF16 TP4, BS1, 128 output tokens;
- Qwen3.6-27B TP2, BS1, 8 output tokens;
- Qwen3.6-35B-A3B TP4, BS1, 8 output tokens.

These are path checks, not cross-model performance comparisons.

## Validation

- Base: `3e7c5035cb89b591e78e26da1d044724d6d73c36`
- Image: `registry.mthreads.com/mcconline/inference/vllm@sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`
- `py_compile`: passed
- Ruff check/format: passed
- `git diff --check`: passed
- Exact-image no-pytest sampler gate: passed
- MUSA generator handoff probe: replay, row permutation, offset continuity,
  and fallback continuity passed

## Review focus

Please review the generator-state contract, the fail-closed gates, and whether
the default-off legacy path should be extended to per-request seeded/unseeded
partitioning. The next experiments will cover the frozen-logits oracle,
Qwen3.5 MoE/Qwen3.6 full A-B-B-A, and logits-to-sampling graph bubbles.
