### PR TITLE
[MUSA] Speed up Qwen GDN mixed-dtype causal-conv decode

### DIFF
--- a/tests/test_causal_conv1d_mixed_dtype.py
+++ b/tests/test_causal_conv1d_mixed_dtype.py
@@ -1,0 +1,124 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("tilelang")
+causal_conv1d = pytest.importorskip("vllm_musa.jit_kernel.tilelang.causal_conv1d")
+
+
+def test_decode_kernel_keeps_supported_mixed_dtypes(monkeypatch):
+    captured = {}
+
+    def fake_kernel(*kernel_config):
+        captured["kernel_config"] = kernel_config
+
+        def run(x, weight, bias, state, indices, mapping, has_init, out, *scalars):
+            captured["x"] = x
+            captured["weight"] = weight
+            captured["state"] = state
+            captured["out"] = out
+            captured["scalars"] = scalars
+            out.copy_(x)
+
+        return run
+
+    monkeypatch.setattr(
+        causal_conv1d,
+        "_causal_conv1d_decode_width4_batched_kernel",
+        fake_kernel,
+    )
+    monkeypatch.setattr(causal_conv1d, "_DECODE_HAS_INIT_BUF", {})
+
+    x = torch.randn(4, 16, dtype=torch.bfloat16)
+    state = torch.randn(4, 16, 3, dtype=torch.float32)
+    weight = torch.randn(16, 4, dtype=torch.float32)
+    indices = torch.arange(4, dtype=torch.int32)
+
+    output = causal_conv1d.musa_tilelang_causal_conv1d_update(
+        x,
+        state,
+        weight,
+        activation="silu",
+        conv_state_indices=indices,
+    )
+
+    assert output is not None
+    assert output.dtype == torch.bfloat16
+    assert captured["x"].dtype == torch.bfloat16
+    assert captured["weight"].dtype == torch.float32
+    assert captured["state"].dtype == torch.float32
+    assert captured["out"].dtype == torch.bfloat16
+    assert captured["kernel_config"][:5] == (
+        "bfloat16",
+        "float32",
+        "bfloat16",
+        "float32",
+        "bfloat16",
+    )
+    assert captured["kernel_config"][13] is True
+    assert captured["kernel_config"][16] is True
+    assert captured["scalars"][-1] == causal_conv1d.NULL_BLOCK_ID
+
+
+def test_decode_kernel_preserves_same_dtype_path(monkeypatch):
+    captured = {}
+
+    def fake_kernel(*kernel_config):
+        captured["kernel_config"] = kernel_config
+
+        def run(x, weight, bias, state, indices, mapping, has_init, out, *scalars):
+            captured["x"] = x
+            captured["scalars"] = scalars
+            out.copy_(x)
+
+        return run
+
+    monkeypatch.setattr(
+        causal_conv1d,
+        "_causal_conv1d_decode_width4_batched_kernel",
+        fake_kernel,
+    )
+    monkeypatch.setattr(causal_conv1d, "_DECODE_HAS_INIT_BUF", {})
+
+    x = torch.randn(2, 8, dtype=torch.float32)
+    state = torch.randn(2, 8, 3, dtype=torch.float32)
+    weight = torch.randn(8, 4, dtype=torch.float32)
+
+    output = causal_conv1d.musa_tilelang_causal_conv1d_update(
+        x,
+        state,
+        weight,
+    )
+
+    assert output is not None
+    assert output.dtype == torch.float32
+    assert captured["x"] is not None
+    assert captured["x"].dtype == torch.float32
+    assert captured["kernel_config"][:5] == ("float32",) * 5
+    assert captured["kernel_config"][13] is False
+    assert captured["kernel_config"][16] is False
+    assert captured["scalars"][-1] == causal_conv1d.PAD_SLOT_ID
+
+
+def test_decode_kernel_rejects_unverified_mixed_dtype_tuple():
+    x = torch.randn(2, 8, dtype=torch.float32)
+    state = torch.randn(2, 8, 3, dtype=torch.bfloat16)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+
+    assert (
+        causal_conv1d.musa_tilelang_causal_conv1d_update(x, state, weight) is None
+    )
+
+
+def test_decode_kernel_rejects_noncontiguous_indices():
+    x = torch.randn(2, 8, dtype=torch.bfloat16)
+    state = torch.randn(4, 8, 3, dtype=torch.float32)
+    weight = torch.randn(8, 4, dtype=torch.float32)
+    indices = torch.arange(4, dtype=torch.int32)[::2]
+
+    assert not indices.is_contiguous()
+    assert (
+        causal_conv1d.musa_tilelang_causal_conv1d_update(
+            x, state, weight, conv_state_indices=indices
+        )
+        is None
+    )

--- a/vllm_musa/jit_kernel/tilelang/causal_conv1d.py
+++ b/vllm_musa/jit_kernel/tilelang/causal_conv1d.py
@@ -15,6 +15,7 @@ from vllm_musa.jit_kernel.tilelang.utils import (
 )
 
 PAD_SLOT_ID = -1  # MUSA: match vllm mamba causal_conv1d PAD_SLOT_ID
+NULL_BLOCK_ID = 0  # MUSA: match vllm mamba causal_conv1d NULL_BLOCK_ID
 
 
 def register_custom_op(fn=None, **_kw):
@@ -941,7 +942,11 @@ _causal_conv1d_prefill_width4_body_kernel.mode = "lazy"
     compile_flags=MUSA_COMPILE_FLAGS,
 )
 def _causal_conv1d_decode_width4_batched_kernel(
-    dtype: str,
+    x_dtype: str,
+    weight_dtype: str,
+    bias_dtype: str,
+    state_dtype: str,
+    out_dtype: str,
     cache_indices_dtype: str,
     x_stride_token: int,
     w_stride_dim: int,
@@ -970,14 +975,14 @@ def _causal_conv1d_decode_width4_batched_kernel(
 
     @T.prim_func
     def musa_causal_conv1d_decode_width4_batched(
-        x: T.Tensor((x_numel,), dtype),
-        weight: T.Tensor((w_numel,), dtype),
-        bias: T.Tensor((bias_numel,), dtype),
-        conv_states: T.Tensor((state_numel,), dtype),
+        x: T.Tensor((x_numel,), x_dtype),
+        weight: T.Tensor((w_numel,), weight_dtype),
+        bias: T.Tensor((bias_numel,), bias_dtype),
+        conv_states: T.Tensor((state_numel,), state_dtype),
         cache_indices: T.Tensor((cache_numel,), cache_indices_dtype),
         cache_index_mapping: T.Tensor((mapping_numel,), "int32"),
         has_initial_state: T.Tensor((init_numel,), "bool"),
-        out: T.Tensor((out_numel,), dtype),
+        out: T.Tensor((out_numel,), out_dtype),
         batch: T.int32,
         dim: T.int32,
         num_cache_lines: T.int32,
@@ -1016,6 +1021,15 @@ def _causal_conv1d_decode_width4_batched_kernel(
             if cache_idx >= num_cache_lines:
                 valid = False
 
+            # The upstream update kernel aliases its output with x and returns
+            # before touching a null cache block.  Preserve that output value
+            # while leaving the null block unchanged.
+            if seq_idx < batch and feat < dim and not valid:
+                x_base = seq_idx * x_stride_token + feat
+                out[seq_idx * o_stride_token + feat] = T.Cast(
+                    out_dtype, x[x_base]
+                )
+
             if valid:
                 load_init = False
                 if has_initial_states:
@@ -1048,7 +1062,7 @@ def _causal_conv1d_decode_width4_batched_kernel(
                 if silu_activation:
                     acc = acc / (1.0 + T.exp2(-acc * _LOG2E))
 
-                out[seq_idx * o_stride_token + feat] = T.Cast(dtype, acc)
+                out[seq_idx * o_stride_token + feat] = T.Cast(out_dtype, acc)
                 if load_init:
                     conv_states[state_base] = conv_states[
                         state_base + state_stride_token
@@ -1057,9 +1071,13 @@ def _causal_conv1d_decode_width4_batched_kernel(
                         state_base + 2 * state_stride_token
                     ]
                 else:
-                    conv_states[state_base] = T.Cast(dtype, 0.0)
-                    conv_states[state_base + state_stride_token] = T.Cast(dtype, 0.0)
-                conv_states[state_base + 2 * state_stride_token] = T.Cast(dtype, x_cur)
+                    conv_states[state_base] = T.Cast(state_dtype, 0.0)
+                    conv_states[state_base + state_stride_token] = T.Cast(
+                        state_dtype, 0.0
+                    )
+                conv_states[state_base + 2 * state_stride_token] = T.Cast(
+                    state_dtype, x_cur
+                )
 
     return musa_causal_conv1d_decode_width4_batched
 
@@ -1231,7 +1249,11 @@ def _causal_conv1d_fwd_impl(
         and weight.stride(1) == 1
     ):
         _causal_conv1d_decode_width4_batched_kernel(
-            dtype,
+            tilelang_dtype(x.dtype),
+            tilelang_dtype(weight.dtype),
+            tilelang_dtype(bias.dtype if bias is not None else x.dtype),
+            tilelang_dtype(conv_states.dtype),
+            tilelang_dtype(out.dtype),
             cache_indices_dtype,
             int(x.stride(1)),
             int(weight.stride(0)),
@@ -1572,6 +1594,7 @@ def musa_tilelang_causal_conv1d_fn(
 # decode kernel. Drop-in for vllm Triton causal_conv1d_update; returns None when
 # the fast path does not apply so the caller keeps the Triton path.
 _DECODE_HAS_INIT_BUF = {}
+_DECODE_MIXED_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
 
 
 def _decode_has_init_buffer(batch, device):
@@ -1590,6 +1613,7 @@ def musa_tilelang_causal_conv1d_update(
     bias=None,
     activation=None,
     conv_state_indices=None,
+    null_block_id=NULL_BLOCK_ID,
     **_,
 ):
     """Width-4 single-token decode conv. x:[batch,dim], conv_state:[lines,dim,>=3],
@@ -1599,9 +1623,42 @@ def musa_tilelang_causal_conv1d_update(
     if conv_state.dim() != 3 or conv_state.size(2) < 3 or x.dim() != 2:
         return None
     batch, dim = x.shape
-    orig_dtype = x.dtype
-    if x.dtype != conv_state.dtype:
-        x = x.to(conv_state.dtype)
+    if batch == 0 or dim != weight.size(0) or dim != conv_state.size(1):
+        return None
+    if x.device != conv_state.device or x.device != weight.device:
+        return None
+    if x.stride(1) != 1 or weight.stride(1) != 1:
+        return None
+    if bias is not None and (
+        bias.device != x.device
+        or bias.dim() != 1
+        or bias.numel() != dim
+        or bias.stride(0) != 1
+    ):
+        return None
+    if conv_state_indices is not None and (
+        conv_state_indices.device != x.device
+        or conv_state_indices.dim() != 1
+        or conv_state_indices.numel() < batch
+        or conv_state_indices.stride(0) != 1
+        or conv_state_indices.dtype not in (torch.int32, torch.int64)
+    ):
+        return None
+
+    same_dtype = (
+        x.dtype == conv_state.dtype == weight.dtype
+        and (bias is None or bias.dtype == x.dtype)
+        and x.dtype in _DECODE_MIXED_DTYPES
+    )
+    qwen_bf16_fp32_state = (
+        x.dtype == torch.bfloat16
+        and conv_state.dtype == torch.float32
+        and weight.dtype == torch.float32
+        and (bias is None or bias.dtype == torch.float32)
+    )
+    if not (same_dtype or qwen_bf16_fp32_state):
+        return None
+
     xt = x.transpose(0, 1)  # [dim, batch] VIEW, stride(0)==1
     out_bd = torch.empty_like(x)  # [batch, dim]
     outt = out_bd.transpose(0, 1)  # [dim, batch] VIEW, stride(0)==1
@@ -1609,10 +1666,16 @@ def musa_tilelang_causal_conv1d_update(
         idx = torch.arange(batch, device=x.device, dtype=torch.int32)
     else:
         idx = conv_state_indices
+    has_cache_indices = conv_state_indices is not None
+    use_null_block = has_cache_indices and null_block_id is not None
     has_init = _decode_has_init_buffer(batch, x.device)
     silu = activation in ("silu", "swish", True)
     ker = _causal_conv1d_decode_width4_batched_kernel(
         tilelang_dtype(xt.dtype),
+        tilelang_dtype(weight.dtype),
+        tilelang_dtype(bias.dtype if bias is not None else xt.dtype),
+        tilelang_dtype(conv_state.dtype),
+        tilelang_dtype(outt.dtype),
         _tilelang_index_dtype(idx.dtype),
         int(xt.stride(1)),
         int(weight.stride(0)),
@@ -1621,10 +1684,10 @@ def musa_tilelang_causal_conv1d_update(
         int(conv_state.stride(2)),
         int(outt.stride(1)),
         bias is not None,
-        True,
+        has_cache_indices,
         False,
         True,
-        True,
+        use_null_block,
         silu,
         256,
         1,
@@ -1641,6 +1704,6 @@ def musa_tilelang_causal_conv1d_update(
         int(batch),
         int(dim),
         int(conv_state.size(0)),
-        int(PAD_SLOT_ID),
+        int(null_block_id if use_null_block else PAD_SLOT_ID),
     )
-    return out_bd.to(orig_dtype)
+    return out_bd

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -155,8 +155,9 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
         from vllm.model_executor.layers.mamba.mamba_utils import (
             is_conv_state_dim_first,
         )
-        from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
-            causal_conv1d_update,
+
+        from vllm_musa.jit_kernel.tilelang.causal_conv1d import (
+            musa_tilelang_causal_conv1d_update,
         )
 
         non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
@@ -182,15 +183,33 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
             self.conv1d.weight.size(0),
             self.conv1d.weight.size(2),
         )
-        mixed_qkv = causal_conv1d_update(
+        # The upstream wrapper casts BF16 activations to the FP32 cache dtype
+        # and casts the result back.  The MUSA kernel accepts those dtypes
+        # directly; keep the upstream path as a structural fallback.
+        mixed_qkv_tilelang = musa_tilelang_causal_conv1d_update(
             mixed_qkv,
             conv_state,
             conv_weights,
             self.conv1d.bias,
             self.activation,
             conv_state_indices=state_indices,
-            validate_data=False,
         )
+        if mixed_qkv_tilelang is None:
+            from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+                causal_conv1d_update,
+            )
+
+            mixed_qkv = causal_conv1d_update(
+                mixed_qkv,
+                conv_state,
+                conv_weights,
+                self.conv1d.bias,
+                self.activation,
+                conv_state_indices=state_indices,
+                validate_data=False,
+            )
+        else:
+            mixed_qkv = mixed_qkv_tilelang
 
         # MUSA: mate's decode kernel reads q/k/v from strided views; split the
         # packed qkv without materializing contiguous copies.


### PR DESCRIPTION
## Summary

- parameterize the existing MUSA TileLang width-4 decode causal-conv kernel with separate input, weight, bias, state, and output dtypes;
- use the mixed-dtype kernel directly in the MUSA Qwen3.5/Qwen3.6 GDN non-spec decode path for the proven BF16 activation + FP32 state/weight/bias tuple;
- preserve the upstream fallback for unsupported dtype, shape, stride, device, and index layouts;
- preserve graph-padding semantics: explicit state indices use `NULL_BLOCK_ID=0`, while state line zero remains valid when indices are absent.

This is entirely inside `vllm-musa`; it does not patch or override `vllm-omni`.

## Motivation

Qwen3.5/Qwen3.6 decode supplies BF16 activations to a causal-conv state stored in FP32. The upstream wrapper converts the input to the state dtype and converts the output back. The MUSA TileLang kernel already accumulates in FP32, so it can load BF16 directly, update FP32 state, and write BF16 output without changing the recurrent-state contract.

## Correctness and regression

- mixed-dtype operator gate on S5000 for BS 1/4/16/64 and `dim=5120`:
  - maximum output difference: `0.001953125`;
  - recurrent-state difference: exactly `0`;
- MUSA graph replay with `[1,2,3,0]`, `[4,5,0,0]`, and `[6,0,0,0]` state-index vectors:
  - full output/state parity versus upstream;
  - null state line 0 remains unchanged;
  - padded output remains equal to input;
  - without explicit indices, state line 0 is still updated as a real cache line;
- Qwen3.5-27B BF16 TP2 normal compiled/captured serving:
  - BS3 graph-padding smoke passed;
  - BS64 input/output 4096/1024 passed 64/64 requests and the 2-rank, 20-step trace gate;
- Qwen3.6-35B-A3B BF16 TP4 final-source sibling smoke:
  - semantic chat passed (`contains_beijing=True`), FA3 and fused MoE selected;
  - BS1 and BS64 compiled/captured decode requests passed;
  - diagnostic trace has 18 usable graph launches and 540 new causal-conv kernels per rank (`30 layers × 18`), with no upstream `_causal_conv1d_update_kernel` rows.

The Qwen3.6 trace is labeled diagnostic because the generic short-run trace gate expected every annotation to be `generation_64`; the captured names were generation 0/5/63/64. Request, semantic, backend, graph, and kernel-count checks passed.

## Performance

Hardware/runtime: one isolated 8×MTT S5000 node, driver `5.2.0-server`, exact image digest `sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`.

Operator result at the Qwen3.5 decode shape:

| BS | Baseline device µs / rows | Candidate device µs / rows | Device delta |
|---:|---:|---:|---:|
| 1 | 13.372 / 4 | 3.530 / 1 | -73.60% |
| 4 | 14.056 / 4 | 4.212 / 1 | -70.03% |
| 16 | 16.500 / 4 | 6.422 / 1 | -61.08% |
| 64 | 26.178 / 4 | 12.758 / 1 | -51.26% |

Qwen3.5-27B BF16, TP2, BS64, nominal 4096 input / 1024 output, FA3, `VLLM_COMPILE + FULL_AND_PIECEWISE`, unseeded top-k=50/min-p=0.05:

| Metric | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| mean TPOT | 85.0998 ms | 84.5111 ms | -0.6917% |
| output throughput | 621.262 tok/s | 624.816 tok/s | +0.5721% |
| mean TTFT | 17638.523 ms | 17642.462 ms | +0.0223% |

The output-64 stabilization geometric mean moved by -0.0286% with both CVs below 0.05%; the repeated saving is clearer in the output-1024 run. The matched trace causal-conv anchor moved from 13.945 to 10.932 µs/call (-21.61%) at 48 calls/step/rank.

Same-named copy and CastOp kernels remain adjacent in the production trace, so this PR does **not** claim those surrounding launches were removed. The trace attribution is limited to the causal-conv anchor and the measured end-to-end result.

## Static checks

- `python -m py_compile` on both changed product files and the focused test;
- `ruff check` on the changed Qwen GDN integration and focused test;
- `git diff --check`;
- local focused pytest collection: `1 skipped` because the development host has no Torch; real MUSA operator, graph replay, and serving gates above passed in the exact image.

The causal-conv file has seven pre-existing whole-file Ruff findings (`UP035`, `UP006`, and one unrelated `F841`); this change does not modify those lines.

## Scope

- optimized: normal non-spec Qwen3.5/Qwen3.6 BF16 GDN decode;
- unchanged: speculative decode, prefill, unsupported dtype/layout combinations, and upstream fallback;
- Qwen3 dense/MoE does not use this GDN causal-conv path and is outside this focused regression.

The Qwen3.5 formal run used the same product logic before a final import-group blank line was added for Ruff. The Qwen3.6 MoE sibling ran the final source hashes.
