### PR TITLE
perf: prefer upstream fused MoE for large Qwen BF16 prefill

### DIFF
--- a/tests/test_qwen_moe_bf16_prefill_policy.py
+++ b/tests/test_qwen_moe_bf16_prefill_policy.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402, I001
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+torchada = pytest.importorskip("torchada")
+import torch
+
+import vllm_musa.model_executor.layers.fused_moe.fused_moe as fused_moe
+
+
+def _inputs(
+    *,
+    tokens: int = 8192,
+    hidden_size: int = 2048,
+    experts: int = 256,
+    topk: int = 8,
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[torch.Tensor, ...]:
+    hidden_states = torch.empty((tokens, hidden_size), dtype=dtype, device="meta")
+    w1 = torch.empty((experts, 256, hidden_size), dtype=dtype, device="meta")
+    w2 = torch.empty((experts, hidden_size, 128), dtype=dtype, device="meta")
+    topk_weights = torch.empty((tokens, topk), dtype=torch.float32, device="meta")
+    topk_ids = torch.empty((tokens, topk), dtype=torch.int32, device="meta")
+    return hidden_states, w1, w2, topk_weights, topk_ids
+
+
+def test_qwen_moe_bf16_prefill_shape_is_enabled_by_default() -> None:
+    assert fused_moe._QWEN_MOE_UPSTREAM_PREFILL_ENABLED
+    assert fused_moe._is_calibrated_qwen_moe_bf16_prefill_shape(
+        *_inputs(), global_num_experts=256
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "global_num_experts"),
+    [
+        ({"tokens": 1023}, 256),
+        ({"hidden_size": 4096}, 256),
+        ({"experts": 128}, 128),
+        ({"topk": 4}, 256),
+        ({"dtype": torch.float16}, 256),
+    ],
+)
+def test_qwen_moe_bf16_prefill_shape_rejects_other_contracts(
+    kwargs: dict[str, object], global_num_experts: int
+) -> None:
+    assert not fused_moe._is_calibrated_qwen_moe_bf16_prefill_shape(
+        *_inputs(**kwargs), global_num_experts=global_num_experts
+    )
+
+
+def test_qwen_moe_bf16_prefill_shape_respects_rollback_gate(monkeypatch) -> None:
+    monkeypatch.setattr(fused_moe, "_QWEN_MOE_UPSTREAM_PREFILL_ENABLED", False)
+    assert not fused_moe._is_calibrated_qwen_moe_bf16_prefill_shape(
+        *_inputs(), global_num_experts=256
+    )
+
+
+def test_qwen_moe_bf16_prefill_policy_wires_upstream_fallback() -> None:
+    root = Path(__file__).resolve().parents[1]
+    source = (
+        root / "vllm_musa/model_executor/layers/fused_moe/fused_moe.py"
+    ).read_text(encoding="utf-8")
+    assert "prefer_upstream_qwen_prefill" in source
+    assert "and not prefer_upstream_qwen_prefill" in source
+    assert "VLLM_MUSA_QWEN_MOE_UPSTREAM_PREFILL" in source

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -63,6 +63,7 @@ _DEEPGEMM_PREFILL_MIN_TOKENS_ENV = "VLLM_MUSA_MOE_DEEPGEMM_PREFILL_MIN_TOKENS"
 _DEEPGEMM_PREFILL_WARNED = False
 _DEEPGEMM_BF16_PREFILL_MIN_TOKENS = 1024
 _DEEPGEMM_BF16_PREFILL_WARNED = False
+_QWEN_MOE_UPSTREAM_PREFILL_ENV = "VLLM_MUSA_QWEN_MOE_UPSTREAM_PREFILL"
 _MUSA_GROUPED_GEMM_AVAILABLE = True
 _MUSA_FUSED_MOE_REQUESTED_BACKEND = parse_dispatch_backend()
 
@@ -84,6 +85,9 @@ def _env_flag_disabled(name: str) -> bool:
 
 
 _MOE_SHAPE_INVENTORY_ENABLED = _env_flag_enabled(_MOE_SHAPE_INVENTORY_ENV)
+_QWEN_MOE_UPSTREAM_PREFILL_ENABLED = not _env_flag_disabled(
+    _QWEN_MOE_UPSTREAM_PREFILL_ENV
+)
 
 
 def _env_int(name: str, default: int) -> int:
@@ -536,6 +540,33 @@ def _can_use_moe_deepgemm_bf16_prefill(
         and K % 128 == 0
         and K == hidden_states.size(1)
         and w2.shape == (E, K, N // 2)
+    )
+
+
+def _is_calibrated_qwen_moe_bf16_prefill_shape(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    global_num_experts: int | None,
+) -> bool:
+    """Match the TP4 Qwen3.5/3.6-35B-A3B BF16 prefill shape."""
+    return (
+        _QWEN_MOE_UPSTREAM_PREFILL_ENABLED
+        and global_num_experts == 256
+        and hidden_states.ndim == 2
+        and hidden_states.dtype == torch.bfloat16
+        and w1.dtype == torch.bfloat16
+        and w2.dtype == torch.bfloat16
+        and hidden_states.shape[0] >= _DEEPGEMM_BF16_PREFILL_MIN_TOKENS
+        and hidden_states.shape[1] == 2048
+        and w1.shape == (256, 256, 2048)
+        and w2.shape == (256, 2048, 128)
+        and topk_weights.ndim == 2
+        and topk_ids.ndim == 2
+        and topk_weights.shape == topk_ids.shape
+        and topk_ids.shape[1] == 8
     )
 
 
@@ -1923,8 +1954,48 @@ def _musa_fused_experts_impl_dispatch(
             _allow_deepgemm_prefill=False,
         )
 
+    prefer_upstream_qwen_prefill = (
+        _MUSA_FUSED_MOE_REQUESTED_BACKEND == MusaFusedMoeBackend.AUTO
+        and _is_calibrated_qwen_moe_bf16_prefill_shape(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            global_num_experts,
+        )
+        and _can_use_moe_deepgemm_bf16_prefill(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_ids=topk_ids,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a8=use_int8_w8a8,
+            use_int8_w8a16=use_int8_w8a16,
+            use_int4_w4a16=use_int4_w4a16,
+            ocp_mx_scheme=ocp_mx_scheme,
+            per_channel_quant=per_channel_quant,
+            expert_map=expert_map,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            block_shape=block_shape,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+        )
+    )
+    if prefer_upstream_qwen_prefill:
+        logger.info_once(
+            "Using the upstream fused MoE path for large BF16 "
+            "Qwen3.5/3.6-35B-A3B prefill batches."
+        )
+
     bf16_prefill_candidate = (
         _MUSA_FUSED_MOE_REQUESTED_BACKEND == MusaFusedMoeBackend.AUTO
+        and not prefer_upstream_qwen_prefill
         and not use_fp8_w8a8
         and hidden_states.shape[0] >= _DEEPGEMM_BF16_PREFILL_MIN_TOKENS
         and w1.dim() == 3


### PR DESCRIPTION
## Summary

- prefer the upstream fused-MoE implementation for the calibrated large BF16
  Qwen3.5/3.6-35B-A3B TP4 prefill shape
- preserve the existing DeepGEMM path for small batches and every unmatched
  model, dtype, expert layout, routing contract, and quantization mode
- add `VLLM_MUSA_QWEN_MOE_UPSTREAM_PREFILL=0` as a rollback/A-B gate

## Motivation

A fresh Qwen3.5-35B-A3B BF16 TP4 profile showed that DeepGEMM's
assign/compact and post-reorder kernels each consume about 5.25% of rank-0
device time. The existing upstream fused-MoE path avoids that layout-conversion
pair and is faster end to end for this shape.

## Performance

S5000 TP4, Qwen3.5-35B-A3B BF16, 64 concurrent requests, exact input lengths
4108--4111, output 1. Order was old-auto / candidate / candidate / old-auto;
each server had one stabilization run and three measured clients.

| metric | old auto | candidate | delta | paired direction |
|---|---:|---:|---:|---:|
| mean TTFT | 3336.06 ms | 3153.91 ms | -5.46% | 6/6 |
| median TTFT | 3341.82 ms | 3159.31 ms | -5.46% | 6/6 |
| p95 TTFT | 6047.14 ms | 5688.49 ms | -5.93% | 6/6 |
| request throughput | 10.2817 req/s | 10.8732 req/s | +5.75% | 6/6 |

Runtime evidence:

- MTT S5000 GPUs 0--3, driver 5.2.0-server
- image digest `sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`
- torch/torch_musa 2.9.1.post1 + MUSA 5.2.0, torchada 0.1.76,
  MATE/flash_attn_3 0.2.4
- normal compiled serving path with FULL decode graph configuration; no eager
  or Dynamo-disable performance flags
- semantic, policy-marker, graph-capture, and measured-window JIT gates passed

## Validation

- `python -m pytest -q tests/test_moe_bf16_deepgemm_source.py tests/test_fused_moe_dispatch_policy.py`
  - 15 passed
- real-S5000 meta-shape/default/rollback policy probe passed
- two complete default-policy serving processes passed, three measured clients
  each
- `ruff check --ignore I001` on changed files, Python compilation, and
  `git diff --check` passed

## Follow-up coverage

The same commit with `VLLM_MUSA_QWEN_MOE_UPSTREAM_PREFILL=0` as control was
also checked at BS1/4/16. Policy mean TTFT deltas were -10.48%, -7.83%, and
-6.97%, respectively, with throughput gains +11.64%, +8.75%, and +7.66%.
Qwen3.6-35B-A3B passed the policy/graph/semantic gates at BS64 (mean TTFT
3126.23 ms across three clients).

## Draft scope / not yet run

- Qwen3.6-35B-A3B BS1/4/16 crossover
- long-output decode regression matrix

The gate is deliberately exact and defaults back to the existing dispatcher
outside the measured TP4 BF16 contract. This PR only changes vLLM-MUSA; it does
not add or override vLLM-Omni integration.
