### PR TITLE
perf(musa): sample unfiltered Qwen logits with Gumbel

### DIFF
--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -157,13 +157,16 @@ def _gumbel_gate_sampler(
     )
 
 
-def _unfiltered_gumbel_gate_sampler(rows: int, vocab_size: int = 151936):
+def _unfiltered_gumbel_gate_sampler(
+    rows: int, vocab_size: int = 151936
+) -> SimpleNamespace:
     states = SimpleNamespace(
         temperature=_state_array([1.0] * rows, torch.float32),
         top_k=_state_array([vocab_size] * rows, torch.int32),
         top_p=_state_array([1.0] * rows, torch.float32),
         min_p=_state_array([0.0] * rows, torch.float32),
         seeds=SimpleNamespace(gpu=object()),
+        has_user_seed=np.zeros(rows, dtype=np.bool_),
     )
     return SimpleNamespace(
         sampling_states=states,
@@ -447,7 +450,7 @@ def test_qwen_v2_gumbel_gate_is_disabled_by_default(monkeypatch) -> None:
 def test_qwen_v2_unfiltered_gumbel_gate_accepts_exact_contract(
     monkeypatch, vocab_size: int
 ) -> None:
-    monkeypatch.setenv("VLLM_MUSA_QWEN_UNFILTERED_GUMBEL", "1")
+    monkeypatch.setattr(sampler, "_MUSA_QWEN_UNFILTERED_GUMBEL_ENABLED", True)
     monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
     monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
     rows = 2
@@ -464,7 +467,7 @@ def test_qwen_v2_unfiltered_gumbel_gate_accepts_exact_contract(
 
 
 def test_qwen_v2_unfiltered_gumbel_gate_rejects_noncontract(monkeypatch) -> None:
-    monkeypatch.setenv("VLLM_MUSA_QWEN_UNFILTERED_GUMBEL", "1")
+    monkeypatch.setattr(sampler, "_MUSA_QWEN_UNFILTERED_GUMBEL_ENABLED", True)
     monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
     monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
     rows = 2
@@ -507,6 +510,14 @@ def test_qwen_v2_unfiltered_gumbel_gate_rejects_noncontract(monkeypatch) -> None
     rejected.append((value, False))
 
     value = _unfiltered_gumbel_gate_sampler(rows)
+    value.sampling_states.has_user_seed[0] = True
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    del value.sampling_states.has_user_seed
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
     rejected.append((value, True))
 
     for candidate, return_logprobs in rejected:
@@ -520,8 +531,10 @@ def test_qwen_v2_unfiltered_gumbel_gate_rejects_noncontract(monkeypatch) -> None
         )
 
 
-def test_qwen_v2_unfiltered_gumbel_gate_is_disabled_by_default(monkeypatch) -> None:
-    monkeypatch.delenv("VLLM_MUSA_QWEN_UNFILTERED_GUMBEL", raising=False)
+def test_qwen_v2_unfiltered_gumbel_gate_rejects_cached_disabled_flag(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(sampler, "_MUSA_QWEN_UNFILTERED_GUMBEL_ENABLED", False)
     rows = 1
     mapping = torch.zeros(rows, dtype=torch.int64)
 

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -157,6 +157,27 @@ def _gumbel_gate_sampler(
     )
 
 
+def _unfiltered_gumbel_gate_sampler(rows: int, vocab_size: int = 151936):
+    states = SimpleNamespace(
+        temperature=_state_array([1.0] * rows, torch.float32),
+        top_k=_state_array([vocab_size] * rows, torch.int32),
+        top_p=_state_array([1.0] * rows, torch.float32),
+        min_p=_state_array([0.0] * rows, torch.float32),
+        seeds=SimpleNamespace(gpu=object()),
+    )
+    return SimpleNamespace(
+        sampling_states=states,
+        num_speculative_tokens=1,
+        use_fp64_gumbel=False,
+        logprobs_mode="raw_logprobs",
+        logit_bias_state=SimpleNamespace(use_logit_bias=np.zeros(rows, dtype=np.bool_)),
+        penalties_state=SimpleNamespace(use_penalty=np.zeros(rows, dtype=np.bool_)),
+        bad_words_state=SimpleNamespace(
+            num_bad_words=SimpleNamespace(np=np.zeros(rows, dtype=np.int32))
+        ),
+    )
+
+
 class _FakeGenerator:
     def __init__(
         self,
@@ -420,6 +441,138 @@ def test_qwen_v2_gumbel_gate_is_disabled_by_default(monkeypatch) -> None:
         mapping,
         False,
     )
+
+
+@pytest.mark.parametrize("vocab_size", [151936, 248320])
+def test_qwen_v2_unfiltered_gumbel_gate_accepts_exact_contract(
+    monkeypatch, vocab_size: int
+) -> None:
+    monkeypatch.setenv("VLLM_MUSA_QWEN_UNFILTERED_GUMBEL", "1")
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    rows = 2
+    mapping = torch.arange(rows, dtype=torch.int64)
+
+    assert sampler.can_use_qwen_v2_unfiltered_gumbel(
+        _unfiltered_gumbel_gate_sampler(rows, vocab_size),
+        torch.empty((rows, vocab_size), dtype=torch.bfloat16),
+        mapping,
+        np.arange(rows, dtype=np.int64),
+        mapping,
+        False,
+    )
+
+
+def test_qwen_v2_unfiltered_gumbel_gate_rejects_noncontract(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_MUSA_QWEN_UNFILTERED_GUMBEL", "1")
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    rows = 2
+    mapping = torch.arange(rows, dtype=torch.int64)
+    mapping_np = np.arange(rows, dtype=np.int64)
+    logits = torch.empty((rows, 151936), dtype=torch.bfloat16)
+
+    rejected = []
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    value.sampling_states.temperature.np[0] = 0.8
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    value.sampling_states.top_k.np[0] = 50
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    value.sampling_states.top_p.np[0] = 0.9
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    value.sampling_states.min_p.np[0] = 0.05
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    value.logit_bias_state.use_logit_bias[0] = True
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    value.penalties_state.use_penalty[0] = True
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    value.bad_words_state.num_bad_words.np[0] = 1
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    value.num_speculative_tokens = 2
+    rejected.append((value, False))
+
+    value = _unfiltered_gumbel_gate_sampler(rows)
+    rejected.append((value, True))
+
+    for candidate, return_logprobs in rejected:
+        assert not sampler.can_use_qwen_v2_unfiltered_gumbel(
+            candidate,
+            logits,
+            mapping,
+            mapping_np,
+            mapping,
+            return_logprobs,
+        )
+
+
+def test_qwen_v2_unfiltered_gumbel_gate_is_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_MUSA_QWEN_UNFILTERED_GUMBEL", raising=False)
+    rows = 1
+    mapping = torch.zeros(rows, dtype=torch.int64)
+
+    assert not sampler.can_use_qwen_v2_unfiltered_gumbel(
+        _unfiltered_gumbel_gate_sampler(rows),
+        torch.empty((rows, 151936), dtype=torch.bfloat16),
+        mapping,
+        np.zeros(rows, dtype=np.int64),
+        mapping,
+        False,
+    )
+
+
+def test_qwen_v2_unfiltered_gumbel_uses_existing_seed_state(monkeypatch) -> None:
+    sentinel = torch.tensor([7, 11])
+    temperature = object()
+    seeds = object()
+    worker = SimpleNamespace(
+        sampling_states=SimpleNamespace(
+            temperature=SimpleNamespace(gpu=temperature),
+            seeds=SimpleNamespace(gpu=seeds),
+        )
+    )
+    logits = torch.empty((2, 151936), dtype=torch.bfloat16)
+    idx_mapping = torch.arange(2)
+    positions = torch.arange(2)
+    captured = {}
+
+    def fake_gumbel(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr(sampler.vllm_worker_sampler, "gumbel_sample", fake_gumbel)
+    sampled, processed_logits = sampler.sample_worker_logits_qwen_v2_unfiltered_gumbel(
+        worker, logits, idx_mapping, positions
+    )
+
+    assert sampled is sentinel
+    assert processed_logits is logits
+    assert captured["args"] == (
+        logits,
+        idx_mapping,
+        temperature,
+        seeds,
+        positions,
+    )
+    assert captured["kwargs"] == {
+        "apply_temperature": False,
+        "use_fp64": False,
+    }
 
 
 def test_uniform_active_min_p_uses_cpu_state() -> None:

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -220,6 +220,157 @@ def _legacy_gumbel_metadata(rows: int, **kwargs) -> SimpleNamespace:
     )
 
 
+class MinPLogitsProcessor:
+    def __init__(self) -> None:
+        self.min_p_count = 0
+
+
+class LogitBiasLogitsProcessor:
+    def __init__(self) -> None:
+        self.biases = {}
+
+
+class MinTokensLogitsProcessor:
+    def __init__(self) -> None:
+        self.min_toks = {}
+
+
+def _legacy_unfiltered_metadata(rows: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        all_random=True,
+        all_greedy=False,
+        uniform_temperature=1.0,
+        top_k=None,
+        top_p=None,
+        generators={},
+        max_num_logprobs=None,
+        logprob_token_ids=None,
+        no_penalties=True,
+        allowed_token_ids_mask=None,
+        bad_words_token_ids={},
+        spec_token_ids=[[] for _ in range(rows)],
+        thinking_budget_state_holder=None,
+        logitsprocs=SimpleNamespace(
+            argmax_invariant=[MinPLogitsProcessor()],
+            non_argmax_invariant=[
+                LogitBiasLogitsProcessor(),
+                MinTokensLogitsProcessor(),
+            ],
+        ),
+    )
+
+
+@pytest.mark.parametrize("vocab_size", [151936, 248320])
+def test_qwen_legacy_unfiltered_gumbel_gate_accepts_exact_contract(
+    monkeypatch, vocab_size: int
+) -> None:
+    monkeypatch.setattr(sampler, "_MUSA_QWEN_UNFILTERED_GUMBEL_ENABLED", True)
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+
+    assert sampler.can_use_qwen_legacy_unfiltered_gumbel(
+        torch.empty((2, vocab_size), dtype=torch.bfloat16),
+        _legacy_unfiltered_metadata(2),
+        "raw_logprobs",
+        False,
+        False,
+    )
+
+
+def test_qwen_legacy_unfiltered_gumbel_gate_fails_closed(monkeypatch) -> None:
+    monkeypatch.setattr(sampler, "_MUSA_QWEN_UNFILTERED_GUMBEL_ENABLED", True)
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    logits = torch.empty((2, 248320), dtype=torch.bfloat16)
+
+    rejected = []
+    value = _legacy_unfiltered_metadata(2)
+    value.uniform_temperature = 0.8
+    rejected.append(value)
+    value = _legacy_unfiltered_metadata(2)
+    value.top_k = torch.full((2,), 50)
+    rejected.append(value)
+    value = _legacy_unfiltered_metadata(2)
+    value.generators = {0: _FakeGenerator(1)}
+    rejected.append(value)
+    value = _legacy_unfiltered_metadata(2)
+    value.no_penalties = False
+    rejected.append(value)
+    value = _legacy_unfiltered_metadata(2)
+    value.logitsprocs.non_argmax_invariant[0].biases[0] = {1: 1.0}
+    rejected.append(value)
+    value = _legacy_unfiltered_metadata(2)
+    value.logitsprocs.argmax_invariant[0].min_p_count = 1
+    rejected.append(value)
+    value = _legacy_unfiltered_metadata(2)
+    value.logitsprocs.argmax_invariant.append(SimpleNamespace())
+    rejected.append(value)
+    value = _legacy_unfiltered_metadata(2)
+    value.spec_token_ids[0] = [1]
+    rejected.append(value)
+
+    for metadata in rejected:
+        assert not sampler.can_use_qwen_legacy_unfiltered_gumbel(
+            logits, metadata, "raw_logprobs", False, False
+        )
+    assert not sampler.can_use_qwen_legacy_unfiltered_gumbel(
+        logits, _legacy_unfiltered_metadata(2), "raw_logprobs", True, False
+    )
+    assert not sampler.can_use_qwen_legacy_unfiltered_gumbel(
+        logits, _legacy_unfiltered_metadata(2), "raw_logprobs", False, True
+    )
+    assert not sampler.can_use_qwen_legacy_unfiltered_gumbel(
+        logits, _legacy_unfiltered_metadata(2), "processed_logits", False, False
+    )
+    assert not sampler.can_use_qwen_legacy_unfiltered_gumbel(
+        logits.float(),
+        _legacy_unfiltered_metadata(2),
+        "raw_logprobs",
+        False,
+        False,
+    )
+
+
+def test_qwen_legacy_unfiltered_gumbel_advances_private_stream(monkeypatch) -> None:
+    rows = 4
+    logits = torch.empty((rows, 151936), dtype=torch.bfloat16)
+    generator = _FakeGenerator(60043, offset=8, device=logits.device)
+    fake_sampler = SimpleNamespace(_musa_qwen_unfiltered_generator=generator)
+    calls = []
+
+    def fake_gumbel(*args, **kwargs):
+        calls.append(
+            (
+                tuple(
+                    value.clone() if isinstance(value, torch.Tensor) else value
+                    for value in args
+                ),
+                kwargs,
+            )
+        )
+        return torch.arange(rows, dtype=torch.int64)
+
+    monkeypatch.setattr(sampler.vllm_worker_sampler, "gumbel_sample", fake_gumbel)
+    first = sampler.sample_qwen_legacy_unfiltered_gumbel(fake_sampler, logits)
+    second = sampler.sample_qwen_legacy_unfiltered_gumbel(fake_sampler, logits)
+
+    assert first.tolist() == second.tolist() == [0, 1, 2, 3]
+    assert calls[0][0][1].tolist() == [0, 0, 0, 0]
+    assert calls[0][0][2].tolist() == [1.0]
+    assert calls[0][0][3].tolist() == [60043]
+    assert calls[0][0][4].tolist() == [2, 3, 4, 5]
+    assert calls[1][0][4].tolist() == [6, 7, 8, 9]
+    assert (
+        calls[0][1]
+        == calls[1][1]
+        == {
+            "apply_temperature": False,
+            "use_fp64": False,
+        }
+    )
+    assert generator.get_offset() == 40
+
+
 def test_qwen_legacy_gumbel_gate_and_generator_handoff(monkeypatch) -> None:
     monkeypatch.setenv("VLLM_MUSA_QWEN_LEGACY_GUMBEL", "1")
     monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -92,6 +92,7 @@ class Envs:
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SEEDED_MULTINOMIAL = EnvBool(True)
     VLLM_MUSA_QWEN_V2_GUMBEL = EnvBool(False)
+    VLLM_MUSA_QWEN_UNFILTERED_GUMBEL = EnvBool(False)
     VLLM_MUSA_QWEN_LEGACY_GUMBEL = EnvBool(False)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
     # Exact-shape Qwen2 RoPE+NHD-cache fusion.  The model, graph, dtype, and

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -451,6 +451,152 @@ def _call_topk_topp_sampler(
         sampler.logprobs_mode = original_logprobs_mode
 
 
+def _legacy_logits_processors_are_inactive(sampling_metadata: Any) -> bool:
+    logitsprocs = getattr(sampling_metadata, "logitsprocs", None)
+    if logitsprocs is None:
+        return False
+    for group_name in ("non_argmax_invariant", "argmax_invariant"):
+        processors = getattr(logitsprocs, group_name, None)
+        if processors is None:
+            return False
+        for processor in processors:
+            name = processor.__class__.__name__
+            if name == "MinPLogitsProcessor":
+                if getattr(processor, "min_p_count", None) != 0:
+                    return False
+            elif name == "LogitBiasLogitsProcessor":
+                biases = getattr(processor, "biases", None)
+                if biases is None or biases:
+                    return False
+            elif name == "MinTokensLogitsProcessor":
+                min_toks = getattr(processor, "min_toks", None)
+                if min_toks is None or min_toks:
+                    return False
+            else:
+                return False
+    return True
+
+
+def can_use_qwen_legacy_unfiltered_gumbel(
+    logits: torch.Tensor,
+    sampling_metadata: Any,
+    logprobs_mode: LogprobsMode,
+    predict_bonus_token: bool,
+    use_fp64_gumbel: bool,
+) -> bool:
+    """Gate raw-logits Gumbel for Qwen models on the legacy GPU runner."""
+    if not musa_qwen_unfiltered_gumbel_enabled():
+        return False
+    if not current_platform.is_musa() or not is_musa_tensor(logits):
+        return False
+    if (
+        logits.dtype != torch.bfloat16
+        or logits.shape[0] == 0
+        or not _is_qwen_sampler_vocab(logits)
+        or logits.stride(-1) != 1
+    ):
+        return False
+    if predict_bonus_token or use_fp64_gumbel or logprobs_mode != "raw_logprobs":
+        return False
+    if (
+        not getattr(sampling_metadata, "all_random", False)
+        or getattr(sampling_metadata, "all_greedy", True)
+        or getattr(sampling_metadata, "uniform_temperature", None) != np.float32(1.0)
+    ):
+        return False
+    if (
+        getattr(sampling_metadata, "top_k", object()) is not None
+        or getattr(sampling_metadata, "top_p", object()) is not None
+        or getattr(sampling_metadata, "generators", None) != {}
+    ):
+        return False
+    if (
+        getattr(sampling_metadata, "max_num_logprobs", object()) is not None
+        or getattr(sampling_metadata, "logprob_token_ids", None)
+        or getattr(sampling_metadata, "no_penalties", False) is not True
+        or getattr(sampling_metadata, "allowed_token_ids_mask", object()) is not None
+        or getattr(sampling_metadata, "bad_words_token_ids", None) != {}
+    ):
+        return False
+
+    spec_token_ids = getattr(sampling_metadata, "spec_token_ids", None)
+    if spec_token_ids and any(spec_token_ids):
+        return False
+    holder = getattr(sampling_metadata, "thinking_budget_state_holder", None)
+    if holder is not None:
+        has_tracked_requests = getattr(holder, "has_tracked_requests", None)
+        if not callable(has_tracked_requests) or has_tracked_requests():
+            return False
+    return _legacy_logits_processors_are_inactive(sampling_metadata)
+
+
+def _get_qwen_legacy_unfiltered_generator(
+    sampler: Any, logits: torch.Tensor
+) -> torch.Generator | None:
+    generator = getattr(sampler, "_musa_qwen_unfiltered_generator", None)
+    if generator is None:
+        seed = int(torch.musa.initial_seed())
+        if seed < 0 or seed > np.iinfo(np.int64).max:
+            return None
+        generator = torch.Generator(device=logits.device)
+        generator.manual_seed(seed)
+        sampler._musa_qwen_unfiltered_generator = generator
+    if getattr(getattr(generator, "device", None), "type", None) != logits.device.type:
+        return None
+    return generator
+
+
+def sample_qwen_legacy_unfiltered_gumbel(
+    sampler: Any, logits: torch.Tensor
+) -> torch.Tensor | None:
+    """Sample raw Qwen logits while advancing one private Philox stream."""
+    generator = _get_qwen_legacy_unfiltered_generator(sampler, logits)
+    if generator is None:
+        return None
+    generator_state = get_qwen_legacy_generator_state({0: generator}, 1)
+    if generator_state is None:
+        return None
+    seeds_cpu, offsets_cpu = generator_state
+    seed = seeds_cpu[0]
+    offset = offsets_cpu[0]
+    rows = logits.shape[0]
+    next_offset = offset + 4 * rows
+    if next_offset > np.iinfo(np.int64).max:
+        return None
+
+    buffers = getattr(sampler, "_musa_qwen_unfiltered_buffers", None)
+    if buffers is None:
+        buffers = {}
+        sampler._musa_qwen_unfiltered_buffers = buffers
+    entry = buffers.get(rows)
+    if entry is None:
+        entry = (
+            torch.zeros(rows, dtype=torch.int32, device=logits.device),
+            torch.ones(1, dtype=torch.float32, device=logits.device),
+            torch.tensor([seed], dtype=torch.int64, device=logits.device),
+            torch.empty(rows, dtype=torch.int64, device=logits.device),
+        )
+        buffers[rows] = entry
+    mapping, temperature, seeds, positions = entry
+    torch.arange(offset // 4, offset // 4 + rows, out=positions)
+    sampled = vllm_worker_sampler.gumbel_sample(
+        logits,
+        mapping,
+        temperature,
+        seeds,
+        positions,
+        apply_temperature=False,
+        use_fp64=False,
+    )
+    try:
+        generator.set_offset(next_offset)
+    except (RuntimeError, TypeError, ValueError) as error:
+        raise RuntimeError(
+            "Failed to advance the legacy-runner unfiltered Gumbel generator"
+        ) from error
+    return sampled
+
+
 def can_use_qwen_legacy_gumbel(
     logits: torch.Tensor,
     sampling_metadata: Any,
@@ -687,6 +833,24 @@ def _sampler_forward(
     logprobs_mode_override: LogprobsMode | None = None,
 ) -> Any:
     original_forward = vllm_sample_sampler.Sampler._musa_original_forward
+    if logprobs_mode_override is None and can_use_qwen_legacy_unfiltered_gumbel(
+        logits,
+        sampling_metadata,
+        self.logprobs_mode,
+        predict_bonus_token,
+        self.use_fp64_gumbel,
+    ):
+        sampled = sample_qwen_legacy_unfiltered_gumbel(self, logits)
+        if sampled is not None:
+            vllm_topk_topp_sampler.logger.info_once(
+                "Using the gated MUSA legacy-runner unfiltered Gumbel sampler "
+                "for Qwen requests.",
+                scope="global",
+            )
+            return vllm_sample_sampler.SamplerOutput(
+                sampled_token_ids=sampled.to(torch.int32).unsqueeze(-1),
+                logprobs_tensors=None,
+            )
     if logprobs_mode_override is None:
         return original_forward(
             self, logits, sampling_metadata, predict_bonus_token, logprobs_mode_override

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 _SAMPLING_EPS = 1e-5
 _MUSA_QWEN_SAMPLER_VOCAB_SIZES = frozenset((151936, 248320))
+_MUSA_QWEN_UNFILTERED_GUMBEL_ENABLED = envs.VLLM_MUSA_QWEN_UNFILTERED_GUMBEL.get()
 
 
 def _is_qwen_sampler_vocab(logits: torch.Tensor) -> bool:
@@ -61,7 +62,7 @@ def musa_qwen_v2_gumbel_enabled() -> bool:
 
 
 def musa_qwen_unfiltered_gumbel_enabled() -> bool:
-    return envs.VLLM_MUSA_QWEN_UNFILTERED_GUMBEL.get()
+    return _MUSA_QWEN_UNFILTERED_GUMBEL_ENABLED
 
 
 def musa_qwen_legacy_gumbel_enabled() -> bool:
@@ -794,6 +795,8 @@ def can_use_qwen_v2_unfiltered_gumbel(
         return False
 
     states = sampler.sampling_states
+    if has_worker_user_seed(states, idx_mapping_np):
+        return False
     if not (
         np.all(states.temperature.np[idx_mapping_np] == np.float32(1.0))
         and np.all(states.top_k.np[idx_mapping_np] == logits.shape[1])
@@ -1041,7 +1044,7 @@ def _apply_worker_sampling_filters_for_seeded_multinomial(
     return logits
 
 
-def _worker_sample(
+def _worker_sample_unfiltered_gumbel(
     self: Any,
     logits: torch.Tensor,
     expanded_idx_mapping: torch.Tensor,
@@ -1070,6 +1073,28 @@ def _worker_sample(
             pos,
         )
 
+    return _worker_sample(
+        self,
+        logits,
+        expanded_idx_mapping,
+        idx_mapping_np,
+        pos,
+        input_ids,
+        expanded_local_pos,
+        return_logprobs=return_logprobs,
+    )
+
+
+def _worker_sample(
+    self: Any,
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    idx_mapping_np: np.ndarray,
+    pos: torch.Tensor,
+    input_ids: torch.Tensor,
+    expanded_local_pos: torch.Tensor,
+    return_logprobs: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
     if can_use_qwen_v2_gumbel(
         self,
         logits,
@@ -1182,7 +1207,11 @@ def install_hooks() -> None:
     worker_cls = vllm_worker_sampler.Sampler
     if not getattr(worker_cls, "_musa_sampling_hooks_installed", False):
         worker_cls._musa_original_sample = worker_cls.sample
-        worker_cls.sample = _worker_sample
+        worker_cls.sample = (
+            _worker_sample_unfiltered_gumbel
+            if _MUSA_QWEN_UNFILTERED_GUMBEL_ENABLED
+            else _worker_sample
+        )
         worker_cls._musa_sampling_hooks_installed = True
 
 

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -60,6 +60,10 @@ def musa_qwen_v2_gumbel_enabled() -> bool:
     return envs.VLLM_MUSA_QWEN_V2_GUMBEL.get()
 
 
+def musa_qwen_unfiltered_gumbel_enabled() -> bool:
+    return envs.VLLM_MUSA_QWEN_UNFILTERED_GUMBEL.get()
+
+
 def musa_qwen_legacy_gumbel_enabled() -> bool:
     return envs.VLLM_MUSA_QWEN_LEGACY_GUMBEL.get()
 
@@ -754,6 +758,62 @@ def can_use_qwen_v2_gumbel(
     return bool(np.all(states.min_p.np[idx_mapping_np] == np.float32(0.05)))
 
 
+def can_use_qwen_v2_unfiltered_gumbel(
+    sampler: Any,
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    idx_mapping_np: np.ndarray,
+    pos: torch.Tensor,
+    return_logprobs: bool,
+) -> bool:
+    """Gate direct logits-domain Gumbel to an unfiltered Qwen contract."""
+    if not musa_qwen_unfiltered_gumbel_enabled():
+        return False
+    if not current_platform.is_musa() or not is_musa_tensor(logits):
+        return False
+    if (
+        logits.dtype != torch.bfloat16
+        or not _is_qwen_sampler_vocab(logits)
+        or logits.stride(-1) != 1
+    ):
+        return False
+    if idx_mapping_np.ndim != 1 or logits.shape[0] != idx_mapping_np.size:
+        return False
+    if (
+        expanded_idx_mapping.ndim != 1
+        or expanded_idx_mapping.numel() != logits.shape[0]
+    ):
+        return False
+    if pos.ndim != 1 or pos.numel() != logits.shape[0]:
+        return False
+    if getattr(sampler, "num_speculative_tokens", 1) != 1:
+        return False
+    if sampler.use_fp64_gumbel or sampler.logprobs_mode != "raw_logprobs":
+        return False
+    if return_logprobs:
+        return False
+
+    states = sampler.sampling_states
+    if not (
+        np.all(states.temperature.np[idx_mapping_np] == np.float32(1.0))
+        and np.all(states.top_k.np[idx_mapping_np] == logits.shape[1])
+        and np.all(states.top_p.np[idx_mapping_np] == np.float32(1.0))
+        and np.all(states.min_p.np[idx_mapping_np] == np.float32(0.0))
+    ):
+        return False
+
+    use_logit_bias = getattr(sampler.logit_bias_state, "use_logit_bias", None)
+    use_penalty = getattr(sampler.penalties_state, "use_penalty", None)
+    num_bad_words = getattr(sampler.bad_words_state, "num_bad_words", None)
+    if use_logit_bias is None or use_penalty is None or num_bad_words is None:
+        return False
+    return bool(
+        not np.any(use_logit_bias[idx_mapping_np])
+        and not np.any(use_penalty[idx_mapping_np])
+        and not np.any(num_bad_words.np[idx_mapping_np])
+    )
+
+
 def can_use_worker_seeded_multinomial(
     logits: torch.Tensor,
     logprobs_mode: LogprobsMode,
@@ -870,6 +930,25 @@ def sample_worker_logits_qwen_v2_gumbel(
     return sampled, processed_logits
 
 
+def sample_worker_logits_qwen_v2_unfiltered_gumbel(
+    sampler: Any,
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    pos: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sample unfiltered categorical Qwen logits without materializing probs."""
+    sampled = vllm_worker_sampler.gumbel_sample(
+        logits,
+        expanded_idx_mapping,
+        sampler.sampling_states.temperature.gpu,
+        sampler.sampling_states.seeds.gpu,
+        pos,
+        apply_temperature=False,
+        use_fp64=False,
+    )
+    return sampled, logits
+
+
 def _sampling_states_init(self: Any, max_num_reqs: int, vocab_size: int):
     original_init = vllm_worker_states.SamplingStates._musa_original_init
     original_init(self, max_num_reqs, vocab_size)
@@ -972,6 +1051,25 @@ def _worker_sample(
     expanded_local_pos: torch.Tensor,
     return_logprobs: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if can_use_qwen_v2_unfiltered_gumbel(
+        self,
+        logits,
+        expanded_idx_mapping,
+        idx_mapping_np,
+        pos,
+        return_logprobs,
+    ):
+        vllm_topk_topp_sampler.logger.info_once(
+            "Using the gated MUSA unfiltered Gumbel sampler for Qwen requests.",
+            scope="global",
+        )
+        return sample_worker_logits_qwen_v2_unfiltered_gumbel(
+            self,
+            logits,
+            expanded_idx_mapping,
+            pos,
+        )
+
     if can_use_qwen_v2_gumbel(
         self,
         logits,


### PR DESCRIPTION
## Summary

- add a default-off Qwen fast path for the unfiltered sampling contract
  (`temperature=1`, `top_p=1`, inactive `top_k`, `min_p=0`)
- sample directly from BF16 logits with the existing worker Gumbel kernel instead
  of materializing FP32 probabilities and running full-vocabulary softmax
- cover both vLLM GPU runners used by the Qwen family: the newer worker sampler
  used by Qwen3 dense models and the legacy sampler used by Qwen3.5 hybrid
  models
- install the newer worker wrapper only when
  `VLLM_MUSA_QWEN_UNFILTERED_GUMBEL=1`; the legacy hook is already installed for
  existing MUSA sampling paths and its new branch returns at the cached flag
  check when disabled
- fail closed for processors, explicit user seeds, speculative decoding,
  logprobs, non-BF16 logits, non-contiguous vocab dimensions, and vocabularies
  outside the validated Qwen sizes (151936 and 248320)

This PR is stacked on #134.

## Correctness

- explicit user seeds are rejected so the optimized unseeded stream cannot
  perturb the generator-based seeded path
- the legacy runner owns a private MUSA Philox generator, advances it by four
  offsets per sampled row, caches only device buffers, and fails closed if the
  seed/offset cannot be represented safely
- unseeded categorical equivalence was checked with 8192 rows over a 128-token
  distribution: total-variation distance 0.040-0.042 and maximum absolute
  frequency error 0.003-0.004; identical seed state replays bitwise
- the real legacy-runner path passed a two-step 8192-row replay/distribution
  gate: bitwise replay, distinct consecutive draws, final offset 65536, TV
  0.0466, and maximum frequency error 0.00256
- targeted sampler tests cover both Qwen vocabulary sizes and reject active
  temperature/top-k/top-p/min-p, processors, speculative decoding, logprobs,
  explicit seeds, and missing seed metadata

## Performance evidence

Environment: one MTT S5000 (MP31), driver 5.2.0-server, BF16 Qwen3-8B TP1,
FlashAttention 3, normal compile plus `FULL_AND_PIECEWISE` graph capture, fixed
4096/1024 workload, exact image digest
`sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`.

Formal fresh-server A-B-B-A, three profiler-off repetitions per leg:

| batch | control mean TPOT | candidate mean TPOT | TPOT delta | output throughput delta |
|---:|---:|---:|---:|---:|
| 1 | 15.6061 ms | 15.4244 ms | **-1.164%** | **+1.164%** |
| 4 | 18.2533 ms | 18.0008 ms | **-1.383%** | **+1.373%** |
| 16 | 25.3793 ms | 25.1903 ms | **-0.745%** | **+0.711%** |
| 64 | 51.0272 ms | 51.0318 ms | +0.009% | -0.015% |

Both adjacent pairs were positive at BS1, BS4, and BS16. BS1 and BS4 had 6/6
positive profiler-off repetitions; BS16 had 5/6, with one `+0.200%` rep but a
positive aggregate and pair deltas of `-0.406%` and `-1.083%` mean TPOT.
BS64 was neutral: one pair was `+0.137%` and the other `-0.119%`, so no BS64
serving win is claimed.

The 20-step trace causality gate passed at every batch size. At BS1 the
logits-to-sampling wall interval fell from about 82.3 us to 24.5 us; at BS64
it fell from about 145.5 us to 19.6 us. In every candidate trace, 20/20
BF16-to-FP32 casts and softmax calls disappeared and 20/20 Gumbel calls were
present.

Three-seed randomized cold-cache operator measurements were positive at every
tested batch size (1/4/16/64), removing roughly 0.17-0.22 ms from the
unfiltered sampling path per step.

Qwen3.5-2B exercises the other 248320-vocabulary/legacy-runner path. A separate
fresh-server A-B-B-A at BS1 produced:

| model / runner | control mean TPOT | candidate mean TPOT | TPOT delta | output throughput delta |
|---|---:|---:|---:|---:|
| Qwen3.5-2B / legacy | 6.9228 ms | 6.6554 ms | **-3.863%** | **+3.999%** |

Both adjacent pairs were positive (`-3.955%` and `-3.771%` mean TPOT), and all
6/6 profiler-off repetitions were positive (`-3.62%` to `-4.06%`).

The exact-image `torch_musa` profiler produced runtime-only traces on two fresh
S5000 leases, so those traces were rejected instead of being used as device
evidence. A task-local MUPTI activity trace was then signal-gated around a
compiled/captured legacy-runner request with the same sampling contract. Normalized per sampling iteration, the
device sampling tail fell from 335.4 us to 57.7 us (`-82.8%` wall time). The
control contained 20/20 large-vocabulary BF16-to-FP32 casts, softmax calls, and
top-p sampling kernels; the candidate contained none of them and used one
Gumbel/argmax/gather sequence per iteration.

## Validation

- `ruff format --check` / `ruff check`: pass
- `python -m compileall`: pass
- targeted sampler/source tests: 45 passed on MUSA
- flag-off and flag-on fresh-process hook selection: pass
- exact task-local source/archive comparison and source-path receipt: pass
- BS1/BS4/BS16/BS64 semantic smoke, frozen input vector, 20-step trace, and
  profiler-off result gates: pass
- Qwen3.5-2B legacy-runner semantic smoke, frozen 4109-token input vector,
  4-leg/12-repetition serving gate, task-local MUPTI device-causality gate, and
  two-step distribution/replay gate: pass
