### PR TITLE
perf(musa): reuse Qwen uniform decode hidden state

### DIFF
--- a/tests/test_uniform_decode_logits_indices_source.py
+++ b/tests/test_uniform_decode_logits_indices_source.py
@@ -11,6 +11,13 @@ PATCH = (
     / "series"
     / "0090-perf-reuse-uniform-decode-logits-indices.patch"
 )
+HIDDEN_VIEW_PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0092-perf-reuse-qwen-uniform-decode-hidden-state.patch"
+)
 
 
 def test_uniform_decode_patch_reuses_uploaded_request_indices() -> None:
@@ -70,3 +77,52 @@ def test_uniform_decode_gate_is_exact_for_positive_query_lengths() -> None:
             assert request_indices == baseline
         else:
             assert request_indices != baseline
+
+
+def test_uniform_decode_hidden_view_patch_preserves_fallbacks() -> None:
+    source = HIDDEN_VIEW_PATCH.read_text()
+
+    assert source.count("if use_cached_decode_logits_indices:") == 2
+    assert source.count("sample_hidden_states = hidden_states\n") == 2
+    assert source.count("sample_hidden_states = hidden_states[:num_reqs]") == 2
+    assert (
+        source.count(
+            "+                    sample_hidden_states = hidden_states[logits_indices]"
+        )
+        == 2
+    )
+    assert source.count("hidden_states.shape[0] != num_reqs") == 2
+
+
+def test_identity_hidden_selection_preserves_padding_and_fallback_semantics() -> None:
+    def select_hidden_states(
+        hidden_states: list[str],
+        num_reqs: int,
+        logits_indices: list[int],
+        use_cached_decode_logits_indices: bool,
+    ) -> list[str]:
+        if use_cached_decode_logits_indices:
+            if len(hidden_states) == num_reqs:
+                return hidden_states
+            return hidden_states[:num_reqs]
+        return [hidden_states[index] for index in logits_indices]
+
+    for num_reqs, padded_reqs in ((1, 1), (4, 4), (16, 16), (63, 64), (64, 64)):
+        hidden_states = [f"row-{index}" for index in range(padded_reqs)]
+        selected = select_hidden_states(
+            hidden_states,
+            num_reqs,
+            list(range(num_reqs)),
+            use_cached_decode_logits_indices=True,
+        )
+        assert selected == hidden_states[:num_reqs]
+        if num_reqs == padded_reqs:
+            assert selected is hidden_states
+
+    hidden_states = ["row-0", "row-1", "row-2", "row-3"]
+    assert select_hidden_states(
+        hidden_states,
+        num_reqs=2,
+        logits_indices=[3, 1],
+        use_cached_decode_logits_indices=False,
+    ) == ["row-3", "row-1"]

--- a/vllm_musa/patches/series/0092-perf-reuse-qwen-uniform-decode-hidden-state.patch
+++ b/vllm_musa/patches/series/0092-perf-reuse-qwen-uniform-decode-hidden-state.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Mon, 27 Jul 2026 05:22:34 +0800
+Subject: [PATCH] perf(musa): reuse Qwen uniform decode hidden state
+
+---
+ vllm/v1/worker/gpu_model_runner.py | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index aacf2cd063..15d7d37173 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -4480,2 +4480,7 @@ class GPUModelRunner(
+-                sample_hidden_states = hidden_states[logits_indices]
++                if use_cached_decode_logits_indices:
++                    sample_hidden_states = hidden_states
++                    if hidden_states.shape[0] != num_reqs:
++                        sample_hidden_states = hidden_states[:num_reqs]
++                else:
++                    sample_hidden_states = hidden_states[logits_indices]
+                 logits = self.model.compute_logits(sample_hidden_states)
+@@ -4486,2 +4491,7 @@ class GPUModelRunner(
+-                sample_hidden_states = hidden_states[logits_indices]
++                if use_cached_decode_logits_indices:
++                    sample_hidden_states = hidden_states
++                    if hidden_states.shape[0] != num_reqs:
++                        sample_hidden_states = hidden_states[:num_reqs]
++                else:
++                    sample_hidden_states = hidden_states[logits_indices]
+                 if not get_pp_group().is_last_rank:


### PR DESCRIPTION
## What

Reuse Qwen uniform-decode hidden states directly instead of gathering them
with cached identity indices.

- full graph bucket: pass the existing hidden tensor to the LM head;
- padded bucket: take a view slice to the actual request count;
- every non-uniform or non-Qwen path keeps the original advanced index.

The implementation is a new `0092` upstream patch.  It does not rewrite the
already-reviewed `0090` patch.

## Why

On MUSA, `hidden_states[int32_arange]` is not free.  Each decode step launches
an int32-to-int64 cast and `IndexVectorizedKernel`, and wraps them in an
`aten::index` host op.  The cached indices are exactly the identity range, so
that work is unnecessary.

Production Qwen3.5 TP2 traces show, per rank and 20 decode steps:

| Target | Parent | Candidate |
|---|---:|---:|
| `aten::index [64, 5120]` | 20 | 0 |
| `IndexVectorizedKernel` | 20 | 0 |
| int32-to-int64 casts | 60 | 40 |

The graph-end-to-LM-head device interval drops from 82.213 us to 67.097 us
mean.  LM-head, IPC logits gather, sampler, and graph-launch counts stay fixed.

## Safety gate

This reuses the existing #132 gate:

- MUSA only;
- Qwen2/Qwen2-MoE/Qwen3/Qwen3-MoE/Qwen3.5 dense or MoE architectures;
- non-pooling and non-speculative;
- exact uniform decode (`max_num_scheduled_tokens == 1` and one actual token
  per request);
- existing environment opt-out remains available.

The old advanced-index path is unchanged outside that gate.  A BS63/64 padded
case is covered by both a semantic source test and a real graph-padding smoke.

## Performance

Qwen3.5-27B BF16, TP2, BS64, 4096 input / 1024 output tokens, FlashAttention,
normal compile/capture, fixed input vector, two stabilization runs per leg:

| Aggregate | Parent TPOT | Candidate TPOT | TPOT delta | Output delta |
|---|---:|---:|---:|---:|
| ABBA | 75.949838 ms | 75.902513 ms | -0.062310% | +0.067686% |
| Reverse BAAB | 76.010655 ms | 75.943508 ms | -0.088338% | +0.047600% |
| All eight legs | 75.980246 ms | 75.923011 ms | -0.075330% | +0.057645% |

Adjacent TPOT pairs were -0.087754%, -0.036837%, -0.314714%, and
+0.138827%; the noisy negative pair is intentionally retained.  TTFT is not
claimed.

The A/B held Draft #127's IPC logits gather fixed to expose the residual tail;
this PR does not depend on #127 and is based only on Draft #133.

## Verification

- `python -m pytest -q tests/test_uniform_decode_logits_indices_source.py`
  (4 passed)
- Ruff check and format check passed.
- Strict replay of all 92 patches on pinned upstream vLLM passed.
- Patched `gpu_model_runner.py` compiled.
- Production two-rank trace gates passed for every formal leg.
- Cold-cache `bench_kineto` at BS1/4/16/63/64: parent target device work
  6.813--8.544 us; candidate target work 0 us; outputs exact.
- Qwen3.5 dense TP2 BS63 graph-padding semantic smoke passed.

Exact image:
`registry.mthreads.com/mcconline/inference/vllm@sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`

Hardware: S5000, driver 5.2.0-server.
