### PR TITLE
perf(musa): cache uniform Qwen decode sample counts

### DIFF
--- a/tests/test_qwen_uniform_sample_counts.py
+++ b/tests/test_qwen_uniform_sample_counts.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: I001
+
+from types import SimpleNamespace
+
+import numpy as np
+import torchada  # noqa: F401
+import torch
+
+from vllm_musa.v1.sample import uniform_sample_counts as sample_counts
+
+
+def make_batch(batch_size: int = 4):
+    return SimpleNamespace(
+        num_reqs=batch_size,
+        num_scheduled_tokens=np.ones(batch_size, dtype=np.int32),
+        is_prefilling_np=np.zeros(batch_size, dtype=np.bool_),
+        num_draft_tokens=0,
+        seq_lens=torch.full((batch_size,), 128, dtype=torch.int32),
+    )
+
+
+def install_test_gates(monkeypatch) -> None:
+    monkeypatch.setattr(sample_counts, "_MUSA_QWEN_UNIFORM_SAMPLE_COUNTS_ENABLED", True)
+    monkeypatch.setattr(sample_counts.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sample_counts, "is_musa_tensor", lambda _tensor: True)
+    monkeypatch.setattr(sample_counts, "_is_qwen_sampler_vocab", lambda _tensor: True)
+
+
+def test_qwen_uniform_sample_counts_accepts_and_reuses(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    sampler = SimpleNamespace()
+    logits = torch.empty((4, 151936), dtype=torch.bfloat16)
+    first = sample_counts.select_qwen_uniform_sample_counts(
+        sampler, logits, make_batch()
+    )
+    second = sample_counts.select_qwen_uniform_sample_counts(
+        sampler, logits, make_batch()
+    )
+
+    assert first is not None and second is not None
+    assert first[0].tolist() == [1, 1, 1, 1]
+    assert first[1].tolist() == [0, 0, 0, 0]
+    assert first[0].data_ptr() == second[0].data_ptr()
+    assert first[1].data_ptr() == second[1].data_ptr()
+
+
+def test_qwen_uniform_sample_counts_grows_and_changes_dtype(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    sampler = SimpleNamespace()
+    logits = torch.empty((4, 151936), dtype=torch.bfloat16)
+    first = sample_counts.select_qwen_uniform_sample_counts(
+        sampler, logits, make_batch()
+    )
+
+    larger_batch = make_batch(8)
+    larger = sample_counts.select_qwen_uniform_sample_counts(
+        sampler,
+        torch.empty((8, 151936), dtype=torch.bfloat16),
+        larger_batch,
+    )
+    int64_batch = make_batch(8)
+    int64_batch.seq_lens = int64_batch.seq_lens.to(torch.int64)
+    int64_counts = sample_counts.select_qwen_uniform_sample_counts(
+        sampler,
+        torch.empty((8, 151936), dtype=torch.bfloat16),
+        int64_batch,
+    )
+
+    assert first is not None and larger is not None and int64_counts is not None
+    assert larger[0].shape == (8,)
+    assert larger[0].data_ptr() != first[0].data_ptr()
+    assert int64_counts[0].dtype == torch.int64
+    assert int64_counts[0].data_ptr() != larger[0].data_ptr()
+
+
+def test_qwen_uniform_sample_counts_bound_hook(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    monkeypatch.setattr(
+        sample_counts.Sampler,
+        "_musa_select_num_sampled_and_rejected",
+        sample_counts.select_qwen_uniform_sample_counts,
+        raising=False,
+    )
+    sampler = sample_counts.Sampler.__new__(sample_counts.Sampler)
+    logits = torch.empty((4, 151936), dtype=torch.bfloat16)
+
+    counts = sampler._musa_select_num_sampled_and_rejected(logits, make_batch())
+
+    assert counts is not None
+    assert counts[0].tolist() == [1, 1, 1, 1]
+    assert counts[1].tolist() == [0, 0, 0, 0]
+
+
+def test_qwen_uniform_sample_counts_fails_closed(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    logits = torch.empty((4, 151936), dtype=torch.bfloat16)
+    cases = []
+    batch = make_batch()
+    batch.num_scheduled_tokens[0] = 2
+    cases.append((logits, batch))
+    batch = make_batch()
+    batch.is_prefilling_np[0] = True
+    cases.append((logits, batch))
+    batch = make_batch()
+    batch.num_draft_tokens = 1
+    cases.append((logits, batch))
+    cases.append((logits[:3], make_batch()))
+    cases.append((logits.float(), make_batch()))
+    batch = make_batch()
+    batch.seq_lens = batch.seq_lens[:3]
+    cases.append((logits, batch))
+    batch = make_batch()
+    del batch.is_prefilling_np
+    cases.append((logits, batch))
+
+    for candidate_logits, batch in cases:
+        assert (
+            sample_counts.select_qwen_uniform_sample_counts(
+                SimpleNamespace(), candidate_logits, batch
+            )
+            is None
+        )
+
+
+def test_qwen_uniform_sample_counts_flag_off(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sample_counts, "_MUSA_QWEN_UNIFORM_SAMPLE_COUNTS_ENABLED", False
+    )
+    logits = torch.empty((4, 151936), dtype=torch.bfloat16)
+    assert (
+        sample_counts.select_qwen_uniform_sample_counts(
+            SimpleNamespace(), logits, make_batch()
+        )
+        is None
+    )

--- a/vllm_musa/patches/series/0094-perf-cache-qwen-uniform-sample-counts.patch
+++ b/vllm_musa/patches/series/0094-perf-cache-qwen-uniform-sample-counts.patch
@@ -1,0 +1,28 @@
+diff --git a/vllm/v1/worker/gpu/sample/sampler.py b/vllm/v1/worker/gpu/sample/sampler.py
+--- a/vllm/v1/worker/gpu/sample/sampler.py
++++ b/vllm/v1/worker/gpu/sample/sampler.py
+@@ -122,13 +122,16 @@ class Sampler(nn.Module):
+         # 1 sampled token per request, except chunked-prefill requests
+         # (seq_len < prefill_len) which aren't done prefilling and produce no
+         # output token. num_rejected is always 0 here (one logit per request).
+-        num_sampled, num_rejected = get_num_sampled_and_rejected(
+-            input_batch.seq_lens.new_ones(input_batch.num_reqs),
+-            input_batch.seq_lens,
+-            input_batch.cu_num_logits,
+-            input_batch.idx_mapping,
+-            self.req_states.prefill_len.gpu,
+-        )
+-
++        selector = getattr(self, "_musa_select_num_sampled_and_rejected", None)
++        counts = None if selector is None else selector(logits, input_batch)
++        if counts is None:
++            counts = get_num_sampled_and_rejected(
++                input_batch.seq_lens.new_ones(input_batch.num_reqs),
++                input_batch.seq_lens,
++                input_batch.cu_num_logits,
++                input_batch.idx_mapping,
++                self.req_states.prefill_len.gpu,
++            )
++        num_sampled, num_rejected = counts
+         # These are GPU tensors.
+         sampler_output = SamplerOutput(

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -95,6 +95,7 @@ class Envs:
     VLLM_MUSA_QWEN_UNFILTERED_GUMBEL = EnvBool(False)
     VLLM_MUSA_QWEN_LEGACY_GUMBEL = EnvBool(False)
     VLLM_MUSA_QWEN_IDENTITY_LOGITS_VIEW = EnvBool(False)
+    VLLM_MUSA_QWEN_UNIFORM_SAMPLE_COUNTS = EnvBool(False)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
     # Exact-shape Qwen2 RoPE+NHD-cache fusion.  The model, graph, dtype, and
     # tensor-layout gates fail closed; the environment switch is an A/B escape

--- a/vllm_musa/v1/sample/__init__.py
+++ b/vllm_musa/v1/sample/__init__.py
@@ -2,3 +2,4 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import vllm_musa.v1.sample.topk_topp_sampler
+import vllm_musa.v1.sample.uniform_sample_counts  # noqa: F401

--- a/vllm_musa/v1/sample/uniform_sample_counts.py
+++ b/vllm_musa/v1/sample/uniform_sample_counts.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import numpy as np
+import torch
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.sample.sampler import Sampler
+
+from vllm_musa.utils.environ import envs
+from vllm_musa.v1.sample.topk_topp_sampler import (
+    _is_qwen_sampler_vocab,
+    is_musa_tensor,
+)
+
+logger = init_logger(__name__)
+
+_MUSA_QWEN_UNIFORM_SAMPLE_COUNTS_ENABLED = (
+    envs.VLLM_MUSA_QWEN_UNIFORM_SAMPLE_COUNTS.get()
+)
+
+
+def select_qwen_uniform_sample_counts(
+    sampler: Any, logits: torch.Tensor, input_batch: Any
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Return cached one/zero counts for non-prefill Qwen decode."""
+    if not _MUSA_QWEN_UNIFORM_SAMPLE_COUNTS_ENABLED:
+        return None
+    if not current_platform.is_musa() or not is_musa_tensor(logits):
+        return None
+    if (
+        logits.dtype != torch.bfloat16
+        or logits.ndim != 2
+        or not logits.is_contiguous()
+        or not _is_qwen_sampler_vocab(logits)
+    ):
+        return None
+
+    try:
+        num_reqs = input_batch.num_reqs
+        num_scheduled_tokens = input_batch.num_scheduled_tokens
+        is_prefilling = input_batch.is_prefilling_np
+        num_draft_tokens = input_batch.num_draft_tokens
+        seq_lens = input_batch.seq_lens
+    except AttributeError:
+        return None
+    if (
+        num_reqs <= 0
+        or logits.shape[0] != num_reqs
+        or num_draft_tokens != 0
+        or num_scheduled_tokens.shape != (num_reqs,)
+        or not np.all(num_scheduled_tokens == 1)
+        or is_prefilling.shape != (num_reqs,)
+        or np.any(is_prefilling)
+        or seq_lens.ndim != 1
+        or seq_lens.shape[0] < num_reqs
+    ):
+        return None
+
+    buffers = getattr(sampler, "_musa_qwen_uniform_sample_count_buffers", None)
+    cache_key = (seq_lens.device, seq_lens.dtype)
+    if buffers is None or buffers[0] != cache_key or buffers[1].shape[0] < num_reqs:
+        capacity = num_reqs
+        num_sampled = torch.ones(
+            capacity,
+            dtype=seq_lens.dtype,
+            device=seq_lens.device,
+        )
+        num_rejected = torch.zeros_like(num_sampled)
+        buffers = (cache_key, num_sampled, num_rejected)
+        sampler._musa_qwen_uniform_sample_count_buffers = buffers
+        logger.info_once(
+            "Using cached MUSA Qwen uniform decode sample counts.",
+            scope="global",
+        )
+    return buffers[1][:num_reqs], buffers[2][:num_reqs]
+
+
+def install_hooks() -> None:
+    if not _MUSA_QWEN_UNIFORM_SAMPLE_COUNTS_ENABLED:
+        return
+    Sampler._musa_select_num_sampled_and_rejected = (  # type: ignore[attr-defined]
+        select_qwen_uniform_sample_counts
+    )
+
+
+install_hooks()


### PR DESCRIPTION
## Summary

This Draft adds a default-off MUSA fast path for the Qwen new GPU runner's
uniform, non-prefill decode case. The upstream sampler currently allocates a
one tensor, allocates an output tensor, and launches
`_get_num_sampled_and_rejected_kernel` every token even when the result is
provably constant: `num_sampled=1`, `num_rejected=0` for every request.

The candidate caches read-only one/zero buffers on the sampler and returns
active-batch views. It is stacked on Draft #142 and keeps #139's unfiltered
Gumbel path plus #142's identity-logits view enabled in all A/B legs.

| Boundary | Before | Candidate |
|---|---|---|
| per-step allocations | `seq_lens.new_ones()` + `empty_like()` | allocate only on first hit or capacity/device/dtype change |
| sample-count device work | one Triton kernel per sampler call | prefill fallback only; steady decode uses cached views |
| unsupported shapes | upstream helper | upstream helper |

## Safety scope

The optimization is behind `VLLM_MUSA_QWEN_UNIFORM_SAMPLE_COUNTS=1` and fails
closed unless all of the following hold:

- MUSA, contiguous BF16 2D logits, validated Qwen vocabulary;
- one logits row and one scheduled token per active request;
- no active prefill/chunked-prefill request and no draft tokens;
- valid 1D sequence-length storage covering the active request count.

Prefill, mixed/chunked prefill, speculative/draft decoding, non-Qwen
vocabularies, other dtype/layouts, and missing required metadata retain the
upstream helper. Cached tensors are keyed by device/dtype and only read by the
downstream output-copy/state-update paths.

## Evidence

- Exact vLLM pin: `ee0da84ab9e04ac7610e28580af62c365e898389`.
- Candidate: `ddc012e1bcaefb7136cf0f29a8c0a58afe8c53d8`.
- Exact archive SHA256:
  `0676552e9e49c4a02b702d56db7f9b8a5ffc0811709159101329c931bf7cba54`.
- Exact-image focused tests: 51/51 pass.
- Compiled/captured Qwen3-8B semantic smoke: pass with Gumbel, identity-view,
  and uniform-count markers.
- BS1/4/16/64 real-MUSA helper parity: pass. Mean host enqueue falls by
  34.3--35.8 us per call in the steady-decode microbenchmark.
- Task-local MUPTI causal gate: sample-count kernel 64 -> 1 over a 64-token
  request, removing 63/63 steady-decode launches while preserving the prefill
  fallback. The control kernel mean is 3.372 us. Gumbel remains 64/64 and the
  pre-model combine kernel remains 64/64.
- Qwen3-8B TP1 BS1, BF16, FLASH_ATTN, normal compile plus
  `FULL_AND_PIECEWISE`, fixed 4096 input / 1024 output, fresh-server A-B-B-A
  with three profiler-off repetitions per leg:

| Fresh-server sweep | Mean TPOT | P50 TPOT | Output throughput | Adjacent pairs | Same-index reps |
|---|---:|---:|---:|---:|---:|
| run 1 | -0.0528% | -0.0442% | +0.0484% | 2/2 positive | 4/6 positive |
| run 2 | -0.4911% | -0.2535% | +0.4932% | 2/2 positive | 6/6 positive |
| combined 12 control + 12 candidate reps | -0.2722% | -0.1839% | +0.2720% | 4/4 positive | 10/12 positive |

The two sweeps have different magnitudes, so this Draft does not treat the
larger run-2 number as a stable point estimate. Both pooled sweeps and all four
adjacent A/B pairs are positive; run 2 also passes the predeclared strict 2/2
pair plus 6/6 same-index gate. Combined TTFT is neutral (+0.0035%).

- The flag-off hook lookup costs 0.19--0.44 us mean host enqueue in the same
  helper microbenchmark; synchronized time has no consistent regression.
- Final remote evidence archive SHA256:
  `950f34562b0792fbbf103303f022d22759a26f3ffe988f8d6ba9b6ec68df037b`.

## Review notes

- This is intentionally Draft while broader batch/model/fallback coverage is
  pending.
- Patch 0094 adds one optional hook lookup to the upstream sampler; flag-off
  retains the original helper.
- The MUPTI trace leaves `_combine_sampled_and_draft_tokens_kernel` at 64/64
  (about 4 us device mean), which is a separate follow-up rather than part of
  this change.
