### PR TITLE
perf(musa): use direct FA3 schedule for Qwen graph-size-64 decode

### DIFF
--- a/tests/test_flash_attn_scheduler_fast_path.py
+++ b/tests/test_flash_attn_scheduler_fast_path.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact gates for the MUSA Qwen direct FA3 decode schedule."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_musa.v1.attention.backends.flash_attn import (
+    _is_musa_qwen_family,
+    _use_musa_qwen_direct_decode_schedule,
+)
+
+
+@pytest.mark.parametrize(
+    ("architectures", "expected"),
+    [
+        (["Qwen2ForCausalLM"], True),
+        (["Qwen3ForCausalLM"], True),
+        (["Qwen3_5ForConditionalGeneration"], True),
+        (["Qwen3_5MoeForConditionalGeneration"], True),
+        (["LlamaForCausalLM"], False),
+        (None, False),
+    ],
+)
+def test_musa_qwen_family_gate(architectures, expected: bool) -> None:
+    model_config = SimpleNamespace(architectures=architectures)
+    assert _is_musa_qwen_family(model_config) is expected
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({}, True),
+        ({"aot_schedule": False}, False),
+        ({"is_bfloat16": False}, False),
+        ({"is_qwen_family": False}, False),
+        ({"common_prefix_len": 1}, False),
+        ({"dcp_world_size": 2}, False),
+        ({"num_reqs": 63, "num_decodes": 63}, False),
+        ({"num_decodes": 63}, False),
+        ({"num_actual_tokens": 63, "num_decode_tokens": 63}, False),
+        ({"num_decode_tokens": 63}, False),
+        ({"max_query_len": 2}, False),
+        ({"max_num_splits": 2}, False),
+    ],
+)
+def test_qwen_direct_decode_schedule_gate(kwargs, expected: bool) -> None:
+    values = {
+        "aot_schedule": True,
+        "is_bfloat16": True,
+        "is_qwen_family": True,
+        "common_prefix_len": 0,
+        "dcp_world_size": 1,
+        "num_reqs": 64,
+        "num_decodes": 64,
+        "num_actual_tokens": 64,
+        "num_decode_tokens": 64,
+        "max_query_len": 1,
+        "max_num_splits": 1,
+    }
+    values.update(kwargs)
+    assert _use_musa_qwen_direct_decode_schedule(**values) is expected

--- a/tests/test_flash_attn_scheduler_fast_path.py
+++ b/tests/test_flash_attn_scheduler_fast_path.py
@@ -4,9 +4,12 @@
 from types import SimpleNamespace
 
 import pytest
+import torch
 
+import vllm_musa.v1.attention.backends.flash_attn as flash_attn
 from vllm_musa.v1.attention.backends.flash_attn import (
-    _is_musa_qwen_family,
+    FlashAttentionMetadataBuilder,
+    _is_musa_qwen_text_generation_architecture,
     _use_musa_qwen_direct_decode_schedule,
 )
 
@@ -15,16 +18,26 @@ from vllm_musa.v1.attention.backends.flash_attn import (
     ("architectures", "expected"),
     [
         (["Qwen2ForCausalLM"], True),
+        (["Qwen2MoeForCausalLM"], True),
         (["Qwen3ForCausalLM"], True),
+        (["Qwen3MoeForCausalLM"], True),
         (["Qwen3_5ForConditionalGeneration"], True),
         (["Qwen3_5MoeForConditionalGeneration"], True),
+        (["Qwen2AudioForConditionalGeneration"], False),
+        (["Qwen2VLForConditionalGeneration"], False),
+        (["Qwen2_5OmniForConditionalGeneration"], False),
+        (["Qwen3ASRForConditionalGeneration"], False),
+        (["Qwen3OmniMoeForConditionalGeneration"], False),
+        (["Qwen3VLForConditionalGeneration"], False),
+        (["Qwen3ForSequenceClassification"], False),
+        (["Qwen3NextMTP"], False),
         (["LlamaForCausalLM"], False),
         (None, False),
     ],
 )
 def test_musa_qwen_family_gate(architectures, expected: bool) -> None:
     model_config = SimpleNamespace(architectures=architectures)
-    assert _is_musa_qwen_family(model_config) is expected
+    assert _is_musa_qwen_text_generation_architecture(model_config) is expected
 
 
 @pytest.mark.parametrize(
@@ -32,14 +45,16 @@ def test_musa_qwen_family_gate(architectures, expected: bool) -> None:
     [
         ({}, True),
         ({"aot_schedule": False}, False),
+        ({"causal": False}, False),
         ({"is_bfloat16": False}, False),
         ({"is_qwen_family": False}, False),
+        ({"use_full_cuda_graph": False}, False),
         ({"common_prefix_len": 1}, False),
         ({"dcp_world_size": 2}, False),
-        ({"num_reqs": 63, "num_decodes": 63}, False),
-        ({"num_decodes": 63}, False),
-        ({"num_actual_tokens": 63, "num_decode_tokens": 63}, False),
-        ({"num_decode_tokens": 63}, False),
+        ({"graph_num_reqs": 63, "graph_num_decodes": 63}, False),
+        ({"graph_num_decodes": 63}, False),
+        ({"graph_num_tokens": 63, "graph_num_decode_tokens": 63}, False),
+        ({"graph_num_decode_tokens": 63}, False),
         ({"max_query_len": 2}, False),
         ({"max_num_splits": 2}, False),
     ],
@@ -47,16 +62,99 @@ def test_musa_qwen_family_gate(architectures, expected: bool) -> None:
 def test_qwen_direct_decode_schedule_gate(kwargs, expected: bool) -> None:
     values = {
         "aot_schedule": True,
+        "causal": True,
         "is_bfloat16": True,
         "is_qwen_family": True,
+        "use_full_cuda_graph": True,
         "common_prefix_len": 0,
         "dcp_world_size": 1,
-        "num_reqs": 64,
-        "num_decodes": 64,
-        "num_actual_tokens": 64,
-        "num_decode_tokens": 64,
+        "graph_num_reqs": 64,
+        "graph_num_decodes": 64,
+        "graph_num_tokens": 64,
+        "graph_num_decode_tokens": 64,
         "max_query_len": 1,
         "max_num_splits": 1,
     }
     values.update(kwargs)
     assert _use_musa_qwen_direct_decode_schedule(**values) is expected
+
+
+def _make_graph_size_64_builder(*, is_qwen_family: bool):
+    builder = object.__new__(FlashAttentionMetadataBuilder)
+    builder.aot_schedule = True
+    builder.aot_sliding_window = (-1, -1)
+    builder.use_full_cuda_graph = True
+    builder.max_cudagraph_size = 64
+    builder.max_num_splits = 32
+    builder._sm_count = 60
+    builder.num_heads_q = 32
+    builder.num_heads_kv = 8
+    builder.headdim = 128
+    builder.block_size = 32
+    builder.dcp_world_size = 1
+    builder.dcp_rank = 0
+    builder.cp_kv_cache_interleave_size = 1
+    builder.kv_cache_dtype = torch.bfloat16
+    builder.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    builder.cache_config = SimpleNamespace(cache_dtype="auto")
+    builder._musa_qwen_family = is_qwen_family
+    builder._cu_seqlens_k_buffer = torch.empty(65, dtype=torch.int32)
+    builder.scheduler_metadata = torch.zeros(257, dtype=torch.int32)
+    return builder
+
+
+def _make_graph_size_64_metadata():
+    return SimpleNamespace(
+        num_reqs=64,
+        num_actual_tokens=64,
+        max_query_len=1,
+        max_seq_len=4159,
+        query_start_loc=torch.arange(65, dtype=torch.int32),
+        seq_lens=torch.arange(4096, 4160, dtype=torch.int32),
+        block_table_tensor=torch.zeros((64, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(64, dtype=torch.int64),
+        causal=True,
+    )
+
+
+def test_builder_skips_aot_metadata_for_qwen_graph_size_64(monkeypatch) -> None:
+    monkeypatch.setattr(
+        flash_attn,
+        "split_decodes_and_prefills",
+        lambda *_args, **_kwargs: (64, 0, 64, 0),
+    )
+
+    def unexpected_scheduler_call(**_kwargs):
+        pytest.fail("direct graph-size-64 path called the AOT scheduler")
+
+    monkeypatch.setattr(flash_attn, "get_scheduler_metadata", unexpected_scheduler_call)
+    metadata = _make_graph_size_64_builder(is_qwen_family=True).build(
+        common_prefix_len=0,
+        common_attn_metadata=_make_graph_size_64_metadata(),
+    )
+
+    assert metadata.max_num_splits == 1
+    assert metadata.scheduler_metadata is None
+
+
+def test_builder_keeps_aot_metadata_outside_qwen_allowlist(monkeypatch) -> None:
+    monkeypatch.setattr(
+        flash_attn,
+        "split_decodes_and_prefills",
+        lambda *_args, **_kwargs: (64, 0, 64, 0),
+    )
+    calls = 0
+
+    def scheduler_metadata(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return torch.ones(1, dtype=torch.int32)
+
+    monkeypatch.setattr(flash_attn, "get_scheduler_metadata", scheduler_metadata)
+    metadata = _make_graph_size_64_builder(is_qwen_family=False).build(
+        common_prefix_len=0,
+        common_attn_metadata=_make_graph_size_64_metadata(),
+    )
+
+    assert calls == 1
+    assert metadata.scheduler_metadata is not None

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -66,13 +66,22 @@ logger = init_logger(__name__)
 
 from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
 
-_MUSA_QWEN_ARCH_PREFIXES = ("Qwen2", "Qwen3")
+_MUSA_QWEN_TEXT_GENERATION_ARCHITECTURES = frozenset(
+    {
+        "Qwen2ForCausalLM",
+        "Qwen2MoeForCausalLM",
+        "Qwen3ForCausalLM",
+        "Qwen3MoeForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    }
+)
 
 
-def _is_musa_qwen_family(model_config: Any) -> bool:
+def _is_musa_qwen_text_generation_architecture(model_config: Any) -> bool:
     architectures = model_config.architectures or ()
     return any(
-        architecture.startswith(_MUSA_QWEN_ARCH_PREFIXES)
+        architecture in _MUSA_QWEN_TEXT_GENERATION_ARCHITECTURES
         for architecture in architectures
     )
 
@@ -80,27 +89,31 @@ def _is_musa_qwen_family(model_config: Any) -> bool:
 def _use_musa_qwen_direct_decode_schedule(
     *,
     aot_schedule: bool,
+    causal: bool,
     is_bfloat16: bool,
     is_qwen_family: bool,
+    use_full_cuda_graph: bool,
     common_prefix_len: int,
     dcp_world_size: int,
-    num_reqs: int,
-    num_decodes: int,
-    num_actual_tokens: int,
-    num_decode_tokens: int,
+    graph_num_reqs: int,
+    graph_num_decodes: int,
+    graph_num_tokens: int,
+    graph_num_decode_tokens: int,
     max_query_len: int,
     max_num_splits: int,
 ) -> bool:
     return (
         aot_schedule
+        and causal
         and is_bfloat16
         and is_qwen_family
+        and use_full_cuda_graph
         and common_prefix_len == 0
         and dcp_world_size == 1
-        and num_reqs == 64
-        and num_decodes == num_reqs
-        and num_actual_tokens == num_reqs
-        and num_decode_tokens == num_actual_tokens
+        and graph_num_reqs == 64
+        and graph_num_decodes == graph_num_reqs
+        and graph_num_tokens == graph_num_reqs
+        and graph_num_decode_tokens == graph_num_tokens
         and max_query_len == 1
         and max_num_splits == 1
     )
@@ -466,7 +479,9 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
 
         self.max_num_splits = 0  # No upper bound on the number of splits.
         self.aot_schedule = get_flash_attn_version() == 3
-        self._musa_qwen_family = _is_musa_qwen_family(self.model_config)
+        self._musa_qwen_family = _is_musa_qwen_text_generation_architecture(
+            self.model_config
+        )
 
         try:
             from vllm.distributed.parallel_state import get_dcp_group
@@ -652,23 +667,27 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         # metadata nor that combine step.
         direct_decode_schedule = _use_musa_qwen_direct_decode_schedule(
             aot_schedule=aot_schedule,
+            causal=common_attn_metadata.causal is True,
             is_bfloat16=(
                 self.model_config.dtype == torch.bfloat16
                 and self.kv_cache_dtype in ("auto", "bfloat16", torch.bfloat16)
             ),
             is_qwen_family=self._musa_qwen_family,
+            use_full_cuda_graph=self.use_full_cuda_graph,
             common_prefix_len=common_prefix_len,
             dcp_world_size=self.dcp_world_size,
-            num_reqs=num_reqs,
-            num_decodes=num_decodes,
-            num_actual_tokens=num_actual_tokens,
-            num_decode_tokens=num_decode_tokens,
+            graph_num_reqs=num_reqs,
+            graph_num_decodes=num_decodes,
+            graph_num_tokens=num_actual_tokens,
+            graph_num_decode_tokens=num_decode_tokens,
             max_query_len=max_query_len,
             max_num_splits=max_num_splits,
         )
         if direct_decode_schedule:
             aot_schedule = False
-            logger.info_once("Using MUSA Qwen direct FA3 decode schedule for BS64.")
+            logger.info_once(
+                "Using MUSA Qwen direct FA3 decode schedule for graph size 64."
+            )
 
         def schedule(
             batch_size, cu_query_lens, max_query_len, seqlens, max_seq_len, causal

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -5,7 +5,7 @@
 
 import copy
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 import torch
@@ -65,6 +65,45 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 logger = init_logger(__name__)
 
 from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+
+_MUSA_QWEN_ARCH_PREFIXES = ("Qwen2", "Qwen3")
+
+
+def _is_musa_qwen_family(model_config: Any) -> bool:
+    architectures = model_config.architectures or ()
+    return any(
+        architecture.startswith(_MUSA_QWEN_ARCH_PREFIXES)
+        for architecture in architectures
+    )
+
+
+def _use_musa_qwen_direct_decode_schedule(
+    *,
+    aot_schedule: bool,
+    is_bfloat16: bool,
+    is_qwen_family: bool,
+    common_prefix_len: int,
+    dcp_world_size: int,
+    num_reqs: int,
+    num_decodes: int,
+    num_actual_tokens: int,
+    num_decode_tokens: int,
+    max_query_len: int,
+    max_num_splits: int,
+) -> bool:
+    return (
+        aot_schedule
+        and is_bfloat16
+        and is_qwen_family
+        and common_prefix_len == 0
+        and dcp_world_size == 1
+        and num_reqs == 64
+        and num_decodes == num_reqs
+        and num_actual_tokens == num_reqs
+        and num_decode_tokens == num_actual_tokens
+        and max_query_len == 1
+        and max_num_splits == 1
+    )
 
 
 def _torch_reduce_scatter_dim(
@@ -427,6 +466,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
 
         self.max_num_splits = 0  # No upper bound on the number of splits.
         self.aot_schedule = get_flash_attn_version() == 3
+        self._musa_qwen_family = _is_musa_qwen_family(self.model_config)
 
         try:
             from vllm.distributed.parallel_state import get_dcp_group
@@ -605,6 +645,30 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
 
         if envs.VLLM_BATCH_INVARIANT:
             max_num_splits = 1
+
+        # With one KV split, the FA3 AOT path still selects the persistent
+        # scheduler and launches a combine kernel per attention layer.  The
+        # direct path selects the single-tile scheduler and needs neither AOT
+        # metadata nor that combine step.
+        direct_decode_schedule = _use_musa_qwen_direct_decode_schedule(
+            aot_schedule=aot_schedule,
+            is_bfloat16=(
+                self.model_config.dtype == torch.bfloat16
+                and self.kv_cache_dtype in ("auto", "bfloat16", torch.bfloat16)
+            ),
+            is_qwen_family=self._musa_qwen_family,
+            common_prefix_len=common_prefix_len,
+            dcp_world_size=self.dcp_world_size,
+            num_reqs=num_reqs,
+            num_decodes=num_decodes,
+            num_actual_tokens=num_actual_tokens,
+            num_decode_tokens=num_decode_tokens,
+            max_query_len=max_query_len,
+            max_num_splits=max_num_splits,
+        )
+        if direct_decode_schedule:
+            aot_schedule = False
+            logger.info_once("Using MUSA Qwen direct FA3 decode schedule for BS64.")
 
         def schedule(
             batch_size, cu_query_lens, max_query_len, seqlens, max_seq_len, causal


### PR DESCRIPTION
## Summary

- use FA3's direct single-tile decode schedule for exact BF16 causal Qwen text-generation graph-size-64 descriptors when the attention split count is one
- remove per-step FA3 AOT scheduler metadata and per-layer split-combine launches on that path
- fail closed for non-Qwen architectures, VL/Omni/ASR/reward models, non-BF16 or quantized KV cache, non-full graphs, prefix cascade, DCP, prefill/mixed/spec decode, and multi-split attention

This PR only changes vllm-musa. It does not override or import anything from vllm-omni.

## Primary result

Qwen3.5-27B BF16, TP2, BS64, 4096/1024, FA3, `FULL_AND_PIECEWISE`, frozen inputs, same 8x S5000 host:

| Metric | Parent mean | A/B candidate mean | Delta | Final SHA leg | Final delta |
|---|---:|---:|---:|---:|---:|
| TPOT | 77.2211 ms | 76.9248 ms | -0.384% | 76.8408 ms | -0.492% |
| Output throughput | 673.187 tok/s | 675.251 tok/s | +0.307% | 675.898 tok/s | +0.403% |
| TTFT | 17625.430 ms | 17629.890 ms | +0.025% | 17625.899 ms | +0.003% |

Parent TPOT repeated at 77.2205/77.2216 ms. Candidate TPOT repeated at 77.0623/76.7873 ms, and the final exact-head leg was 76.8408 ms.

## Attribution

Qwen3.5 per rank over 20 decode steps:

| Kernel path | Parent | Candidate |
|---|---:|---:|
| FA3 scheduler metadata | 20 | 0 |
| StaticPersistentTileScheduler | 320 | 0 |
| FmhaFwdCombine | 320 | 0 |
| SingleTileScheduler | 0 | 320 |

This is intentionally a scheduler-policy switch, not a metadata-only claim.

## Scope and regressions

The full-graph descriptor is padded, so graph size 64 can cover active BS17-64. A matched Qwen3.5 4096/256 sweep ran BS17/32/48/63/64 twice per leg with frozen input contracts. Output-throughput deltas were all within +/-0.06%; TPOT deltas were within +/-0.14%. These rows are treated as non-regression evidence, not as gain claims.

Family sibling rows at BS64 128/128:

| Model | Parent/previous TPOT | Candidate TPOT | Delta |
|---|---:|---:|---:|
| CosyVoice Qwen2 TP1 | 18.5856 ms | 17.5424 ms | -5.61% |
| Qwen3-8B TP2 | 34.1580 ms | 32.8822 ms | -3.73% |
| Qwen3.6-35B-A3B TP4 | 66.6240 ms | 64.2605 ms | -3.55% |

Qwen3 and Qwen3.6 passed the standard semantic, receipt, and trace gates. CosyVoice Qwen2 passed the semantic smoke and completed 64/64 requests with zero failures on both parent and candidate. Its streaming client emitted 125-126 ITL samples for 128 output tokens on both legs, so the shared receipt rejected both raw rows; the matched raw A/B and trace attribution are reported with that limitation instead of weakening the receipt gate.

## Correctness and tests

- 32 focused remote tests passed, including architecture allowlist/fallback and builder call-count coverage
- direct versus AOT FA3 outputs were bitwise identical in 15 cases: Qwen2 D64, Qwen3 D128, and Qwen3.5/3.6 D256 geometries, each at active BS17/32/48/63/64 with varied 4k KV lengths
- all 15 numerical rows were finite with `max_abs_diff=0`
- Qwen2/Qwen3/Qwen3.6 traces all showed zero scheduler-metadata and combine calls on the accepted path
- Ruff, format, compileall, and diff checks passed

## Stack and provenance

- base: `perf/musa-60042-legacy-uniform-topk` / PR #128 at `c868a7d717d27b2e759262e1d0ebaede7424bfa3`
- head: `4f686bc00c60bce100ee87f1e212111bdeed60a9`
- image: `registry.mthreads.com/mcconline/inference/vllm@sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`
- hardware: development-pool S5000, driver `5.2.0-server`

Retarget this PR to `v0.24.0-dev` after the stacked parents merge.
