### PR TITLE
[WIP][MUSA-60043] perf: extend sharded Qwen Gumbel to TP4

### DIFF
--- a/tests/test_qwen_sharded_gumbel_source.py
+++ b/tests/test_qwen_sharded_gumbel_source.py
@@ -17,7 +17,8 @@ def test_sharded_gumbel_is_narrowly_gated_and_uses_ipc_pair_gather() -> None:
     source = SAMPLER.read_text()
     assert "_MUSA_QWEN_SHARDED_MIN_BATCH = 32" in source
     assert '"VLLM_MUSA_SHARDED_QWEN_GUMBEL"' in source
-    assert "tp_size == 2" in source
+    assert "tp_size in (2, 4)" in source
+    assert "tp_size not in (2, 4)" in source
     assert "get_pp_group().world_size != 1" in source
     assert "maybe_musa_jit_logits_all_gather(pair, dim=-1)" in source
     assert "scores = gathered[:, :, 0].contiguous()" in source

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -44,7 +44,7 @@ def _is_qwen_sharded_logits(sampler: Any, logits: torch.Tensor) -> bool:
         logits.ndim == 2
         and global_vocab in _MUSA_QWEN_SAMPLER_VOCAB_SIZES
         and tp_size == get_tensor_model_parallel_world_size()
-        and tp_size == 2
+        and tp_size in (2, 4)
         and logits.shape[0] >= _MUSA_QWEN_SHARDED_MIN_BATCH
         and logits.shape[0] <= 64
         and logits.shape[1] * tp_size == global_vocab
@@ -613,7 +613,7 @@ def musa_compute_logits_if_eligible(
         return model.compute_logits(hidden_states), False
     processor, _lm_head = processor_and_head
     tp_size = get_tensor_model_parallel_world_size()
-    if tp_size != 2:
+    if tp_size not in (2, 4):
         return model.compute_logits(hidden_states), False
     global_vocab = int(getattr(processor, "org_vocab_size", 0))
     if (


### PR DESCRIPTION
## Summary

Extend the existing sharded Qwen Gumbel sampling path from TP2 to TP4.

For the calibrated BF16 Qwen3.5/3.6-35B-A3B shape (vocab 248320), each rank
now runs Gumbel locally and exchanges only the four-value winner pair through
the existing MUSA IPC gather. The gate remains exact and conservative; other
TP sizes and padded dense-Qwen shards stay on the existing full-vocab path.

## Evidence

On an MTT S5000, TP4, BS64, 4096 input / 256 output, normal compiled serving,
the formal A-B-B-A result was:

| Metric | Sharded vs full |
|---|---:|
| output throughput | **+1.32%** (pair +0.71%, +1.94%) |
| mean TPOT | **-1.99%** (pair -1.47%, -2.51%) |
| mean E2EL | **-1.41%** (pair -0.81%, -2.01%) |
| mean TTFT | +0.14% (neutral) |

Both arms completed 64/64 requests and passed graph/semantic gates. A Qwen3.6-
35B-A3B TP4 sharded smoke also passed. The TP4 Gumbel equivalence test covers
vocab 151936/248320 and BS 1/4/16/32/64; the TP4 IPC pair gather test covers
changing inputs at BS32/64 for 20 iterations per rank.

Full evidence is in
`generated/MUSA-60043/round44-tp4-sharded-gumbel/round44-result.md`.

## Scope and follow-up

This PR contains only the TP gate/test change and is stacked on #155. It does
not attempt Qwen3 dense padding-aware shards: Qwen3-8B's TP4 local vocab is
38016 (152064 padded global) while its unpadded vocab is 151936, so the exact
gate correctly leaves it on the full path. A separate follow-up can add a
last-rank padding mask after frozen-logits proof.

## Validation

- `pytest -q tests/test_qwen_sharded_gumbel_source.py`
- `ruff check --ignore I001 ...`; Python compile and `git diff --check`
- TP4 frozen Gumbel equivalence and changing-input IPC gather
- Qwen3.5-35B-A3B and Qwen3.6-35B-A3B TP4 serving semantic/graph smokes

Environment: image
`sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`,
MUSA driver 5.2.0-server, torch 2.9.1.post1, torch_musa
2.9.1.post1+musa5.2.0s5000.
