### PR TITLE
perf(musa): cache Qwen uniform decode logits indices

### DIFF
--- a/tests/test_uniform_decode_logits_indices_source.py
+++ b/tests/test_uniform_decode_logits_indices_source.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source contract for uniform single-token decode logits indices."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0090-perf-reuse-uniform-decode-logits-indices.patch"
+)
+
+
+def test_uniform_decode_patch_reuses_uploaded_request_indices() -> None:
+    source = PATCH.read_text()
+
+    assert "current_platform.is_musa()" in source
+    assert "not self.is_pooling_model" in source
+    assert "self.speculative_config is None" in source
+    for architecture in (
+        "Qwen2ForCausalLM",
+        "Qwen2MoeForCausalLM",
+        "Qwen3ForCausalLM",
+        "Qwen3MoeForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    ):
+        assert architecture in source
+    assert "VLLM_MUSA_QWEN_UNIFORM_DECODE_LOGITS_INDICES" in source
+    assert "max_num_scheduled_tokens == 1" in source
+    assert "num_tokens_unpadded == num_reqs" in source
+    assert "torch.arange(self.max_num_reqs, dtype=torch.int32" in source
+    assert source.count("self._musa_qwen_uniform_decode_logits_indices[") == 1
+    assert "use_cached_decode_logits_indices: bool = False" in source
+    assert "+                logits_indices = query_start_loc[1:] - 1" in source
+    assert "query_start_loc path" in source
+
+
+def test_uniform_decode_gate_is_exact_for_positive_query_lengths() -> None:
+    cases = (
+        [1],
+        [1] * 4,
+        [1] * 16,
+        [1] * 64,
+        [2],
+        [1, 2],
+        [4, 1, 1],
+        [0, 2],
+    )
+
+    for query_lens in cases:
+        total = sum(query_lens)
+        num_reqs = len(query_lens)
+        use_fast_path = max(query_lens) == 1 and total == num_reqs
+
+        query_start_loc = [0]
+        for query_len in query_lens:
+            assert query_len >= 0
+            query_start_loc.append(query_start_loc[-1] + query_len)
+        baseline = [end - 1 for end in query_start_loc[1:]]
+        request_indices = [
+            req_idx
+            for req_idx, query_len in enumerate(query_lens)
+            for _ in range(query_len)
+        ]
+
+        if use_fast_path:
+            assert request_indices == baseline
+        else:
+            assert request_indices != baseline

--- a/vllm_musa/patches/series/0090-perf-reuse-uniform-decode-logits-indices.patch
+++ b/vllm_musa/patches/series/0090-perf-reuse-uniform-decode-logits-indices.patch
@@ -1,0 +1,98 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Mon, 27 Jul 2026 01:36:29 +0800
+Subject: [PATCH] perf(musa): cache Qwen uniform decode logits indices
+
+---
+ vllm/v1/worker/gpu_model_runner.py | 47 +++++++++++++++++++++++++++++-
+ 1 file changed, 46 insertions(+), 1 deletion(-)
+
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index c1f1b43606..8d53ca439e 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -4,6 +4,7 @@
+ import functools
+ import gc
+ import itertools
++import os
+ import threading
+ import time
+ from collections import defaultdict
+@@ -812,6 +813,33 @@ class GPUModelRunner(
+         self.query_pos = self._make_buffer(arange_size, dtype=torch.int64)
+         self._arange_scratch = np.empty(arange_size, dtype=np.int64)
+ 
++        qwen_text_generation_architectures = {
++            "Qwen2ForCausalLM",
++            "Qwen2MoeForCausalLM",
++            "Qwen3ForCausalLM",
++            "Qwen3MoeForCausalLM",
++            "Qwen3_5ForConditionalGeneration",
++            "Qwen3_5MoeForConditionalGeneration",
++        }
++        use_musa_qwen_uniform_decode_indices = (
++            current_platform.is_musa()
++            and not self.is_pooling_model
++            and self.speculative_config is None
++            and any(
++                architecture in qwen_text_generation_architectures
++                for architecture in (self.model_config.architectures or ())
++            )
++            and os.environ.get(
++                "VLLM_MUSA_QWEN_UNIFORM_DECODE_LOGITS_INDICES", "1"
++            ).lower()
++            not in ("0", "false", "no", "off")
++        )
++        self._musa_qwen_uniform_decode_logits_indices = (
++            torch.arange(self.max_num_reqs, dtype=torch.int32, device=self.device)
++            if use_musa_qwen_uniform_decode_indices
++            else None
++        )
++
+         # MUSA-3406: reusable CPU/GPU buffers for speculative metadata indices.
+         # Avoid per-step torch.from_numpy(...).to(device) pageable uploads in
+         # _calc_spec_decode_metadata on the TP8 DeepSeek-V4 decode path.
+@@ -1920,6 +1948,8 @@ class GPUModelRunner(
+         self,
+         scheduler_output: "SchedulerOutput",
+         num_scheduled_tokens: np.ndarray,
++        *,
++        use_cached_decode_logits_indices: bool = False,
+     ) -> tuple[
+         torch.Tensor,
+         SpecDecodeMetadata | None,
+@@ -2195,7 +2225,13 @@ class GPUModelRunner(
+             # from these partial requests, we do so for simplicity.
+             # We will ignore the sampled tokens from the partial requests.
+             # TODO: Support prompt logprobs.
+-            logits_indices = query_start_loc[1:] - 1
++            if use_cached_decode_logits_indices:
++                assert self._musa_qwen_uniform_decode_logits_indices is not None
++                logits_indices = self._musa_qwen_uniform_decode_logits_indices[
++                    :num_reqs
++                ]
++            else:
++                logits_indices = query_start_loc[1:] - 1
+             spec_decode_metadata = None
+             num_sampled_tokens = np.ones(num_reqs, dtype=np.int32)
+         else:
+@@ -4198,9 +4234,18 @@ class GPUModelRunner(
+             max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
+             num_tokens_unpadded = scheduler_output.total_num_scheduled_tokens
+ 
++            # Keep graph padding and mixed/chunked prefills on the existing
++            # query_start_loc path. This gate uses only actual requests/tokens.
++            use_cached_decode_logits_indices = (
++                self._musa_qwen_uniform_decode_logits_indices is not None
++                and max_num_scheduled_tokens == 1
++                and num_tokens_unpadded == num_reqs
++            )
++
+             logits_indices, spec_decode_metadata = self._prepare_inputs(
+                 scheduler_output,
+                 num_scheduled_tokens_np,
++                use_cached_decode_logits_indices=use_cached_decode_logits_indices,
+             )
+ 
+             cascade_attn_prefix_lens = None

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -15,7 +15,7 @@ is pre-patched.
   sequence and patches removed from the commit stack cannot leave stale files.
   Author headers are normalized to the synthetic `musa <musa@local>` identity.
 
-Currently **89 patches** — the MUSA source edits against the immutable vLLM commit
+Currently **90 patches** — the MUSA source edits against the immutable vLLM commit
 recorded as `VLLM_COMMIT` in `third_party/PINS` (release label `v0.24.0`), applied
 at build. Runtime object/registration patches (which patch live objects at import)
 are kept separately in `vllm_musa/patches/`, not in this build-time series. Run


### PR DESCRIPTION
## Summary

- Cache one immutable int32 logits-index arange for strictly uniform Qwen
  decode on MUSA.
- Remove two scalar materializations and one int32 subtraction kernel per
  decode step without changing the downstream hidden-state index dtype.
- Keep mixed/chunked prefill, graph padding, pooling, speculative, non-Qwen,
  and opt-out paths on the existing fallback.
- Add a focused source/math contract test and an initialization-time escape
  hatch: `VLLM_MUSA_QWEN_UNIFORM_DECODE_LOGITS_INDICES=0`.

This is a vLLM-MUSA build-time upstream patch only. It does not modify or
override vLLM-Omni.

## Performance evidence

Exact image:

`registry.mthreads.com/mcconline/inference/vllm@sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`

MTT S5000, driver `5.2.0-server`, Qwen3.5-27B BF16, TP2,
`FLASH_ATTN`, `VLLM_COMPILE`, `FULL_AND_PIECEWISE`, frozen BS64 4096/1024:

| Leg | Source | TPOT (ms) | Output tok/s | TTFT (ms) | Requests |
|---|---|---:|---:|---:|---:|
| A1 parent | `2a60eb11e21d` | 77.167975 | 673.686809 | 17611.146269 | 64/64 |
| B1 candidate | `03276099f924` | 76.673915 | 677.111836 | 17624.518325 | 64/64 |
| B2 candidate | `03276099f924` | 76.624915 | 677.419438 | 17630.179960 | 64/64 |
| A2 parent | `2a60eb11e21d` | 76.822624 | 675.925296 | 17638.232222 | 64/64 |

| Metric | Parent mean | Candidate mean | Candidate delta |
|---|---:|---:|---:|
| TPOT | 76.995300 ms | 76.649415 ms | -0.449228% |
| Output throughput | 674.806052 tok/s | 677.265637 tok/s | +0.364488% |
| TTFT | 17624.689246 ms | 17627.349142 ms | +0.015092% |

Both ordered pairs improved. All four legs completed 64/64 and passed frozen
input, per-leg semantic, compiled-graph, and dual-rank 20-step trace receipts.

Per rank over 20 captured steps:

| Event | Parent | Candidate |
|---|---:|---:|
| target int32 `aten::sub([64], 1)` | 20 | 0 |
| `aten::item` | 40 | 0 |
| MUSA int32 unary-sub kernel | 20 | 0 |
| hidden-state int32 index kernel | 20 | 20 |
| `musaGraphLaunch` | 20 | 20 |

BS63 padded to capture64 also completed 63/63 and passed its semantic receipt.

## Validation

- Full 90-patch replay from pinned
  `ee0da84ab9e04ac7610e28580af62c365e898389`: 90/90 applied.
- Focused source/math test: `2 passed`; Ruff and format passed.
- Candidate source Ruff and `py_compile` passed.
- Exact-image source runner: `SOURCE_GATE_OK tests=2`.
- Exact-image pytest: not run because pytest is not installed.
- All six valid hardware runs recorded no GPU process after shutdown.
- Performance tracker: four rows accepted; report/targets regenerated; SQLite
  integrity `ok`.
- Product worktree is clean at `03276099f924272ad5cecf2633ab391e9f70d5b5`.

## Qwen family checkpoint coverage

The exact candidate source also completed real generation for every
architecture class in the allowlist:

| Family | Checkpoint | Resolved architecture | TP | Result |
|---|---|---|---:|---|
| Qwen3 dense | Qwen3-8B BF16 | `Qwen3ForCausalLM` | 1 | 8 tokens, HTTP 200 |
| Qwen3 MoE | Qwen3-235B-A22B FP8 | `Qwen3MoeForCausalLM` | 8 | 8 tokens, HTTP 200 |
| Qwen3.5 dense | Qwen3.5-27B BF16 | `Qwen3_5ForConditionalGeneration` | 2 | formal compiled A/B/A/B |
| Qwen3.5 MoE | Qwen3.5-35B-A3B BF16 | `Qwen3_5MoeForConditionalGeneration` | 2 | 7 tokens, HTTP 200 |
| Qwen3.6 dense | Qwen3.6-27B BF16 | `Qwen3_5ForConditionalGeneration` | 2 | 7 tokens, HTTP 200 |
| Qwen3.6 MoE | Qwen3.6-35B-A3B BF16 | `Qwen3_5MoeForConditionalGeneration` | 2 | 7 tokens, HTTP 200 |

The five new checkpoint rows used `--enforce-eager --language-model-only` and
are functional diagnostics, not new performance claims. All selected MUSA
FLASH_ATTN v3, returned non-empty completions, and recorded no GPU process
after shutdown.

Full report and evidence:

- `generated/MUSA-60042/round12-uniform-decode-logits-indices/summary.md`
- `r12-all-valid-legs.tar.gz` SHA256
  `dbea9ac8f1d28788f4cf89f98cd64b2b42d2611a261948fb356ccddd057f27d5`
- `generated/MUSA-60042/round13-qwen-family-smoke/summary.md`
- `round13-qwen-family-smoke.tar.gz` SHA256
  `9263d9fdabd48fe391715ce19b788fa00a1cb094530e9a0ef2916e29a926b5e4`

## Draft scope

The former Qwen dense/MoE architecture-coverage blocker is closed. Keep this
PR Draft for maintainer review and merge it after its stacked parent #131.
Formal end-to-end performance remains scoped to Qwen3.5-27B dense; the broader
matrix is functional regression evidence.
