### PR TITLE
perf(musa): add registered TP logits gather primitive

### DIFF
--- a/tests/test_musa_jit_registered_all_gather.py
+++ b/tests/test_musa_jit_registered_all_gather.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON_WRAPPER = ROOT / "vllm_musa/jit_kernel/csrc/allreduce.py"
+MUSA_SOURCE = ROOT / "vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu"
+
+
+def _registered_body(source: str) -> str:
+    start = source.index("void vllm_musa_custom_ar_launch_all_gather_registered(")
+    end = source.index(
+        "TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_meta_size",
+        start,
+    )
+    return source[start:end]
+
+
+def test_registered_all_gather_wrapper_exports_ffi_entry() -> None:
+    source = PYTHON_WRAPPER.read_text(encoding="utf-8")
+    ast.parse(source)
+    assert "def launch_all_gather_registered(" in source
+    assert "vllm_musa_custom_ar_launch_all_gather_registered" in source
+
+
+def test_registered_all_gather_reuses_fenced_kernel_without_staging() -> None:
+    source = MUSA_SOURCE.read_text(encoding="utf-8")
+    body = _registered_body(source)
+    assert "musaMemcpyAsync" not in body
+    assert "dispatch_all_gather_world_size" in body
+    assert "TVM_FFI_ICHECK_EQ(data.ptrs[rank], inp.data_ptr())" in body
+    assert "world_size == 2 || world_size == 4 || world_size == 8" in body
+    assert "TVM_FFI_ICHECK_EQ(inp.device().device_id, out.device().device_id)" in body
+    assert "TVM_FFI_ICHECK_GT(inp.size(0), 0)" in body
+    assert "TVM_FFI_ICHECK_GT(inp.size(1), 0)" in body
+
+
+def test_registered_all_gather_keeps_system_scope_fences() -> None:
+    source = MUSA_SOURCE.read_text(encoding="utf-8")
+    assert "cross_device_all_gather_start_barrier" in source
+    assert "cross_device_all_gather_end_barrier" in source
+    assert source.count("__threadfence_system();") >= 4
+    assert "vllm_musa_custom_ar_launch_all_gather_registered," in source

--- a/vllm_musa/jit_kernel/csrc/allreduce.py
+++ b/vllm_musa/jit_kernel/csrc/allreduce.py
@@ -121,3 +121,27 @@ def launch_all_gather(
         int(rank),
         int(world_size),
     )
+
+
+def launch_all_gather_registered(
+    rank_data: torch.Tensor,
+    signal_ptrs_cpu: torch.Tensor,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    rank: int,
+    world_size: int,
+) -> None:
+    """Gather directly from persistent IPC-registered input shards.
+
+    This probe-only entry point deliberately omits the eager staging copy. The
+    caller owns the input tensors and every peer IPC mapping for the full
+    lifetime of the launch.
+    """
+    _custom_ar_module(int(world_size)).vllm_musa_custom_ar_launch_all_gather_registered(
+        rank_data,
+        signal_ptrs_cpu,
+        inp,
+        out,
+        int(rank),
+        int(world_size),
+    )

--- a/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
@@ -653,10 +653,14 @@ void vllm_musa_custom_ar_launch_all_gather_registered(
   // by the alternating replay/rank-skew stress harness.
   CHECK_MUSA_CONTIGUOUS(inp);
   CHECK_MUSA_CONTIGUOUS(out);
+  TVM_FFI_ICHECK(world_size == 2 || world_size == 4 || world_size == 8);
+  TVM_FFI_ICHECK_EQ(inp.device().device_id, out.device().device_id);
+  TVM_FFI_ICHECK_EQ(rank_data.ndim(), 1);
   TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
   TVM_FFI_ICHECK(rank_data.IsContiguous());
   TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
   TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.ndim(), 1);
   TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
   TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
   TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
@@ -664,6 +668,8 @@ void vllm_musa_custom_ar_launch_all_gather_registered(
   TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
   TVM_FFI_ICHECK_EQ(inp.ndim(), 2);
   TVM_FFI_ICHECK_EQ(out.ndim(), 2);
+  TVM_FFI_ICHECK_GT(inp.size(0), 0);
+  TVM_FFI_ICHECK_GT(inp.size(1), 0);
   TVM_FFI_ICHECK_EQ(inp.size(0), out.size(0));
   TVM_FFI_ICHECK_EQ(inp.size(1) * world_size, out.size(1));
   const bool same_dtype = dtype_equal(inp.dtype(), out.dtype());

--- a/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
@@ -640,7 +640,101 @@ void vllm_musa_custom_ar_launch_all_gather(
       << "MUSA custom all-gather kernel failed: " << musaGetErrorString(err);
 }
 
+void vllm_musa_custom_ar_launch_all_gather_registered(
+    ffi::TensorView rank_data,
+    ffi::TensorView signal_ptrs_cpu,
+    ffi::TensorView inp,
+    ffi::TensorView out,
+    int64_t rank,
+    int64_t world_size) {
+  // Probe-only path: the producer allocation must remain live until this
+  // launch.  The existing start barrier provides the system-scope publication
+  // point before peer loads; graph-producer visibility is validated separately
+  // by the alternating replay/rank-skew stress harness.
+  CHECK_MUSA_CONTIGUOUS(inp);
+  CHECK_MUSA_CONTIGUOUS(out);
+  TVM_FFI_ICHECK_EQ(rank_data.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(rank_data.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(rank_data.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(rank_data.size(0), kMaxRanks);
+  TVM_FFI_ICHECK_EQ(signal_ptrs_cpu.device().device_type, kDLCPU);
+  TVM_FFI_ICHECK(signal_ptrs_cpu.IsContiguous());
+  TVM_FFI_ICHECK(dtype_equal(signal_ptrs_cpu.dtype(), dl_int64));
+  TVM_FFI_ICHECK_GE(signal_ptrs_cpu.size(0), world_size);
+  TVM_FFI_ICHECK(rank >= 0 && rank < world_size);
+  TVM_FFI_ICHECK_EQ(inp.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(out.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(inp.size(0), out.size(0));
+  TVM_FFI_ICHECK_EQ(inp.size(1) * world_size, out.size(1));
+  const bool same_dtype = dtype_equal(inp.dtype(), out.dtype());
+  const bool bfloat16_to_float32 =
+      dtype_equal(inp.dtype(), dl_bfloat16) &&
+      dtype_equal(out.dtype(), dl_float32);
+  TVM_FFI_ICHECK(same_dtype || bfloat16_to_float32);
+
+  RankSignals sg{};
+  const auto* signal_ptrs =
+      static_cast<const int64_t*>(signal_ptrs_cpu.data_ptr());
+  for (int i = 0; i < world_size; ++i) {
+    sg.signals[i] = reinterpret_cast<Signal*>(signal_ptrs[i]);
+    TVM_FFI_ICHECK(sg.signals[i] != nullptr);
+  }
+  RankData data{};
+  const auto* rank_ptrs = static_cast<const int64_t*>(rank_data.data_ptr());
+  for (int i = 0; i < kMaxRanks; ++i) {
+    data.ptrs[i] = reinterpret_cast<const void*>(rank_ptrs[i]);
+  }
+  for (int i = 0; i < world_size; ++i) {
+    TVM_FFI_ICHECK(data.ptrs[i] != nullptr);
+  }
+  TVM_FFI_ICHECK_EQ(data.ptrs[rank], inp.data_ptr());
+
+  auto* self_sg = sg.signals[rank];
+  auto stream = get_stream(out.device());
+  const int64_t input_numel = tensor_numel(inp);
+  const int64_t output_numel = tensor_numel(out);
+  TVM_FFI_ICHECK_LE(input_numel,
+                    static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  TVM_FFI_ICHECK_LE(output_numel,
+                    static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+
+  const int rows = static_cast<int>(inp.size(0));
+  const int shard_size = static_cast<int>(inp.size(1));
+  if (bfloat16_to_float32) {
+    dispatch_all_gather_world_size<__mt_bfloat16, float>(
+        data, sg, self_sg, static_cast<float*>(out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
+        stream);
+  } else if (dtype_equal(out.dtype(), dl_float16)) {
+    dispatch_all_gather_world_size<half, half>(
+        data, sg, self_sg, static_cast<half*>(out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
+        stream);
+  } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
+    dispatch_all_gather_world_size<__mt_bfloat16, __mt_bfloat16>(
+        data, sg, self_sg, static_cast<__mt_bfloat16*>(out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
+        stream);
+  } else if (dtype_equal(out.dtype(), dl_float32)) {
+    dispatch_all_gather_world_size<float, float>(
+        data, sg, self_sg, static_cast<float*>(out.data_ptr()),
+        static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
+        stream);
+  } else {
+    TVM_FFI_THROW(ValueError)
+        << "registered custom all-gather only supports same-dtype "
+           "fp16/bf16/fp32 or bf16-to-fp32";
+  }
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA registered custom all-gather kernel failed: "
+      << musaGetErrorString(err);
+}
+
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_meta_size, vllm_musa_custom_ar_meta_size);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_unregistered, vllm_musa_custom_ar_launch_unregistered);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(vllm_musa_custom_ar_launch_all_gather,
                               vllm_musa_custom_ar_launch_all_gather);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    vllm_musa_custom_ar_launch_all_gather_registered,
+    vllm_musa_custom_ar_launch_all_gather_registered);

--- a/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
+++ b/vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu
@@ -673,10 +673,7 @@ void vllm_musa_custom_ar_launch_all_gather_registered(
   TVM_FFI_ICHECK_EQ(inp.size(0), out.size(0));
   TVM_FFI_ICHECK_EQ(inp.size(1) * world_size, out.size(1));
   const bool same_dtype = dtype_equal(inp.dtype(), out.dtype());
-  const bool bfloat16_to_float32 =
-      dtype_equal(inp.dtype(), dl_bfloat16) &&
-      dtype_equal(out.dtype(), dl_float32);
-  TVM_FFI_ICHECK(same_dtype || bfloat16_to_float32);
+  TVM_FFI_ICHECK(same_dtype);
 
   RankSignals sg{};
   const auto* signal_ptrs =
@@ -706,30 +703,25 @@ void vllm_musa_custom_ar_launch_all_gather_registered(
 
   const int rows = static_cast<int>(inp.size(0));
   const int shard_size = static_cast<int>(inp.size(1));
-  if (bfloat16_to_float32) {
-    dispatch_all_gather_world_size<__mt_bfloat16, float>(
-        data, sg, self_sg, static_cast<float*>(out.data_ptr()),
-        static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
-        stream);
-  } else if (dtype_equal(out.dtype(), dl_float16)) {
-    dispatch_all_gather_world_size<half, half>(
+  if (dtype_equal(out.dtype(), dl_float16)) {
+    dispatch_all_gather_world_size<half>(
         data, sg, self_sg, static_cast<half*>(out.data_ptr()),
         static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
         stream);
   } else if (dtype_equal(out.dtype(), dl_bfloat16)) {
-    dispatch_all_gather_world_size<__mt_bfloat16, __mt_bfloat16>(
+    dispatch_all_gather_world_size<__mt_bfloat16>(
         data, sg, self_sg, static_cast<__mt_bfloat16*>(out.data_ptr()),
         static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
         stream);
   } else if (dtype_equal(out.dtype(), dl_float32)) {
-    dispatch_all_gather_world_size<float, float>(
+    dispatch_all_gather_world_size<float>(
         data, sg, self_sg, static_cast<float*>(out.data_ptr()),
         static_cast<int>(rank), static_cast<int>(world_size), rows, shard_size,
         stream);
   } else {
     TVM_FFI_THROW(ValueError)
         << "registered custom all-gather only supports same-dtype "
-           "fp16/bf16/fp32 or bf16-to-fp32";
+           "fp16/bf16/fp32";
   }
   const musaError_t err = musaGetLastError();
   TVM_FFI_ICHECK_EQ(err, musaSuccess)


### PR DESCRIPTION
## Production blocker (Round 17D/E)

Keep this PR **probe-only**. Do not wire this entry into serving or treat the
microbenchmark as a shipping claim.

An exact Qwen3.5-27B-BF16 TP2 serving A/B on 2 x S5000, driver
5.2.0-server, found a deterministic semantic mismatch:

| Path | Greedy semantic result |
|---|---|
| staged control | length 7, SHA256 `65bb46ed...`, content `Beijing` |
| registered candidate | length 56, SHA256 `d740d7ba...` |
| registered candidate + global producer sync | same length 56 / `d740d7ba...` |
| registered entry invoked but staged result returned | restored `Beijing` |

In the real logits path, simultaneously computed registered and staged outputs
were not equal: max absolute differences were about 3.46 and 3.43 on ranks 0
and 1 for shape `(64, 248320)`. CUDAGraph `NONE` reproduced the mismatch, so
this is not a graph-capture-only issue. The standalone synthetic primitive
probe remains bitwise equal, including registered-before-reference and
registered-versus-staged schedules; it is therefore insufficient to prove
production safety. The kernel source also labels this entry as a probe-only
path.

No end-to-end performance result is accepted, and no production integration
will be proposed from this primitive until the real-tensor correctness gap is
root-caused and fixed.

## Summary

This stacked draft adds a graph-external registered-pointer entry for the MUSA
JIT TP all-gather. The new entry reuses the existing fenced all-gather kernel
but reads each rank's persistent producer buffer directly, so it does not issue
the staging `musaMemcpyAsync` used by the current eager path.

The API is deliberately low-level and same-dtype on this stack. It validates
the supported 2/4/8 world sizes, CPU pointer metadata, rank, shape, dtype,
device, pointer identity, and int32 launch bounds before dispatch.

This PR is stacked on #127 (`perf/musa-60043-logits-graph-gap`). It should be
retargeted to `v0.24.0-dev` after #127 is merged. BF16-to-FP32 logits support is
owned by the later #135 stack and will be reconciled after that merge rather
than duplicated here.

## Round 17C microbenchmark evidence

Probe shape: TP2, BS64, hidden 5120, global vocab 248320, BF16, 2 x S5000,
driver 5.2.0-server, exact image digest
`sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`.
Timing uses max-rank MUSA events, interleaving, and an 8-GiB L2 flush.

| Full-tail variant | Mean (us) | p50 (us) |
|---|---:|---:|
| `F.linear + staged gather` | 1653.583 | 1643.600 |
| `mm(out=) + staged gather` | 1664.249 | 1648.140 |
| `mm(out=) + registered gather` | 1637.864 | 1636.420 |

Paired registered-versus-current deltas were -15.719 us mean and -27.240 us
p50. Registered-versus-fixed-output-staged deltas were -26.385 us mean and
-20.260 us p50. Gather-only mean improved by 43.279 us.

The isolated primitive probes passed changing-pattern, rank-skew, pointer
lifetime, exact BF16 reference, and copy-ledger checks. Round 17D/E proves
those probes do not cover the production failure above.

## Validation

- `python -m pytest -q tests/test_musa_jit_registered_all_gather.py` — 3 passed
- `ruff check` and `ruff format --check` on touched Python files — passed
- exact-image no-GPU mp31 JIT compile/link —
  `R17C_DRAFT_PR_JIT_BUILDCHECK_PASS`
- Qwen3.5 production serving integration — rejected on semantic correctness

## Draft status

This remains a low-level experimental primitive. No merge or production use is
requested while the Round 17D/E correctness blocker is open.
