### PR TITLE
perf(musa): partition mixed Qwen seeded sampling

### DIFF
--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -178,9 +178,23 @@ def test_qwen_legacy_gumbel_gate_fails_closed(monkeypatch) -> None:
         None,
         False,
     )
-    assert not sampler.can_use_qwen_legacy_gumbel(
+    assert sampler.can_use_qwen_legacy_gumbel(
         logits,
         _legacy_gumbel_metadata(4, generators={0: _FakeGenerator(1)}),
+        "raw_logprobs",
+        None,
+        False,
+    )
+    assert not sampler.can_use_qwen_legacy_gumbel(
+        logits,
+        _legacy_gumbel_metadata(4, generators={}),
+        "raw_logprobs",
+        None,
+        False,
+    )
+    assert not sampler.can_use_qwen_legacy_gumbel(
+        logits,
+        _legacy_gumbel_metadata(4, generators={4: _FakeGenerator(1)}),
         "raw_logprobs",
         None,
         False,
@@ -230,6 +244,65 @@ def test_qwen_legacy_gumbel_rolls_back_partial_generator_advance(
         )
 
     assert [generator.get_offset() for generator in generators.values()] == [0] * rows
+
+
+def test_qwen_legacy_gumbel_partitions_seeded_and_unseeded_rows(
+    monkeypatch,
+) -> None:
+    rows = 4
+    logits = torch.randn((rows, 248320))
+    generators = {0: _FakeGenerator(60043), 2: _FakeGenerator(60045)}
+    captured = {}
+
+    def fake_gumbel_sample(
+        processed_logits,
+        mapping,
+        temperature,
+        seeds,
+        positions,
+        **kwargs,
+    ):
+        captured.update(
+            processed_logits=processed_logits.clone(),
+            mapping=mapping.clone(),
+            temperature=temperature.clone(),
+            seeds=seeds.clone(),
+            positions=positions.clone(),
+            kwargs=kwargs,
+        )
+        return torch.tensor([10, 20], dtype=torch.int64)
+
+    def fake_multinomial(probs, subset_generators):
+        captured.update(
+            unseeded_probs=probs.clone(),
+            unseeded_generators=subset_generators,
+        )
+        return torch.tensor([11, 13], dtype=torch.int64)
+
+    monkeypatch.setattr(sampler, "_apply_top_k_top_p", lambda tensor, *_args: tensor)
+    monkeypatch.setattr(
+        sampler.vllm_worker_sampler, "gumbel_sample", fake_gumbel_sample
+    )
+    monkeypatch.setattr(sampler, "sample_probs_seeded_multinomial", fake_multinomial)
+
+    sampled = sampler.sample_qwen_legacy_gumbel_partitioned(
+        logits,
+        generators,
+        torch.full((rows,), 50, dtype=torch.int32),
+    )
+
+    assert sampled.tolist() == [10, 11, 20, 13]
+    assert torch.equal(captured["processed_logits"], logits[[0, 2]])
+    assert captured["mapping"].tolist() == [0, 1]
+    assert captured["seeds"].tolist() == [60043, 60045]
+    assert captured["positions"].tolist() == [0, 0]
+    assert captured["kwargs"] == {"apply_temperature": False, "use_fp64": False}
+    assert torch.allclose(
+        captured["unseeded_probs"],
+        logits[[1, 3]].softmax(dim=-1, dtype=torch.float32),
+    )
+    assert captured["unseeded_generators"] == {}
+    assert [generator.get_offset() for generator in generators.values()] == [4, 4]
 
 
 def test_qwen_legacy_gumbel_gate_is_disabled_by_default(monkeypatch) -> None:

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -418,7 +418,7 @@ def can_use_qwen_legacy_gumbel(
 
     generators = sampling_metadata.generators
     rows = logits.shape[0]
-    if len(generators) != rows or not all(row in generators for row in range(rows)):
+    if not generators or any(row < 0 or row >= rows for row in generators):
         return False
     return all(
         hasattr(generator, "initial_seed")
@@ -430,15 +430,15 @@ def can_use_qwen_legacy_gumbel(
     )
 
 
-def get_qwen_legacy_generator_state(
-    generators: dict[int, torch.Generator], rows: int
+def _get_qwen_legacy_generator_state_for_rows(
+    generators: dict[int, torch.Generator], row_indices: list[int]
 ) -> tuple[list[int], list[int]] | None:
-    """Read a valid per-row seed/Philox-offset snapshot without mutation."""
+    """Read a valid sparse per-row seed/offset snapshot without mutation."""
     seeds = []
     offsets = []
     int64_max = np.iinfo(np.int64).max
     try:
-        for row in range(rows):
+        for row in row_indices:
             generator = generators[row]
             seed = int(generator.initial_seed())
             offset = int(generator.get_offset())
@@ -451,6 +451,13 @@ def get_qwen_legacy_generator_state(
     return seeds, offsets
 
 
+def get_qwen_legacy_generator_state(
+    generators: dict[int, torch.Generator], rows: int
+) -> tuple[list[int], list[int]] | None:
+    """Read a valid contiguous per-row seed/offset snapshot without mutation."""
+    return _get_qwen_legacy_generator_state_for_rows(generators, list(range(rows)))
+
+
 def sample_qwen_legacy_gumbel(
     logits: torch.Tensor,
     generators: dict[int, torch.Generator],
@@ -459,6 +466,15 @@ def sample_qwen_legacy_gumbel(
 ) -> torch.Tensor:
     """Batch MRV1 seeded rows and preserve one-call generator offsets."""
     logits = _apply_top_k_top_p(logits, top_k, None)
+    return _sample_qwen_legacy_gumbel_filtered(logits, generators, generator_state)
+
+
+def _sample_qwen_legacy_gumbel_filtered(
+    logits: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    generator_state: tuple[list[int], list[int]],
+) -> torch.Tensor:
+    """Sample already-filtered logits and advance the remapped generators."""
     seeds_cpu, offsets_cpu = generator_state
     rows = logits.shape[0]
     mapping = torch.arange(rows, dtype=torch.int32, device=logits.device)
@@ -495,6 +511,54 @@ def sample_qwen_legacy_gumbel(
                 "Failed to advance and fully roll back legacy MUSA generators"
             ) from error
         raise RuntimeError("Failed to advance legacy MUSA generators") from error
+    return sampled
+
+
+def sample_qwen_legacy_gumbel_partitioned(
+    logits: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    top_k: torch.Tensor,
+) -> torch.Tensor | None:
+    """Use Gumbel for seeded rows and preserve multinomial for unseeded rows."""
+    rows = logits.shape[0]
+    seeded_rows = sorted(generators)
+    if not seeded_rows or any(row < 0 or row >= rows for row in seeded_rows):
+        return None
+    seeded_state = _get_qwen_legacy_generator_state_for_rows(generators, seeded_rows)
+    if seeded_state is None:
+        return None
+    if len(seeded_rows) == rows:
+        return sample_qwen_legacy_gumbel(
+            logits,
+            generators,
+            top_k,
+            seeded_state,
+        )
+
+    filtered_logits = _apply_top_k_top_p(logits, top_k, None)
+    seeded_index = torch.tensor(seeded_rows, dtype=torch.long, device=logits.device)
+    unseeded_rows = [row for row in range(rows) if row not in generators]
+    seeded_logits = filtered_logits.index_select(0, seeded_index)
+    remapped_generators = {
+        new_row: generators[old_row] for new_row, old_row in enumerate(seeded_rows)
+    }
+    seeded_sampled = _sample_qwen_legacy_gumbel_filtered(
+        seeded_logits,
+        remapped_generators,
+        seeded_state,
+    )
+
+    sampled = torch.empty(rows, dtype=torch.long, device=logits.device)
+    sampled.index_copy_(0, seeded_index, seeded_sampled)
+    if unseeded_rows:
+        unseeded_index = torch.tensor(
+            unseeded_rows, dtype=torch.long, device=logits.device
+        )
+        unseeded_probs = filtered_logits.index_select(0, unseeded_index).softmax(
+            dim=-1, dtype=torch.float32
+        )
+        unseeded_sampled = sample_probs_seeded_multinomial(unseeded_probs, {})
+        sampled.index_copy_(0, unseeded_index, unseeded_sampled)
     return sampled
 
 
@@ -543,22 +607,27 @@ def _sample(
         musa_min_p,
         self.use_fp64_gumbel,
     )
-    legacy_generator_state = (
-        get_qwen_legacy_generator_state(sampling_metadata.generators, logits.shape[0])
-        if use_legacy_gumbel
-        else None
-    )
-    if legacy_generator_state is not None:
-        vllm_topk_topp_sampler.logger.info_once(
-            "Using the gated MUSA legacy Gumbel sampler for Qwen requests.",
-            scope="global",
-        )
-        random_sampled = sample_qwen_legacy_gumbel(
+    legacy_sampled = (
+        sample_qwen_legacy_gumbel_partitioned(
             logits,
             sampling_metadata.generators,
             sampling_metadata.top_k,
-            legacy_generator_state,
         )
+        if use_legacy_gumbel
+        else None
+    )
+    if legacy_sampled is not None:
+        if len(sampling_metadata.generators) < logits.shape[0]:
+            vllm_topk_topp_sampler.logger.info_once(
+                "Using mixed seeded/unseeded MUSA legacy Gumbel partition.",
+                scope="global",
+            )
+        else:
+            vllm_topk_topp_sampler.logger.info_once(
+                "Using the gated MUSA legacy Gumbel sampler for Qwen requests.",
+                scope="global",
+            )
+        random_sampled = legacy_sampled
         processed_logprobs = None
     elif musa_min_p is None:
         random_sampled, processed_logprobs = _call_topk_topp_sampler(


### PR DESCRIPTION
## Summary

This is a dependent follow-up to draft PR #123:
https://github.com/MooreThreads/vllm-musa/pull/123

It extends the default-off Qwen legacy Gumbel experiment to batches that mix
explicitly seeded and unseeded requests. The implementation keeps the existing
per-row multinomial behavior for unseeded rows, uses the batched stateless
Gumbel path only for seeded rows, and restores the original row order.

The PR is intentionally stacked on
`perf/musa-60043-qwen-family-formal`; it does not change vLLM-Omni and does not
enable the experiment by default.

## Implementation

- Accept a non-empty sparse generator map whose keys are valid batch rows.
- Apply the existing top-k filter once to the full batch.
- Compact seeded rows for one stateless Gumbel launch, remapping generator
  rows only inside that launch.
- Sample unseeded rows with the existing multinomial helper and global MUSA RNG.
- Scatter both results back to the original batch order.
- Preserve the all-seeded path from PR #123 without adding partition/index
  launches.
- Add CPU-state unit coverage for sparse validation, row restoration, seed and
  offset handoff, and the unseeded probability path.

## Evidence

### Fixed-logits semantic/operator probe

One isolated S5000, BS 1/4/16/64:

- all seeded rows matched a standalone Gumbel launch for the same seed/offset;
- unseeded rows matched the all-multinomial control exactly;
- the next global MUSA RNG token matched control;
- every seeded generator advanced from offset 0 to 4.

BS64 fixed-filtered-logits host-timed comparison:

| Seeded rows | Existing multinomial | Partitioned candidate | Speedup |
|---:|---:|---:|---:|
| 25% | 43.498 ms | 35.062 ms | 1.241x |
| 50% | 44.150 ms | 24.206 ms | 1.824x |
| 75% | 42.981 ms | 14.455 ms | 2.974x |
| 100% | 45.195 ms | 4.466 ms | 10.119x |

This is operator evidence, not an end-to-end claim.

Raw result: `generated/MUSA-60043/probes/legacy-mixed-partition-v1.json`

Archive SHA256:
`9d44333d67da46d8efa6a84272ef12f83f02335a736b62cb3dee82f6a8f42df0`

### Compiled serving smoke

Qwen3.5-27B BF16 TP2, normal `VLLM_COMPILE` /
`FULL_AND_PIECEWISE` / FA3 path, with two seeded and two unseeded concurrent
requests. Runtime diagnostics observed `rows=4`, `generators=[0, 1]`, and the
mixed partition marker; all four requests returned HTTP 200.

Serving archive SHA256:
`37ef54631c411183da542d1d4e43805c6d338b692658287f73ade78c44799b84`

No formal mixed-composition serving A/B is claimed yet. That is the next gate,
after review of this default-off prototype.

## Validation

- `python -m py_compile vllm_musa/v1/sample/topk_topp_sampler.py tests/test_sampler_cpu_state_fast_paths.py`
- `ruff check vllm_musa/v1/sample/topk_topp_sampler.py tests/test_sampler_cpu_state_fast_paths.py`
- `ruff format --check vllm_musa/v1/sample/topk_topp_sampler.py tests/test_sampler_cpu_state_fast_paths.py`
- `git diff --check`
- Remote S5000 semantic/operator probe and compiled serving smoke: passed.
- Local pytest collection: not run to completion because the host Python
  environment lacks `numpy`; the remote probe and the existing PR #123 test
  environment provide hardware-path coverage.

## Risk / rollout

The environment gate remains `VLLM_MUSA_QWEN_LEGACY_GUMBEL=0` by default.
Speculative decoding, logprobs, deferred min-p, unsupported vocabularies, and
invalid generator state continue to fall back to the existing sampler.
