### PR TITLE
perf(musa): reuse uniform Qwen top-k sampling path

### DIFF
--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -2,12 +2,16 @@
 # ruff: noqa: I001
 """CPU-state contracts for MUSA V2 sampling fast paths."""
 
+import inspect
+from dataclasses import fields
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 import torchada  # noqa: F401
 import torch
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.worker.gpu_input_batch import InputBatch
 
 from vllm_musa.v1.sample import topk_topp_sampler as sampler
 
@@ -16,6 +20,14 @@ requires_musa = pytest.mark.skipif(
     not hasattr(torch, "musa") or not torch.musa.is_available(),
     reason="requires a MUSA device",
 )
+
+
+def test_uniform_top_k_metadata_patch_is_active_and_qwen_gated() -> None:
+    assert "uniform_top_k" in {field.name for field in fields(SamplingMetadata)}
+    source = inspect.getsource(InputBatch._make_sampling_metadata)
+    assert "uniform_top_k" in source
+    assert "self.vocab_size in (151936, 248320)" in source
+    assert "candidate_top_k == 50" in source
 
 
 def _state_array(
@@ -333,6 +345,103 @@ def test_uniform_active_min_p_uses_cpu_state() -> None:
     )
     assert (
         sampler._uniform_active_min_p(np.asarray([0.05, 0.1], dtype=np.float32)) is None
+    )
+
+
+def test_legacy_uniform_min_p_uses_cpu_hint_only_for_qwen_vocab() -> None:
+    min_p = torch.full((4,), 0.05, dtype=torch.float32)
+    processor = SimpleNamespace(
+        min_p=min_p,
+        min_p_cpu=np.full((4,), 0.05, dtype=np.float32),
+    )
+
+    qwen_logits = torch.empty((4, 248320))
+    assert sampler._legacy_min_p_with_cpu_hint(processor, qwen_logits) == pytest.approx(
+        0.05
+    )
+
+    non_qwen_logits = torch.empty((4, 32000))
+    assert sampler._legacy_min_p_with_cpu_hint(processor, non_qwen_logits) is min_p
+
+    processor.min_p_cpu[1] = 0.04
+    assert sampler._legacy_min_p_with_cpu_hint(processor, qwen_logits) is min_p
+
+
+def test_legacy_uniform_top_k_uses_cpu_hint_only_for_musa_native_sampler(
+    monkeypatch,
+) -> None:
+    top_k = torch.full((4,), 50, dtype=torch.int32)
+    metadata = SimpleNamespace(uniform_top_k=50, generators={})
+    musa_sampler = SimpleNamespace(forward=SimpleNamespace(__name__="forward_musa"))
+    logits = torch.empty((4, 248320))
+
+    def can_use_native(_logits, generators, logprobs_mode):
+        return not generators and logprobs_mode == "raw_logprobs"
+
+    monkeypatch.setattr(sampler, "can_use_musa_sampler", can_use_native)
+
+    assert (
+        sampler._legacy_top_k_with_cpu_hint(
+            metadata, top_k, musa_sampler, logits, "raw_logprobs"
+        )
+        == 50
+    )
+
+    metadata.uniform_top_k = 49
+    assert (
+        sampler._legacy_top_k_with_cpu_hint(
+            metadata, top_k, musa_sampler, logits, "raw_logprobs"
+        )
+        is top_k
+    )
+
+    metadata.uniform_top_k = 50
+    fallback_sampler = SimpleNamespace(
+        forward=SimpleNamespace(__name__="forward_native")
+    )
+    assert (
+        sampler._legacy_top_k_with_cpu_hint(
+            metadata, top_k, fallback_sampler, logits, "raw_logprobs"
+        )
+        is top_k
+    )
+
+    metadata.uniform_top_k = None
+    heterogeneous_top_k = torch.tensor([50, 49, 50, 49], dtype=torch.int32)
+    assert (
+        sampler._legacy_top_k_with_cpu_hint(
+            metadata,
+            heterogeneous_top_k,
+            musa_sampler,
+            logits,
+            "raw_logprobs",
+        )
+        is heterogeneous_top_k
+    )
+
+    metadata.uniform_top_k = 50
+    metadata.generators = {0: object()}
+    assert (
+        sampler._legacy_top_k_with_cpu_hint(
+            metadata, top_k, musa_sampler, logits, "raw_logprobs"
+        )
+        is top_k
+    )
+
+    metadata.generators = {}
+    assert (
+        sampler._legacy_top_k_with_cpu_hint(
+            metadata, top_k, musa_sampler, logits, "processed_logprobs"
+        )
+        is top_k
+    )
+
+    non_qwen_logits = torch.empty((4, 32000))
+    assert (
+        sampler._legacy_top_k_with_cpu_hint(
+            metadata, top_k, musa_sampler, non_qwen_logits, "raw_logprobs"
+        )
+        is top_k
     )
 
 

--- a/vllm_musa/patches/series/0088-MUSA-propagate-uniform-top-k-sampling-metadata.patch
+++ b/vllm_musa/patches/series/0088-MUSA-propagate-uniform-top-k-sampling-metadata.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sun, 26 Jul 2026 16:53:48 +0800
+Subject: [PATCH] MUSA: propagate uniform top-k sampling metadata
+
+---
+ vllm/v1/sample/metadata.py        | 2 ++
+ vllm/v1/worker/gpu_input_batch.py | 8 ++++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/vllm/v1/sample/metadata.py b/vllm/v1/sample/metadata.py
+index fa4ceac8e7..252cf746a0 100644
+--- a/vllm/v1/sample/metadata.py
++++ b/vllm/v1/sample/metadata.py
+@@ -53,3 +53,5 @@ class SamplingMetadata:
+     # When non-None, use ``holder.has_tracked_requests()`` to see if this batch applies
+     # thinking-token-budget logits (holder may exist with an empty tracking set).
+     thinking_budget_state_holder: ThinkingBudgetStateHolder | None = None
++    # CPU-side hint for exact-gated platform sampler specializations.
++    uniform_top_k: int | None = None
+diff --git a/vllm/v1/worker/gpu_input_batch.py b/vllm/v1/worker/gpu_input_batch.py
+index 589fbd43ef..6c48e7fcb9 100644
+--- a/vllm/v1/worker/gpu_input_batch.py
++++ b/vllm/v1/worker/gpu_input_batch.py
+@@ -917,6 +917,13 @@ class InputBatch:
+                     req_index = self.req_id_to_index[req_id]
+                     logprob_token_ids_by_index[req_index] = token_ids
+ 
++        uniform_top_k = None
++        if self.vocab_size in (151936, 248320) and not self.no_top_k and num_reqs > 0:
++            top_k_cpu = self.top_k_cpu[:num_reqs]
++            candidate_top_k = int(top_k_cpu[0])
++            if candidate_top_k == 50 and np.all(top_k_cpu == candidate_top_k):
++                uniform_top_k = candidate_top_k
++
+         return SamplingMetadata(
+             temperature=temperature,
+             all_greedy=self.all_greedy,
+@@ -937,6 +944,7 @@ class InputBatch:
+             bad_words_token_ids=self.bad_words_token_ids,
+             logitsprocs=self.logitsprocs,
+             thinking_budget_state_holder=self.thinking_budget_state_holder,
++            uniform_top_k=uniform_top_k,
+         )
+ 
+     def get_pooling_params(self) -> list[PoolingParams]:

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -285,9 +285,9 @@ def forward_musa(
     self: Any,
     logits: torch.Tensor,
     generators: dict[int, torch.Generator],
-    k: torch.Tensor | None,
-    p: torch.Tensor | None,
-    min_p: torch.Tensor | None = None,
+    k: torch.Tensor | int | None,
+    p: torch.Tensor | float | None,
+    min_p: torch.Tensor | float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     if (
         generators
@@ -357,14 +357,48 @@ def get_processor_min_p(processor: Any) -> torch.Tensor:
     return _squeeze_filter_tensor(min_p)
 
 
+def _legacy_min_p_with_cpu_hint(
+    processor: Any,
+    logits: torch.Tensor,
+) -> torch.Tensor | float:
+    min_p = get_processor_min_p(processor)
+    min_p_cpu = getattr(processor, "min_p_cpu", None)
+    if min_p_cpu is None or not _is_qwen_sampler_vocab(logits):
+        return min_p
+    uniform_min_p = _uniform_active_min_p(min_p_cpu[: logits.shape[0]])
+    return uniform_min_p if uniform_min_p is not None else min_p
+
+
+def _legacy_top_k_with_cpu_hint(
+    sampling_metadata: Any,
+    top_k: torch.Tensor | None,
+    topk_topp_sampler: Any,
+    logits: torch.Tensor,
+    logprobs_mode: LogprobsMode,
+) -> int | torch.Tensor | None:
+    if (
+        top_k is not None
+        and getattr(topk_topp_sampler.forward, "__name__", "") == "forward_musa"
+        and can_use_musa_sampler(
+            logits,
+            sampling_metadata.generators,
+            logprobs_mode,
+        )
+        and _is_qwen_sampler_vocab(logits)
+        and getattr(sampling_metadata, "uniform_top_k", None) == 50
+    ):
+        return 50
+    return top_k
+
+
 def _call_topk_topp_sampler(
     sampler: Any,
     logprobs_mode: LogprobsMode,
     logits: torch.Tensor,
     generators: dict[int, torch.Generator],
-    top_k: torch.Tensor | None,
-    top_p: torch.Tensor | None,
-    min_p: torch.Tensor | None = None,
+    top_k: torch.Tensor | int | None,
+    top_p: torch.Tensor | float | None,
+    min_p: torch.Tensor | float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     original_logprobs_mode = sampler.logprobs_mode
     sampler.logprobs_mode = logprobs_mode
@@ -524,6 +558,14 @@ def _sample(
         logits, sampling_metadata.temperature, sampling_metadata.all_random
     )
 
+    top_k = _legacy_top_k_with_cpu_hint(
+        sampling_metadata,
+        sampling_metadata.top_k,
+        self.topk_topp_sampler,
+        logits,
+        logprobs_mode,
+    )
+
     musa_min_p = None
     defer_min_p = (
         getattr(self.topk_topp_sampler.forward, "__name__", "") == "forward_musa"
@@ -532,7 +574,7 @@ def _sample(
         if defer_min_p and should_defer_min_p_processor(
             logits, sampling_metadata.generators, logprobs_mode, processor
         ):
-            musa_min_p = get_processor_min_p(processor)
+            musa_min_p = _legacy_min_p_with_cpu_hint(processor, logits)
             continue
         logits = processor.apply(logits)
 
@@ -566,7 +608,7 @@ def _sample(
             logprobs_mode,
             logits,
             sampling_metadata.generators,
-            sampling_metadata.top_k,
+            top_k,
             sampling_metadata.top_p,
         )
     else:
@@ -575,7 +617,7 @@ def _sample(
             logprobs_mode,
             logits,
             sampling_metadata.generators,
-            sampling_metadata.top_k,
+            top_k,
             sampling_metadata.top_p,
             min_p=musa_min_p,
         )


### PR DESCRIPTION
## Summary

- propagate a CPU-side uniform `top_k=50` hint only for the validated Qwen vocabularies (`151936` and `248320`)
- let the legacy Qwen sampler reuse the existing RubyMine top-k renormalization kernel and scalarize uniform active `min_p`
- preserve the original tensor path for non-Qwen vocabularies, heterogeneous parameters, seeded requests, processed-logprob modes, and non-MUSA-native sampling
- add no new kernel or ABI

This Draft is stacked on #123 so its review diff contains only this round's commit. It should be retargeted to `v0.24.0-dev` after #123 merges.

## Qwen3.5 formal A/B/A/B

Qwen3.5-27B BF16, TP2, BS64, 4096 input / 1024 output, unseeded `temperature=1, top_p=1, top_k=50, min_p=0.05`, FA3, `VLLM_COMPILE`, `FULL_AND_PIECEWISE`, one S5000 node.

| Leg | Mean TPOT (ms) | Output throughput (tok/s) | Mean TTFT (ms) |
|---|---:|---:|---:|
| Parent A1 | 85.936 | 615.340 | 17789.672 |
| Candidate B1 | 77.626 | 669.712 | 17714.817 |
| Parent A2 | 85.615 | 617.393 | 17774.197 |
| Exact-SHA candidate B2 | 77.719 | 668.670 | 17772.318 |
| Pair mean change | **-9.45%** | **+8.57%** | **-0.22%** |

All four legs completed 64/64 requests with the same frozen input-vector contract.

Profiler evidence on both ranks:

- FlashInfer `TopKRenormProbKernel`: `20 -> 0` calls
- RubyMine `top_k_renorm_kernel<512, 512>`: `0 -> 20` calls
- top-k mean device time: about `8.43/8.55 ms -> 0.223/0.224 ms` per step
- rank-0 sampling device total: `172.143 ms -> 7.763 ms` across 20 steps
- D2H copies: `120 -> 80` across 20 steps

## Validation

- exact commit: `c868a7d717d27b2e759262e1d0ebaede7424bfa3`
- image: `registry.mthreads.com/mcconline/inference/vllm@sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`
- hardware: 8x MTT S5000, driver `5.2.0-server`; formal run used TP2
- focused + RubyMine tests: `60 passed`
- patch series: all 88 build-applied patches replay cleanly; the full verifier still reports the pre-existing `v1.attention.backends.flash_attn` drift tripwire

Cold-cache vocab-248320 microbenchmark:

| BS | Generic (us) | RubyMine (us) | Speedup |
|---:|---:|---:|---:|
| 1 | 2745.98 | 105.72 | 96.15% |
| 4 | 2664.89 | 113.56 | 95.74% |
| 16 | 3280.78 | 191.20 | 94.17% |
| 64 | 4673.90 | 262.82 | 94.38% |

Support masks matched and maximum row-sum error was at most `1.2e-7` for every shape.

## Sibling validation

- Qwen3.6-35B-A3B BF16 resolved to the shared `Qwen3_5MoeForConditionalGeneration` path. TP4 BS64 128/128 completed 64/64 requests with FA3/GDN/compile/cudagraph; all four ranks recorded RubyMine 20 times, FlashInfer zero times, at about 223-225 us.
- Qwen3-8B BF16 retained the V2 Model Runner. TP2 BS64 128/128 completed 64/64 requests; both ranks recorded RubyMine 20 times, FlashInfer zero times, at about 141-142 us.

Local evidence archive: `generated/MUSA-60042/round5-sampling/qwen-uniform-topk-r5-final-20260726.tar.gz`, SHA256 `20a6e97324bec4ad87e42b1b1ad943c16687f8d92873738bbfa6cced226f5157`.

Cleanup removed the exact task container and host task root, verified all eight GPUs had zero memory and no processes, and released lease `lease-ae6053c7642c`.
