### PR TITLE
perf(musa): fuse Qwen next-token input updates

### DIFF
--- a/tests/test_qwen_fused_next_input_ids.py
+++ b/tests/test_qwen_fused_next_input_ids.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: I001
+
+from types import SimpleNamespace
+
+import numpy as np
+import torchada  # noqa: F401
+import torch
+
+from vllm_musa.v1.worker import qwen_fused_next_input_ids as fused_inputs
+
+
+def make_runner(capacity: int = 8):
+    return SimpleNamespace(
+        input_buffers=SimpleNamespace(
+            input_ids=torch.zeros(capacity, dtype=torch.int32)
+        ),
+        model_state=SimpleNamespace(num_new_sampled_tokens_per_step=1),
+        use_pp=False,
+    )
+
+
+def call_selector(runner, batch_size: int = 4, **overrides):
+    arguments = {
+        "req_ids": [f"req-{index}" for index in range(batch_size)],
+        "num_scheduled_tokens": np.ones(batch_size, dtype=np.int32),
+        "is_prefilling_np": np.zeros(batch_size, dtype=np.bool_),
+        "total_num_draft_tokens": 0,
+        "total_num_logits": batch_size,
+        "num_tokens": batch_size,
+        "num_tokens_after_padding": batch_size,
+        "num_reqs_after_padding": batch_size,
+    }
+    arguments.update(overrides)
+    return fused_inputs.select_qwen_fused_decode_inputs(runner, **arguments)
+
+
+def install_test_gates(monkeypatch) -> None:
+    monkeypatch.setattr(fused_inputs, "_MUSA_QWEN_FUSED_NEXT_INPUT_IDS_ENABLED", True)
+    monkeypatch.setattr(fused_inputs.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(fused_inputs, "_is_musa_tensor", lambda tensor: True)
+    monkeypatch.setattr(fused_inputs, "_is_qwen_runner", lambda runner: True)
+
+
+def test_qwen_fused_next_input_ids_primes_then_reuses(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    runner = make_runner()
+    log_calls = []
+    monkeypatch.setattr(
+        fused_inputs.logger,
+        "info_once",
+        lambda *args, **kwargs: log_calls.append((args, kwargs)),
+    )
+
+    assert call_selector(runner) is None
+    next_input_ids = fused_inputs.select_qwen_next_input_ids_buffer(runner)
+    assert next_input_ids is runner.input_buffers.input_ids
+
+    selected = call_selector(runner)
+    assert selected is not None
+    input_ids, logits_indices = selected
+    assert input_ids.data_ptr() == runner.input_buffers.input_ids.data_ptr()
+    assert input_ids.shape == (4,)
+    assert logits_indices.tolist() == [0, 1, 2, 3]
+
+    fused_inputs.select_qwen_next_input_ids_buffer(runner)
+    selected_again = call_selector(runner)
+    assert selected_again is not None
+    assert selected_again[1].data_ptr() == logits_indices.data_ptr()
+    assert len(log_calls) == 1
+
+
+def test_qwen_fused_next_input_ids_request_change_falls_back(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    runner = make_runner()
+    assert call_selector(runner) is None
+    fused_inputs.select_qwen_next_input_ids_buffer(runner)
+
+    assert call_selector(runner, req_ids=["req-0", "req-1", "req-2", "new"]) is None
+
+
+def test_qwen_fused_next_input_ids_preserves_batch_order(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    runner = make_runner()
+    req_ids = ["req-3", "req-0", "req-2", "req-1"]
+    assert call_selector(runner, req_ids=req_ids) is None
+    next_input_ids = fused_inputs.select_qwen_next_input_ids_buffer(runner)
+    assert next_input_ids is not None
+    next_input_ids[:4] = torch.tensor([13, 10, 12, 11], dtype=torch.int32)
+
+    selected = call_selector(runner, req_ids=req_ids)
+    assert selected is not None
+    assert selected[0].tolist() == [13, 10, 12, 11]
+    assert selected[1].tolist() == [0, 1, 2, 3]
+
+
+def test_qwen_fused_next_input_ids_preserves_graph_padding(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    runner = make_runner()
+    padding = {
+        "num_tokens_after_padding": 8,
+        "num_reqs_after_padding": 8,
+    }
+    assert call_selector(runner, **padding) is None
+    fused_inputs.select_qwen_next_input_ids_buffer(runner)
+
+    selected = call_selector(runner, **padding)
+    assert selected is not None
+    assert selected[0].shape == (8,)
+    assert selected[1].shape == (4,)
+
+
+def test_qwen_fused_next_input_ids_fail_closed(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    batch_size = 4
+    cases = [
+        {"num_scheduled_tokens": np.array([1, 1, 2, 1], dtype=np.int32)},
+        {"is_prefilling_np": np.array([False, True, False, False])},
+        {"total_num_draft_tokens": 1},
+        {"total_num_logits": 5},
+        {"num_tokens": 5},
+        {"num_tokens_after_padding": 3},
+        {"num_reqs_after_padding": 3},
+        {"num_tokens_after_padding": 8, "num_reqs_after_padding": 4},
+    ]
+    for overrides in cases:
+        runner = make_runner()
+        runner._musa_qwen_primed_input_req_ids = tuple(
+            f"req-{index}" for index in range(batch_size)
+        )
+        assert call_selector(runner, **overrides) is None
+        assert fused_inputs.select_qwen_next_input_ids_buffer(runner) is None
+
+    runner = make_runner()
+    runner.model_state.num_new_sampled_tokens_per_step = 0
+    runner._musa_qwen_primed_input_req_ids = tuple(
+        f"req-{index}" for index in range(batch_size)
+    )
+    assert call_selector(runner) is None
+
+
+def test_qwen_fused_next_input_ids_flag_off(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    monkeypatch.setattr(fused_inputs, "_MUSA_QWEN_FUSED_NEXT_INPUT_IDS_ENABLED", False)
+    runner = make_runner()
+    assert call_selector(runner) is None

--- a/tests/test_qwen_fused_next_input_ids_source.py
+++ b/tests/test_qwen_fused_next_input_ids_source.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+
+PATCH = (
+    Path(__file__).parents[1]
+    / "vllm_musa/patches/series/0095-perf-fuse-qwen-next-input-ids.patch"
+)
+
+
+def test_qwen_fused_next_input_ids_patch_wires_both_boundaries() -> None:
+    source = PATCH.read_text()
+    assert 'getattr(self, "_musa_select_uniform_decode_model_inputs", None)' in source
+    assert 'getattr(self, "_musa_select_next_input_ids_buffer", None)' in source
+    assert "next_input_ids=next_input_ids" in source
+    assert "WRITE_NEXT_INPUT_IDS=next_input_ids is not None" in source
+    assert "tl.store(next_input_ids_ptr + req_id, token_id)" in source
+    assert "input_ids=input_ids" in source
+    assert "idx_mapping_np," not in source

--- a/vllm_musa/patches/series/0095-perf-fuse-qwen-next-input-ids.patch
+++ b/vllm_musa/patches/series/0095-perf-fuse-qwen-next-input-ids.patch
@@ -1,0 +1,116 @@
+diff --git a/vllm/v1/worker/gpu/input_batch.py b/vllm/v1/worker/gpu/input_batch.py
+--- a/vllm/v1/worker/gpu/input_batch.py
++++ b/vllm/v1/worker/gpu/input_batch.py
+@@ -457,6 +457,8 @@ def _post_update_kernel(
+     all_token_ids_ptr,
+     all_token_ids_stride,
+     total_len_ptr,
++    next_input_ids_ptr,
++    WRITE_NEXT_INPUT_IDS: tl.constexpr,
+ ):
+     req_id = tl.program_id(0)
+     req_state_idx = tl.load(idx_mapping_ptr + req_id)
+@@ -472,6 +474,8 @@ def _post_update_kernel(
+         )
+         tl.store(last_sampled_tokens_ptr + req_state_idx, token_id)
+         tl.store(total_len_ptr + req_state_idx, total_len + num_sampled)
++        if WRITE_NEXT_INPUT_IDS:
++            tl.store(next_input_ids_ptr + req_id, token_id)
+-
++
+     for i in range(num_sampled):
+         token_id = tl.load(sampled_tokens_ptr + req_id * sampled_tokens_stride + i)
+@@ -524,6 +528,7 @@ def post_update(
+     all_token_ids: torch.Tensor,
+     # [max_num_reqs]
+     total_len: torch.Tensor,
++    next_input_ids: torch.Tensor | None = None,
+ ) -> None:
+     num_reqs = idx_mapping.shape[0]
+     _post_update_kernel[(num_reqs,)](
+@@ -540,5 +545,7 @@ def post_update(
+         all_token_ids,
+         all_token_ids.stride(0),
+         total_len,
++        next_input_ids if next_input_ids is not None else last_sampled_tokens,
++        WRITE_NEXT_INPUT_IDS=next_input_ids is not None,
+         num_warps=1,
+     )
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -949,18 +949,36 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+-
++
+         # Some input token ids are directly read from the last sampled tokens
+         # and draft tokens. Also, get the logits indices to sample tokens from.
+-        logits_indices = combine_sampled_and_draft_tokens(
+-            self.input_buffers.input_ids,
+-            idx_mapping,
+-            self.req_states.last_sampled_tokens,
+-            query_start_loc,
+-            seq_lens,
+-            self.req_states.prefill_len.gpu,
+-            self.req_states.draft_tokens,
+-            cu_num_logits,
+-            total_num_logits,
+-            self.model_state.num_new_sampled_tokens_per_step,
+-        )
++        selector = getattr(self, "_musa_select_uniform_decode_model_inputs", None)
++        model_inputs = None
++        if selector is not None:
++            model_inputs = selector(
++                req_ids,
++                num_scheduled_tokens,
++                is_prefilling_np,
++                total_num_draft_tokens,
++                total_num_logits,
++                num_tokens,
++                num_tokens_after_padding,
++                num_reqs_padded,
++            )
++        if model_inputs is None:
++            logits_indices = combine_sampled_and_draft_tokens(
++                self.input_buffers.input_ids,
++                idx_mapping,
++                self.req_states.last_sampled_tokens,
++                query_start_loc,
++                seq_lens,
++                self.req_states.prefill_len.gpu,
++                self.req_states.draft_tokens,
++                cu_num_logits,
++                total_num_logits,
++                self.model_state.num_new_sampled_tokens_per_step,
++            )
++            input_ids = self.input_buffers.input_ids[:num_tokens_after_padding]
++        else:
++            input_ids, logits_indices = model_inputs
+-
++
+         # CPU upper bound on seq_lens; padded entries left at zero.
+         num_computed_tokens_np = self.req_states.num_computed_tokens_np[idx_mapping_np]
+@@ -999,6 +1023,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+             is_prefilling_np=is_prefilling_np,
+             max_seq_len_np=max_seq_len_np,
+-            input_ids=self.input_buffers.input_ids[:num_tokens_after_padding],
++            input_ids=input_ids,
+             positions=self.input_buffers.positions[:num_tokens_after_padding],
+             logits_indices=logits_indices,
+             cu_num_logits=cu_num_logits,
+@@ -1082,5 +1106,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         else:
+             output_bin_counts = None
++        selector = getattr(self, "_musa_select_next_input_ids_buffer", None)
++        next_input_ids = None if selector is None else selector()
+         post_update(
+             idx_mapping,
+             self.req_states.num_computed_tokens.gpu,
+@@ -1098,6 +1125,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+             query_start_loc,
+             self.req_states.all_token_ids.gpu,
+             self.req_states.total_len.gpu,
++            next_input_ids=next_input_ids,
+         )
+-
++
+         self.model_state.postprocess_state(idx_mapping, num_sampled)

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -96,6 +96,7 @@ class Envs:
     VLLM_MUSA_QWEN_LEGACY_GUMBEL = EnvBool(False)
     VLLM_MUSA_QWEN_IDENTITY_LOGITS_VIEW = EnvBool(False)
     VLLM_MUSA_QWEN_UNIFORM_SAMPLE_COUNTS = EnvBool(False)
+    VLLM_MUSA_QWEN_FUSED_NEXT_INPUT_IDS = EnvBool(False)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
     # Exact-shape Qwen2 RoPE+NHD-cache fusion.  The model, graph, dtype, and
     # tensor-layout gates fail closed; the environment switch is an A/B escape

--- a/vllm_musa/v1/worker/__init__.py
+++ b/vllm_musa/v1/worker/__init__.py
@@ -1,3 +1,4 @@
+from vllm_musa.v1.worker import qwen_fused_next_input_ids as qwen_fused_next_input_ids
 from vllm_musa.v1.worker import qwen_identity_logits_view as qwen_identity_logits_view
 
-__all__ = ["qwen_identity_logits_view"]
+__all__ = ["qwen_fused_next_input_ids", "qwen_identity_logits_view"]

--- a/vllm_musa/v1/worker/qwen_fused_next_input_ids.py
+++ b/vllm_musa/v1/worker/qwen_fused_next_input_ids.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import numpy as np
+import torch
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+
+from vllm_musa.utils.environ import envs
+from vllm_musa.v1.worker.qwen_identity_logits_view import (
+    _is_musa_tensor,
+    _is_qwen_runner,
+)
+
+logger = init_logger(__name__)
+
+_MUSA_QWEN_FUSED_NEXT_INPUT_IDS_ENABLED = envs.VLLM_MUSA_QWEN_FUSED_NEXT_INPUT_IDS.get()
+
+
+def select_qwen_fused_decode_inputs(
+    runner: Any,
+    req_ids: list[str],
+    num_scheduled_tokens: np.ndarray,
+    is_prefilling_np: np.ndarray,
+    total_num_draft_tokens: int,
+    total_num_logits: int,
+    num_tokens: int,
+    num_tokens_after_padding: int,
+    num_reqs_after_padding: int,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Use input IDs written by the preceding post-update kernel."""
+    primed_req_ids = getattr(runner, "_musa_qwen_primed_input_req_ids", None)
+    runner._musa_qwen_primed_input_req_ids = None
+    runner._musa_qwen_pending_input_req_ids = None
+
+    if not _MUSA_QWEN_FUSED_NEXT_INPUT_IDS_ENABLED:
+        return None
+    input_ids = runner.input_buffers.input_ids
+    if (
+        not current_platform.is_musa()
+        or not _is_musa_tensor(input_ids)
+        or not _is_qwen_runner(runner)
+        or getattr(runner, "use_pp", False)
+    ):
+        return None
+
+    num_reqs = len(req_ids)
+    if (
+        num_reqs <= 0
+        or input_ids.dtype != torch.int32
+        or input_ids.ndim != 1
+        or not input_ids.is_contiguous()
+        or num_tokens != num_reqs
+        or num_tokens_after_padding < num_reqs
+        or num_reqs_after_padding < num_reqs
+        or num_tokens_after_padding != num_reqs_after_padding
+        or input_ids.shape[0] < num_tokens_after_padding
+        or total_num_logits != num_reqs
+        or total_num_draft_tokens != 0
+        or getattr(
+            getattr(runner, "model_state", None),
+            "num_new_sampled_tokens_per_step",
+            None,
+        )
+        != 1
+        or num_scheduled_tokens.shape != (num_reqs,)
+        or not np.all(num_scheduled_tokens == 1)
+        or is_prefilling_np.shape != (num_reqs,)
+        or np.any(is_prefilling_np)
+    ):
+        return None
+
+    current_req_ids = tuple(req_ids)
+    runner._musa_qwen_pending_input_req_ids = current_req_ids
+    if primed_req_ids != current_req_ids:
+        return None
+
+    cache = getattr(runner, "_musa_qwen_decode_logits_indices", None)
+    if cache is None or cache.device != input_ids.device or cache.shape[0] < num_reqs:
+        cache = torch.arange(num_reqs, dtype=torch.int64, device=input_ids.device)
+        runner._musa_qwen_decode_logits_indices = cache
+        logger.info_once(
+            "Using fused MUSA Qwen next-token input IDs for uniform decode.",
+            scope="global",
+        )
+    return input_ids[:num_tokens_after_padding], cache[:num_reqs]
+
+
+def select_qwen_next_input_ids_buffer(runner: Any) -> torch.Tensor | None:
+    pending_req_ids = getattr(runner, "_musa_qwen_pending_input_req_ids", None)
+    runner._musa_qwen_pending_input_req_ids = None
+    if pending_req_ids is None:
+        runner._musa_qwen_primed_input_req_ids = None
+        return None
+    runner._musa_qwen_primed_input_req_ids = pending_req_ids
+    return runner.input_buffers.input_ids
+
+
+def install_hooks() -> None:
+    if not _MUSA_QWEN_FUSED_NEXT_INPUT_IDS_ENABLED:
+        return
+    GPUModelRunner._musa_select_uniform_decode_model_inputs = (  # type: ignore[attr-defined]
+        select_qwen_fused_decode_inputs
+    )
+    GPUModelRunner._musa_select_next_input_ids_buffer = (  # type: ignore[attr-defined]
+        select_qwen_next_input_ids_buffer
+    )
+
+
+install_hooks()


### PR DESCRIPTION
## Summary

This stacked, default-off change removes the residual per-step
`_combine_sampled_and_draft_tokens_kernel` from the steady uniform Qwen decode
path. The existing `post_update` Triton kernel writes each sampled token into
the next int32 input-id buffer, and the next decode step reuses that buffer plus
a cached logits-index tensor.

The selector is deliberately narrow: MUSA Qwen runner, one sampled token per
request, no prefill/draft/speculative decode/PP, stable request order, contiguous
int32 input IDs, and compatible graph padding. Any mismatch clears state and
uses the upstream combine path.

## Source

- Commit: `2fcae39386caa70204bfb7c93702f4d2080c23f7`
- Parent: `ddc012e1bcaefb7136cf0f29a8c0a58afe8c53d8` (Draft #143)
- Archive SHA256: `ccbda33e0af8114c89517af2a018df642f86ecbfb1f7b9db03f3ea264dca6ae2`
- New flag: `VLLM_MUSA_QWEN_FUSED_NEXT_INPUT_IDS=1`

## Evidence

Validation used one leased MTT S5000 on `10.20.32.88`, MUSA driver
`5.2.0-server`, pinned vLLM
`ee0da84ab9e04ac7610e28580af62c365e898389`, and image digest
`sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`.

- Exact-pin replay: 95/95 patches, zero conflicts.
- Focused source/runtime tests: 73 passed.
- Qwen3-8B semantic smoke: BF16, FLASH_ATTN, compile enabled,
  FULL_AND_PIECEWISE graph capture, all four cumulative fast-path markers.
- Graph-padding sibling smoke: batch 3 padded into captured graph shapes, 3/3
  requests and 192/192 output tokens, no request errors, fused marker present.
  The old receipt helper rejected this result because the current benchmark
  JSON omits TTFT/ITL arrays; a focused schema-independent gate passed.

Exact-final MUPTI control/candidate traces observed:

| metric | control | candidate |
|---|---:|---:|
| `_combine_sampled_and_draft_tokens_kernel` launches | 64 | 2 |
| `_post_update_kernel` launches | 64 | 64 |
| `_gumbel_sample_kernel` launches | 64 | 64 |
| sample-count kernel launches | 1 | 1 |
| combine + post-update device time | 577.001 us | 326.320 us |

That removes 62 steady-decode launches and saves `250.681 us` over the
64-token trace, or `3.9169 us/token`, without increasing the post-update kernel
mean (`4.9956 -> 4.9719 us`).

Two independent fresh-server A-B-B-A sweeps used Qwen3-8B, BS1, 4096 input /
1024 output, unseeded unfiltered Gumbel, FLASH_ATTN, compile and graph capture,
with 3 profiler-off repetitions per leg:

| serving result | sweep 1 | sweep 2 | combined 12+12 reps |
|---|---:|---:|---:|
| mean TPOT | -0.02535% | -0.07345% | -0.04940% |
| output throughput | +0.01105% | +0.07170% | +0.04138% |
| mean TTFT | +0.82489% | +0.05683% | +0.43948% |

Both sweeps and the pooled mean are TPOT-positive; the combined median TPOT is
`-0.08392%`. The signal is intentionally reported as microsecond-scale: strict
consistency did not pass (`2/4` adjacent pairs, `9/12` same-index comparisons),
while the exact device-time attribution and pooled direction agree. The flag
cannot affect TTFT before the first sampled token, so the TTFT movement is
reported as run noise, not a causal regression or win.

Local evidence archive:
`generated/MUSA-60043/round22-combine-fusion/r22-final-evidence-2fcae3938.tar.gz`
(SHA256
`7a7506a362f1656226c5fc8b4db0c0e5ba33e72e9aa78dbee9b411df47d16516`).

## Review points

- Verify the post-update write uses batch order (`req_id`) while state updates
  continue to use `idx_mapping`.
- Verify the first uniform decode step falls back and primes the next buffer;
  request-set/order changes clear the primed state.
- Verify graph-padded input views retain the original model input shape.
- Verify the flag-off path and non-Qwen/prefill/speculative paths remain byte-
  for-byte on the existing combine implementation.
