### PR TITLE
perf(musa): view identity Qwen decode hidden states

### DIFF
--- a/tests/test_qwen_identity_logits_view.py
+++ b/tests/test_qwen_identity_logits_view.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from vllm_musa.v1.worker import qwen_identity_logits_view as identity_view
+
+
+def make_runner(architecture: str = "Qwen3ForCausalLM", sampled_tokens: int = 1):
+    return SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(architectures=[architecture])
+        ),
+        model_state=SimpleNamespace(num_new_sampled_tokens_per_step=sampled_tokens),
+    )
+
+
+def make_batch(batch_size: int = 4):
+    return SimpleNamespace(
+        num_reqs=batch_size,
+        num_scheduled_tokens=np.ones(batch_size, dtype=np.int32),
+        num_draft_tokens=0,
+        logits_indices=torch.arange(batch_size, dtype=torch.int64),
+    )
+
+
+def test_qwen_identity_logits_view_accepts_uniform_decode(monkeypatch) -> None:
+    monkeypatch.setattr(identity_view, "_MUSA_QWEN_IDENTITY_LOGITS_VIEW_ENABLED", True)
+    monkeypatch.setattr(identity_view.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(identity_view, "_is_musa_tensor", lambda _tensor: True)
+    hidden_states = torch.randn((4, 32), dtype=torch.bfloat16)
+
+    selected = identity_view.select_qwen_identity_logits_view(
+        make_runner(), hidden_states, make_batch()
+    )
+
+    assert selected is not None
+    assert selected.data_ptr() == hidden_states.data_ptr()
+    assert torch.equal(selected, hidden_states)
+
+
+def test_qwen_identity_logits_view_fails_closed(monkeypatch) -> None:
+    monkeypatch.setattr(identity_view, "_MUSA_QWEN_IDENTITY_LOGITS_VIEW_ENABLED", True)
+    monkeypatch.setattr(identity_view.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(identity_view, "_is_musa_tensor", lambda _tensor: True)
+    hidden_states = torch.randn((4, 32), dtype=torch.bfloat16)
+
+    cases = []
+    batch = make_batch()
+    batch.num_scheduled_tokens[0] = 2
+    cases.append((make_runner(), hidden_states, batch))
+    batch = make_batch()
+    batch.num_draft_tokens = 1
+    cases.append((make_runner(), hidden_states, batch))
+    batch = make_batch()
+    batch.logits_indices = batch.logits_indices[:3]
+    cases.append((make_runner(), hidden_states, batch))
+    cases.append((make_runner(sampled_tokens=2), hidden_states, make_batch()))
+    cases.append((make_runner("LlamaForCausalLM"), hidden_states, make_batch()))
+    cases.append((make_runner(), hidden_states.float(), make_batch()))
+
+    for runner, candidate_hidden_states, batch in cases:
+        assert (
+            identity_view.select_qwen_identity_logits_view(
+                runner, candidate_hidden_states, batch
+            )
+            is None
+        )
+
+
+def test_qwen_identity_logits_view_flag_off(monkeypatch) -> None:
+    monkeypatch.setattr(identity_view, "_MUSA_QWEN_IDENTITY_LOGITS_VIEW_ENABLED", False)
+    hidden_states = torch.randn((4, 32), dtype=torch.bfloat16)
+    assert (
+        identity_view.select_qwen_identity_logits_view(
+            make_runner(), hidden_states, make_batch()
+        )
+        is None
+    )

--- a/vllm_musa/patches/series/0093-perf-view-qwen-identity-logits-hidden-state.patch
+++ b/vllm_musa/patches/series/0093-perf-view-qwen-identity-logits-hidden-state.patch
@@ -1,0 +1,17 @@
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -1040,7 +1040,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         input_batch: InputBatch,
+         grammar_output: GrammarOutput | None,
+     ) -> tuple[SamplerOutput, torch.Tensor, torch.Tensor]:
+-        sample_hidden_states = hidden_states[input_batch.logits_indices]
++        selector = getattr(self, "_musa_select_sample_hidden_states", None)
++        sample_hidden_states = (
++            None if selector is None else selector(hidden_states, input_batch)
++        )
++        if sample_hidden_states is None:
++            sample_hidden_states = hidden_states[input_batch.logits_indices]
+         logits = self.model.compute_logits(sample_hidden_states)
+         if grammar_output is not None:
+             # Apply grammar bitmask to the logits in-place.

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -94,6 +94,7 @@ class Envs:
     VLLM_MUSA_QWEN_V2_GUMBEL = EnvBool(False)
     VLLM_MUSA_QWEN_UNFILTERED_GUMBEL = EnvBool(False)
     VLLM_MUSA_QWEN_LEGACY_GUMBEL = EnvBool(False)
+    VLLM_MUSA_QWEN_IDENTITY_LOGITS_VIEW = EnvBool(False)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
     # Exact-shape Qwen2 RoPE+NHD-cache fusion.  The model, graph, dtype, and
     # tensor-layout gates fail closed; the environment switch is an A/B escape

--- a/vllm_musa/v1/__init__.py
+++ b/vllm_musa/v1/__init__.py
@@ -4,3 +4,4 @@ import vllm_musa.v1.attention.backends.mla.flashmla_sparse
 import vllm_musa.v1.executor
 import vllm_musa.v1.sample
 import vllm_musa.v1.spec_decode.utils
+import vllm_musa.v1.worker  # noqa: F401

--- a/vllm_musa/v1/worker/__init__.py
+++ b/vllm_musa/v1/worker/__init__.py
@@ -1,0 +1,3 @@
+from vllm_musa.v1.worker import qwen_identity_logits_view as qwen_identity_logits_view
+
+__all__ = ["qwen_identity_logits_view"]

--- a/vllm_musa/v1/worker/qwen_identity_logits_view.py
+++ b/vllm_musa/v1/worker/qwen_identity_logits_view.py
@@ -1,0 +1,87 @@
+from typing import Any
+
+import numpy as np
+import torch
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+
+from vllm_musa.utils.environ import envs
+
+logger = init_logger(__name__)
+
+_MUSA_QWEN_IDENTITY_LOGITS_VIEW_ENABLED = envs.VLLM_MUSA_QWEN_IDENTITY_LOGITS_VIEW.get()
+_QWEN_ARCHITECTURES = frozenset(
+    {
+        "Qwen3ForCausalLM",
+        "Qwen3MoeForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    }
+)
+_MISSING = object()
+
+
+def _is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return tensor.device.type == "musa"
+
+
+def _is_qwen_runner(runner: Any) -> bool:
+    cached = getattr(runner, "_musa_identity_logits_is_qwen", _MISSING)
+    if cached is not _MISSING:
+        return cached
+    model_config = getattr(getattr(runner, "vllm_config", None), "model_config", None)
+    architectures = getattr(model_config, "architectures", None) or ()
+    is_qwen = bool(_QWEN_ARCHITECTURES.intersection(architectures))
+    runner._musa_identity_logits_is_qwen = is_qwen
+    return is_qwen
+
+
+def select_qwen_identity_logits_view(
+    runner: Any, hidden_states: torch.Tensor, input_batch: Any
+) -> torch.Tensor | None:
+    """Return a view when uniform decode makes logits indices the identity."""
+    if not _MUSA_QWEN_IDENTITY_LOGITS_VIEW_ENABLED:
+        return None
+    if not current_platform.is_musa() or not _is_musa_tensor(hidden_states):
+        return None
+    if not _is_qwen_runner(runner):
+        return None
+    if (
+        hidden_states.dtype != torch.bfloat16
+        or hidden_states.ndim != 2
+        or not hidden_states.is_contiguous()
+    ):
+        return None
+
+    num_reqs = input_batch.num_reqs
+    num_scheduled_tokens = input_batch.num_scheduled_tokens
+    logits_indices = input_batch.logits_indices
+    if (
+        num_reqs <= 0
+        or hidden_states.shape[0] < num_reqs
+        or logits_indices.ndim != 1
+        or logits_indices.shape[0] != num_reqs
+        or input_batch.num_draft_tokens != 0
+        or getattr(runner.model_state, "num_new_sampled_tokens_per_step", None) != 1
+        or num_scheduled_tokens.shape != (num_reqs,)
+        or not np.all(num_scheduled_tokens == 1)
+    ):
+        return None
+
+    logger.info_once(
+        "Using MUSA identity logits view for uniform Qwen decode.",
+        scope="global",
+    )
+    return hidden_states[:num_reqs]
+
+
+def install_hooks() -> None:
+    if not _MUSA_QWEN_IDENTITY_LOGITS_VIEW_ENABLED:
+        return
+    GPUModelRunner._musa_select_sample_hidden_states = (  # type: ignore[attr-defined]
+        select_qwen_identity_logits_view
+    )
+
+
+install_hooks()


### PR DESCRIPTION
## Summary

- avoid materializing `hidden_states[input_batch.logits_indices]` when steady
  Qwen decode makes the logits indices exactly `arange(num_reqs)`
- return `hidden_states[:num_reqs]` as an aliasing view on the new vLLM GPU
  runner, removing one MUSA advanced-index allocation/launch per decode step
- keep the optimization default-off behind
  `VLLM_MUSA_QWEN_IDENTITY_LOGITS_VIEW=1` while the broader Qwen matrix is run

This PR stacks on #139 so both legs include the accepted unfiltered-Gumbel
sampling path.

## Safety gate

The view is used only when all of the following hold:

- MUSA BF16 contiguous 2-D hidden states
- an allowlisted Qwen3/Qwen3.5 dense or MoE architecture
- one scheduled token for every request
- one new sampled token per step
- no draft/speculative tokens
- one logits index for every request

Prefill, chunked prefill, MTP/speculative decoding, non-Qwen models, different
dtypes/layouts, and mismatched shapes retain the existing advanced-index path.
The flag-off path also retains the existing behavior.

## Evidence

Exact candidate: `19888a34e0f5667d7f6979bd6895748656dbe47a` on S5000,
driver 5.2, BF16, TP1, FlashAttention, normal compiled/captured serving.

- exact-source targeted tests: 48 passed
- flag-on Qwen3-8B semantic serving smoke: pass; production marker observed
- strict patch apply/reverse-dry-run against pinned vLLM
  `ee0da84ab9e04ac7610e28580af62c365e898389`: pass

Task-local MUSA microbench (`hidden_size=4096`) measured the Python/device
enqueue before synchronization:

| BS | advanced index | identity view | delta |
|---:|---:|---:|---:|
| 1 | 15.04 us | 3.23 us | -11.81 us |
| 4 | 15.03 us | 3.22 us | -11.82 us |
| 16 | 14.52 us | 3.20 us | -11.32 us |
| 64 | 15.08 us | 3.18 us | -11.90 us |

Qwen3-8B BS1, input/output 4096/1024, fresh-server A-B-B-A, 4 stabilization
runs plus 3 profiler-off repetitions per leg:

| metric | control | candidate | delta |
|---|---:|---:|---:|
| mean TPOT | 15.4804 ms | 15.4655 ms | **-0.096%** |
| p50 TPOT | 15.4681 ms | 15.4548 ms | **-0.086%** |
| output throughput | 64.276 tok/s | 64.338 tok/s | **+0.096%** |

Both adjacent pairs were positive (`-0.080%`, `-0.112%`) and all 6/6
same-index profiler-off comparisons were positive.

The exact-image torch profiler was runtime-only, so device causality was gated
with the existing task-local MUPTI tracer. For a 64-token compiled/captured
request, the control had 64 BF16 `IndexVectorizedKernel` launches. The
candidate retained one prefill fallback and removed all 63/63 steady-decode
launches. The removed kernel averaged 3.67 us device time; combined with the
~11.8 us host enqueue reduction, this matches the ~14.9 us/token end-to-end
delta.

Additional negative/fallback coverage:

- Qwen3.5-2B was served with the flag enabled on its legacy GPU runner; the
  semantic request passed and the new-runner marker remained absent
- the MUPTI candidate retained exactly one BF16 index kernel for prefill while
  removing all 63 steady-decode instances
- an initial BS4 extension was rejected rather than quoted because the serving
  client recorded incomplete ITL arrays for part of one streaming leg, despite
  HTTP 200 and complete token counts; it will be rerun with a validated client
  receipt before adding BS4 numbers

Evidence bundle SHA256:
`0fd40c84cbec465ed3e5bc92c66da660bfda01744febe83244cf219b5ddcf170`.

## Remaining Draft work

- rerun BS4/16/64 serving A-B-B-A with complete streaming timing receipts
- run Qwen3 MoE and verify Qwen3.5/3.6 continue using their existing legacy
  selector where applicable
- add real prefill/speculative fallback smokes beyond the focused unit cases
