### PR TITLE
perf(musa): fuse Qwen logits gather cast

### DIFF
--- a/tests/test_musa_jit_custom_all_gather.py
+++ b/tests/test_musa_jit_custom_all_gather.py
@@ -32,6 +32,8 @@ def test_custom_all_gather_gate_accepts_only_last_dim_packed_2d():
     accepted = torch.empty((4, 32), dtype=torch.bfloat16)
 
     assert impl.should_custom_all_gather(accepted, -1)
+    assert impl.should_custom_all_gather(accepted, -1, output_dtype=torch.float32)
+    assert not impl.should_custom_all_gather(accepted, -1, output_dtype=torch.float16)
     assert impl.should_custom_all_gather(accepted, 1)
     assert not impl.should_custom_all_gather(accepted, 0)
     assert not impl.should_custom_all_gather(accepted[:, ::2], -1)
@@ -46,6 +48,9 @@ def test_custom_all_gather_gate_accepts_only_last_dim_packed_2d():
     )
     impl.max_size = accepted.numel() * accepted.element_size()
     assert not impl.should_custom_all_gather(accepted, -1)
+    impl.max_size = accepted.numel() * accepted.element_size() * impl.world_size
+    assert impl.should_custom_all_gather(accepted, -1)
+    assert not impl.should_custom_all_gather(accepted, -1, output_dtype=torch.float32)
     impl.max_size = 1024 * 1024
     impl.world_size = 6
     assert not impl.should_custom_all_gather(accepted, -1)
@@ -104,6 +109,33 @@ def test_custom_all_gather_launches_with_last_dim_concatenated(monkeypatch):
     assert captured["world_size"] == 2
 
 
+def test_custom_all_gather_launches_bfloat16_to_float32(monkeypatch):
+    impl = _impl()
+    input_tensor = torch.arange(128, dtype=torch.bfloat16).view(4, 32)
+    captured = {}
+
+    def launch_all_gather(
+        rank_data,
+        signals,
+        inp,
+        out,
+        self_signal_ptr,
+        self_buffer_ptr,
+        max_size_bytes,
+        rank,
+        world_size,
+    ):
+        captured.update(inp=inp, out=out)
+
+    monkeypatch.setattr(custom_ar.jit_ar, "launch_all_gather", launch_all_gather)
+    output = impl._custom_all_gather_impl(input_tensor, output_dtype=torch.float32)
+
+    assert output.shape == (4, 64)
+    assert output.dtype == torch.float32
+    assert captured["inp"] is input_tensor
+    assert captured["out"] is output
+
+
 @pytest.mark.parametrize(
     "capturing,stream_capturing,compiling",
     [
@@ -141,11 +173,15 @@ def test_custom_all_gather_fails_closed_on_non_default_stream(monkeypatch):
 
 
 def test_logits_helper_uses_only_musa_jit_communicator(monkeypatch):
-    expected = torch.empty((4, 64), dtype=torch.bfloat16)
+    expected = torch.empty((4, 64), dtype=torch.float32)
     communicator = object.__new__(custom_ar.MusaJitCustomAllreduce)
     communicator._jit_comm = SimpleNamespace(disabled=False)
     monkeypatch.setattr(
-        communicator, "custom_all_gather", lambda input_tensor, dim: expected
+        communicator,
+        "custom_all_gather",
+        lambda input_tensor, dim, output_dtype=None: (
+            expected if output_dtype == torch.float32 else None
+        ),
     )
 
     import vllm.distributed.parallel_state as parallel_state
@@ -158,7 +194,8 @@ def test_logits_helper_uses_only_musa_jit_communicator(monkeypatch):
         ),
     )
     output = custom_ar.maybe_musa_jit_logits_all_gather(
-        torch.empty((4, 32), dtype=torch.bfloat16)
+        torch.empty((4, 32), dtype=torch.bfloat16),
+        output_dtype=torch.float32,
     )
     assert output is expected
 

--- a/tests/test_musa_logits_ipc_gather.py
+++ b/tests/test_musa_logits_ipc_gather.py
@@ -14,6 +14,10 @@ custom_ar = pytest.importorskip(
 def _processor(org_vocab_size: int):
     processor = object.__new__(logits_processor.LogitsProcessor)
     processor.org_vocab_size = org_vocab_size
+    processor.scale = 1.0
+    processor.soft_cap = None
+    processor.use_all_gather = True
+    processor._musa_fp32_logits_gather = True
     return processor
 
 
@@ -55,8 +59,8 @@ def test_qwen_bf16_logits_use_ipc_gather(monkeypatch, org_vocab_size, shard_size
     gathered = torch.empty((1, shard_size * 2), dtype=torch.bfloat16)
     calls = []
 
-    def gather(input_tensor, dim):
-        calls.append((input_tensor, dim))
+    def gather(input_tensor, dim, output_dtype=None):
+        calls.append((input_tensor, dim, output_dtype))
         return gathered
 
     monkeypatch.setattr(custom_ar, "maybe_musa_jit_logits_all_gather", gather)
@@ -73,6 +77,82 @@ def test_qwen_bf16_logits_use_ipc_gather(monkeypatch, org_vocab_size, shard_size
     assert len(calls) == 1
     assert calls[0][0] is local_logits
     assert calls[0][1] == -1
+    assert calls[0][2] is None
+
+
+@pytest.mark.parametrize(
+    "world_size,shard_size",
+    [(4, 37984), (8, 18992)],
+)
+def test_standard_qwen_logits_request_float32_ipc_output(
+    monkeypatch, world_size, shard_size
+):
+    _patch_tp(monkeypatch, world_size=world_size)
+    local_logits = torch.empty((1, shard_size), dtype=torch.bfloat16)
+    gathered = torch.empty((1, 151936), dtype=torch.float32)
+    calls = []
+
+    def gather(input_tensor, dim, output_dtype=None):
+        calls.append((input_tensor, dim, output_dtype))
+        return gathered
+
+    monkeypatch.setattr(custom_ar, "maybe_musa_jit_logits_all_gather", gather)
+    processor = _processor(151936)
+    monkeypatch.setattr(processor, "_use_musa_logits_all_reduce", lambda: True)
+
+    output = processor._gather_logits(local_logits, SimpleNamespace())
+
+    assert output is gathered
+    assert calls == [(local_logits, -1, torch.float32)]
+
+
+def test_tp2_standard_qwen_logits_keep_same_dtype_ipc_output(monkeypatch):
+    _patch_tp(monkeypatch, world_size=2)
+    local_logits = torch.empty((1, 75968), dtype=torch.bfloat16)
+    gathered = torch.empty((1, 151936), dtype=torch.bfloat16)
+    output_dtypes = []
+
+    def gather(input_tensor, dim, output_dtype=None):
+        output_dtypes.append(output_dtype)
+        return gathered
+
+    monkeypatch.setattr(custom_ar, "maybe_musa_jit_logits_all_gather", gather)
+    processor = _processor(151936)
+    monkeypatch.setattr(processor, "_use_musa_logits_all_reduce", lambda: True)
+
+    output = processor._gather_logits(local_logits, SimpleNamespace())
+
+    assert output is gathered
+    assert output_dtypes == [None]
+
+
+@pytest.mark.parametrize(
+    "scale,soft_cap,enabled",
+    [(2.0, None, True), (1.0, 30.0, True), (1.0, None, False)],
+)
+def test_transformed_qwen_logits_keep_same_dtype_ipc_output(
+    monkeypatch, scale, soft_cap, enabled
+):
+    _patch_tp(monkeypatch, world_size=4)
+    local_logits = torch.empty((1, 37984), dtype=torch.bfloat16)
+    gathered = torch.empty((1, 151936), dtype=torch.bfloat16)
+    output_dtypes = []
+
+    def gather(input_tensor, dim, output_dtype=None):
+        output_dtypes.append(output_dtype)
+        return gathered
+
+    monkeypatch.setattr(custom_ar, "maybe_musa_jit_logits_all_gather", gather)
+    processor = _processor(151936)
+    processor.scale = scale
+    processor.soft_cap = soft_cap
+    processor._musa_fp32_logits_gather = enabled
+    monkeypatch.setattr(processor, "_use_musa_logits_all_reduce", lambda: True)
+
+    output = processor._gather_logits(local_logits, SimpleNamespace())
+
+    assert output is gathered
+    assert output_dtypes == [None]
 
 
 @pytest.mark.parametrize(

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -322,7 +322,12 @@ class _MusaJitCustomAllreduceImpl:
             return False
         return inp.is_contiguous()
 
-    def should_custom_all_gather(self, inp: torch.Tensor, dim: int = -1) -> bool:
+    def should_custom_all_gather(
+        self,
+        inp: torch.Tensor,
+        dim: int = -1,
+        output_dtype: torch.dtype | None = None,
+    ) -> bool:
         if self.disabled or self.world_size not in (2, 4, 8) or inp.ndim != 2:
             return False
         if not self._is_communicator_tensor(inp):
@@ -332,6 +337,12 @@ class _MusaJitCustomAllreduceImpl:
             return False
         if inp.dtype not in (torch.float16, torch.bfloat16, torch.float32):
             return False
+        if output_dtype is None:
+            output_dtype = inp.dtype
+        if output_dtype != inp.dtype and not (
+            inp.dtype == torch.bfloat16 and output_dtype == torch.float32
+        ):
+            return False
         if not inp.is_contiguous() or inp.shape[0] <= 0 or inp.shape[1] <= 0:
             return False
         pack = 16 // inp.element_size()
@@ -339,7 +350,8 @@ class _MusaJitCustomAllreduceImpl:
             return False
         inp_size = inp.numel() * inp.element_size()
         output_numel = inp.numel() * self.world_size
-        output_size = output_numel * inp.element_size()
+        output_element_size = 4 if output_dtype == torch.float32 else inp.element_size()
+        output_size = output_numel * output_element_size
         return (
             inp_size <= self.max_size
             and inp_size % 16 == 0
@@ -422,9 +434,12 @@ class _MusaJitCustomAllreduceImpl:
         return out
 
     def custom_all_gather(
-        self, input: torch.Tensor, dim: int = -1
+        self,
+        input: torch.Tensor,
+        dim: int = -1,
+        output_dtype: torch.dtype | None = None,
     ) -> torch.Tensor | None:
-        if not self.should_custom_all_gather(input, dim):
+        if not self.should_custom_all_gather(input, dim, output_dtype):
             return None
         # Logits currently run outside the model graph. Fail closed if a future
         # runner moves this call under Dynamo or graph capture; that path needs
@@ -436,12 +451,20 @@ class _MusaJitCustomAllreduceImpl:
             or not self._is_default_stream(input)
         ):
             return None
-        return self._custom_all_gather_impl(input)
+        return self._custom_all_gather_impl(input, output_dtype)
 
-    def _custom_all_gather_impl(self, input: torch.Tensor) -> torch.Tensor:
+    def _custom_all_gather_impl(
+        self,
+        input: torch.Tensor,
+        output_dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
         assert self.buffer_rank_data is not None
         output_shape = (*input.shape[:-1], input.shape[-1] * self.world_size)
-        out = torch.empty(output_shape, dtype=input.dtype, device=input.device)
+        out = torch.empty(
+            output_shape,
+            dtype=output_dtype if output_dtype is not None else input.dtype,
+            device=input.device,
+        )
         jit_ar.launch_all_gather(
             self.buffer_rank_data,
             self.signal_ptrs_cpu,
@@ -561,10 +584,15 @@ class MusaJitCustomAllreduce:
         return None
 
     def custom_all_gather(
-        self, input: torch.Tensor, dim: int = -1
+        self,
+        input: torch.Tensor,
+        dim: int = -1,
+        output_dtype: torch.dtype | None = None,
     ) -> torch.Tensor | None:
-        if self._jit_available and self._jit_comm.should_custom_all_gather(input, dim):
-            return self._jit_comm.custom_all_gather(input, dim)
+        if self._jit_available and self._jit_comm.should_custom_all_gather(
+            input, dim, output_dtype
+        ):
+            return self._jit_comm.custom_all_gather(input, dim, output_dtype)
         return None
 
     def close(self) -> None:
@@ -580,7 +608,9 @@ class MusaJitCustomAllreduce:
 
 
 def maybe_musa_jit_logits_all_gather(
-    input: torch.Tensor, dim: int = -1
+    input: torch.Tensor,
+    dim: int = -1,
+    output_dtype: torch.dtype | None = None,
 ) -> torch.Tensor | None:
     """Use the MUSA IPC communicator for a last-dimension logits gather."""
     from vllm.distributed.parallel_state import get_tp_group
@@ -589,7 +619,7 @@ def maybe_musa_jit_logits_all_gather(
     custom_ar = getattr(device_communicator, "ca_comm", None)
     if not isinstance(custom_ar, MusaJitCustomAllreduce):
         return None
-    output = custom_ar.custom_all_gather(input, dim)
+    output = custom_ar.custom_all_gather(input, dim, output_dtype)
     if output is not None:
         logger.info_once("Using MUSA JIT IPC all-gather for TP logits.")
     return output

--- a/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
@@ -322,12 +322,13 @@ __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) custom_all_reduce_2sho
   } while (idx_base < size);
 }
 
-template <typename T, int nranks>
+template <typename InputT, typename OutputT, int nranks>
 __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
-    cross_device_all_gather_last_dim(RankData data, T* __restrict__ out,
+    cross_device_all_gather_last_dim(RankData data, OutputT* __restrict__ out,
                                      int rows,
                                      int shard_packed_size) {
-  using P = typename packed_t<T>::P;
+  using InputP = typename packed_t<InputT>::P;
+  using OutputP = array_t<OutputT, InputP::size>;
   const int region_count = rows * nranks;
   if (gridDim.x >= region_count) {
     const int region = blockIdx.x % region_count;
@@ -335,25 +336,35 @@ __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1)
     const int blocks_per_region = gridDim.x / region_count;
     const int row = region / nranks;
     const int source_rank = region - row * nranks;
-    const P* source = reinterpret_cast<const P*>(data.ptrs[source_rank]) +
-                      row * shard_packed_size;
-    P* destination = reinterpret_cast<P*>(out) + region * shard_packed_size;
+    const InputP* source = reinterpret_cast<const InputP*>(data.ptrs[source_rank]) +
+                           row * shard_packed_size;
+    OutputP* destination = reinterpret_cast<OutputP*>(out) +
+                           region * shard_packed_size;
     for (int column = block_in_region * blockDim.x + threadIdx.x;
          column < shard_packed_size;
          column += blocks_per_region * blockDim.x) {
-      destination[column] = source[column];
+      if constexpr (std::is_same<InputT, OutputT>::value) {
+        destination[column] = source[column];
+      } else {
+        destination[column] = upcast(source[column]);
+      }
     }
   } else {
     for (int region = blockIdx.x; region < region_count;
          region += gridDim.x) {
       const int row = region / nranks;
       const int source_rank = region - row * nranks;
-      const P* source = reinterpret_cast<const P*>(data.ptrs[source_rank]) +
-                        row * shard_packed_size;
-      P* destination = reinterpret_cast<P*>(out) + region * shard_packed_size;
+      const InputP* source = reinterpret_cast<const InputP*>(data.ptrs[source_rank]) +
+                             row * shard_packed_size;
+      OutputP* destination = reinterpret_cast<OutputP*>(out) +
+                             region * shard_packed_size;
       for (int column = threadIdx.x; column < shard_packed_size;
            column += blockDim.x) {
-        destination[column] = source[column];
+        if constexpr (std::is_same<InputT, OutputT>::value) {
+          destination[column] = source[column];
+        } else {
+          destination[column] = upcast(source[column]);
+        }
       }
     }
   }
@@ -392,11 +403,11 @@ __global__ void cross_device_all_gather_end_barrier(RankSignals sg,
   __syncthreads_lm();
 }
 
-template <typename T, int nranks>
+template <typename InputT, typename OutputT, int nranks>
 void launch_all_gather_last_dim(RankData data, RankSignals sg,
-                                Signal* self_sg, T* out, int rank, int rows,
+                                Signal* self_sg, OutputT* out, int rank, int rows,
                                 int shard_size, musaStream_t stream) {
-  const int pack = packed_t<T>::P::size;
+  const int pack = packed_t<InputT>::P::size;
   TVM_FFI_ICHECK_EQ(shard_size % pack, 0);
   const int shard_packed_size = shard_size / pack;
   const int region_count = rows * nranks;
@@ -410,7 +421,7 @@ void launch_all_gather_last_dim(RankData data, RankSignals sg,
   }
   cross_device_all_gather_start_barrier<nranks>
       <<<1, nranks, 0, stream>>>(sg, self_sg, rank);
-  cross_device_all_gather_last_dim<T, nranks>
+  cross_device_all_gather_last_dim<InputT, OutputT, nranks>
       <<<blocks, kDefaultThreads, 0, stream>>>(data, out, rows,
                                                shard_packed_size);
   cross_device_all_gather_end_barrier<nranks>
@@ -459,23 +470,23 @@ void dispatch_world_size(RankData data, RankSignals sg, Signal* self_sg, T* out,
   }
 }
 
-template <typename T>
+template <typename InputT, typename OutputT>
 void dispatch_all_gather_world_size(RankData data, RankSignals sg,
-                                    Signal* self_sg, T* out, int rank,
+                                    Signal* self_sg, OutputT* out, int rank,
                                     int world_size, int rows, int shard_size,
                                     musaStream_t stream) {
   switch (world_size) {
     case 2:
-      launch_all_gather_last_dim<T, 2>(data, sg, self_sg, out, rank, rows,
-                                       shard_size, stream);
+      launch_all_gather_last_dim<InputT, OutputT, 2>(
+          data, sg, self_sg, out, rank, rows, shard_size, stream);
       break;
     case 4:
-      launch_all_gather_last_dim<T, 4>(data, sg, self_sg, out, rank, rows,
-                                       shard_size, stream);
+      launch_all_gather_last_dim<InputT, OutputT, 4>(
+          data, sg, self_sg, out, rank, rows, shard_size, stream);
       break;
     case 8:
-      launch_all_gather_last_dim<T, 8>(data, sg, self_sg, out, rank, rows,
-                                       shard_size, stream);
+      launch_all_gather_last_dim<InputT, OutputT, 8>(
+          data, sg, self_sg, out, rank, rows, shard_size, stream);
       break;
     default:
       TVM_FFI_THROW(ValueError) << "all-gather world_size must be one of 2/4/8";
@@ -576,7 +587,11 @@ void vllm_musa_custom_ar_launch_all_gather(
   TVM_FFI_ICHECK_EQ(out.ndim(), 2);
   TVM_FFI_ICHECK_EQ(inp.size(0), out.size(0));
   TVM_FFI_ICHECK_EQ(inp.size(1) * world_size, out.size(1));
-  TVM_FFI_ICHECK(dtype_equal(inp.dtype(), out.dtype()));
+  const bool same_dtype = dtype_equal(inp.dtype(), out.dtype());
+  const bool bfloat16_to_float32 =
+      dtype_equal(inp.dtype(), dl_bfloat16) &&
+      dtype_equal(out.dtype(), dl_float32);
+  TVM_FFI_ICHECK(same_dtype || bfloat16_to_float32);
 
   RankSignals sg{};
   const auto* ptrs = static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
@@ -601,10 +616,12 @@ void vllm_musa_custom_ar_launch_all_gather(
                     static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
   TVM_FFI_ICHECK_LE(output_numel,
                     static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
-  const int64_t element_bytes =
+  const int64_t input_element_bytes =
       (static_cast<int64_t>(inp.dtype().bits) * inp.dtype().lanes + 7) / 8;
-  const int64_t input_nbytes = input_numel * element_bytes;
-  const int64_t output_nbytes = output_numel * element_bytes;
+  const int64_t output_element_bytes =
+      (static_cast<int64_t>(out.dtype().bits) * out.dtype().lanes + 7) / 8;
+  const int64_t input_nbytes = input_numel * input_element_bytes;
+  const int64_t output_nbytes = output_numel * output_element_bytes;
   TVM_FFI_ICHECK_LE(input_nbytes, max_size_bytes);
   TVM_FFI_ICHECK_LE(output_nbytes, max_size_bytes);
   const musaError_t copy_err = musaMemcpyAsync(
@@ -616,24 +633,30 @@ void vllm_musa_custom_ar_launch_all_gather(
 
   const int rows = static_cast<int>(inp.size(0));
   const int shard_size = static_cast<int>(inp.size(1));
-  if (dtype_equal(out.dtype(), dl_float16)) {
-    dispatch_all_gather_world_size(
+  if (bfloat16_to_float32) {
+    dispatch_all_gather_world_size<__mt_bfloat16, float>(
+        data, sg, self_sg, static_cast<float*>(out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
+        stream);
+  } else if (dtype_equal(out.dtype(), dl_float16)) {
+    dispatch_all_gather_world_size<half, half>(
         data, sg, self_sg, static_cast<half*>(out.data_ptr()),
         static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
         stream);
   } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
-    dispatch_all_gather_world_size(
+    dispatch_all_gather_world_size<__mt_bfloat16, __mt_bfloat16>(
         data, sg, self_sg, static_cast<__mt_bfloat16*>(out.data_ptr()),
         static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
         stream);
   } else if (dtype_equal(out.dtype(), dl_float32)) {
-    dispatch_all_gather_world_size(
+    dispatch_all_gather_world_size<float, float>(
         data, sg, self_sg, static_cast<float*>(out.data_ptr()),
         static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
         stream);
   } else {
     TVM_FFI_THROW(ValueError)
-        << "custom all-gather only supports fp16/bf16/fp32";
+        << "custom all-gather only supports same-dtype fp16/bf16/fp32 or "
+           "bf16-to-fp32";
   }
   const musaError_t err = musaGetLastError();
   TVM_FFI_ICHECK_EQ(err, musaSuccess)

--- a/vllm_musa/patches/series/0088-MUSA-request-FP32-Qwen-IPC-logits.patch
+++ b/vllm_musa/patches/series/0088-MUSA-request-FP32-Qwen-IPC-logits.patch
@@ -1,0 +1,74 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Mon, 27 Jul 2026 07:01:37 +0800
+Subject: [PATCH] MUSA: request FP32 Qwen IPC logits
+
+---
+ .../model_executor/layers/logits_processor.py | 21 +++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/vllm/model_executor/layers/logits_processor.py b/vllm/model_executor/layers/logits_processor.py
+index 9ded650ebf..4654e32866 100644
+--- a/vllm/model_executor/layers/logits_processor.py
++++ b/vllm/model_executor/layers/logits_processor.py
+@@ -2,6 +2,8 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ """A layer that compute logits from hidden_stats."""
+ 
++import os
++
+ import torch
+ 
+ from vllm.distributed import (
+@@ -50,6 +52,9 @@ class LogitsProcessor(PluggableLayer):
+         self.org_vocab_size = org_vocab_size or vocab_size
+         # Soft cap the logits. Used in Gemma 2.
+         self.soft_cap = soft_cap
++        self._musa_fp32_logits_gather = os.environ.get(
++            "VLLM_MUSA_QWEN_FP32_LOGITS_GATHER", "1"
++        ).lower() not in {"0", "false", "no", "off"}
+         # Whether to use gather or all-gather to gather the logits.
+         self.use_all_gather = current_platform.use_all_gather()
+ 
+@@ -82,11 +87,14 @@ class LogitsProcessor(PluggableLayer):
+         self,
+         logits: torch.Tensor,
+         lm_head: VocabParallelEmbedding,
++        output_dtype: torch.dtype | None = None,
+     ) -> torch.Tensor:
+         """Rebuild all-gathered logits with MUSA IPC or all-reduce fallback."""
+         tp_size = get_tensor_model_parallel_world_size()
+         if tp_size == 1:
+             return logits
++        if tp_size not in (4, 8):
++            output_dtype = None
+ 
+         use_ipc_gather = (
+             self.org_vocab_size in (151936, 248320)
+@@ -105,7 +113,7 @@ class LogitsProcessor(PluggableLayer):
+             )
+ 
+             gathered = musa_jit_ar.maybe_musa_jit_logits_all_gather(
+-                logits, dim=-1
++                logits, dim=-1, output_dtype=output_dtype
+             )
+             if gathered is not None:
+                 return gathered
+@@ -135,7 +143,16 @@ class LogitsProcessor(PluggableLayer):
+             if self._use_musa_logits_all_reduce():
+                 # Preserve the all-gather layout while avoiding MCCL
+                 # gather/all_gather paths that are not reliable on MUSA.
+-                logits = self._musa_all_reduce_logits(logits, lm_head)
++                output_dtype = (
++                    torch.float32
++                    if self._musa_fp32_logits_gather
++                    and self.scale == 1.0
++                    and self.soft_cap is None
++                    else None
++                )
++                logits = self._musa_all_reduce_logits(
++                    logits, lm_head, output_dtype=output_dtype
++                )
+             else:
+                 logits = tensor_model_parallel_all_gather(logits)
+         else:


### PR DESCRIPTION
## What

Fuse Qwen's TP IPC logits gather with its required BF16-to-FP32 conversion.

- extend the MUSA JIT all-gather with a narrowly supported BF16-input/FP32-output mode;
- upcast packed BF16 values while writing the gathered FP32 output;
- request that mode only for normal Qwen logits at TP4/TP8, unit scale, and no soft cap;
- preserve same-dtype behavior for TP2, MTP, transformed logits, and every other caller;
- retain the existing stream, shape, dtype, Dynamo, and graph-capture fail-closed gates;
- provide `VLLM_MUSA_QWEN_FP32_LOGITS_GATHER=0` as an opt-out.

The cross-rank start/end barriers and system-scope fences from #127 are unchanged.

## Why

After #127's IPC gather, Qwen still launches a standalone full-vocabulary
BF16-to-FP32 cast before sampling.  A TP4 Qwen3.5 production trace shows one
cast per decode step on every rank.

| Target per rank / 20 steps | Parent | Candidate |
|---|---:|---:|
| `aten::_to_copy [64, 248320]` | 20 | 0 |
| BF16 cast kernel | 20 | 0 |
| IPC gather kernel | 20 | 20 |
| start / end barriers | 20 / 20 | 20 / 20 |

The gather grows by only about 1.5--2.4 us and removes a 67--68 us cast, for a
conservative causal saving of roughly 65--66 us per decode step.

## Safety gate

| Case | Behavior |
|---|---|
| Qwen normal logits, BF16, TP4/TP8, unit scale, no soft cap | fused FP32 gather |
| TP2 | existing same-dtype gather |
| MTP or direct helper caller | existing same-dtype gather by default |
| non-unit scale or soft cap | existing logits transforms |
| unsupported dtype/shape/world size/stream/capture | fail closed to the existing fallback |

The FFI accepts only same-dtype FP16/BF16/FP32 or BF16-to-FP32.  Input and
output byte sizes are validated independently.

## Performance

Qwen3.5-27B BF16, TP4, BS64, 4096 input / 1024 output tokens, FlashAttention
3, normal Inductor plus `FULL_AND_PIECEWISE` graph capture, frozen input vector,
two stabilization runs per leg:

| Aggregate | Parent TPOT | Candidate TPOT | TPOT delta | Output delta |
|---|---:|---:|---:|---:|
| ABBA | 59.392296 ms | 58.617539 ms | -1.304474% | +1.141025% |
| Reverse BAAB | 59.084724 ms | 58.719888 ms | -0.617479% | +0.524985% |
| All eight legs | 59.238510 ms | 58.668714 ms | -0.961868% | +0.832292% |

Both counterbalanced orders are positive.  Because the serving delta is larger
than the trace-derived Amdahl effect, the causal claim is limited to the
65--66 us device saving above.

The same TP2 campaign was inconsistent (ABBA `-0.298%`, reverse BAAB
`+0.487%`, all-eight `+0.093%` TPOT), so the final implementation explicitly
disables the fused-output mode at TP2.

Cold-cache `bench_kineto` plus MUSA-event measurements covered TP4/TP8,
vocabulary 151936/248320, and rows 1/4/16/64.  All 16 shipped-shape event-p50
comparisons were positive, with exact outputs and 20/20 reliability checks.

## Verification

- remote focused tests after the final gate: 23 passed;
- Ruff check/format and Python compile checks passed;
- strict replay of all 88 patches on pinned upstream vLLM passed, with patched
  `logits_processor.py` compiling;
- formal TP4 campaign: 8/8 result, semantic, frozen-input, graph, and trace
  gates passed;
- selected causal traces: all four ranks have exactly 20 expected decode
  annotations and graph launches;
- distributed cold-cache microbench: TP2/4/8, both vocabulary sizes,
  BS1/4/16/64, exact output and fail-closed checks passed.

Exact image:
`registry.mthreads.com/mcconline/inference/vllm@sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`

Hardware: isolated 8x S5000 node, driver `5.2.0-server`; formal run used TP4.

Not run yet: TP8 end-to-end serving, Qwen vocabulary 151936 end-to-end serving,
and the broader dense/MoE regression matrix.  This PR remains Draft for those
review/merge gates.
