### PR TITLE
perf(musa): reuse uniform top-k in legacy Gumbel

### DIFF
--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -445,6 +445,42 @@ def test_legacy_uniform_top_k_uses_cpu_hint_only_for_musa_native_sampler(
     )
 
 
+def test_legacy_gumbel_uniform_top_k_uses_cpu_hint_with_generators() -> None:
+    top_k = torch.full((4,), 50, dtype=torch.int32)
+    metadata = SimpleNamespace(uniform_top_k=50)
+
+    assert (
+        sampler._legacy_gumbel_top_k_with_cpu_hint(
+            metadata, torch.empty((4, 248320)), top_k
+        )
+        == 50
+    )
+
+    metadata.uniform_top_k = None
+    assert (
+        sampler._legacy_gumbel_top_k_with_cpu_hint(
+            metadata, torch.empty((4, 248320)), top_k
+        )
+        is top_k
+    )
+
+    metadata.uniform_top_k = None
+    heterogeneous_top_k = torch.tensor([50, 49, 50, 49], dtype=torch.int32)
+    assert (
+        sampler._legacy_gumbel_top_k_with_cpu_hint(
+            metadata, torch.empty((4, 248320)), heterogeneous_top_k
+        )
+        is heterogeneous_top_k
+    )
+    metadata.uniform_top_k = 50
+    assert (
+        sampler._legacy_gumbel_top_k_with_cpu_hint(
+            metadata, torch.empty((4, 131072)), top_k
+        )
+        is top_k
+    )
+
+
 def test_uniform_top_k_threshold_preserves_ties() -> None:
     logits = torch.arange(64, dtype=torch.float32).repeat(2, 1)
     logits[:, 12:17] = 14.0

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -391,6 +391,30 @@ def _legacy_top_k_with_cpu_hint(
     return top_k
 
 
+def _legacy_gumbel_top_k_with_cpu_hint(
+    sampling_metadata: Any,
+    logits: torch.Tensor,
+    top_k: torch.Tensor | None,
+) -> int | torch.Tensor | None:
+    """Use the CPU-proven uniform k in the legacy seeded path.
+
+    Legacy Gumbel still needs the top-k support mask, but it does not need the
+    per-row device tensor when the scheduler already proved that every Qwen
+    row uses k=50.  Passing the scalar keeps the fixed-k path from reading a
+    device tensor back to the host for dispatch checks.  Heterogeneous and
+    non-Qwen requests retain the original tensor path.
+    """
+    if getattr(
+        sampling_metadata, "uniform_top_k", None
+    ) == 50 and _is_qwen_sampler_vocab(logits):
+        vllm_topk_topp_sampler.logger.info_once(
+            "Using the CPU uniform top-k hint for gated MUSA legacy Gumbel.",
+            scope="global",
+        )
+        return 50
+    return top_k
+
+
 def _call_topk_topp_sampler(
     sampler: Any,
     logprobs_mode: LogprobsMode,
@@ -488,7 +512,7 @@ def get_qwen_legacy_generator_state(
 def sample_qwen_legacy_gumbel(
     logits: torch.Tensor,
     generators: dict[int, torch.Generator],
-    top_k: torch.Tensor,
+    top_k: int | torch.Tensor | None,
     generator_state: tuple[list[int], list[int]],
 ) -> torch.Tensor:
     """Batch MRV1 seeded rows and preserve one-call generator offsets."""
@@ -595,10 +619,13 @@ def _sample(
             "Using the gated MUSA legacy Gumbel sampler for Qwen requests.",
             scope="global",
         )
+        legacy_top_k = _legacy_gumbel_top_k_with_cpu_hint(
+            sampling_metadata, logits, sampling_metadata.top_k
+        )
         random_sampled = sample_qwen_legacy_gumbel(
             logits,
             sampling_metadata.generators,
-            sampling_metadata.top_k,
+            legacy_top_k,
             legacy_generator_state,
         )
         processed_logprobs = None


### PR DESCRIPTION
## Summary

Reuse the CPU-proven uniform `top_k=50` metadata in the existing, opt-in MUSA
legacy-Gumbel sampler. The fixed-k mask no longer reads the per-row device
tensor back to the host for dispatch checks; heterogeneous and unsupported
requests keep the existing path.

This is an independent follow-up stacked on PR #129. It changes only
`vllm_musa/v1/sample/topk_topp_sampler.py` and its focused sampler contract
test; vLLM-Omni is untouched.

## Evidence

Qwen3.5-27B BF16 TP2 on one isolated S5000 host, exact pinned image, BS64,
4096/1024 seeded decode, A/B/A/B with the same frozen input vector:

| | Parent mean | Candidate mean | Delta |
|---|---:|---:|---:|
| TPOT | 81.649242 ms | 80.906384 ms | **-0.910%** |
| Output throughput | 642.868 tok/s | 647.799 tok/s | **+0.767%** |
| TTFT | 17645.708 ms | 17641.734 ms | -0.023% |

Both candidate legs completed 64/64 requests, passed semantic receipts and
20-iteration dual-rank graph trace gates. Per rank, `aten::item` fell from 200
to 100 events over the capture window; the corresponding item device-time sum
fell from about 1.07--1.15s to 3.3--3.5ms. Top-k/Gumbel kernel counts stayed
unchanged, and direct MUSA scalar/tensor mask parity passed bitwise.

The legacy-Gumbel environment gate remains default-off and all fallback paths
remain unchanged.

Evidence report: `generated/MUSA-60042/round8-seeded-topk/summary.md`.
