### PR TITLE
perf(musa): reuse Qwen uniform sample counts on host

### DIFF
--- a/tests/test_qwen_uniform_async_output.py
+++ b/tests/test_qwen_uniform_async_output.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import numpy as np
+from vllm.v1.worker.gpu import async_utils
+
+from vllm_musa.v1.sample.uniform_sample_counts import (
+    UNIFORM_NUM_SAMPLED_TOKENS_HOST_ATTR,
+)
+
+
+class FakeEvent:
+    def __init__(self) -> None:
+        self.recorded = False
+        self.synchronized = False
+
+    def record(self, stream) -> None:
+        del stream
+        self.recorded = True
+
+    def synchronize(self) -> None:
+        self.synchronized = True
+
+
+class FakeDeviceModule:
+    Event = FakeEvent
+
+    @staticmethod
+    @contextmanager
+    def stream(copy_stream):
+        del copy_stream
+        yield
+
+
+class FakeCopyStream:
+    def __init__(self) -> None:
+        self.waited = False
+
+    def wait_stream(self, main_stream) -> None:
+        del main_stream
+        self.waited = True
+
+
+def make_output(counts) -> tuple[SimpleNamespace, SimpleNamespace]:
+    return (
+        SimpleNamespace(prompt_logprobs_dict={}),
+        SimpleNamespace(
+            sampled_token_ids=object(),
+            logprobs_tensors=None,
+            num_nans=None,
+            num_sampled_tokens=counts,
+        ),
+    )
+
+
+def test_async_output_skips_only_tagged_uniform_count_copy(monkeypatch) -> None:
+    sampled_host = np.asarray([[7], [11]], dtype=np.int64)
+    fallback_host = np.ones(2, dtype=np.int32)
+    calls = []
+
+    def fake_copy(value):
+        calls.append(value)
+        return sampled_host if len(calls) % 2 == 1 else fallback_host
+
+    monkeypatch.setattr(
+        async_utils.torch, "get_device_module", lambda: FakeDeviceModule
+    )
+    monkeypatch.setattr(async_utils, "async_copy_to_np", fake_copy)
+
+    tagged_counts = SimpleNamespace()
+    cached_host = np.ones(2, dtype=np.int32)
+    setattr(tagged_counts, UNIFORM_NUM_SAMPLED_TOKENS_HOST_ATTR, cached_host)
+    model_output, sampler_output = make_output(tagged_counts)
+    tagged_stream = FakeCopyStream()
+    tagged = async_utils.AsyncOutput(
+        model_output, sampler_output, tagged_counts, object(), tagged_stream
+    )
+    assert len(calls) == 1
+    assert tagged.num_sampled_tokens_np is cached_host
+    assert tagged_stream.waited
+    assert tagged.copy_event.recorded
+    assert tagged.get_output().sampled_token_ids == [[7], [11]]
+    assert tagged.copy_event.synchronized
+
+    calls.clear()
+    fallback_counts = SimpleNamespace()
+    model_output, sampler_output = make_output(fallback_counts)
+    fallback_stream = FakeCopyStream()
+    fallback = async_utils.AsyncOutput(
+        model_output, sampler_output, fallback_counts, object(), fallback_stream
+    )
+    assert len(calls) == 2
+    assert fallback.num_sampled_tokens_np is fallback_host
+    assert fallback_stream.waited
+    assert fallback.get_output().sampled_token_ids == [[7], [11]]

--- a/tests/test_qwen_uniform_async_output.py
+++ b/tests/test_qwen_uniform_async_output.py
@@ -25,14 +25,10 @@ class FakeEvent:
         self.synchronized = True
 
 
-class FakeDeviceModule:
-    Event = FakeEvent
-
-    @staticmethod
-    @contextmanager
-    def stream(copy_stream):
-        del copy_stream
-        yield
+@contextmanager
+def fake_stream(to_stream, from_stream):
+    del to_stream, from_stream
+    yield
 
 
 class FakeCopyStream:
@@ -65,9 +61,8 @@ def test_async_output_skips_only_tagged_uniform_count_copy(monkeypatch) -> None:
         calls.append(value)
         return sampled_host if len(calls) % 2 == 1 else fallback_host
 
-    monkeypatch.setattr(
-        async_utils.torch, "get_device_module", lambda: FakeDeviceModule
-    )
+    monkeypatch.setattr(async_utils, "stream", fake_stream)
+    monkeypatch.setattr(async_utils.torch.cuda, "Event", FakeEvent)
     monkeypatch.setattr(async_utils, "async_copy_to_np", fake_copy)
 
     tagged_counts = SimpleNamespace()

--- a/tests/test_qwen_uniform_sample_counts.py
+++ b/tests/test_qwen_uniform_sample_counts.py
@@ -51,7 +51,7 @@ def test_qwen_uniform_sample_counts_accepts_and_reuses(monkeypatch) -> None:
     assert first_host.ctypes.data == second_host.ctypes.data
 
 
-def test_qwen_uniform_sample_counts_accepts_all_qwen_vocab_families(
+def test_qwen_uniform_sample_counts_accepts_supported_qwen_vocab_sizes(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(sample_counts.current_platform, "is_musa", lambda: True)

--- a/tests/test_qwen_uniform_sample_counts.py
+++ b/tests/test_qwen_uniform_sample_counts.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # ruff: noqa: I001
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -43,6 +44,11 @@ def test_qwen_uniform_sample_counts_accepts_and_reuses(monkeypatch) -> None:
     assert first[1].tolist() == [0, 0, 0, 0]
     assert first[0].data_ptr() == second[0].data_ptr()
     assert first[1].data_ptr() == second[1].data_ptr()
+    first_host = getattr(first[0], sample_counts.UNIFORM_NUM_SAMPLED_TOKENS_HOST_ATTR)
+    second_host = getattr(second[0], sample_counts.UNIFORM_NUM_SAMPLED_TOKENS_HOST_ATTR)
+    assert first_host.dtype == np.int32
+    assert first_host.tolist() == [1, 1, 1, 1]
+    assert first_host.ctypes.data == second_host.ctypes.data
 
 
 def test_qwen_uniform_sample_counts_grows_and_changes_dtype(monkeypatch) -> None:
@@ -72,6 +78,11 @@ def test_qwen_uniform_sample_counts_grows_and_changes_dtype(monkeypatch) -> None
     assert larger[0].data_ptr() != first[0].data_ptr()
     assert int64_counts[0].dtype == torch.int64
     assert int64_counts[0].data_ptr() != larger[0].data_ptr()
+    int64_host = getattr(
+        int64_counts[0], sample_counts.UNIFORM_NUM_SAMPLED_TOKENS_HOST_ATTR
+    )
+    assert int64_host.dtype == np.int64
+    assert int64_host.tolist() == [1] * 8
 
 
 def test_qwen_uniform_sample_counts_bound_hook(monkeypatch) -> None:
@@ -132,3 +143,44 @@ def test_qwen_uniform_sample_counts_rejects_non_qwen_trait(monkeypatch) -> None:
         )
         is None
     )
+
+
+def test_qwen_uniform_sample_counts_rejects_unsupported_count_dtype(
+    monkeypatch,
+) -> None:
+    install_test_gates(monkeypatch)
+    batch = make_batch(2)
+    batch.seq_lens = batch.seq_lens.to(torch.float32)
+    logits = torch.empty((2, 151936), dtype=torch.bfloat16)
+    assert (
+        sample_counts.select_qwen_uniform_sample_counts(
+            SimpleNamespace(_musa_qwen_family=True), logits, batch
+        )
+        is None
+    )
+
+
+def test_qwen_async_output_patch_is_tag_gated() -> None:
+    patch = (
+        Path(__file__).parents[1]
+        / "vllm_musa"
+        / "patches"
+        / "series"
+        / "0097-perf-elide-qwen-uniform-count-dtoh.patch"
+    ).read_text()
+    assert sample_counts.UNIFORM_NUM_SAMPLED_TOKENS_HOST_ATTR in patch
+    assert "if host_num_sampled_tokens is None" in patch
+    assert "async_copy_to_np(num_sampled_tokens)" in patch
+    assert "import vllm_musa" not in patch
+
+
+def test_qwen_uniform_count_host_tag_can_be_disabled(monkeypatch) -> None:
+    install_test_gates(monkeypatch)
+    monkeypatch.setattr(sample_counts, "_use_uniform_count_host", False)
+    output = sample_counts.select_qwen_uniform_sample_counts(
+        SimpleNamespace(_musa_qwen_family=True),
+        torch.empty((2, 151936), dtype=torch.bfloat16),
+        make_batch(2),
+    )
+    assert output is not None
+    assert not hasattr(output[0], sample_counts.UNIFORM_NUM_SAMPLED_TOKENS_HOST_ATTR)

--- a/tests/test_qwen_uniform_sample_counts.py
+++ b/tests/test_qwen_uniform_sample_counts.py
@@ -51,6 +51,30 @@ def test_qwen_uniform_sample_counts_accepts_and_reuses(monkeypatch) -> None:
     assert first_host.ctypes.data == second_host.ctypes.data
 
 
+def test_qwen_uniform_sample_counts_accepts_all_qwen_vocab_families(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(sample_counts.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sample_counts, "is_musa_tensor", lambda _tensor: True)
+    for vocab_size in (151936, 248320):
+        output = sample_counts.select_qwen_uniform_sample_counts(
+            SimpleNamespace(_musa_qwen_family=True),
+            torch.empty((2, vocab_size), dtype=torch.bfloat16),
+            make_batch(2),
+        )
+        assert output is not None
+        assert output[0].tolist() == [1, 1]
+
+    assert (
+        sample_counts.select_qwen_uniform_sample_counts(
+            SimpleNamespace(_musa_qwen_family=True),
+            torch.empty((2, 32000), dtype=torch.bfloat16),
+            make_batch(2),
+        )
+        is None
+    )
+
+
 def test_qwen_uniform_sample_counts_grows_and_changes_dtype(monkeypatch) -> None:
     install_test_gates(monkeypatch)
     sampler = SimpleNamespace(_musa_qwen_family=True)

--- a/vllm_musa/patches/series/0097-perf-elide-qwen-uniform-count-dtoh.patch
+++ b/vllm_musa/patches/series/0097-perf-elide-qwen-uniform-count-dtoh.patch
@@ -1,0 +1,28 @@
+Subject: [PATCH] perf: reuse proven Qwen sample counts on host
+
+The MUSA Qwen pure-decode selector already proves that every request produces
+exactly one token and returns a tagged cached count tensor. Reuse its cached
+host array in AsyncOutput instead of issuing a second per-step DtoH copy. The
+untagged upstream path remains unchanged for prefill, speculative decoding,
+non-Qwen models, and every selector fallback.
+
+--- a/vllm/v1/worker/gpu/async_utils.py
++++ b/vllm/v1/worker/gpu/async_utils.py
+@@ -38,7 +38,16 @@ class AsyncOutput(AsyncModelRunnerOutput):
+             self.num_nans: np.ndarray | None = None
+             if sampler_output.num_nans is not None:
+                 self.num_nans = async_copy_to_np(sampler_output.num_nans)
+-            self.num_sampled_tokens_np = async_copy_to_np(num_sampled_tokens)
++            host_num_sampled_tokens = getattr(
++                num_sampled_tokens,
++                "_vllm_musa_uniform_num_sampled_tokens_host",
++                None,
++            )
++            self.num_sampled_tokens_np = (
++                async_copy_to_np(num_sampled_tokens)
++                if host_num_sampled_tokens is None
++                else host_num_sampled_tokens
++            )
+             self.prompt_logprobs_dict = {
+                 k: v.to_cpu_nonblocking() if v is not None else None
+                 for k, v in self.model_runner_output.prompt_logprobs_dict.items()

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -92,6 +92,7 @@ class Envs:
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SEEDED_MULTINOMIAL = EnvBool(True)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
+    VLLM_MUSA_QWEN_UNIFORM_COUNT_HOST = EnvBool(True)
 
 
 envs = Envs()

--- a/vllm_musa/v1/sample/uniform_sample_counts.py
+++ b/vllm_musa/v1/sample/uniform_sample_counts.py
@@ -9,12 +9,16 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 
+from vllm_musa.utils.environ import envs
 from vllm_musa.v1.sample.topk_topp_sampler import (
     _is_qwen_sampler_vocab,
     is_musa_tensor,
 )
 
 logger = init_logger(__name__)
+
+UNIFORM_NUM_SAMPLED_TOKENS_HOST_ATTR = "_vllm_musa_uniform_num_sampled_tokens_host"
+_use_uniform_count_host = envs.VLLM_MUSA_QWEN_UNIFORM_COUNT_HOST.get()
 
 
 def select_qwen_uniform_sample_counts(
@@ -32,7 +36,6 @@ def select_qwen_uniform_sample_counts(
         or not _is_qwen_sampler_vocab(logits)
     ):
         return None
-
     try:
         num_reqs = input_batch.num_reqs
         num_scheduled_tokens = input_batch.num_scheduled_tokens
@@ -40,6 +43,12 @@ def select_qwen_uniform_sample_counts(
         num_draft_tokens = input_batch.num_draft_tokens
         seq_lens = input_batch.seq_lens
     except AttributeError:
+        return None
+    if seq_lens.dtype == torch.int32:
+        host_dtype = np.int32
+    elif seq_lens.dtype == torch.int64:
+        host_dtype = np.int64
+    else:
         return None
     if (
         num_reqs <= 0
@@ -64,13 +73,21 @@ def select_qwen_uniform_sample_counts(
             device=seq_lens.device,
         )
         num_rejected = torch.zeros_like(num_sampled)
-        buffers = (cache_key, num_sampled, num_rejected)
+        num_sampled_host = np.ones(capacity, dtype=host_dtype)
+        buffers = (cache_key, num_sampled, num_rejected, num_sampled_host)
         sampler._musa_qwen_uniform_sample_count_buffers = buffers
         logger.info_once(
             "Using cached MUSA Qwen uniform decode sample counts.",
             scope="global",
         )
-    return buffers[1][:num_reqs], buffers[2][:num_reqs]
+    num_sampled_tokens = buffers[1][:num_reqs]
+    if _use_uniform_count_host:
+        setattr(
+            num_sampled_tokens,
+            UNIFORM_NUM_SAMPLED_TOKENS_HOST_ATTR,
+            buffers[3][:num_reqs],
+        )
+    return num_sampled_tokens, buffers[2][:num_reqs]
 
 
 def install_hooks() -> None:


### PR DESCRIPTION
## Summary

- cache a NumPy ones buffer beside the existing Qwen pure-decode GPU count
  buffers;
- tag only counts produced by the selector that already proves every scheduled
  request emits one token;
- reuse the tagged host counts in `AsyncOutput`, while preserving the original
  `async_copy_to_np(num_sampled_tokens)` fallback for every untagged path;
- add `VLLM_MUSA_QWEN_UNIFORM_COUNT_HOST=0` as a fresh-server kill switch.

This Draft is stacked on #147. Please review the five Round29 commits only.

## Scope

The optimization applies to the Qwen new-GPU-worker BF16 pure-decode path with
one scheduled token per request, no prefill, no draft tokens, no prompt
logprobs, a supported Qwen vocabulary, and int32/int64 count tensors.

Current Qwen3.5/Qwen3.6 legacy-runner paths already issue only one sampled-token
DtoH copy per step, so this change is currently a no-op for those paths. The
`248320` vocabulary test protects a future transition to the new worker path;
it is not a current Qwen3.5/Qwen3.6 performance claim.

## Performance

Hardware: one MTT S5000 on an isolated eight-S5000 node, driver
`5.2.0-server`. Model/workload: Qwen3-8B BF16, FlashAttention,
FULL_AND_PIECEWISE graph capture, 4096 input / 1024 output tokens,
fresh-server A-B-B-A, three repetitions per leg.

| Batch | Control TPOT | Candidate TPOT | Delta | Adjacent wins | Same-index wins |
|---:|---:|---:|---:|---:|---:|
| 1 | 14.734079 ms | 14.569118 ms | **-1.119590%** | 2/2 | 6/6 |
| 64 | 50.232437 ms | 49.915409 ms | **-0.631121%** | 2/2 | 6/6 |

TTFT changed by `+0.0122%` at BS1 and `-0.0134%` at BS64. Output throughput
improved by `+1.1129%` and `+0.5504%`, respectively.

## Trace mechanism

Each 20-step trace preserves 20 graph launches and 20 CPU/GPU generation
annotations while reducing total DtoH copies from 40 to 20:

- uniform sample-count DtoH: `20 -> 0`;
- sampled-ID DtoH: `20 -> 20`;
- total DtoH: `40 -> 20`.

At BS64 these are `256B` count copies and `512B` ID copies. Both independent
control/candidate trace pairs pass the direction-and-size mechanism gate.

## Validation

- exact source: `71713cd385b1ae0f457bbb5cac7f2b6181522024`;
- stacked base: `aae95d413b261d8fba38fa23bcca6a82ec822957`;
- source archive SHA256:
  `f8d271beafe59cdd3235214b22019c63f20bbcc42047d5b3b39dd1bf243557c8`;
- 100/100 build-time patches applied; native import passed;
- focused tests: `10 passed in 9.52s`;
- actual MUSA smoke passed for vocabularies `151936` and `248320`;
- tagged/fallback asynchronous copies: `1/2`, with identical sampled IDs and
  counts;
- sealed formal evidence SHA256:
  `a6dc508151fd3b88a057d26a2153f1b2318f34cad157815e7478989cca3fd9b0`.

The untagged path performs one private-attribute lookup and retains the original
asynchronous host copy unchanged. The environment flag provides an immediate
fallback without rebuilding.

## Not run

- repository CI: pending on this Draft PR;
- current Qwen3.5/Qwen3.6 legacy-runner performance claim: not applicable,
  because profiling shows that path has no redundant count DtoH to remove.
