### PR TITLE
perf(musa): avoid identity Qwen sampling gathers

### DIFF
--- a/tests/test_qwen_sample_input_views.py
+++ b/tests/test_qwen_sample_input_views.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from vllm_musa.v1.sample import qwen_sample_input_views as sample_views
+
+
+def make_batch(batch_size: int = 4, padded: int = 8):
+    return SimpleNamespace(
+        num_reqs=batch_size,
+        num_reqs_after_padding=padded,
+        num_tokens=batch_size,
+        num_tokens_after_padding=padded,
+        num_draft_tokens=0,
+        num_scheduled_tokens=np.ones(batch_size, dtype=np.int32),
+        is_prefilling_np=np.zeros(batch_size, dtype=np.bool_),
+        positions=torch.arange(padded, dtype=torch.int64),
+        input_ids=torch.arange(padded, dtype=torch.int32),
+    )
+
+
+def select(monkeypatch, batch=None, **kwargs):
+    monkeypatch.setattr(
+        sample_views.envs.VLLM_MUSA_QWEN_SAMPLE_INPUT_VIEWS,
+        "get",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "vllm_musa.v1.sample.topk_topp_sampler.can_use_qwen_v2_unfiltered_gumbel",
+        lambda *args, **kw: True,
+    )
+    batch = batch or make_batch()
+    logits = torch.zeros(batch.num_reqs, 16, dtype=torch.bfloat16)
+    return sample_views._select_qwen_sample_input_views(
+        SimpleNamespace(),
+        logits,
+        batch,
+        torch.arange(batch.num_reqs, dtype=torch.int32),
+        np.arange(batch.num_reqs, dtype=np.int32),
+        kwargs.pop("return_logprobs", False),
+    )
+
+
+def test_uniform_decode_uses_identity_views(monkeypatch):
+    batch = make_batch()
+    selected = select(monkeypatch, batch)
+    assert selected is not None
+    assert selected[0].data_ptr() == batch.positions.data_ptr()
+    assert selected[1].data_ptr() == batch.input_ids.data_ptr()
+    assert selected[0].shape == selected[1].shape == (batch.num_reqs,)
+
+
+def test_non_uniform_or_logprobs_falls_back(monkeypatch):
+    for overrides in (
+        {"num_scheduled_tokens": np.array([1, 1, 2, 1], dtype=np.int32)},
+        {"is_prefilling_np": np.array([False, True, False, False])},
+        {"num_draft_tokens": 1},
+        {"return_logprobs": True},
+    ):
+        batch = make_batch()
+        for key, value in overrides.items():
+            if key != "return_logprobs":
+                setattr(batch, key, value)
+        assert select(monkeypatch, batch, **overrides) is None
+
+
+def test_mismatched_padding_falls_back(monkeypatch):
+    batch = make_batch()
+    batch.num_reqs_after_padding = 4
+    batch.num_tokens_after_padding = 8
+    assert select(monkeypatch, batch) is None

--- a/tests/test_qwen_sample_input_views_source.py
+++ b/tests/test_qwen_sample_input_views_source.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_sample_input_view_patch_has_fallback_and_gate():
+    root = Path(__file__).parents[1]
+    source = (
+        root / "vllm_musa/patches/series/0096-perf-view-qwen-sampling-inputs.patch"
+    ).read_text()
+    assert "_musa_select_qwen_sample_input_views" in source
+    assert "input_batch.positions[input_batch.logits_indices]" in source
+    assert "input_batch.input_ids[input_batch.logits_indices]" in source
+    assert "sample_inputs is None" in source
+    assert "return_logprobs" in source

--- a/vllm_musa/patches/series/0096-perf-view-qwen-sampling-inputs.patch
+++ b/vllm_musa/patches/series/0096-perf-view-qwen-sampling-inputs.patch
@@ -1,0 +1,43 @@
+Subject: [PATCH] perf: reuse identity Qwen sampling input views
+
+The Qwen uniform decode path already has identity logits indices. Avoid
+materializing positions and input_ids through two gather kernels before the
+unfiltered sampler when the MUSA-gated selector proves that the gathers are
+redundant. The upstream gathers remain the fallback.
+
+--- a/vllm/v1/worker/gpu/sample/sampler.py
++++ b/vllm/v1/worker/gpu/sample/sampler.py
+@@ -77,8 +77,6 @@ class Sampler:
+         idx_mapping_np = input_batch.idx_mapping_np
+         cu_num_logits_np = input_batch.cu_num_logits_np
+         expanded_local_pos = input_batch.expanded_local_pos
+-        pos = input_batch.positions[input_batch.logits_indices]
+-        input_ids = input_batch.input_ids[input_batch.logits_indices]
+-
++
+         # NOTE(woosuk): We intentionally compute num_nans before sampling to make clear
+@@ -90,6 +88,24 @@ class Sampler:
+             idx_mapping_np
+         )
+         return_logprobs = max_num_logprobs != NO_LOGPROBS or max_per_req_token_ids > 0
++        selector = getattr(self, "_musa_select_qwen_sample_input_views", None)
++        sample_inputs = (
++            None
++            if selector is None
++            else selector(
++                logits,
++                input_batch,
++                expanded_idx_mapping,
++                idx_mapping_np,
++                return_logprobs,
++            )
++        )
++        if sample_inputs is None:
++            pos = input_batch.positions[input_batch.logits_indices]
++            input_ids = input_batch.input_ids[input_batch.logits_indices]
++        else:
++            pos, input_ids = sample_inputs
+-
++
+         sampled, processed_logits = self.sample(
+             logits,

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -97,6 +97,7 @@ class Envs:
     VLLM_MUSA_QWEN_IDENTITY_LOGITS_VIEW = EnvBool(False)
     VLLM_MUSA_QWEN_UNIFORM_SAMPLE_COUNTS = EnvBool(False)
     VLLM_MUSA_QWEN_FUSED_NEXT_INPUT_IDS = EnvBool(False)
+    VLLM_MUSA_QWEN_SAMPLE_INPUT_VIEWS = EnvBool(False)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
     # Exact-shape Qwen2 RoPE+NHD-cache fusion.  The model, graph, dtype, and
     # tensor-layout gates fail closed; the environment switch is an A/B escape

--- a/vllm_musa/v1/sample/qwen_sample_input_views.py
+++ b/vllm_musa/v1/sample/qwen_sample_input_views.py
@@ -1,0 +1,77 @@
+"""Gated views for Qwen's uniform decode sampling inputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+# isort: off
+import numpy as np
+import torchada  # noqa: F401
+import torch
+# isort: on
+
+from vllm_musa.utils.environ import envs
+
+
+def _select_qwen_sample_input_views(
+    sampler: Any,
+    logits: torch.Tensor,
+    input_batch: Any,
+    expanded_idx_mapping: torch.Tensor,
+    idx_mapping_np: np.ndarray,
+    return_logprobs: bool,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    if not envs.VLLM_MUSA_QWEN_SAMPLE_INPUT_VIEWS.get():
+        return None
+    if return_logprobs:
+        return None
+
+    # Import lazily to preserve vLLM sampler import order.
+    from vllm_musa.v1.sample.topk_topp_sampler import (
+        can_use_qwen_v2_unfiltered_gumbel,
+    )
+
+    num_reqs = input_batch.num_reqs
+    if (
+        num_reqs <= 0
+        or input_batch.num_reqs_after_padding < num_reqs
+        or input_batch.num_tokens != num_reqs
+        or input_batch.num_tokens_after_padding < num_reqs
+        or input_batch.num_tokens_after_padding != input_batch.num_reqs_after_padding
+        or input_batch.num_draft_tokens != 0
+        or input_batch.num_scheduled_tokens.shape != (num_reqs,)
+        or not np.all(input_batch.num_scheduled_tokens == 1)
+        or input_batch.is_prefilling_np.shape != (num_reqs,)
+        or np.any(input_batch.is_prefilling_np)
+        or logits.ndim != 2
+        or logits.shape[0] != num_reqs
+        or logits.dtype != torch.bfloat16
+        or logits.stride(-1) != 1
+        or input_batch.positions.ndim != 1
+        or input_batch.input_ids.ndim != 1
+        or input_batch.positions.shape[0] < input_batch.num_tokens_after_padding
+        or input_batch.input_ids.shape[0] < input_batch.num_tokens_after_padding
+    ):
+        return None
+
+    pos = input_batch.positions[:num_reqs]
+    if not can_use_qwen_v2_unfiltered_gumbel(
+        sampler,
+        logits,
+        expanded_idx_mapping,
+        idx_mapping_np,
+        pos,
+        return_logprobs,
+    ):
+        return None
+
+    return pos, input_batch.input_ids[:num_reqs]
+
+
+def install_qwen_sample_input_views() -> None:
+    if not envs.VLLM_MUSA_QWEN_SAMPLE_INPUT_VIEWS.get():
+        return
+    from vllm.v1.worker.gpu.sample.sampler import Sampler
+
+    if not hasattr(Sampler, "_musa_select_qwen_sample_input_views"):
+        Sampler._musa_select_qwen_sample_input_views = _select_qwen_sample_input_views

--- a/vllm_musa/v1/worker/__init__.py
+++ b/vllm_musa/v1/worker/__init__.py
@@ -1,4 +1,9 @@
+from vllm_musa.v1.sample.qwen_sample_input_views import (
+    install_qwen_sample_input_views,
+)
 from vllm_musa.v1.worker import qwen_fused_next_input_ids as qwen_fused_next_input_ids
 from vllm_musa.v1.worker import qwen_identity_logits_view as qwen_identity_logits_view
+
+install_qwen_sample_input_views()
 
 __all__ = ["qwen_fused_next_input_ids", "qwen_identity_logits_view"]


### PR DESCRIPTION
## Summary

- Add a default-off `VLLM_MUSA_QWEN_SAMPLE_INPUT_VIEWS` fast path for uniform Qwen decode.
- Reuse identity `logits_indices`/`input_ids` buffers as views before unfiltered sampling, avoiding two GPU index gathers.
- Keep the upstream gather path as the fail-closed fallback; no vLLM-Omni changes.

## Evidence

- Commit: `70074de00117cded9c8436fdb88103bd37f0eb71`
- Exact 96/96 patch replay.
- Remote focused tests: 77/77 passed.
- Compiled/captured Qwen3-8B BF16 + FLASH_ATTN semantic smoke passed.
- Exact-final MUPTI: int64 and int32 gathers each fall 64 -> 1 because the first prefill sample deliberately uses the fallback; all 63/63 steady-decode gathers are removed. This saves 815.284 us over the 64-token trace (12.739 us/output token), with Gumbel/post-update/completion parity 64/64.
- Two independent BS1 4096/1024 profiler-off A-B-B-A sweeps (12 control + 12 candidate reps): combined mean TPOT -0.3907%, median -0.2411%, throughput +0.3890%; 2/2 sweeps and 9/12 same-index reps positive.

The serving result is reported as directional; the causal claim is the MUPTI launch/time removal.

Stacked on #145.

Candidate archive: `generated/MUSA-60043/round23-sample-input-views/vllm-musa-candidate-70074de00.tar.gz` (SHA256 `d15f01b09aad2e5c22b2711420dadad0f679188e58957389de0d9cd8e23a98b0`).

Final evidence bundle: `generated/MUSA-60043/round23-sample-input-views/r23-final-evidence-70074de00.tar.gz` (SHA256 `1c48685ec91bea1e36c177f11aeab2aaba51a39f6ae5368586b78b25860d28b1`).