### PR TITLE
perf(musa): gather Qwen TP logits through IPC

### DIFF
--- a/tests/test_musa_jit_custom_all_gather.py
+++ b/tests/test_musa_jit_custom_all_gather.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+custom_ar = pytest.importorskip(
+    "vllm_musa.distributed.device_communicators.musa_jit_custom_all_reduce"
+)
+
+
+def _impl() -> custom_ar._MusaJitCustomAllreduceImpl:
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl.disabled = False
+    impl.world_size = 2
+    impl.rank = 0
+    impl.max_size = 1024 * 1024
+    impl.device = torch.device("musa:0")
+    impl.buffer_rank_data = torch.zeros(8, dtype=torch.int64)
+    impl.signal_ptrs_cpu = torch.zeros(2, dtype=torch.int64)
+    impl.meta_ptrs = [101, 102]
+    impl.buffer_ptrs = [201, 202]
+    impl._IS_CAPTURING = False
+    impl._is_communicator_tensor = lambda input_tensor: True
+    impl._is_default_stream = lambda input_tensor: True
+    return impl
+
+
+def test_custom_all_gather_gate_accepts_only_last_dim_packed_2d():
+    impl = _impl()
+    accepted = torch.empty((4, 32), dtype=torch.bfloat16)
+
+    assert impl.should_custom_all_gather(accepted, -1)
+    assert impl.should_custom_all_gather(accepted, 1)
+    assert not impl.should_custom_all_gather(accepted, 0)
+    assert not impl.should_custom_all_gather(accepted[:, ::2], -1)
+    assert not impl.should_custom_all_gather(
+        torch.empty((4, 31), dtype=torch.bfloat16), -1
+    )
+    assert not impl.should_custom_all_gather(
+        torch.empty((4, 32), dtype=torch.int32), -1
+    )
+    assert not impl.should_custom_all_gather(
+        torch.empty((2, 4, 32), dtype=torch.bfloat16), -1
+    )
+    impl.max_size = accepted.numel() * accepted.element_size()
+    assert not impl.should_custom_all_gather(accepted, -1)
+    impl.max_size = 1024 * 1024
+    impl.world_size = 6
+    assert not impl.should_custom_all_gather(accepted, -1)
+
+
+def test_custom_all_gather_gate_rejects_non_musa_tensor():
+    impl = _impl()
+    del impl._is_communicator_tensor
+
+    assert not impl.should_custom_all_gather(
+        torch.empty((4, 32), dtype=torch.bfloat16), -1
+    )
+
+
+def test_custom_all_gather_launches_with_last_dim_concatenated(monkeypatch):
+    impl = _impl()
+    input_tensor = torch.arange(128, dtype=torch.bfloat16).view(4, 32)
+    captured = {}
+
+    def launch_all_gather(
+        rank_data,
+        signals,
+        inp,
+        out,
+        self_signal_ptr,
+        self_buffer_ptr,
+        max_size_bytes,
+        rank,
+        world_size,
+    ):
+        captured.update(
+            rank_data=rank_data,
+            signals=signals,
+            inp=inp,
+            out=out,
+            self_signal_ptr=self_signal_ptr,
+            self_buffer_ptr=self_buffer_ptr,
+            max_size_bytes=max_size_bytes,
+            rank=rank,
+            world_size=world_size,
+        )
+
+    monkeypatch.setattr(custom_ar.jit_ar, "launch_all_gather", launch_all_gather)
+    output = impl._custom_all_gather_impl(input_tensor)
+
+    assert output.shape == (4, 64)
+    assert output.dtype == input_tensor.dtype
+    assert captured["rank_data"] is impl.buffer_rank_data
+    assert captured["signals"] is impl.signal_ptrs_cpu
+    assert captured["inp"] is input_tensor
+    assert captured["out"] is output
+    assert captured["self_signal_ptr"] == 101
+    assert captured["self_buffer_ptr"] == 201
+    assert captured["max_size_bytes"] == impl.max_size
+    assert captured["rank"] == 0
+    assert captured["world_size"] == 2
+
+
+@pytest.mark.parametrize(
+    "capturing,stream_capturing,compiling",
+    [
+        (True, False, False),
+        (False, True, False),
+        (False, False, True),
+    ],
+)
+def test_custom_all_gather_fails_closed_outside_eager(
+    monkeypatch, capturing, stream_capturing, compiling
+):
+    impl = _impl()
+    impl._IS_CAPTURING = capturing
+    monkeypatch.setattr(impl, "_is_current_stream_capturing", lambda: stream_capturing)
+    monkeypatch.setattr(impl, "_is_torch_compiling", lambda: compiling)
+    monkeypatch.setattr(
+        impl,
+        "_custom_all_gather_impl",
+        lambda input_tensor: pytest.fail("eager launch must not run"),
+    )
+
+    assert impl.custom_all_gather(torch.empty((4, 32), dtype=torch.bfloat16)) is None
+
+
+def test_custom_all_gather_fails_closed_on_non_default_stream(monkeypatch):
+    impl = _impl()
+    monkeypatch.setattr(impl, "_is_default_stream", lambda input_tensor: False)
+    monkeypatch.setattr(
+        impl,
+        "_custom_all_gather_impl",
+        lambda input_tensor: pytest.fail("non-default stream must not launch"),
+    )
+
+    assert impl.custom_all_gather(torch.empty((4, 32), dtype=torch.bfloat16)) is None
+
+
+def test_logits_helper_uses_only_musa_jit_communicator(monkeypatch):
+    expected = torch.empty((4, 64), dtype=torch.bfloat16)
+    communicator = object.__new__(custom_ar.MusaJitCustomAllreduce)
+    communicator._jit_comm = SimpleNamespace(disabled=False)
+    monkeypatch.setattr(
+        communicator, "custom_all_gather", lambda input_tensor, dim: expected
+    )
+
+    import vllm.distributed.parallel_state as parallel_state
+
+    monkeypatch.setattr(
+        parallel_state,
+        "get_tp_group",
+        lambda: SimpleNamespace(
+            device_communicator=SimpleNamespace(ca_comm=communicator)
+        ),
+    )
+    output = custom_ar.maybe_musa_jit_logits_all_gather(
+        torch.empty((4, 32), dtype=torch.bfloat16)
+    )
+    assert output is expected
+
+    monkeypatch.setattr(
+        parallel_state,
+        "get_tp_group",
+        lambda: SimpleNamespace(device_communicator=SimpleNamespace(ca_comm=object())),
+    )
+    assert (
+        custom_ar.maybe_musa_jit_logits_all_gather(
+            torch.empty((4, 32), dtype=torch.bfloat16)
+        )
+        is None
+    )
+
+
+def test_communicator_fails_closed_when_a_peer_rank_is_unavailable(monkeypatch):
+    closed = []
+
+    class FakeImpl:
+        disabled = False
+
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setattr(
+        custom_ar,
+        "_MusaJitCustomAllreduceImpl",
+        lambda **kwargs: FakeImpl(),
+    )
+
+    def mark_peer_unavailable(availability, **kwargs):
+        availability.zero_()
+
+    monkeypatch.setattr(custom_ar.dist, "all_reduce", mark_peer_unavailable)
+    communicator = custom_ar.MusaJitCustomAllreduce(group=object(), device="musa:0")
+
+    assert communicator.disabled
+    assert closed == [True]

--- a/tests/test_musa_logits_ipc_gather.py
+++ b/tests/test_musa_logits_ipc_gather.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+logits_processor = pytest.importorskip("vllm.model_executor.layers.logits_processor")
+custom_ar = pytest.importorskip(
+    "vllm_musa.distributed.device_communicators.musa_jit_custom_all_reduce"
+)
+
+
+def _processor(org_vocab_size: int):
+    processor = object.__new__(logits_processor.LogitsProcessor)
+    processor.org_vocab_size = org_vocab_size
+    return processor
+
+
+def _patch_tp(monkeypatch, world_size: int = 2, rank: int = 0):
+    monkeypatch.setattr(
+        logits_processor,
+        "get_tensor_model_parallel_world_size",
+        lambda: world_size,
+    )
+    monkeypatch.setattr(
+        logits_processor, "get_tensor_model_parallel_rank", lambda: rank
+    )
+
+
+def test_tp1_logits_skip_collectives(monkeypatch):
+    _patch_tp(monkeypatch, world_size=1)
+    local_logits = torch.arange(32, dtype=torch.int32).to(torch.bfloat16).view(1, 32)
+    monkeypatch.setattr(
+        custom_ar,
+        "maybe_musa_jit_logits_all_gather",
+        lambda input_tensor, dim: pytest.fail("TP1 must skip IPC gather"),
+    )
+
+    output = _processor(151936)._musa_all_reduce_logits(local_logits, SimpleNamespace())
+
+    assert output is local_logits
+
+
+@pytest.mark.parametrize(
+    "org_vocab_size,shard_size", [(151936, 75968), (248320, 124160)]
+)
+def test_qwen_bf16_logits_use_ipc_gather(monkeypatch, org_vocab_size, shard_size):
+    _patch_tp(monkeypatch)
+    local_logits = (
+        torch.arange(shard_size, dtype=torch.int32)
+        .to(torch.bfloat16)
+        .view(1, shard_size)
+    )
+    gathered = torch.empty((1, shard_size * 2), dtype=torch.bfloat16)
+    calls = []
+
+    def gather(input_tensor, dim):
+        calls.append((input_tensor, dim))
+        return gathered
+
+    monkeypatch.setattr(custom_ar, "maybe_musa_jit_logits_all_gather", gather)
+    monkeypatch.setattr(
+        logits_processor,
+        "tensor_model_parallel_all_reduce",
+        lambda input_tensor: pytest.fail("all-reduce fallback must not run"),
+    )
+
+    output = _processor(org_vocab_size)._musa_all_reduce_logits(
+        local_logits, SimpleNamespace()
+    )
+    assert output is gathered
+    assert len(calls) == 1
+    assert calls[0][0] is local_logits
+    assert calls[0][1] == -1
+
+
+@pytest.mark.parametrize(
+    "org_vocab_size,shape,dtype",
+    [
+        (32000, (4, 16000), torch.bfloat16),
+        (248320, (65, 124160), torch.bfloat16),
+        (248320, (4, 124160), torch.float32),
+    ],
+)
+def test_unsupported_logits_preserve_all_reduce_fallback(
+    monkeypatch, org_vocab_size, shape, dtype
+):
+    _patch_tp(monkeypatch)
+    local_logits = (
+        torch.arange(shape[0] * shape[1], dtype=torch.int32).to(dtype).view(shape)
+    )
+    fallback_inputs = []
+
+    monkeypatch.setattr(
+        custom_ar,
+        "maybe_musa_jit_logits_all_gather",
+        lambda input_tensor, dim: pytest.fail("IPC gather gate must not run"),
+    )
+
+    def all_reduce(input_tensor):
+        fallback_inputs.append(input_tensor.clone())
+        return input_tensor
+
+    monkeypatch.setattr(
+        logits_processor, "tensor_model_parallel_all_reduce", all_reduce
+    )
+    output = _processor(org_vocab_size)._musa_all_reduce_logits(
+        local_logits, SimpleNamespace()
+    )
+
+    assert output.shape == (*shape[:-1], shape[-1] * 2)
+    assert torch.equal(output[..., : shape[-1]], local_logits)
+    assert torch.count_nonzero(output[..., shape[-1] :]).item() == 0
+    assert len(fallback_inputs) == 1
+
+
+def test_tp6_logits_preserve_all_reduce_fallback(monkeypatch):
+    _patch_tp(monkeypatch, world_size=6, rank=3)
+    local_logits = torch.arange(32, dtype=torch.int32).to(torch.bfloat16).view(1, 32)
+    monkeypatch.setattr(
+        custom_ar,
+        "maybe_musa_jit_logits_all_gather",
+        lambda input_tensor, dim: pytest.fail("TP6 IPC gather must stay disabled"),
+    )
+    monkeypatch.setattr(
+        logits_processor,
+        "tensor_model_parallel_all_reduce",
+        lambda input_tensor: input_tensor,
+    )
+
+    output = _processor(248320)._musa_all_reduce_logits(local_logits, SimpleNamespace())
+
+    assert output.shape == (1, 32 * 6)
+    assert torch.equal(output[:, 32 * 3 : 32 * 4], local_logits)

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -8,12 +8,13 @@ from typing import Any
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
+from vllm.logger import init_logger
 from vllm.utils.torch_utils import direct_register_custom_op
 
-from vllm.logger import init_logger
 from vllm_musa.jit_kernel.csrc import allreduce as jit_ar
 
 logger = init_logger(__name__)
+_INT32_MAX = (1 << 31) - 1
 
 
 cudaError_t = ctypes.c_int
@@ -127,9 +128,7 @@ def _musa_jit_custom_all_reduce(input: torch.Tensor, comm_id: int) -> torch.Tens
     return comm._custom_all_reduce_impl(input)
 
 
-def _musa_jit_custom_all_reduce_fake(
-    input: torch.Tensor, comm_id: int
-) -> torch.Tensor:
+def _musa_jit_custom_all_reduce_fake(input: torch.Tensor, comm_id: int) -> torch.Tensor:
     return torch.empty_like(input)
 
 
@@ -257,9 +256,7 @@ class _MusaJitCustomAllreduceImpl:
 
         try:
             meta_bytes = jit_ar.meta_size(self.world_size)
-            meta_buffer = _make_shared_buffer(
-                meta_bytes + self.max_size, group=group
-            )
+            meta_buffer = _make_shared_buffer(meta_bytes + self.max_size, group=group)
             self.meta_ptrs = meta_buffer.pointers
             self.meta_opened_ipc_ptrs = meta_buffer.opened_ipc_ptrs
             buffer = _make_shared_buffer(self.max_size, group=group)
@@ -325,6 +322,42 @@ class _MusaJitCustomAllreduceImpl:
             return False
         return inp.is_contiguous()
 
+    def should_custom_all_gather(self, inp: torch.Tensor, dim: int = -1) -> bool:
+        if self.disabled or self.world_size not in (2, 4, 8) or inp.ndim != 2:
+            return False
+        if not self._is_communicator_tensor(inp):
+            return False
+        normalized_dim = dim if dim >= 0 else inp.ndim + dim
+        if normalized_dim != inp.ndim - 1:
+            return False
+        if inp.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            return False
+        if not inp.is_contiguous() or inp.shape[0] <= 0 or inp.shape[1] <= 0:
+            return False
+        pack = 16 // inp.element_size()
+        if inp.shape[1] % pack != 0:
+            return False
+        inp_size = inp.numel() * inp.element_size()
+        output_numel = inp.numel() * self.world_size
+        output_size = output_numel * inp.element_size()
+        return (
+            inp_size <= self.max_size
+            and inp_size % 16 == 0
+            and output_size <= self.max_size
+            and output_numel <= _INT32_MAX
+        )
+
+    def _is_communicator_tensor(self, inp: torch.Tensor) -> bool:
+        return inp.device.type == "musa" and inp.device.index == self.device.index
+
+    def _is_default_stream(self, inp: torch.Tensor) -> bool:
+        try:
+            current = torch.musa.current_stream(device=inp.device)
+            default = torch.musa.default_stream(device=inp.device)
+            return current == default
+        except Exception:
+            return False
+
     @staticmethod
     def _is_current_stream_capturing() -> bool:
         try:
@@ -385,6 +418,40 @@ class _MusaJitCustomAllreduceImpl:
             self.rank,
             self.world_size,
             shot,
+        )
+        return out
+
+    def custom_all_gather(
+        self, input: torch.Tensor, dim: int = -1
+    ) -> torch.Tensor | None:
+        if not self.should_custom_all_gather(input, dim):
+            return None
+        # Logits currently run outside the model graph. Fail closed if a future
+        # runner moves this call under Dynamo or graph capture; that path needs
+        # pointer-registration semantics rather than an eager FFI call.
+        if (
+            self._IS_CAPTURING
+            or self._is_current_stream_capturing()
+            or self._is_torch_compiling()
+            or not self._is_default_stream(input)
+        ):
+            return None
+        return self._custom_all_gather_impl(input)
+
+    def _custom_all_gather_impl(self, input: torch.Tensor) -> torch.Tensor:
+        assert self.buffer_rank_data is not None
+        output_shape = (*input.shape[:-1], input.shape[-1] * self.world_size)
+        out = torch.empty(output_shape, dtype=input.dtype, device=input.device)
+        jit_ar.launch_all_gather(
+            self.buffer_rank_data,
+            self.signal_ptrs_cpu,
+            input,
+            out,
+            self.meta_ptrs[self.rank],
+            self.buffer_ptrs[self.rank],
+            self.max_size,
+            self.rank,
+            self.world_size,
         )
         return out
 
@@ -454,6 +521,16 @@ class MusaJitCustomAllreduce:
         except Exception:
             logger.exception("Failed to initialize MUSA JIT custom all-reduce.")
 
+        availability = torch.tensor([int(self._jit_available)], dtype=torch.int32)
+        dist.all_reduce(availability, op=dist.ReduceOp.MIN, group=group)
+        if not bool(availability.item()) and self._jit_comm is not None:
+            self._jit_comm.close()
+            self._jit_comm = None
+            logger.warning_once(
+                "MUSA JIT custom all-reduce disabled because a peer rank "
+                "failed initialization."
+            )
+
         if self._jit_available:
             logger.info_once(
                 "Using MUSA JIT custom all-reduce for eager and CUDA graph paths."
@@ -483,6 +560,13 @@ class MusaJitCustomAllreduce:
             return self._jit_comm.custom_all_reduce(input)
         return None
 
+    def custom_all_gather(
+        self, input: torch.Tensor, dim: int = -1
+    ) -> torch.Tensor | None:
+        if self._jit_available and self._jit_comm.should_custom_all_gather(input, dim):
+            return self._jit_comm.custom_all_gather(input, dim)
+        return None
+
     def close(self) -> None:
         if self._jit_comm is not None:
             self._jit_comm.close()
@@ -493,3 +577,19 @@ class MusaJitCustomAllreduce:
             self.close()
         except Exception:
             pass
+
+
+def maybe_musa_jit_logits_all_gather(
+    input: torch.Tensor, dim: int = -1
+) -> torch.Tensor | None:
+    """Use the MUSA IPC communicator for a last-dimension logits gather."""
+    from vllm.distributed.parallel_state import get_tp_group
+
+    device_communicator = get_tp_group().device_communicator
+    custom_ar = getattr(device_communicator, "ca_comm", None)
+    if not isinstance(custom_ar, MusaJitCustomAllreduce):
+        return None
+    output = custom_ar.custom_all_gather(input, dim)
+    if output is not None:
+        logger.info_once("Using MUSA JIT IPC all-gather for TP logits.")
+    return output

--- a/vllm_musa/jit_kernel/csrc/allreduce.py
+++ b/vllm_musa/jit_kernel/csrc/allreduce.py
@@ -97,3 +97,27 @@ def launch_unregistered(
         int(world_size),
         int(shot),
     )
+
+
+def launch_all_gather(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    self_signal_ptr: int,
+    self_buffer_ptr: int,
+    max_size_bytes: int,
+    rank: int,
+    world_size: int,
+) -> None:
+    _custom_ar_module(int(world_size)).vllm_musa_custom_ar_launch_all_gather(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        out,
+        int(self_signal_ptr),
+        int(self_buffer_ptr),
+        int(max_size_bytes),
+        int(rank),
+        int(world_size),
+    )

--- a/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
@@ -323,6 +323,101 @@ __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) custom_all_reduce_2sho
 }
 
 template <typename T, int nranks>
+__global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
+    cross_device_all_gather_last_dim(RankData data, T* __restrict__ out,
+                                     int rows,
+                                     int shard_packed_size) {
+  using P = typename packed_t<T>::P;
+  const int region_count = rows * nranks;
+  if (gridDim.x >= region_count) {
+    const int region = blockIdx.x % region_count;
+    const int block_in_region = blockIdx.x / region_count;
+    const int blocks_per_region = gridDim.x / region_count;
+    const int row = region / nranks;
+    const int source_rank = region - row * nranks;
+    const P* source = reinterpret_cast<const P*>(data.ptrs[source_rank]) +
+                      row * shard_packed_size;
+    P* destination = reinterpret_cast<P*>(out) + region * shard_packed_size;
+    for (int column = block_in_region * blockDim.x + threadIdx.x;
+         column < shard_packed_size;
+         column += blocks_per_region * blockDim.x) {
+      destination[column] = source[column];
+    }
+  } else {
+    for (int region = blockIdx.x; region < region_count;
+         region += gridDim.x) {
+      const int row = region / nranks;
+      const int source_rank = region - row * nranks;
+      const P* source = reinterpret_cast<const P*>(data.ptrs[source_rank]) +
+                        row * shard_packed_size;
+      P* destination = reinterpret_cast<P*>(out) + region * shard_packed_size;
+      for (int column = threadIdx.x; column < shard_packed_size;
+           column += blockDim.x) {
+        destination[column] = source[column];
+      }
+    }
+  }
+}
+
+template <int nranks>
+__global__ void cross_device_all_gather_start_barrier(RankSignals sg,
+                                                       Signal* self_sg,
+                                                       int rank) {
+  // Each signalling lane owns its system-scope release/acquire pair.
+  if (threadIdx.x < nranks) {
+    __threadfence_system();
+  }
+  __syncthreads_lm();
+  multi_rank_barrier<nranks, true>(sg, self_sg, rank);
+  if (threadIdx.x < nranks) {
+    __threadfence_system();
+  }
+  __syncthreads_lm();
+}
+
+template <int nranks>
+__global__ void cross_device_all_gather_end_barrier(RankSignals sg,
+                                                     Signal* self_sg,
+                                                     int rank) {
+  // The same stream reaches this kernel only after every local copy block has
+  // completed. Wait for peers before allowing the next staging overwrite.
+  if (threadIdx.x < nranks) {
+    __threadfence_system();
+  }
+  __syncthreads_lm();
+  multi_rank_barrier<nranks, false>(sg, self_sg, rank);
+  if (threadIdx.x < nranks) {
+    __threadfence_system();
+  }
+  __syncthreads_lm();
+}
+
+template <typename T, int nranks>
+void launch_all_gather_last_dim(RankData data, RankSignals sg,
+                                Signal* self_sg, T* out, int rank, int rows,
+                                int shard_size, musaStream_t stream) {
+  const int pack = packed_t<T>::P::size;
+  TVM_FFI_ICHECK_EQ(shard_size % pack, 0);
+  const int shard_packed_size = shard_size / pack;
+  const int region_count = rows * nranks;
+  const int block_limit = std::min(kDefaultBlockLimit, kMaxBlocks);
+  int blocks = block_limit;
+  if (blocks >= region_count) {
+    blocks = (blocks / region_count) * region_count;
+  }
+  if (blocks <= 0) {
+    return;
+  }
+  cross_device_all_gather_start_barrier<nranks>
+      <<<1, nranks, 0, stream>>>(sg, self_sg, rank);
+  cross_device_all_gather_last_dim<T, nranks>
+      <<<blocks, kDefaultThreads, 0, stream>>>(data, out, rows,
+                                               shard_packed_size);
+  cross_device_all_gather_end_barrier<nranks>
+      <<<1, nranks, 0, stream>>>(sg, self_sg, rank);
+}
+
+template <typename T, int nranks>
 void launch_ar(RankData data, RankSignals sg, Signal* self_sg, T* out, int rank, int size, int shot, musaStream_t stream) {
   const int pack = packed_t<T>::P::size;
   TVM_FFI_ICHECK_EQ(size % pack, 0);
@@ -361,6 +456,29 @@ void dispatch_world_size(RankData data, RankSignals sg, Signal* self_sg, T* out,
       break;
     default:
       TVM_FFI_THROW(ValueError) << "world_size must be one of 2/4/6/8";
+  }
+}
+
+template <typename T>
+void dispatch_all_gather_world_size(RankData data, RankSignals sg,
+                                    Signal* self_sg, T* out, int rank,
+                                    int world_size, int rows, int shard_size,
+                                    musaStream_t stream) {
+  switch (world_size) {
+    case 2:
+      launch_all_gather_last_dim<T, 2>(data, sg, self_sg, out, rank, rows,
+                                       shard_size, stream);
+      break;
+    case 4:
+      launch_all_gather_last_dim<T, 4>(data, sg, self_sg, out, rank, rows,
+                                       shard_size, stream);
+      break;
+    case 8:
+      launch_all_gather_last_dim<T, 8>(data, sg, self_sg, out, rank, rows,
+                                       shard_size, stream);
+      break;
+    default:
+      TVM_FFI_THROW(ValueError) << "all-gather world_size must be one of 2/4/8";
   }
 }
 
@@ -433,5 +551,96 @@ void vllm_musa_custom_ar_launch_unregistered(
   TVM_FFI_ICHECK_EQ(err, musaSuccess) << "MUSA custom AR kernel failed: " << musaGetErrorString(err);
 }
 
+void vllm_musa_custom_ar_launch_all_gather(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView out,
+    int64_t self_signal_ptr,
+    int64_t self_buffer_ptr,
+    int64_t max_size_bytes,
+    int64_t rank,
+    int64_t world_size) {
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(out);
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+  TVM_FFI_ICHECK_EQ(inp.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(out.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(inp.size(0), out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1) * world_size, out.size(1));
+  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), out.dtype()));
+
+  RankSignals sg{};
+  const auto* ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(ptrs[i]);
+  }
+  RankData data{};
+  const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+  for (int i = 0; i < kMaxRanks; ++i) {
+    data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+  // The local input is still live for this eager call and is typically hot
+  // from LM-head GEMM. Peers read the published IPC staging copy, while this
+  // rank can read its original shard directly.
+  data.ptrs[rank] = inp.data_ptr();
+
+  auto* self_sg = reinterpret_cast<Signal*>(self_signal_ptr);
+  auto stream = get_stream(out.device());
+  const int64_t input_numel = tensor_numel(inp);
+  const int64_t output_numel = tensor_numel(out);
+  TVM_FFI_ICHECK_LE(input_numel,
+                    static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  TVM_FFI_ICHECK_LE(output_numel,
+                    static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const int64_t element_bytes =
+      (static_cast<int64_t>(inp.dtype().bits) * inp.dtype().lanes + 7) / 8;
+  const int64_t input_nbytes = input_numel * element_bytes;
+  const int64_t output_nbytes = output_numel * element_bytes;
+  TVM_FFI_ICHECK_LE(input_nbytes, max_size_bytes);
+  TVM_FFI_ICHECK_LE(output_nbytes, max_size_bytes);
+  const musaError_t copy_err = musaMemcpyAsync(
+      reinterpret_cast<void*>(self_buffer_ptr), inp.data_ptr(),
+      static_cast<size_t>(input_nbytes), musaMemcpyDeviceToDevice, stream);
+  TVM_FFI_ICHECK_EQ(copy_err, musaSuccess)
+      << "MUSA custom all-gather copy failed: "
+      << musaGetErrorString(copy_err);
+
+  const int rows = static_cast<int>(inp.size(0));
+  const int shard_size = static_cast<int>(inp.size(1));
+  if (dtype_equal(out.dtype(), dl_float16)) {
+    dispatch_all_gather_world_size(
+        data, sg, self_sg, static_cast<half*>(out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
+        stream);
+  } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
+    dispatch_all_gather_world_size(
+        data, sg, self_sg, static_cast<__mt_bfloat16*>(out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
+        stream);
+  } else if (dtype_equal(out.dtype(), dl_float32)) {
+    dispatch_all_gather_world_size(
+        data, sg, self_sg, static_cast<float*>(out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
+        stream);
+  } else {
+    TVM_FFI_THROW(ValueError)
+        << "custom all-gather only supports fp16/bf16/fp32";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA custom all-gather kernel failed: " << musaGetErrorString(err);
+}
+
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_meta_size, vllm_musa_custom_ar_meta_size);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_unregistered, vllm_musa_custom_ar_launch_unregistered);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_all_gather,
+                              vllm_musa_custom_ar_launch_all_gather);

--- a/vllm_musa/patches/series/0072-MUSA-avoid-logits-gather-collectives-on-TP.patch
+++ b/vllm_musa/patches/series/0072-MUSA-avoid-logits-gather-collectives-on-TP.patch
@@ -4,11 +4,11 @@ Date: Mon, 29 Jun 2026 16:55:00 +0800
 Subject: [PATCH] MUSA: avoid logits gather collectives on TP
 
 ---
- .../model_executor/layers/logits_processor.py | 49 +++++++++++++++++--
- 1 file changed, 46 insertions(+), 3 deletions(-)
+ .../model_executor/layers/logits_processor.py | 71 +++++++++++++++++--
+ 1 file changed, 68 insertions(+), 3 deletions(-)
 
 diff --git a/vllm/model_executor/layers/logits_processor.py b/vllm/model_executor/layers/logits_processor.py
-index 3541b9706..651505ab0 100644
+index 3541b9706..9ded650eb 100644
 --- a/vllm/model_executor/layers/logits_processor.py
 +++ b/vllm/model_executor/layers/logits_processor.py
 @@ -5,8 +5,10 @@
@@ -22,7 +22,7 @@ index 3541b9706..651505ab0 100644
      tensor_model_parallel_gather,
  )
  from vllm.model_executor.custom_op import PluggableLayer
-@@ -72,7 +74,35 @@ class LogitsProcessor(PluggableLayer):
+@@ -72,7 +74,57 @@ class LogitsProcessor(PluggableLayer):
                  logits *= self.scale
          return logits
  
@@ -36,10 +36,32 @@ index 3541b9706..651505ab0 100644
 +        logits: torch.Tensor,
 +        lm_head: VocabParallelEmbedding,
 +    ) -> torch.Tensor:
-+        """Rebuild all-gathered logits using the TP all-reduce backend."""
++        """Rebuild all-gathered logits with MUSA IPC or all-reduce fallback."""
 +        tp_size = get_tensor_model_parallel_world_size()
 +        if tp_size == 1:
 +            return logits
++
++        use_ipc_gather = (
++            self.org_vocab_size in (151936, 248320)
++            and tp_size in (2, 4, 8)
++            and logits.dtype == torch.bfloat16
++            and logits.ndim == 2
++            and 0 < logits.shape[0] <= 64
++            and logits.shape[1] > 0
++            and logits.shape[1] % 8 == 0
++            and logits.is_contiguous()
++            and logits.shape[1] * tp_size >= self.org_vocab_size
++        )
++        if use_ipc_gather:
++            from vllm_musa.distributed.device_communicators import (
++                musa_jit_custom_all_reduce as musa_jit_ar,
++            )
++
++            gathered = musa_jit_ar.maybe_musa_jit_logits_all_gather(
++                logits, dim=-1
++            )
++            if gathered is not None:
++                return gathered
 +
 +        tp_rank = get_tensor_model_parallel_rank()
 +        shard_size = logits.shape[-1]
@@ -59,7 +81,7 @@ index 3541b9706..651505ab0 100644
          """gather/all-gather the logits tensor across model parallel group."""
          if self.use_all_gather:
              # Gather is not supported for some devices such as TPUs.
-@@ -80,7 +110,12 @@ class LogitsProcessor(PluggableLayer):
+@@ -80,7 +132,12 @@ class LogitsProcessor(PluggableLayer):
              # NOTE(woosuk): Here, the outputs of every device should not be None
              # because XLA requires strict SPMD among all devices. Every device
              # should execute the same operations after gathering the logits.
@@ -73,7 +95,7 @@ index 3541b9706..651505ab0 100644
          else:
              # None may be returned for rank > 0
              logits = tensor_model_parallel_gather(logits)
-@@ -96,7 +131,7 @@ class LogitsProcessor(PluggableLayer):
+@@ -96,7 +153,7 @@ class LogitsProcessor(PluggableLayer):
          logits = lm_head.quant_method.apply(lm_head, hidden_states, bias=embedding_bias)
  
          # Gather logits for TP
@@ -82,7 +104,7 @@ index 3541b9706..651505ab0 100644
  
          # Remove paddings in vocab (if any).
          if logits is not None:
-@@ -128,6 +163,14 @@ class LogitsProcessor(PluggableLayer):
+@@ -128,6 +185,14 @@ class LogitsProcessor(PluggableLayer):
          if self.scale != 1.0:
              logits = logits * self.scale
  


### PR DESCRIPTION
## Summary

- replace the MUSA Qwen TP-logits `zeros + local copy + custom all-reduce`
  reconstruction with a direct last-dimension gather from the existing IPC
  staging buffers;
- publish each local shard with signalling-lane system-scope fences and use an
  end barrier before staging reuse;
- require rank-wide JIT availability and the communicator default stream, with
  fail-closed fallback for capture/Dynamo, unsupported streams, shapes,
  dtypes, TP sizes, vocabularies, or communicators;
- exact-gate the production path to BF16 Qwen vocabularies 151936/248320,
  TP2/4/8, contiguous 2-D logits, and rows 1--64.

This changes vLLM-MUSA only. It does not patch or override vLLM-Omni.

## Why

On Qwen3.5-27B BF16 TP2 BS64, the graph-external logits tail materialized a
full-vocabulary zero tensor, copied the local shard, staged the full 31.8 MB
tensor, and reduced it across ranks. The paired final traces show the TP logits
kernel falling from 918.60 us/step to 453.35 us/step.

`musaMemcpy2DAsync` was also tested and rejected: it rose to approximately
1.4--1.7 ms at BS4--64 on this stack. The shipped candidate is the peer-load
kernel, not the memcpy2D experiment.

## Performance

Qwen3.5-27B BF16, TP2, BS64, nominal 4096 input / 1024 output, unseeded
top-k=50/min-p=0.05, FlashAttention 3, `VLLM_COMPILE + FULL_AND_PIECEWISE`,
identical input vector:

| Metric | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| Mean TPOT | 85.450 ms | 84.287 ms | -1.163 ms (-1.36%) |
| Mean ITL | 85.366 ms | 84.205 ms | -1.162 ms (-1.36%) |
| P50 TPOT | 85.667 ms | 84.493 ms | -1.174 ms (-1.37%) |
| P95 TPOT | 99.219 ms | 98.074 ms | -1.144 ms (-1.15%) |
| Output throughput | 619.035 tok/s | 626.003 tok/s | +6.968 tok/s (+1.13%) |
| Mean TTFT | 17653.532 ms | 17672.299 ms | +18.767 ms (+0.11%) |

Paired 20-step trace:

| Segment | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| LM-head end to sampling start, mean | 1623.22 us | 1117.89 us | -505.33 us |
| Same interval, P50 | 1604.88 us | 1120.44 us | -484.44 us |
| Intermediate device busy | 1338.56 us | 869.41 us | -469.15 us |

Final-source TP2 cold-cache operator P50:

| Rows | Baseline | Candidate | Speedup |
|---:|---:|---:|---:|
| 1 | 81.06 us | 41.78 us | 1.94x |
| 4 | 133.32 us | 64.54 us | 2.07x |
| 16 | 323.38 us | 154.76 us | 2.09x |
| 64 | 1007.46 us | 524.68 us | 1.92x |

## Validation

- vllm-musa base: `3e7c5035cb89b591e78e26da1d044724d6d73c36`
- candidate: `c8fcfac191bc7299e422af6f6d3b3d70d35ef601`
- patched vLLM: `ee0da84ab9e04ac7610e28580af62c365e898389`
- image:
  `sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`
- hardware: one isolated 8x MTT S5000 node, driver `5.2.0-server`
- runtime: torch/torch_musa `2.9.1.post1+musa5.2.0s5000`, torchada
  `0.1.76`, MATE `0.2.4`
- focused tests: `16 passed`
- full vllm-musa patch series applied to the pinned vLLM checkout
- final Qwen3.5 formal request, semantic, FA3, compile/cudagraph, frozen input
  vector, and two-rank 20-step trace gates passed
- Qwen3-8B BF16 TP2 sibling: BS1/BS64 request, semantic, FA3, candidate marker,
  compile/cudagraph, and two-rank 20-step trace gates passed
- Qwen3.6-35B-A3B BF16 TP4 sibling: BS1/BS64 request, semantic, FA3,
  fused-MoE/GDN, candidate marker, compile/cudagraph, and four-rank 20-step
  trace gates passed
- changing-pattern stress passed for both Qwen vocabularies, TP2/4/8, and rows
  1/4/16/64: 2000 iterations/cell, no host barrier, eight back-to-back
  enqueues, rotating 500-us rank skew
- non-default-stream probe returned the fallback path

The first TP8 stress attempt used 257 as an expected BF16 value and produced a
deterministic test-only mismatch because 257 rounds to 256. The corrected
BF16-exact 0--127 pattern passed both TP8 vocabularies; the rejected log is
retained in the evidence archive.

Local evidence archive:
`generated/MUSA-60043/profiles/logits-ipc-round4-final/logits-ipc-round4-final-v2-20260726.tar.gz`
(`bd0733cb04e838699188f1f8a1998576437d6a5fba2d30be04bdd3f8dbf9e463`).

## Risk boundary

- logits remain graph-external; this PR optimizes their TP reconstruction but
  does not claim to capture logits or sampling;
- only the default stream uses the shared staging buffer; other streams keep
  the existing path;
- all unsupported cases retain the existing all-reduce reconstruction;
- CI is pending, so this remains a Draft PR.
