### PR TITLE
[MUSA] Register custom all-reduce graph inputs

### DIFF
--- a/tests/test_musa_jit_custom_all_reduce_graph.py
+++ b/tests/test_musa_jit_custom_all_reduce_graph.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import ctypes
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+custom_ar = pytest.importorskip(
+    "vllm_musa.distributed.device_communicators.musa_jit_custom_all_reduce"
+)
+
+
+def test_register_graph_buffers_populates_persistent_rank_data(monkeypatch):
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl.rank = 0
+    impl.world_size = 2
+    impl.group = object()
+    impl.device = torch.device("cpu")
+    impl.graph_rank_data = torch.zeros((4, 8), dtype=torch.int64)
+    impl._pending_graph_inputs = [torch.empty(4), torch.empty(8)]
+    impl._graph_input_refs = []
+    impl._graph_peer_bases = {}
+    impl._graph_opened_ptrs = []
+    impl._next_graph_slot = 0
+
+    local_handles = [(b"a" * 64, 8), (b"b" * 64, 16)]
+    peer_handles = [(b"c" * 64, 24), (b"d" * 64, 32)]
+    monkeypatch.setattr(impl, "_graph_pointer_meta", lambda tensor: local_handles.pop(0))
+
+    def all_gather_object(output, local_meta, group):
+        assert group is impl.group
+        output[0] = list(local_meta)
+        output[1] = peer_handles
+
+    peer_bases = {ord("c"): 10_000, ord("d"): 20_000}
+
+    class FakeRuntime:
+        def ipc_open_mem_handle(self, handle):
+            first_byte = ctypes.string_at(ctypes.byref(handle), 1)[0]
+            return ctypes.c_void_p(peer_bases[first_byte])
+
+    monkeypatch.setattr(custom_ar.dist, "all_gather_object", all_gather_object)
+    monkeypatch.setattr(custom_ar, "_MusaRTLibrary", FakeRuntime)
+    monkeypatch.setattr(
+        custom_ar.torch,
+        "musa",
+        SimpleNamespace(synchronize=lambda device: None),
+    )
+
+    inputs = list(impl._pending_graph_inputs)
+    impl._register_graph_buffers()
+
+    assert impl.graph_rank_data[0, 0].item() == inputs[0].data_ptr()
+    assert impl.graph_rank_data[0, 1].item() == 10_024
+    assert impl.graph_rank_data[1, 0].item() == inputs[1].data_ptr()
+    assert impl.graph_rank_data[1, 1].item() == 20_032
+    assert impl._next_graph_slot == 2
+    assert impl._pending_graph_inputs == []
+    assert impl._graph_input_refs == inputs
+    assert sorted(impl._graph_opened_ptrs) == [10_000, 20_000]
+
+
+def test_capture_resets_state_when_registration_fails(monkeypatch):
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl._IS_CAPTURING = False
+    impl._pending_graph_inputs = []
+
+    def fail_registration():
+        raise RuntimeError("registration failed")
+
+    monkeypatch.setattr(impl, "_register_graph_buffers", fail_registration)
+    with pytest.raises(RuntimeError, match="registration failed"):
+        with impl.capture():
+            assert impl._IS_CAPTURING is True
+            impl._pending_graph_inputs.append(torch.empty(1))
+    assert impl._IS_CAPTURING is False
+
+
+def test_graph_launch_uses_next_persistent_slot(monkeypatch):
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl.graph_rank_data = torch.zeros((8, 8), dtype=torch.int64)
+    impl.signal_ptrs_cpu = torch.zeros(2, dtype=torch.int64)
+    impl._pending_graph_inputs = []
+    impl._next_graph_slot = 3
+    impl.rank = 0
+    impl.world_size = 2
+    captured = {}
+
+    def launch(rank_data, signals, input_tensor, output, rank, world_size, shot):
+        captured["rank_data"] = rank_data
+        captured["signals"] = signals
+        captured["input"] = input_tensor
+        captured["output"] = output
+        captured["rank"] = rank
+        captured["world_size"] = world_size
+        captured["shot"] = shot
+
+    monkeypatch.setattr(custom_ar.jit_ar, "launch_graph_registered", launch)
+    monkeypatch.setattr(custom_ar.jit_ar, "preferred_shot", lambda world, nbytes: 2)
+
+    input_tensor = torch.randn(4, dtype=torch.bfloat16)
+    output = impl._graph_custom_all_reduce_impl(input_tensor)
+
+    assert captured["rank_data"].data_ptr() == impl.graph_rank_data[3].data_ptr()
+    assert captured["input"] is input_tensor
+    assert captured["output"] is output
+    assert captured["rank"] == 0
+    assert captured["world_size"] == 2
+    assert captured["shot"] == 2
+    assert impl._pending_graph_inputs == [input_tensor]

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -8,12 +8,17 @@ from typing import Any
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
+from vllm.logger import init_logger
 from vllm.utils.torch_utils import direct_register_custom_op
 
-from vllm.logger import init_logger
 from vllm_musa.jit_kernel.csrc import allreduce as jit_ar
 
 logger = init_logger(__name__)
+
+
+_MAX_GRAPH_RANK_DATA_BYTES = 8 * 1024 * 1024
+_MAX_RANKS = 8
+_MU_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11
 
 
 cudaError_t = ctypes.c_int
@@ -106,6 +111,57 @@ class _MusaRTLibrary:
 
     def ipc_close_mem_handle(self, ptr: ctypes.c_void_p) -> None:
         self.check(self.funcs["cudaIpcCloseMemHandle"](ptr))
+
+
+class _MusaDriverLibrary:
+    _exported_functions = (
+        _Function(
+            "muPointerGetAttribute",
+            ctypes.c_int,
+            [ctypes.c_void_p, ctypes.c_int, ctypes.c_uint64],
+        ),
+        _Function(
+            "muGetErrorString",
+            ctypes.c_int,
+            [ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)],
+        ),
+    )
+    _library_cache: dict[str, Any] = {}
+    _func_cache: dict[str, dict[str, Any]] = {}
+
+    def __init__(self, so_file: str = "libmusa.so") -> None:
+        if so_file not in self._library_cache:
+            self._library_cache[so_file] = ctypes.CDLL(so_file)
+        self.lib = self._library_cache[so_file]
+
+        if so_file not in self._func_cache:
+            funcs: dict[str, Any] = {}
+            for func in self._exported_functions:
+                f = getattr(self.lib, func.name)
+                f.restype = func.restype
+                f.argtypes = func.argtypes
+                funcs[func.name] = f
+            self._func_cache[so_file] = funcs
+        self.funcs = self._func_cache[so_file]
+
+    def check(self, result: int) -> None:
+        if result == 0:
+            return
+        error = ctypes.c_char_p()
+        self.funcs["muGetErrorString"](result, ctypes.byref(error))
+        message = error.value.decode() if error.value is not None else "unknown"
+        raise RuntimeError(f"MUSA driver error {result}: {message}")
+
+    def allocation_base(self, pointer: int) -> int:
+        base = ctypes.c_uint64()
+        self.check(
+            self.funcs["muPointerGetAttribute"](
+                ctypes.byref(base),
+                _MU_POINTER_ATTRIBUTE_RANGE_START_ADDR,
+                ctypes.c_uint64(pointer),
+            )
+        )
+        return int(base.value)
 
 
 _COMM_REGISTRY: dict[int, Any] = {}
@@ -236,6 +292,13 @@ class _MusaJitCustomAllreduceImpl:
         self.buffer_ptrs: list[int] = []
         self.buffer_opened_ipc_ptrs: list[int] = []
         self.buffer_rank_data: torch.Tensor | None = None
+        self.graph_rank_data: torch.Tensor | None = None
+        self._pending_graph_inputs: list[torch.Tensor] = []
+        self._graph_input_refs: list[torch.Tensor] = []
+        self._graph_local_handles: dict[int, bytes] = {}
+        self._graph_peer_bases: dict[tuple[int, bytes], int] = {}
+        self._graph_opened_ptrs: list[int] = []
+        self._next_graph_slot = 0
 
         if isinstance(device, int):
             device = torch.device(f"musa:{device}")
@@ -299,6 +362,14 @@ class _MusaJitCustomAllreduceImpl:
         self.signal_ptrs_cpu = torch.tensor(self.meta_ptrs, dtype=torch.int64)
         buffer_ptrs = self.buffer_ptrs + [0] * (8 - self.world_size)
         self.buffer_rank_data = torch.tensor(buffer_ptrs, dtype=torch.int64)
+        graph_slots = _MAX_GRAPH_RANK_DATA_BYTES // (
+            _MAX_RANKS * torch.tensor([], dtype=torch.int64).element_size()
+        )
+        self.graph_rank_data = torch.zeros(
+            (graph_slots, _MAX_RANKS),
+            dtype=torch.int64,
+            device=self.device,
+        )
         self._comm_id = _register_comm(self)
         self.disabled = False
         logger.info_once(
@@ -309,11 +380,83 @@ class _MusaJitCustomAllreduceImpl:
 
     @contextmanager
     def capture(self):
+        self._pending_graph_inputs = []
         try:
             self._IS_CAPTURING = True
             yield
         finally:
-            self._IS_CAPTURING = False
+            try:
+                if self._pending_graph_inputs:
+                    self._register_graph_buffers()
+            finally:
+                self._IS_CAPTURING = False
+
+    def _graph_pointer_meta(self, tensor: torch.Tensor) -> tuple[bytes, int]:
+        pointer = tensor.data_ptr()
+        base = _MusaDriverLibrary().allocation_base(pointer)
+        handle = self._graph_local_handles.get(base)
+        if handle is None:
+            handle = _ipc_handle_to_bytes(
+                _MusaRTLibrary().ipc_get_mem_handle(ctypes.c_void_p(base))
+            )
+            self._graph_local_handles[base] = handle
+        return handle, pointer - base
+
+    def _register_graph_buffers(self) -> None:
+        assert self.graph_rank_data is not None
+        count = len(self._pending_graph_inputs)
+        start = self._next_graph_slot
+        end = start + count
+        if end > self.graph_rank_data.shape[0]:
+            raise RuntimeError(
+                "MUSA custom AR exhausted graph rank-data slots: "
+                f"need={end}, capacity={self.graph_rank_data.shape[0]}"
+            )
+
+        local_meta = [
+            self._graph_pointer_meta(tensor)
+            for tensor in self._pending_graph_inputs
+        ]
+        gathered: list[list[tuple[bytes, int]] | None] = [None] * self.world_size
+        dist.all_gather_object(gathered, local_meta, group=self.group)
+        if any(peer_meta is None for peer_meta in gathered):
+            raise RuntimeError("MUSA custom AR graph metadata gather was incomplete")
+        gathered_meta = [peer_meta for peer_meta in gathered if peer_meta is not None]
+        if any(len(peer_meta) != count for peer_meta in gathered_meta):
+            raise RuntimeError(
+                "MUSA custom AR graph buffer count differs across ranks: "
+                f"local={count}, gathered={[len(meta) for meta in gathered_meta]}"
+            )
+
+        runtime = _MusaRTLibrary()
+        rows: list[list[int]] = []
+        for buffer_index, local_tensor in enumerate(self._pending_graph_inputs):
+            row = [0] * _MAX_RANKS
+            for peer_rank, peer_meta in enumerate(gathered_meta):
+                handle, offset = peer_meta[buffer_index]
+                if peer_rank == self.rank:
+                    pointer = local_tensor.data_ptr()
+                else:
+                    peer_key = (peer_rank, handle)
+                    peer_base = self._graph_peer_bases.get(peer_key)
+                    if peer_base is None:
+                        peer_base = int(
+                            runtime.ipc_open_mem_handle(
+                                _ipc_handle_from_bytes(handle)
+                            ).value
+                        )
+                        self._graph_peer_bases[peer_key] = peer_base
+                        self._graph_opened_ptrs.append(peer_base)
+                    pointer = peer_base + int(offset)
+                row[peer_rank] = pointer
+            rows.append(row)
+
+        rank_data_cpu = torch.tensor(rows, dtype=torch.int64)
+        self.graph_rank_data[start:end].copy_(rank_data_cpu.to(self.device))
+        torch.musa.synchronize(self.device)
+        self._graph_input_refs.extend(self._pending_graph_inputs)
+        self._pending_graph_inputs = []
+        self._next_graph_slot = end
 
     def should_custom_ar(self, inp: torch.Tensor) -> bool:
         if self.disabled:
@@ -355,7 +498,7 @@ class _MusaJitCustomAllreduceImpl:
             if not self._is_current_stream_capturing():
                 # Match vLLM's CustomAllreduce warmup semantics. During graph
                 # warmup no communication should run; the real graph capture
-                # below records the scratch-buffer copy plus JIT AR kernel.
+                # below records the registered-input JIT AR kernel.
                 return torch.empty_like(input)
             return self._custom_all_reduce_custom_op(input)
         if self._is_torch_compiling():
@@ -363,13 +506,15 @@ class _MusaJitCustomAllreduceImpl:
             # loader. The registered op provides the compile-time fake impl and
             # launches the same fixed-staging kernel at runtime.
             return self._custom_all_reduce_custom_op(input)
-        # Use fixed staging buffers instead of caching peer IPC pointers for
-        # each input. This keeps eager and graph replay on the same
-        # pointer-stable kernel.
+        # Eager tensors are not pointer-stable, so retain the fixed staging
+        # path outside graph capture.
         return self._custom_all_reduce_impl(input)
 
     def _custom_all_reduce_impl(self, input: torch.Tensor) -> torch.Tensor:
         assert self.buffer_rank_data is not None
+        assert self.signal_ptrs_cpu is not None
+        if self._IS_CAPTURING and self._is_current_stream_capturing():
+            return self._graph_custom_all_reduce_impl(input)
         out = torch.empty_like(input)
         shot = jit_ar.preferred_shot(
             self.world_size, input.numel() * input.element_size()
@@ -388,11 +533,32 @@ class _MusaJitCustomAllreduceImpl:
         )
         return out
 
+    def _graph_custom_all_reduce_impl(self, input: torch.Tensor) -> torch.Tensor:
+        assert self.graph_rank_data is not None
+        assert self.signal_ptrs_cpu is not None
+        slot = self._next_graph_slot + len(self._pending_graph_inputs)
+        if slot >= self.graph_rank_data.shape[0]:
+            raise RuntimeError("MUSA custom AR graph rank-data buffer is full")
+        out = torch.empty_like(input)
+        self._pending_graph_inputs.append(input)
+        jit_ar.launch_graph_registered(
+            self.graph_rank_data[slot],
+            self.signal_ptrs_cpu,
+            input,
+            out,
+            self.rank,
+            self.world_size,
+            jit_ar.preferred_shot(self.world_size, input.nbytes),
+        )
+        return out
+
     def close(self) -> None:
         if self.meta_opened_ipc_ptrs:
             _close_ipc_handles(self.meta_opened_ipc_ptrs)
         if self.buffer_opened_ipc_ptrs:
             _close_ipc_handles(self.buffer_opened_ipc_ptrs)
+        if self._graph_opened_ptrs:
+            _close_ipc_handles(self._graph_opened_ptrs)
         if self.meta_ptrs:
             try:
                 _free_own_shared_buffer(self.meta_ptrs, rank=self.rank)
@@ -415,6 +581,13 @@ class _MusaJitCustomAllreduceImpl:
         self.buffer_ptrs = []
         self.buffer_opened_ipc_ptrs = []
         self.buffer_rank_data = None
+        self.graph_rank_data = None
+        self._graph_opened_ptrs = []
+        self._graph_peer_bases = {}
+        self._graph_local_handles = {}
+        self._graph_input_refs = []
+        self._pending_graph_inputs = []
+        self._next_graph_slot = 0
         self.disabled = True
 
     def __del__(self) -> None:

--- a/vllm_musa/jit_kernel/csrc/allreduce.py
+++ b/vllm_musa/jit_kernel/csrc/allreduce.py
@@ -97,3 +97,43 @@ def launch_unregistered(
         int(world_size),
         int(shot),
     )
+
+
+def launch_registered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    rank: int,
+    world_size: int,
+    shot: int,
+) -> None:
+    _custom_ar_module(int(world_size)).vllm_musa_custom_ar_launch_registered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        out,
+        int(rank),
+        int(world_size),
+        int(shot),
+    )
+
+
+def launch_graph_registered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    rank: int,
+    world_size: int,
+    shot: int,
+) -> None:
+    _custom_ar_module(int(world_size)).vllm_musa_custom_ar_launch_graph_registered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        out,
+        int(rank),
+        int(world_size),
+        int(shot),
+    )

--- a/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
@@ -172,9 +172,12 @@ __device__ __forceinline__ P packed_reduce(const P* ptrs[], int idx) {
   return downcast<P>(tmp);
 }
 
-template <typename T, int nranks>
+template <typename T, int nranks, bool indirect>
 __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_reduce_1stage(
-    RankData data, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+    RankData data, const RankData* data_ptr, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+  if constexpr (indirect) {
+    data = *data_ptr;
+  }
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
   multi_rank_barrier<nranks, true>(sg, self_sg, rank);
@@ -189,9 +192,12 @@ __device__ __forceinline__ P* get_tmp_buf(Signal* signal) {
   return reinterpret_cast<P*>(signal + 1);
 }
 
-template <typename T, int nranks>
+template <typename T, int nranks, bool indirect>
 __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) cross_device_reduce_2stage(
-    RankData data, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+    RankData data, const RankData* data_ptr, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+  if constexpr (indirect) {
+    data = *data_ptr;
+  }
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = gridDim.x * blockDim.x;
   using P = typename packed_t<T>::P;
@@ -239,9 +245,12 @@ __device__ __forceinline__ void shfl_reduce(float* res) {
   }
 }
 
-template <typename T, int nranks, int vlen = 8>
+template <typename T, int nranks, bool indirect, int vlen = 8>
 __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) custom_all_reduce_2shot(
-    RankData data, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+    RankData data, const RankData* data_ptr, RankSignals sg, Signal* self_sg, T* __restrict__ out, int rank, int size) {
+  if constexpr (indirect) {
+    data = *data_ptr;
+  }
   static_assert((nranks & (nranks - 1)) == 0, "custom_all_reduce_2shot requires power-of-two nranks");
   constexpr int nranks_sft = (nranks >> 1) - (nranks >> 3);
   constexpr int coalesce_num = 8;
@@ -322,8 +331,8 @@ __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) custom_all_reduce_2sho
   } while (idx_base < size);
 }
 
-template <typename T, int nranks>
-void launch_ar(RankData data, RankSignals sg, Signal* self_sg, T* out, int rank, int size, int shot, musaStream_t stream) {
+template <typename T, int nranks, bool indirect>
+void launch_ar(RankData data, const RankData* data_ptr, RankSignals sg, Signal* self_sg, T* out, int rank, int size, int shot, musaStream_t stream) {
   const int pack = packed_t<T>::P::size;
   TVM_FFI_ICHECK_EQ(size % pack, 0);
   int packed_size = size / pack;
@@ -332,12 +341,12 @@ void launch_ar(RankData data, RankSignals sg, Signal* self_sg, T* out, int rank,
     return;
   }
   if (shot == 1) {
-    cross_device_reduce_1stage<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(data, sg, self_sg, out, rank, packed_size);
+    cross_device_reduce_1stage<T, nranks, indirect><<<blocks, kDefaultThreads, 0, stream>>>(data, data_ptr, sg, self_sg, out, rank, packed_size);
   } else if (shot == 2) {
     if constexpr (std::is_same<T, float>::value || nranks == 6) {
-      cross_device_reduce_2stage<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(data, sg, self_sg, out, rank, packed_size);
+      cross_device_reduce_2stage<T, nranks, indirect><<<blocks, kDefaultThreads, 0, stream>>>(data, data_ptr, sg, self_sg, out, rank, packed_size);
     } else {
-      custom_all_reduce_2shot<T, nranks><<<blocks, kDefaultThreads, 0, stream>>>(data, sg, self_sg, out, rank, packed_size);
+      custom_all_reduce_2shot<T, nranks, indirect><<<blocks, kDefaultThreads, 0, stream>>>(data, data_ptr, sg, self_sg, out, rank, packed_size);
     }
   } else {
     TVM_FFI_THROW(ValueError) << "shot must be 1 or 2";
@@ -348,16 +357,37 @@ template <typename T>
 void dispatch_world_size(RankData data, RankSignals sg, Signal* self_sg, T* out, int rank, int world_size, int size, int shot, musaStream_t stream) {
   switch (world_size) {
     case 2:
-      launch_ar<T, 2>(data, sg, self_sg, out, rank, size, shot, stream);
+      launch_ar<T, 2, false>(data, nullptr, sg, self_sg, out, rank, size, shot, stream);
       break;
     case 4:
-      launch_ar<T, 4>(data, sg, self_sg, out, rank, size, shot, stream);
+      launch_ar<T, 4, false>(data, nullptr, sg, self_sg, out, rank, size, shot, stream);
       break;
     case 6:
-      launch_ar<T, 6>(data, sg, self_sg, out, rank, size, shot, stream);
+      launch_ar<T, 6, false>(data, nullptr, sg, self_sg, out, rank, size, shot, stream);
       break;
     case 8:
-      launch_ar<T, 8>(data, sg, self_sg, out, rank, size, shot, stream);
+      launch_ar<T, 8, false>(data, nullptr, sg, self_sg, out, rank, size, shot, stream);
+      break;
+    default:
+      TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
+  }
+}
+
+template <typename T>
+void dispatch_world_size_indirect(const RankData* data_ptr, RankSignals sg, Signal* self_sg, T* out, int rank, int world_size, int size, int shot, musaStream_t stream) {
+  RankData data{};
+  switch (world_size) {
+    case 2:
+      launch_ar<T, 2, true>(data, data_ptr, sg, self_sg, out, rank, size, shot, stream);
+      break;
+    case 4:
+      launch_ar<T, 4, true>(data, data_ptr, sg, self_sg, out, rank, size, shot, stream);
+      break;
+    case 6:
+      launch_ar<T, 6, true>(data, data_ptr, sg, self_sg, out, rank, size, shot, stream);
+      break;
+    case 8:
+      launch_ar<T, 8, true>(data, data_ptr, sg, self_sg, out, rank, size, shot, stream);
       break;
     default:
       TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
@@ -433,5 +463,106 @@ void vllm_musa_custom_ar_launch_unregistered(
   TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA custom AR kernel failed: " << musaGetErrorString(err);
 }
 
+void vllm_musa_custom_ar_launch_registered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView out,
+    int64_t rank,
+    int64_t world_size,
+    int64_t shot) {
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(out);
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), out.dtype()));
+  TVM_FFI_ICHECK_EQ(tensor_numel(inp), tensor_numel(out));
+
+  RankSignals sg{};
+  const auto* signal_ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(signal_ptrs[i]);
+  }
+  RankData data{};
+  const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+  for (int i = 0; i < kMaxRanks; ++i) {
+    data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+  TVM_FFI_ICHECK_EQ(data.ptrs[rank], inp.data_ptr());
+
+  auto* self_sg = sg.signals[rank];
+  auto stream = get_stream(out.device());
+  const int64_t numel64 = tensor_numel(out);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int size = static_cast<int>(numel64);
+
+  if (dtype_equal(out.dtype(), dl_float16)) {
+    dispatch_world_size(data, sg, self_sg, static_cast<half*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
+    dispatch_world_size(data, sg, self_sg, static_cast<__mt_bfloat16*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_float32)) {
+    dispatch_world_size(data, sg, self_sg, static_cast<float*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom ar only supports fp16/bf16/fp32";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA custom AR kernel failed: " << musaGetErrorString(err);
+}
+
+void vllm_musa_custom_ar_launch_graph_registered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView out,
+    int64_t rank,
+    int64_t world_size,
+    int64_t shot) {
+  CHECK_MUSA_CONTIGUOUS(rank_data);
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(out);
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(tensor_numel(rank_data), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), out.dtype()));
+  TVM_FFI_ICHECK_EQ(tensor_numel(inp), tensor_numel(out));
+
+  RankSignals sg{};
+  const auto* signal_ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(signal_ptrs[i]);
+  }
+  const auto* data_ptr = static_cast<const RankData*>(rank_data.data_ptr());
+  auto* self_sg = sg.signals[rank];
+  auto stream = get_stream(out.device());
+  const int64_t numel64 = tensor_numel(out);
+  TVM_FFI_ICHECK_LE(numel64, static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int size = static_cast<int>(numel64);
+
+  if (dtype_equal(out.dtype(), dl_float16)) {
+    dispatch_world_size_indirect(data_ptr, sg, self_sg, static_cast<half*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
+    dispatch_world_size_indirect(data_ptr, sg, self_sg, static_cast<__mt_bfloat16*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else if (dtype_equal(out.dtype(), dl_float32)) {
+    dispatch_world_size_indirect(data_ptr, sg, self_sg, static_cast<float*>(out.data_ptr()), static_cast<int>(rank), static_cast<int>(world_size), size, static_cast<int>(shot), stream);
+  } else {
+    TVM_FFI_THROW(ValueError) << "custom ar only supports fp16/bf16/fp32";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA custom AR kernel failed: " << musaGetErrorString(err);
+}
+
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_meta_size, vllm_musa_custom_ar_meta_size);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_unregistered, vllm_musa_custom_ar_launch_unregistered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_registered, vllm_musa_custom_ar_launch_registered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_graph_registered, vllm_musa_custom_ar_launch_graph_registered);


### PR DESCRIPTION
## Summary

- preserve the existing fixed staging buffer for eager/non-captured MUSA JIT custom all-reduce;
- register graph-captured input allocations after capture by exchanging allocation-base IPC handles and offsets across ranks;
- store the peer pointers in a persistent device rank-data table and let graph kernels load them indirectly during replay;
- retain graph input tensors and opened peer mappings for the communicator lifetime, with fail-closed rank-count and capacity checks.

This change is contained in `vllm-musa`; it does not patch `vllm-omni`.

## Motivation

In the Qwen3.5 TP2 BS64 decode trace, each rank launches 128 graph-contained custom all-reduces per decode step. The current MUSA implementation first copies every 655,360-byte input into a fixed IPC-shared buffer. Those D2D copies average about 3.28 µs each, or about 420 µs of copy device time per step/rank.

Graph inputs are pointer-stable after capture. This PR records those inputs during capture, resolves the underlying allocation base through the MUSA driver, exchanges IPC handles and offsets after capture, and populates a persistent device pointer table before replay. Eager inputs remain on the existing staging path because their lifetime is not guaranteed.

## Correctness and regression

- TP2 persistent-input probe at BF16 hidden size 5120, BS1/4/16/64:
  - registered and fixed-staging outputs were bitwise identical;
  - registered event time improved by 10.08% to 24.82% across the four shapes;
- production lifecycle probe:
  - captured two separate graphs using two different input allocations;
  - populated two different persistent pointer-table slots;
  - replayed both graphs three times with bitwise parity to the eager fixed-staging path;
  - 20 profiled replays contained the custom-AR kernel and no D2D copy row;
- Qwen3.5-27B BF16 TP2 normal compiled/captured serving:
  - all 4 PIECEWISE and 4 FULL capture groups completed;
  - BS64 input/output 4096/1024 completed 64/64 requests;
  - two-rank, 20-step formal trace gate passed;
- Qwen3.6-35B-A3B BF16 TP4 final-source sibling smoke:
  - world-size-4 graph registration/capture passed;
  - semantic chat, FA3/fused-MoE selection, BS1, and BS64 64/64 requests passed;
  - diagnostic trace confirms registered world-size-4 kernels and staging-copy removal.

The Qwen3.6 trace is diagnostic because the intentionally short run captures generation 0/5/63/64 annotations instead of satisfying the generic all-`generation_64` gate. Request, semantic, backend, graph-capture, and copy-count checks passed.

## Performance

Hardware/runtime: one isolated 8×MTT S5000 node, driver `5.2.0-server`, exact image digest `sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`.

Qwen3.5-27B BF16, TP2, BS64, nominal 4096 input / 1024 output, FA3, `VLLM_COMPILE + FULL_AND_PIECEWISE`, unseeded top-k=50/min-p=0.05:

| Metric | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| mean TPOT | 85.0998 ms | 84.7968 ms | -0.3560% |
| mean ITL | 85.0167 ms | 84.7140 ms | -0.3560% |
| output throughput | 621.262 tok/s | 622.756 tok/s | +0.2405% |
| mean TTFT | 17638.523 ms | 17699.921 ms | +0.3481% |

The output-64 stabilization geometric mean was neutral (308.7224 versus 308.7223 ms); the output-1024 run exposes the repeated decode saving.

Trace proof per rank:

- 655,360-byte D2D rows: `2580 -> 20`;
- graph-contained staging copies: `128/step -> 0` across 20 captured steps;
- one graph-external all-reduce/step retains the eager staging path.

The remaining graph-external row is intentionally outside this PR. Its location is consistent with the separate logits-outside-graph investigation.

For the Qwen3.6 MoE TP4 diagnostic trace, the 262,144-byte staging-copy rows fell from `1375 -> 15` per rank.

## Lifetime and failure behavior

- the communicator owns an 8 MiB device rank-data table;
- graph input tensors and opened peer mappings are retained until `close()`;
- allocation-base handles and tensor offsets are exchanged only after capture;
- ranks must register the same number of buffers; mismatch, driver failure, or slot exhaustion raises instead of replaying invalid pointers;
- eager/non-captured calls keep the existing fixed-staging implementation.

## Static and build checks

- `python -m py_compile` on changed Python files and the focused test;
- `ruff check` on changed Python files and the focused test;
- `git diff --check`;
- local focused pytest collection: `1 skipped` because the development host has no Torch;
- the changed MUSA JIT `.mu` source compiled and executed successfully for TP2 and TP4 in the exact image.

## Scope

- optimized: captured MUSA JIT custom all-reduce for supported TP world sizes;
- unchanged: eager custom all-reduce, unsupported sizes/dtypes, logits/external all-reduce placement, and attention/MoE backends;
- this is a MUSA-source-and-silicon result; no CUDA no-op assumption is used as evidence.
