### PR TITLE
perf(musa): skip no-op Qwen unit-temperature divide

### DIFF
--- a/tests/test_qwen_unit_temperature_source.py
+++ b/tests/test_qwen_unit_temperature_source.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source contract for the Qwen unit-temperature divide skip."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0091-perf-skip-qwen-unit-temperature-divide.patch"
+)
+SAMPLER = ROOT / "vllm_musa" / "v1" / "sample" / "topk_topp_sampler.py"
+
+
+def test_qwen_unit_temperature_metadata_gate_is_fail_closed() -> None:
+    source = PATCH.read_text()
+
+    assert "uniform_temperature: float | None = None" in source
+    assert "self.vocab_size in (151936, 248320)" in source
+    assert "num_reqs > 0" in source
+    assert "temperature_cpu == np.float32(1.0)" in source
+    assert "VLLM_MUSA_QWEN_SKIP_UNIT_TEMPERATURE" in source
+    assert '("0", "false", "no", "off")' in source
+    assert "uniform_temperature=uniform_temperature" in source
+
+
+def test_qwen_unit_temperature_sampler_keeps_original_fallback() -> None:
+    source = SAMPLER.read_text()
+
+    assert "def _can_skip_legacy_qwen_unit_temperature" in source
+    assert 'getattr(sampling_metadata, "all_random", False)' in source
+    assert "_is_qwen_sampler_vocab(logits)" in source
+    assert 'sampling_metadata, "uniform_temperature", None' in source
+    assert "if not _can_skip_legacy_qwen_unit_temperature" in source
+    assert "logits = self.apply_temperature(" in source

--- a/tests/test_qwen_unit_temperature_source.py
+++ b/tests/test_qwen_unit_temperature_source.py
@@ -11,25 +11,47 @@ PATCH = (
     / "series"
     / "0091-perf-skip-qwen-unit-temperature-divide.patch"
 )
+DECODE_PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0090-perf-reuse-uniform-decode-logits-indices.patch"
+)
 SAMPLER = ROOT / "vllm_musa" / "v1" / "sample" / "topk_topp_sampler.py"
 
 
 def test_qwen_unit_temperature_metadata_gate_is_fail_closed() -> None:
     source = PATCH.read_text()
+    cumulative_source = DECODE_PATCH.read_text() + source
 
     assert "uniform_temperature: float | None = None" in source
     assert "self.vocab_size in (151936, 248320)" in source
+    assert "self.all_random" in source
     assert "num_reqs > 0" in source
     assert "temperature_cpu == np.float32(1.0)" in source
     assert "VLLM_MUSA_QWEN_SKIP_UNIT_TEMPERATURE" in source
     assert '("0", "false", "no", "off")' in source
     assert "uniform_temperature=uniform_temperature" in source
+    assert "current_platform.is_musa()" in source
+    assert "not self.is_pooling_model" in source
+    assert "self.speculative_config is None" in source
+    for architecture in (
+        "Qwen2ForCausalLM",
+        "Qwen2MoeForCausalLM",
+        "Qwen3ForCausalLM",
+        "Qwen3MoeForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    ):
+        assert architecture in cumulative_source
 
 
 def test_qwen_unit_temperature_sampler_keeps_original_fallback() -> None:
     source = SAMPLER.read_text()
 
     assert "def _can_skip_legacy_qwen_unit_temperature" in source
+    assert 'getattr(sampler, "_musa_qwen_skip_unit_temperature", False)' in source
     assert 'getattr(sampling_metadata, "all_random", False)' in source
     assert "_is_qwen_sampler_vocab(logits)" in source
     assert 'sampling_metadata, "uniform_temperature", None' in source

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -81,7 +81,9 @@ def test_legacy_sample_skips_only_cpu_proven_qwen_unit_temperature(
     fake_sampler = SimpleNamespace(
         logprobs_mode="raw_logprobs",
         apply_temperature=apply_temperature,
-        topk_topp_sampler=object(),
+        topk_topp_sampler=SimpleNamespace(
+            forward=SimpleNamespace(__name__="forward_native")
+        ),
         use_fp64_gumbel=False,
         _musa_qwen_skip_unit_temperature=True,
     )

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -31,34 +31,41 @@ def test_uniform_sampler_metadata_patch_is_active_and_qwen_gated() -> None:
     assert "uniform_temperature" in source
     assert "self.vocab_size in (151936, 248320)" in source
     assert "candidate_top_k == 50" in source
-    assert "VLLM_MUSA_QWEN_SKIP_UNIT_TEMPERATURE" in source
+    assert "self.all_random" in source
     assert "temperature_cpu == np.float32(1.0)" in source
 
 
 def test_legacy_qwen_unit_temperature_skip_is_exact_and_vocab_gated() -> None:
+    enabled_sampler = SimpleNamespace(_musa_qwen_skip_unit_temperature=True)
     metadata = SimpleNamespace(all_random=True, uniform_temperature=1.0)
     assert sampler._can_skip_legacy_qwen_unit_temperature(
-        torch.empty((4, 248320)), metadata
+        enabled_sampler, torch.empty((4, 248320)), metadata
     )
     assert sampler._can_skip_legacy_qwen_unit_temperature(
-        torch.empty((1, 151936)), metadata
+        enabled_sampler, torch.empty((1, 151936)), metadata
     )
 
     metadata.uniform_temperature = None
     assert not sampler._can_skip_legacy_qwen_unit_temperature(
-        torch.empty((4, 248320)), metadata
+        enabled_sampler, torch.empty((4, 248320)), metadata
     )
     metadata.uniform_temperature = 0.7
     assert not sampler._can_skip_legacy_qwen_unit_temperature(
-        torch.empty((4, 248320)), metadata
+        enabled_sampler, torch.empty((4, 248320)), metadata
     )
     metadata.uniform_temperature = 1.0
     assert not sampler._can_skip_legacy_qwen_unit_temperature(
-        torch.empty((4, 32000)), metadata
+        enabled_sampler, torch.empty((4, 32000)), metadata
     )
     metadata.all_random = False
     assert not sampler._can_skip_legacy_qwen_unit_temperature(
-        torch.empty((4, 248320)), metadata
+        enabled_sampler, torch.empty((4, 248320)), metadata
+    )
+    metadata.all_random = True
+    assert not sampler._can_skip_legacy_qwen_unit_temperature(
+        SimpleNamespace(_musa_qwen_skip_unit_temperature=False),
+        torch.empty((4, 248320)),
+        metadata,
     )
 
 
@@ -76,6 +83,7 @@ def test_legacy_sample_skips_only_cpu_proven_qwen_unit_temperature(
         apply_temperature=apply_temperature,
         topk_topp_sampler=object(),
         use_fp64_gumbel=False,
+        _musa_qwen_skip_unit_temperature=True,
     )
     metadata = SimpleNamespace(
         all_greedy=False,
@@ -104,6 +112,10 @@ def test_legacy_sample_skips_only_cpu_proven_qwen_unit_temperature(
     metadata.uniform_temperature = 1.0
     sampler._sample(fake_sampler, torch.empty((4, 32000)), metadata)
     assert len(temperature_calls) == 2
+
+    fake_sampler._musa_qwen_skip_unit_temperature = False
+    sampler._sample(fake_sampler, torch.empty((4, 248320)), metadata)
+    assert len(temperature_calls) == 3
 
 
 def _state_array(

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -22,12 +22,88 @@ requires_musa = pytest.mark.skipif(
 )
 
 
-def test_uniform_top_k_metadata_patch_is_active_and_qwen_gated() -> None:
-    assert "uniform_top_k" in {field.name for field in fields(SamplingMetadata)}
+def test_uniform_sampler_metadata_patch_is_active_and_qwen_gated() -> None:
+    metadata_fields = {field.name for field in fields(SamplingMetadata)}
+    assert "uniform_top_k" in metadata_fields
+    assert "uniform_temperature" in metadata_fields
     source = inspect.getsource(InputBatch._make_sampling_metadata)
     assert "uniform_top_k" in source
+    assert "uniform_temperature" in source
     assert "self.vocab_size in (151936, 248320)" in source
     assert "candidate_top_k == 50" in source
+    assert "VLLM_MUSA_QWEN_SKIP_UNIT_TEMPERATURE" in source
+    assert "temperature_cpu == np.float32(1.0)" in source
+
+
+def test_legacy_qwen_unit_temperature_skip_is_exact_and_vocab_gated() -> None:
+    metadata = SimpleNamespace(all_random=True, uniform_temperature=1.0)
+    assert sampler._can_skip_legacy_qwen_unit_temperature(
+        torch.empty((4, 248320)), metadata
+    )
+    assert sampler._can_skip_legacy_qwen_unit_temperature(
+        torch.empty((1, 151936)), metadata
+    )
+
+    metadata.uniform_temperature = None
+    assert not sampler._can_skip_legacy_qwen_unit_temperature(
+        torch.empty((4, 248320)), metadata
+    )
+    metadata.uniform_temperature = 0.7
+    assert not sampler._can_skip_legacy_qwen_unit_temperature(
+        torch.empty((4, 248320)), metadata
+    )
+    metadata.uniform_temperature = 1.0
+    assert not sampler._can_skip_legacy_qwen_unit_temperature(
+        torch.empty((4, 32000)), metadata
+    )
+    metadata.all_random = False
+    assert not sampler._can_skip_legacy_qwen_unit_temperature(
+        torch.empty((4, 248320)), metadata
+    )
+
+
+def test_legacy_sample_skips_only_cpu_proven_qwen_unit_temperature(
+    monkeypatch,
+) -> None:
+    temperature_calls = []
+
+    def apply_temperature(logits, temperature, all_random):
+        temperature_calls.append((temperature, all_random))
+        return logits
+
+    fake_sampler = SimpleNamespace(
+        logprobs_mode="raw_logprobs",
+        apply_temperature=apply_temperature,
+        topk_topp_sampler=object(),
+        use_fp64_gumbel=False,
+    )
+    metadata = SimpleNamespace(
+        all_greedy=False,
+        all_random=True,
+        temperature=torch.ones(4),
+        top_k=None,
+        top_p=None,
+        generators={},
+        logitsprocs=SimpleNamespace(argmax_invariant=[]),
+        uniform_temperature=1.0,
+    )
+    monkeypatch.setattr(sampler, "can_use_qwen_legacy_gumbel", lambda *_args: False)
+    monkeypatch.setattr(
+        sampler,
+        "_call_topk_topp_sampler",
+        lambda *_args, **_kwargs: (torch.zeros(4, dtype=torch.int64), None),
+    )
+
+    sampler._sample(fake_sampler, torch.empty((4, 248320)), metadata)
+    assert temperature_calls == []
+
+    metadata.uniform_temperature = None
+    sampler._sample(fake_sampler, torch.empty((4, 248320)), metadata)
+    assert len(temperature_calls) == 1
+
+    metadata.uniform_temperature = 1.0
+    sampler._sample(fake_sampler, torch.empty((4, 32000)), metadata)
+    assert len(temperature_calls) == 2
 
 
 def _state_array(

--- a/vllm_musa/patches/series/0091-perf-skip-qwen-unit-temperature-divide.patch
+++ b/vllm_musa/patches/series/0091-perf-skip-qwen-unit-temperature-divide.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Mon, 27 Jul 2026 03:17:22 +0800
+Subject: [PATCH] perf(musa): propagate Qwen unit temperature metadata
+
+---
+ vllm/v1/sample/metadata.py        |  2 ++
+ vllm/v1/worker/gpu_input_batch.py | 13 +++++++++++++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/vllm/v1/sample/metadata.py b/vllm/v1/sample/metadata.py
+index 252cf746a0..22e9793780 100644
+--- a/vllm/v1/sample/metadata.py
++++ b/vllm/v1/sample/metadata.py
+@@ -55,3 +55,5 @@ class SamplingMetadata:
+     thinking_budget_state_holder: ThinkingBudgetStateHolder | None = None
+     # CPU-side hint for exact-gated platform sampler specializations.
+     uniform_top_k: int | None = None
++    # Exact CPU-side temperature hint for platform sampler specializations.
++    uniform_temperature: float | None = None
+diff --git a/vllm/v1/worker/gpu_input_batch.py b/vllm/v1/worker/gpu_input_batch.py
+index 6c48e7fcb9..5e50933b2d 100644
+--- a/vllm/v1/worker/gpu_input_batch.py
++++ b/vllm/v1/worker/gpu_input_batch.py
+@@ -2,6 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ # Datastructures defining a GPU input batch
+ 
++import os
+ from dataclasses import dataclass
+ from typing import cast
+ 
+@@ -924,6 +925,17 @@ class InputBatch:
+             if candidate_top_k == 50 and np.all(top_k_cpu == candidate_top_k):
+                 uniform_top_k = candidate_top_k
+ 
++        uniform_temperature = None
++        if self.vocab_size in (151936, 248320) and num_reqs > 0:
++            skip_unit_temperature_enabled = os.environ.get(
++                "VLLM_MUSA_QWEN_SKIP_UNIT_TEMPERATURE", "1"
++            ).lower() not in ("0", "false", "no", "off")
++            temperature_cpu = self.temperature_cpu[:num_reqs]
++            if skip_unit_temperature_enabled and np.all(
++                temperature_cpu == np.float32(1.0)
++            ):
++                uniform_temperature = 1.0
++
+         return SamplingMetadata(
+             temperature=temperature,
+             all_greedy=self.all_greedy,
+@@ -945,6 +957,7 @@ class InputBatch:
+             logitsprocs=self.logitsprocs,
+             thinking_budget_state_holder=self.thinking_budget_state_holder,
+             uniform_top_k=uniform_top_k,
++            uniform_temperature=uniform_temperature,
+         )
+ 
+     def get_pooling_params(self) -> list[PoolingParams]:

--- a/vllm_musa/patches/series/0091-perf-skip-qwen-unit-temperature-divide.patch
+++ b/vllm_musa/patches/series/0091-perf-skip-qwen-unit-temperature-divide.patch
@@ -1,12 +1,13 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: musa <musa@local>
-Date: Mon, 27 Jul 2026 03:17:22 +0800
+Date: Mon, 27 Jul 2026 03:23:27 +0800
 Subject: [PATCH] perf(musa): propagate Qwen unit temperature metadata
 
 ---
- vllm/v1/sample/metadata.py        |  2 ++
- vllm/v1/worker/gpu_input_batch.py | 13 +++++++++++++
- 2 files changed, 15 insertions(+)
+ vllm/v1/sample/metadata.py         |  2 ++
+ vllm/v1/worker/gpu_input_batch.py  |  7 +++++++
+ vllm/v1/worker/gpu_model_runner.py | 10 +++++++++-
+ 3 files changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/vllm/v1/sample/metadata.py b/vllm/v1/sample/metadata.py
 index 252cf746a0..22e9793780 100644
@@ -19,36 +20,23 @@ index 252cf746a0..22e9793780 100644
 +    # Exact CPU-side temperature hint for platform sampler specializations.
 +    uniform_temperature: float | None = None
 diff --git a/vllm/v1/worker/gpu_input_batch.py b/vllm/v1/worker/gpu_input_batch.py
-index 6c48e7fcb9..5e50933b2d 100644
+index 6c48e7fcb9..c0e3fb61d6 100644
 --- a/vllm/v1/worker/gpu_input_batch.py
 +++ b/vllm/v1/worker/gpu_input_batch.py
-@@ -2,6 +2,7 @@
- # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
- # Datastructures defining a GPU input batch
- 
-+import os
- from dataclasses import dataclass
- from typing import cast
- 
-@@ -924,6 +925,17 @@ class InputBatch:
+@@ -924,6 +924,12 @@ class InputBatch:
              if candidate_top_k == 50 and np.all(top_k_cpu == candidate_top_k):
                  uniform_top_k = candidate_top_k
  
 +        uniform_temperature = None
-+        if self.vocab_size in (151936, 248320) and num_reqs > 0:
-+            skip_unit_temperature_enabled = os.environ.get(
-+                "VLLM_MUSA_QWEN_SKIP_UNIT_TEMPERATURE", "1"
-+            ).lower() not in ("0", "false", "no", "off")
++        if self.vocab_size in (151936, 248320) and self.all_random and num_reqs > 0:
 +            temperature_cpu = self.temperature_cpu[:num_reqs]
-+            if skip_unit_temperature_enabled and np.all(
-+                temperature_cpu == np.float32(1.0)
-+            ):
++            if np.all(temperature_cpu == np.float32(1.0)):
 +                uniform_temperature = 1.0
 +
          return SamplingMetadata(
              temperature=temperature,
              all_greedy=self.all_greedy,
-@@ -945,6 +957,7 @@ class InputBatch:
+@@ -945,6 +951,7 @@ class InputBatch:
              logitsprocs=self.logitsprocs,
              thinking_budget_state_holder=self.thinking_budget_state_holder,
              uniform_top_k=uniform_top_k,
@@ -56,3 +44,38 @@ index 6c48e7fcb9..5e50933b2d 100644
          )
  
      def get_pooling_params(self) -> list[PoolingParams]:
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index 8d53ca439e..aacf2cd063 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -821,7 +821,7 @@ class GPUModelRunner(
+             "Qwen3_5ForConditionalGeneration",
+             "Qwen3_5MoeForConditionalGeneration",
+         }
+-        use_musa_qwen_uniform_decode_indices = (
++        is_musa_qwen_text_generation = (
+             current_platform.is_musa()
+             and not self.is_pooling_model
+             and self.speculative_config is None
+@@ -829,6 +829,9 @@ class GPUModelRunner(
+                 architecture in qwen_text_generation_architectures
+                 for architecture in (self.model_config.architectures or ())
+             )
++        )
++        use_musa_qwen_uniform_decode_indices = (
++            is_musa_qwen_text_generation
+             and os.environ.get(
+                 "VLLM_MUSA_QWEN_UNIFORM_DECODE_LOGITS_INDICES", "1"
+             ).lower()
+@@ -839,6 +842,11 @@ class GPUModelRunner(
+             if use_musa_qwen_uniform_decode_indices
+             else None
+         )
++        self.sampler._musa_qwen_skip_unit_temperature = (
++            is_musa_qwen_text_generation
++            and os.environ.get("VLLM_MUSA_QWEN_SKIP_UNIT_TEMPERATURE", "1").lower()
++            not in ("0", "false", "no", "off")
++        )
+ 
+         # MUSA-3406: reusable CPU/GPU buffers for speculative metadata indices.
+         # Avoid per-step torch.from_numpy(...).to(device) pageable uploads in

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -41,11 +41,12 @@ def _uniform_active_min_p(min_p: np.ndarray) -> float | None:
 
 
 def _can_skip_legacy_qwen_unit_temperature(
-    logits: torch.Tensor, sampling_metadata: Any
+    sampler: Any, logits: torch.Tensor, sampling_metadata: Any
 ) -> bool:
     """Use the scheduler's exact CPU hint to avoid a device divide by one."""
     return (
-        getattr(sampling_metadata, "all_random", False)
+        getattr(sampler, "_musa_qwen_skip_unit_temperature", False)
+        and getattr(sampling_metadata, "all_random", False)
         and _is_qwen_sampler_vocab(logits)
         and getattr(sampling_metadata, "uniform_temperature", None) == np.float32(1.0)
     )
@@ -589,7 +590,7 @@ def _sample(
             return greedy_sampled, processed_logprobs
 
     assert sampling_metadata.temperature is not None
-    if not _can_skip_legacy_qwen_unit_temperature(logits, sampling_metadata):
+    if not _can_skip_legacy_qwen_unit_temperature(self, logits, sampling_metadata):
         logits = self.apply_temperature(
             logits, sampling_metadata.temperature, sampling_metadata.all_random
         )

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -40,6 +40,17 @@ def _uniform_active_min_p(min_p: np.ndarray) -> float | None:
     return value if value != 0.0 else None
 
 
+def _can_skip_legacy_qwen_unit_temperature(
+    logits: torch.Tensor, sampling_metadata: Any
+) -> bool:
+    """Use the scheduler's exact CPU hint to avoid a device divide by one."""
+    return (
+        getattr(sampling_metadata, "all_random", False)
+        and _is_qwen_sampler_vocab(logits)
+        and getattr(sampling_metadata, "uniform_temperature", None) == np.float32(1.0)
+    )
+
+
 def musa_seeded_multinomial_enabled() -> bool:
     return envs.VLLM_MUSA_SEEDED_MULTINOMIAL.get()
 
@@ -578,9 +589,10 @@ def _sample(
             return greedy_sampled, processed_logprobs
 
     assert sampling_metadata.temperature is not None
-    logits = self.apply_temperature(
-        logits, sampling_metadata.temperature, sampling_metadata.all_random
-    )
+    if not _can_skip_legacy_qwen_unit_temperature(logits, sampling_metadata):
+        logits = self.apply_temperature(
+            logits, sampling_metadata.temperature, sampling_metadata.all_random
+        )
 
     top_k = _legacy_top_k_with_cpu_hint(
         sampling_metadata,


### PR DESCRIPTION
## Summary

- propagate an exact CPU `uniform_temperature` fact for the legacy sampler;
- skip the full Qwen logits divide only when all active temperatures are
  exactly 1.0;
- gate the path to MUSA, non-pooling/non-speculative Qwen2/Qwen3/Qwen3.5-3.6
  dense/MoE text-generation architectures and validated Qwen vocabularies;
- keep the original path for mixed/non-unit/unsupported requests and provide
  `VLLM_MUSA_QWEN_SKIP_UNIT_TEMPERATURE=0` as an opt-out;
- leave the V2 worker sampler unchanged because it already CPU-skips 0/1.

This is stacked on Draft PR #132.

## Why

The Qwen3.5-27B BS64 decode trace executed one legacy broadcast divide per
step even at temperature 1.0:

- `aten::div_([64,248320],[64,1])`: 20 per rank;
- host mean: `36.062 / 37.008 us`;
- MUSA `TrueDivOp`: 20 per rank at `61.736 / 61.382 us` mean.

The operation is after the model graph in the sampling tail. The candidate
uses existing CPU request state, so it adds no device sync, tensor copy, or hot
path torch operation.

## Trace A/B

Same candidate source, frozen input, two ranks, 20 decode steps:

| Event per rank | feature OFF | feature ON |
|---|---:|---:|
| target `aten::div_` | 20 | 0 |
| MUSA `TrueDivOp` | 20 | 0 |
| softmax | 20 | 20 |
| RubyMine top-k | 20 | 20 |
| fused min-p | 20 | 20 |
| graph launch | 20 | 20 |

The OFF switch restores the original device operation, proving the intended
fallback rather than incidental trace drift.

## End-to-end performance

Qwen3.5-27B BF16, TP2, BS64, 4096/1024, FlashAttention 3, normal
`VLLM_COMPILE` + `FULL_AND_PIECEWISE`, frozen input vector, two stabilization
runs per leg:

| Counterbalanced block | OFF TPOT ms | ON TPOT ms | TPOT | Output throughput |
|---|---:|---:|---:|---:|
| ABBA | 76.780878 | 76.663581 | -0.152768% | +0.114056% |
| reverse BAAB | 76.658700 | 76.572641 | -0.112262% | +0.091606% |
| all 8 legs | 76.719789 | 76.618111 | **-0.132531%** | **+0.102824%** |

TTFT is flat/no claim (`+0.029595%`). Adjacent-pair TPOT deltas are noisy:
`-0.5661%`, `+0.2628%`, `-0.3212%`, `+0.0970%`. This is intentionally
reported as a small counterbalanced win, not a large single-run improvement.
Both temporal block orders improve, and the overall result is close to the
`~0.1279%` host-plus-device trace fraction removed.

## Validation

- fresh 91/91 replay from pinned upstream
  `ee0da84ab9e04ac7610e28580af62c365e898389`, zero conflicts;
- source contract: 2/2 passed;
- exact-image runtime gate: 7/7 passed;
- Ruff, format, and Python compilation passed for touched source/tests;
- exact-image pytest: not run (`pytest` is absent from the image);
- trace probes: 2/2 ranks and all 20 steps passed;
- formal runs: 8/8 legs, 64/64 requests, frozen input and semantic gates;
- final GPU receipt: 0 MiB and no running process;
- exact container/root removed and task lease released.

Exact image:
`registry.mthreads.com/mcconline/inference/vllm@sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`

## Evidence

- `generated/MUSA-60042/round14-unit-temperature/summary.md`
- `generated/MUSA-60042/round14-unit-temperature/source-receipt.md`
- `r14-valid-evidence.tar.gz` SHA256
  `5e1d45af06fb8dc0c1b44fdfede3dfae7bb6961c81c694e5cc2ddc898b7676c0`

## Draft scope

Review the exact gates and whether the small counterbalanced gain is worth the
metadata plumbing. Merge only after stacked parent #132. The opt-out provides
a direct rollback if a downstream sampling configuration exposes an
unexpected interaction.
