### PR TITLE
perf(musa): skip empty GDN graph metadata fill

### DIFF
--- a/tests/test_gdn_full_graph_metadata_source.py
+++ b/tests/test_gdn_full_graph_metadata_source.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source contract for sync-free FULL-graph GDN decode padding."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0089-perf-skip-empty-full-graph-GDN-metadata-fill.patch"
+)
+
+
+def test_full_occupancy_skips_empty_gdn_query_padding_fill():
+    source = PATCH.read_text()
+
+    assert source.count("diff --git") == 1
+    assert (
+        "diff --git a/vllm/v1/attention/backends/gdn_attn.py "
+        "b/vllm/v1/attention/backends/gdn_attn.py"
+    ) in source
+    assert "+            if num_decodes < batch_size:" in source
+    assert (
+        "-            non_spec_query_start_loc[num_decodes + 1 :].fill_("
+        "non_spec_num_query_tokens)"
+    ) in source
+
+
+def test_partial_bucket_uses_existing_cpu_terminal_token_count():
+    source = PATCH.read_text()
+
+    assert "+                assert non_spec_query_start_loc_cpu is not None" in source
+    assert "+                    non_spec_query_start_loc_cpu[-1].item()" in source
+    assert source.count("non_spec_query_start_loc_cpu[-1].item()") == 1

--- a/vllm_musa/patches/series/0089-perf-skip-empty-full-graph-GDN-metadata-fill.patch
+++ b/vllm_musa/patches/series/0089-perf-skip-empty-full-graph-GDN-metadata-fill.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sun, 26 Jul 2026 22:51:53 +0800
+Subject: [PATCH] perf: skip empty full-graph GDN metadata fill
+
+---
+ vllm/v1/attention/backends/gdn_attn.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/vllm/v1/attention/backends/gdn_attn.py b/vllm/v1/attention/backends/gdn_attn.py
+index 09f296bda7..a8cede7414 100644
+--- a/vllm/v1/attention/backends/gdn_attn.py
++++ b/vllm/v1/attention/backends/gdn_attn.py
+@@ -488,7 +488,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+             )
+             non_spec_num_query_tokens = non_spec_query_start_loc[-1]  # type: ignore[index]
+             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
+-            non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
++            if num_decodes < batch_size:
++                assert non_spec_query_start_loc_cpu is not None
++                non_spec_query_start_loc[num_decodes + 1 :].fill_(
++                    non_spec_query_start_loc_cpu[-1].item()
++                )
+ 
+         attn_metadata = GDNAttentionMetadata(
+             num_prefills=num_prefills,

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -15,7 +15,7 @@ is pre-patched.
   sequence and patches removed from the commit stack cannot leave stale files.
   Author headers are normalized to the synthetic `musa <musa@local>` identity.
 
-Currently **87 patches** — the MUSA source edits against the immutable vLLM commit
+Currently **89 patches** — the MUSA source edits against the immutable vLLM commit
 recorded as `VLLM_COMMIT` in `third_party/PINS` (release label `v0.24.0`), applied
 at build. Runtime object/registration patches (which patch live objects at import)
 are kept separately in `vllm_musa/patches/`, not in this build-time series. Run


### PR DESCRIPTION
## Summary

- Skip the empty `non_spec_query_start_loc` tail fill in the existing
  FULL/no-prefill/no-spec GDN graph path when `num_decodes == batch_size`.
- Keep partial-bucket behavior and use the existing CPU terminal cu-seqlen
  mirror for the non-empty tail, avoiding a MUSA device-scalar read.
- Add a source contract test for the build-time patch.

This is a vLLM-MUSA build-time patch only. It does not modify vLLM-Omni or the
Qwen OOT layer implementation.

## Evidence

Exact image:

`registry.mthreads.com/mcconline/inference/vllm@sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`

MTT S5000, TP2, Qwen3.5-27B BF16, `FLASH_ATTN`, `FULL_AND_PIECEWISE`, frozen
BS64 4096/1024 vector, 64/64 semantic receipt:

The complete #130 parent upstream Python tree, including build patches through
0088, was active. The only A/B toggle was patch 0089's upstream GDN metadata
change.

| Leg | Source | TPOT (ms) | Output tok/s | TTFT (ms) | Requests |
|---|---|---:|---:|---:|---:|
| A1 parent | `d1fc5c7b43ed` | 78.097215 | 666.308884 | 17725.862940 | 64/64 |
| B1 candidate | `2a60eb11e21d` | 77.284218 | 671.993664 | 17733.135120 | 64/64 |
| B2 candidate | `2a60eb11e21d` | 77.087442 | 673.411630 | 17728.296902 | 64/64 |
| A2 parent | `d1fc5c7b43ed` | 77.409118 | 671.019057 | 17743.577257 | 64/64 |

| Metric | Parent mean | Candidate mean | Candidate delta |
|---|---:|---:|---:|
| TPOT | 77.753167 ms | 77.185830 ms | -0.729664% |
| Output throughput | 668.663971 tok/s | 672.702647 tok/s | +0.603992% |
| TTFT | 17734.720098 ms | 17730.716011 ms | -0.022578% |

Matched reverse legs were B2/A2; all four legs passed the graph receipt and
dual-rank 20-step trace gates. Sampling was unseeded, so each leg passed its
own semantic receipt; generated-token digests are not claimed to match.

Per rank over 20 steps (A1/B1):

| Event | Parent | Candidate |
|---|---:|---:|
| `musaGraphLaunch` | 20 | 20 |
| `gated_deltanet_decode_fp32_vk_kernel` | 960 | 960 |
| `aten::item` | 100 | 40 |
| `musaStreamSynchronize` | 60 | 0 |
| empty-destination `aten::fill_` | 260 | 200 |

BS63/capture64 partial-bucket parent/candidate semantic gate also passed
63/63; the candidate retained correct padding and reduced target events
15 times over 5 steps.

Full report and archives:

- `generated/MUSA-60042/round11-full-stack-revalidate/summary.md`
- `r11-fullstack-four-valid-legs.tar.gz` SHA256
  `c672ff83fa92629055bd3e2ccf448d2daae6a277bc2256161aed9abca4cb7dc9`
- `r11-review-evidence.tar.gz` SHA256
  `dd40b94cd296a25d773e7d4dbee1752502c86a67c4be761bff4def3ac6044bb3`
- Source receipt:
  `generated/MUSA-60042/round11-full-stack-revalidate/source-receipt.md`

## Validation

- Full 89-patch replay from pinned `ee0da84ab9e04ac7610e28580af62c365e898389`.
- Complete-stack compiled/captured A/B/A/B: 64/64 in every leg, with matched
  frozen input and dual-rank trace receipts.
- Local focused pytest: `2 passed`.
- `ruff check`, `ruff format --check`, and source `py_compile` passed.
