### PR TITLE
[NO-GO] perf(musa): fuse Qwen GDN prefill state gather and mask

### DIFF
--- a/tests/test_qwen_gdn_prefill_state_gather.py
+++ b/tests/test_qwen_gdn_prefill_state_gather.py
@@ -1,52 +1,58 @@
 # SPDX-License-Identifier: Apache-2.0
 """Focused caller contract for fused Qwen GDN prefill state gathering."""
 
-from types import SimpleNamespace
-
 # isort: off
 import torchada  # noqa: F401
 import torch
 # isort: on
 
+from vllm_musa.jit_kernel import fused_gdn_gating as gating
 from vllm_musa.jit_kernel import gdn_state_gather_mask as fused_state
 from vllm_musa.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
 
 
+def _attention() -> gdn.MusaQwenGatedDeltaNetAttention:
+    attention = object.__new__(gdn.MusaQwenGatedDeltaNetAttention)
+    attention.num_k_heads = 2
+    attention.num_v_heads = 2
+    attention.tp_size = 1
+    attention.head_k_dim = 2
+    attention.head_v_dim = 2
+    attention.A_log = torch.ones(2)
+    attention.dt_bias = torch.ones(2)
+    return attention
+
+
 def _inputs() -> tuple[torch.Tensor, ...]:
-    q = torch.randn(4, 2, 2)
-    k = torch.randn(4, 2, 2)
-    v = torch.randn(4, 2, 2)
-    g = torch.randn(4, 2)
-    beta = torch.randn(4, 2)
-    output = torch.empty_like(v)
-    return q, k, v, g, beta, output
-
-
-def _layer() -> tuple[gdn.Qwen3_5GatedDeltaNet, torch.Tensor]:
-    layer = object.__new__(gdn.Qwen3_5GatedDeltaNet)
+    mixed_qkv = torch.randn(4, 12)
+    a = torch.randn(4, 2)
+    b = torch.randn(4, 2)
     state = torch.arange(4 * 2 * 2 * 2, dtype=torch.float32).reshape(4, 2, 2, 2)
-    layer.kv_cache = [torch.empty(0), state]
-    return layer, state
+    indices = torch.tensor([1, 3], dtype=torch.int32)
+    query_start = torch.tensor([0, 2, 4], dtype=torch.int32)
+    has_initial = torch.tensor([True, False])
+    output = torch.empty(4, 2, 2)
+    return mixed_qkv, a, b, state, indices, query_start, has_initial, output
 
 
-def _metadata() -> SimpleNamespace:
-    return SimpleNamespace(
-        num_prefills=2,
-        num_prefill_tokens=4,
-        num_decode_tokens=0,
+def _patch_gating(monkeypatch) -> None:
+    monkeypatch.setattr(
+        gating,
+        "fused_gdn_gating",
+        lambda _a_log, a, b, _dt_bias: (torch.ones_like(a), torch.ones_like(b)),
     )
+    monkeypatch.setattr(gdn, "_MATE_GDN_PREFILL_HAS_IS_LOG_SPACE", True)
+    monkeypatch.setattr(gdn, "_MATE_GDN_PREFILL_HAS_OUTPUT", True)
 
 
 def test_prefill_uses_fused_initial_state_and_preserves_scatter(monkeypatch) -> None:
-    layer, state = _layer()
-    q, k, v, g, beta, output = _inputs()
-    indices = torch.tensor([1, 3], dtype=torch.int32)
-    has_initial = torch.tensor([True, False])
-    query_start = torch.tensor([0, 2, 4], dtype=torch.int32)
+    attention = _attention()
+    mixed_qkv, a, b, state, indices, query_start, has_initial, output = _inputs()
     fused_initial = torch.full((2, 2, 2, 2), 7.0)
     final_state = torch.full_like(fused_initial, 11.0)
     seen: dict[str, torch.Tensor] = {}
 
+    _patch_gating(monkeypatch)
     monkeypatch.setattr(
         fused_state, "can_use_fused_gdn_state_gather_mask", lambda *args: True
     )
@@ -55,26 +61,23 @@ def test_prefill_uses_fused_initial_state_and_preserves_scatter(monkeypatch) -> 
         "fused_gdn_state_gather_mask",
         lambda *args: fused_initial,
     )
-    monkeypatch.setattr(gdn, "_MATE_GDN_PREFILL_HAS_OUTPUT", True)
 
-    def fake_chunk(*args, initial_state, output, **kwargs):
-        seen["initial_state"] = initial_state
-        output.fill_(3.0)
-        return output, final_state
+    def fake_chunk(**kwargs):
+        seen["initial_state"] = kwargs["initial_state"]
+        kwargs["output"].fill_(3.0)
+        return kwargs["output"], final_state
 
     monkeypatch.setattr(gdn, "chunk_gated_delta_rule", fake_chunk)
 
-    result = layer._try_mate_prefill(
-        q,
-        k,
-        v,
-        g,
-        beta,
-        output,
-        _metadata(),
-        query_start,
+    result = attention._try_mate_prefill(
+        mixed_qkv,
+        a,
+        b,
+        state,
         indices,
+        query_start,
         has_initial,
+        out=output,
     )
 
     assert result is not None
@@ -85,36 +88,68 @@ def test_prefill_uses_fused_initial_state_and_preserves_scatter(monkeypatch) -> 
 
 
 def test_prefill_falls_back_to_index_and_mask(monkeypatch) -> None:
-    layer, state = _layer()
-    q, k, v, g, beta, output = _inputs()
-    indices = torch.tensor([1, 3], dtype=torch.int32)
-    has_initial = torch.tensor([True, False])
-    query_start = torch.tensor([0, 2, 4], dtype=torch.int32)
+    attention = _attention()
+    mixed_qkv, a, b, state, indices, query_start, has_initial, output = _inputs()
     expected_initial = torch.stack((state[1], torch.zeros_like(state[3])))
     seen: dict[str, torch.Tensor] = {}
 
+    _patch_gating(monkeypatch)
     monkeypatch.setattr(
         fused_state, "can_use_fused_gdn_state_gather_mask", lambda *args: False
     )
-    monkeypatch.setattr(gdn, "_MATE_GDN_PREFILL_HAS_OUTPUT", True)
 
-    def fake_chunk(*args, initial_state, output, **kwargs):
-        seen["initial_state"] = initial_state.clone()
-        return output.zero_(), torch.zeros_like(initial_state)
+    def fake_chunk(**kwargs):
+        seen["initial_state"] = kwargs["initial_state"].clone()
+        return kwargs["output"].zero_(), torch.zeros_like(kwargs["initial_state"])
 
     monkeypatch.setattr(gdn, "chunk_gated_delta_rule", fake_chunk)
 
-    result = layer._try_mate_prefill(
-        q,
-        k,
-        v,
-        g,
-        beta,
-        output,
-        _metadata(),
-        query_start,
+    result = attention._try_mate_prefill(
+        mixed_qkv,
+        a,
+        b,
+        state,
         indices,
+        query_start,
         has_initial,
+        out=output,
+    )
+
+    assert result is not None
+    torch.testing.assert_close(seen["initial_state"], expected_initial)
+
+
+def test_prefill_fused_failure_keeps_mate_prefill(monkeypatch) -> None:
+    attention = _attention()
+    mixed_qkv, a, b, state, indices, query_start, has_initial, output = _inputs()
+    expected_initial = torch.stack((state[1], torch.zeros_like(state[3])))
+    seen: dict[str, torch.Tensor] = {}
+
+    _patch_gating(monkeypatch)
+    monkeypatch.setattr(
+        fused_state, "can_use_fused_gdn_state_gather_mask", lambda *args: True
+    )
+
+    def fail_fused_gather(*args):
+        raise RuntimeError("synthetic fused-gather failure")
+
+    monkeypatch.setattr(fused_state, "fused_gdn_state_gather_mask", fail_fused_gather)
+
+    def fake_chunk(**kwargs):
+        seen["initial_state"] = kwargs["initial_state"].clone()
+        return kwargs["output"].zero_(), torch.zeros_like(kwargs["initial_state"])
+
+    monkeypatch.setattr(gdn, "chunk_gated_delta_rule", fake_chunk)
+
+    result = attention._try_mate_prefill(
+        mixed_qkv,
+        a,
+        b,
+        state,
+        indices,
+        query_start,
+        has_initial,
+        out=output,
     )
 
     assert result is not None

--- a/tests/test_qwen_gdn_prefill_state_gather.py
+++ b/tests/test_qwen_gdn_prefill_state_gather.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused caller contract for fused Qwen GDN prefill state gathering."""
+
+from types import SimpleNamespace
+
+# isort: off
+import torchada  # noqa: F401
+import torch
+# isort: on
+
+from vllm_musa.jit_kernel import gdn_state_gather_mask as fused_state
+from vllm_musa.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+
+
+def _inputs() -> tuple[torch.Tensor, ...]:
+    q = torch.randn(4, 2, 2)
+    k = torch.randn(4, 2, 2)
+    v = torch.randn(4, 2, 2)
+    g = torch.randn(4, 2)
+    beta = torch.randn(4, 2)
+    output = torch.empty_like(v)
+    return q, k, v, g, beta, output
+
+
+def _layer() -> tuple[gdn.Qwen3_5GatedDeltaNet, torch.Tensor]:
+    layer = object.__new__(gdn.Qwen3_5GatedDeltaNet)
+    state = torch.arange(4 * 2 * 2 * 2, dtype=torch.float32).reshape(4, 2, 2, 2)
+    layer.kv_cache = [torch.empty(0), state]
+    return layer, state
+
+
+def _metadata() -> SimpleNamespace:
+    return SimpleNamespace(
+        num_prefills=2,
+        num_prefill_tokens=4,
+        num_decode_tokens=0,
+    )
+
+
+def test_prefill_uses_fused_initial_state_and_preserves_scatter(monkeypatch) -> None:
+    layer, state = _layer()
+    q, k, v, g, beta, output = _inputs()
+    indices = torch.tensor([1, 3], dtype=torch.int32)
+    has_initial = torch.tensor([True, False])
+    query_start = torch.tensor([0, 2, 4], dtype=torch.int32)
+    fused_initial = torch.full((2, 2, 2, 2), 7.0)
+    final_state = torch.full_like(fused_initial, 11.0)
+    seen: dict[str, torch.Tensor] = {}
+
+    monkeypatch.setattr(
+        fused_state, "can_use_fused_gdn_state_gather_mask", lambda *args: True
+    )
+    monkeypatch.setattr(
+        fused_state,
+        "fused_gdn_state_gather_mask",
+        lambda *args: fused_initial,
+    )
+    monkeypatch.setattr(gdn, "_MATE_GDN_PREFILL_HAS_OUTPUT", True)
+
+    def fake_chunk(*args, initial_state, output, **kwargs):
+        seen["initial_state"] = initial_state
+        output.fill_(3.0)
+        return output, final_state
+
+    monkeypatch.setattr(gdn, "chunk_gated_delta_rule", fake_chunk)
+
+    result = layer._try_mate_prefill(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        output,
+        _metadata(),
+        query_start,
+        indices,
+        has_initial,
+    )
+
+    assert result is not None
+    torch.testing.assert_close(seen["initial_state"], fused_initial)
+    torch.testing.assert_close(result, torch.full_like(result, 3.0))
+    torch.testing.assert_close(state[1], final_state[0])
+    torch.testing.assert_close(state[3], final_state[1])
+
+
+def test_prefill_falls_back_to_index_and_mask(monkeypatch) -> None:
+    layer, state = _layer()
+    q, k, v, g, beta, output = _inputs()
+    indices = torch.tensor([1, 3], dtype=torch.int32)
+    has_initial = torch.tensor([True, False])
+    query_start = torch.tensor([0, 2, 4], dtype=torch.int32)
+    expected_initial = torch.stack((state[1], torch.zeros_like(state[3])))
+    seen: dict[str, torch.Tensor] = {}
+
+    monkeypatch.setattr(
+        fused_state, "can_use_fused_gdn_state_gather_mask", lambda *args: False
+    )
+    monkeypatch.setattr(gdn, "_MATE_GDN_PREFILL_HAS_OUTPUT", True)
+
+    def fake_chunk(*args, initial_state, output, **kwargs):
+        seen["initial_state"] = initial_state.clone()
+        return output.zero_(), torch.zeros_like(initial_state)
+
+    monkeypatch.setattr(gdn, "chunk_gated_delta_rule", fake_chunk)
+
+    result = layer._try_mate_prefill(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        output,
+        _metadata(),
+        query_start,
+        indices,
+        has_initial,
+    )
+
+    assert result is not None
+    torch.testing.assert_close(seen["initial_state"], expected_initial)

--- a/tests/test_qwen_gdn_prefill_state_gather_source.py
+++ b/tests/test_qwen_gdn_prefill_state_gather_source.py
@@ -15,7 +15,7 @@ def test_fused_gdn_state_gather_has_narrow_shape_and_dtype_gate() -> None:
     assert "state.dtype == torch.float32" in source
     assert "state_indices.dtype == torch.int32" in source
     assert "has_initial_state.dtype == torch.bool" in source
-    assert "0 < state_indices.numel() <= 64" in source
+    assert "num_sequences == 1 or 8 <= num_sequences <= 64" in source
 
 
 def test_qwen_gdn_prefill_preserves_fallback_and_scatter() -> None:

--- a/tests/test_qwen_gdn_prefill_state_gather_source.py
+++ b/tests/test_qwen_gdn_prefill_state_gather_source.py
@@ -10,7 +10,8 @@ CALLER = ROOT / "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.
 
 def test_fused_gdn_state_gather_has_narrow_shape_and_dtype_gate() -> None:
     source = KERNEL.read_text()
-    assert "_QWEN_GDN_STATE_SHAPE = (32, 128, 128)" in source
+    assert "_QWEN_GDN_LOCAL_HEAD_COUNTS = (8, 16, 32)" in source
+    assert "tuple(state.shape[2:]) == (128, 128)" in source
     assert "state.dtype == torch.float32" in source
     assert "state_indices.dtype == torch.int32" in source
     assert "has_initial_state.dtype == torch.bool" in source

--- a/tests/test_qwen_gdn_prefill_state_gather_source.py
+++ b/tests/test_qwen_gdn_prefill_state_gather_source.py
@@ -16,6 +16,7 @@ def test_fused_gdn_state_gather_has_narrow_shape_and_dtype_gate() -> None:
     assert "state_indices.dtype == torch.int32" in source
     assert "has_initial_state.dtype == torch.bool" in source
     assert "num_sequences == 64" in source
+    assert "_SMALL_HEAD_BLOCK_SIZE if state.shape[1] == 8" in source
     assert "if state.shape[1] == 8" in source
 
 

--- a/tests/test_qwen_gdn_prefill_state_gather_source.py
+++ b/tests/test_qwen_gdn_prefill_state_gather_source.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source contract for the fused Qwen GDN prefill state gather."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+KERNEL = ROOT / "vllm_musa/jit_kernel/gdn_state_gather_mask.py"
+CALLER = ROOT / "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
+
+
+def test_fused_gdn_state_gather_has_narrow_shape_and_dtype_gate() -> None:
+    source = KERNEL.read_text()
+    assert "_QWEN_GDN_STATE_SHAPE = (32, 128, 128)" in source
+    assert "state.dtype == torch.float32" in source
+    assert "state_indices.dtype == torch.int32" in source
+    assert "has_initial_state.dtype == torch.bool" in source
+    assert "0 < state_indices.numel() <= 64" in source
+
+
+def test_qwen_gdn_prefill_preserves_fallback_and_scatter() -> None:
+    source = CALLER.read_text()
+    assert "if fused_initial_state is None:" in source
+    assert "initial_state = ssm_state[state_indices].to(torch.float32)" in source
+    assert "initial_state[~has_initial_state, ...] = 0" in source
+    assert "ssm_state.index_copy_(" in source

--- a/tests/test_qwen_gdn_prefill_state_gather_source.py
+++ b/tests/test_qwen_gdn_prefill_state_gather_source.py
@@ -15,7 +15,8 @@ def test_fused_gdn_state_gather_has_narrow_shape_and_dtype_gate() -> None:
     assert "state.dtype == torch.float32" in source
     assert "state_indices.dtype == torch.int32" in source
     assert "has_initial_state.dtype == torch.bool" in source
-    assert "num_sequences == 1 or 8 <= num_sequences <= 64" in source
+    assert "num_sequences == 64" in source
+    assert "if state.shape[1] == 8" in source
 
 
 def test_qwen_gdn_prefill_preserves_fallback_and_scatter() -> None:

--- a/vllm_musa/jit_kernel/gdn_state_gather_mask.py
+++ b/vllm_musa/jit_kernel/gdn_state_gather_mask.py
@@ -62,6 +62,7 @@ def can_use_fused_gdn_state_gather_mask(
     has_initial_state: torch.Tensor,
 ) -> bool:
     """Return whether the narrow Qwen3.5/3.6 GDN prefill contract is met."""
+    num_sequences = state_indices.numel()
     return (
         _env_enabled()
         and state.dtype == torch.float32
@@ -72,7 +73,7 @@ def can_use_fused_gdn_state_gather_mask(
         and state_indices.dtype == torch.int32
         and state_indices.ndim == 1
         and state_indices.is_contiguous()
-        and 0 < state_indices.numel() <= 64
+        and (num_sequences == 1 or 8 <= num_sequences <= 64)
         and has_initial_state.dtype == torch.bool
         and has_initial_state.shape == state_indices.shape
         and has_initial_state.is_contiguous()

--- a/vllm_musa/jit_kernel/gdn_state_gather_mask.py
+++ b/vllm_musa/jit_kernel/gdn_state_gather_mask.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused Qwen GDN prefill state gather and initial-state masking."""
+
+from __future__ import annotations
+
+import os
+
+# isort: off
+import torchada  # noqa: F401
+import torch
+from vllm.logger import init_logger
+from vllm.triton_utils import tl, triton
+# isort: on
+
+logger = init_logger(__name__)
+
+_FUSED_GDN_STATE_GATHER_ENV = "VLLM_MUSA_FUSED_GDN_STATE_GATHER"
+_QWEN_GDN_STATE_SHAPE = (32, 128, 128)
+_BLOCK_SIZE = 256
+_ITEMS_PER_PROGRAM = 16
+
+
+@triton.jit
+def _gather_mask_gdn_state_kernel(
+    state_ptr,
+    state_indices_ptr,
+    has_initial_state_ptr,
+    output_ptr,
+    state_size: tl.constexpr,
+    block_size: tl.constexpr,
+    items_per_program: tl.constexpr,
+):
+    seq_idx = tl.program_id(0)
+    tile_idx = tl.program_id(1)
+    state_idx = tl.load(state_indices_ptr + seq_idx)
+    has_initial_state = tl.load(has_initial_state_ptr + seq_idx)
+    tile_base = tile_idx * block_size * items_per_program
+    offsets = tl.arange(0, block_size)
+    for item_idx in range(items_per_program):
+        state_offset = tile_base + item_idx * block_size + offsets
+        valid = state_offset < state_size
+        value = tl.load(
+            state_ptr + state_idx * state_size + state_offset,
+            mask=valid & has_initial_state,
+            other=0.0,
+        )
+        tl.store(output_ptr + seq_idx * state_size + state_offset, value, mask=valid)
+
+
+def _env_enabled() -> bool:
+    return os.getenv(_FUSED_GDN_STATE_GATHER_ENV, "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def can_use_fused_gdn_state_gather_mask(
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+) -> bool:
+    """Return whether the narrow Qwen3.5/3.6 GDN prefill contract is met."""
+    return (
+        _env_enabled()
+        and state.dtype == torch.float32
+        and state.is_contiguous()
+        and state.ndim == 4
+        and tuple(state.shape[1:]) == _QWEN_GDN_STATE_SHAPE
+        and state_indices.dtype == torch.int32
+        and state_indices.ndim == 1
+        and state_indices.is_contiguous()
+        and 0 < state_indices.numel() <= 64
+        and has_initial_state.dtype == torch.bool
+        and has_initial_state.shape == state_indices.shape
+        and has_initial_state.is_contiguous()
+    )
+
+
+def fused_gdn_state_gather_mask(
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+) -> torch.Tensor:
+    """Gather selected fp32 states and zero rows without initial state."""
+    if not can_use_fused_gdn_state_gather_mask(state, state_indices, has_initial_state):
+        raise ValueError("unsupported fused Qwen GDN state-gather contract")
+
+    num_sequences = state_indices.numel()
+    state_size = state[0].numel()
+    output = torch.empty(
+        (num_sequences, *state.shape[1:]), dtype=state.dtype, device=state.device
+    )
+    grid = (
+        num_sequences,
+        triton.cdiv(state_size, _BLOCK_SIZE * _ITEMS_PER_PROGRAM),
+    )
+    _gather_mask_gdn_state_kernel[grid](
+        state,
+        state_indices,
+        has_initial_state,
+        output,
+        state_size=state_size,
+        block_size=_BLOCK_SIZE,
+        items_per_program=_ITEMS_PER_PROGRAM,
+        num_warps=4,
+        num_stages=1,
+    )
+    logger.info_once("Using fused MUSA Qwen GDN prefill state gather and mask.")
+    return output

--- a/vllm_musa/jit_kernel/gdn_state_gather_mask.py
+++ b/vllm_musa/jit_kernel/gdn_state_gather_mask.py
@@ -8,11 +8,8 @@ import os
 # isort: off
 import torchada  # noqa: F401
 import torch
-from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 # isort: on
-
-logger = init_logger(__name__)
 
 _FUSED_GDN_STATE_GATHER_ENV = "VLLM_MUSA_FUSED_GDN_STATE_GATHER"
 _QWEN_GDN_LOCAL_HEAD_COUNTS = (8, 16, 32)
@@ -80,6 +77,7 @@ def can_use_fused_gdn_state_gather_mask(
     )
 
 
+@torch.compile(dynamic=True)
 def fused_gdn_state_gather_mask(
     state: torch.Tensor,
     state_indices: torch.Tensor,
@@ -109,5 +107,4 @@ def fused_gdn_state_gather_mask(
         num_warps=4,
         num_stages=1,
     )
-    logger.info_once("Using fused MUSA Qwen GDN prefill state gather and mask.")
     return output

--- a/vllm_musa/jit_kernel/gdn_state_gather_mask.py
+++ b/vllm_musa/jit_kernel/gdn_state_gather_mask.py
@@ -14,7 +14,8 @@ from vllm.triton_utils import tl, triton
 _FUSED_GDN_STATE_GATHER_ENV = "VLLM_MUSA_FUSED_GDN_STATE_GATHER"
 _QWEN_GDN_LOCAL_HEAD_COUNTS = (8, 16, 32)
 _BLOCK_SIZE = 256
-_ITEMS_PER_PROGRAM = 16
+_DEFAULT_ITEMS_PER_PROGRAM = 16
+_SMALL_HEAD_ITEMS_PER_PROGRAM = 8
 
 
 @triton.jit
@@ -70,31 +71,32 @@ def can_use_fused_gdn_state_gather_mask(
         and state_indices.dtype == torch.int32
         and state_indices.ndim == 1
         and state_indices.is_contiguous()
-        and (num_sequences == 1 or 8 <= num_sequences <= 64)
+        and num_sequences == 64
         and has_initial_state.dtype == torch.bool
         and has_initial_state.shape == state_indices.shape
         and has_initial_state.is_contiguous()
     )
 
 
-@torch.compile(dynamic=True)
 def fused_gdn_state_gather_mask(
     state: torch.Tensor,
     state_indices: torch.Tensor,
     has_initial_state: torch.Tensor,
 ) -> torch.Tensor:
-    """Gather selected fp32 states and zero rows without initial state."""
-    if not can_use_fused_gdn_state_gather_mask(state, state_indices, has_initial_state):
-        raise ValueError("unsupported fused Qwen GDN state-gather contract")
-
+    """Run after ``can_use_fused_gdn_state_gather_mask`` accepts the inputs."""
     num_sequences = state_indices.numel()
     state_size = state[0].numel()
+    items_per_program = (
+        _SMALL_HEAD_ITEMS_PER_PROGRAM
+        if state.shape[1] == 8
+        else _DEFAULT_ITEMS_PER_PROGRAM
+    )
     output = torch.empty(
         (num_sequences, *state.shape[1:]), dtype=state.dtype, device=state.device
     )
     grid = (
         num_sequences,
-        triton.cdiv(state_size, _BLOCK_SIZE * _ITEMS_PER_PROGRAM),
+        triton.cdiv(state_size, _BLOCK_SIZE * items_per_program),
     )
     _gather_mask_gdn_state_kernel[grid](
         state,
@@ -103,7 +105,7 @@ def fused_gdn_state_gather_mask(
         output,
         state_size=state_size,
         block_size=_BLOCK_SIZE,
-        items_per_program=_ITEMS_PER_PROGRAM,
+        items_per_program=items_per_program,
         num_warps=4,
         num_stages=1,
     )

--- a/vllm_musa/jit_kernel/gdn_state_gather_mask.py
+++ b/vllm_musa/jit_kernel/gdn_state_gather_mask.py
@@ -15,7 +15,7 @@ from vllm.triton_utils import tl, triton
 logger = init_logger(__name__)
 
 _FUSED_GDN_STATE_GATHER_ENV = "VLLM_MUSA_FUSED_GDN_STATE_GATHER"
-_QWEN_GDN_STATE_SHAPE = (32, 128, 128)
+_QWEN_GDN_LOCAL_HEAD_COUNTS = (8, 16, 32)
 _BLOCK_SIZE = 256
 _ITEMS_PER_PROGRAM = 16
 
@@ -67,7 +67,8 @@ def can_use_fused_gdn_state_gather_mask(
         and state.dtype == torch.float32
         and state.is_contiguous()
         and state.ndim == 4
-        and tuple(state.shape[1:]) == _QWEN_GDN_STATE_SHAPE
+        and state.shape[1] in _QWEN_GDN_LOCAL_HEAD_COUNTS
+        and tuple(state.shape[2:]) == (128, 128)
         and state_indices.dtype == torch.int32
         and state_indices.ndim == 1
         and state_indices.is_contiguous()

--- a/vllm_musa/jit_kernel/gdn_state_gather_mask.py
+++ b/vllm_musa/jit_kernel/gdn_state_gather_mask.py
@@ -13,7 +13,8 @@ from vllm.triton_utils import tl, triton
 
 _FUSED_GDN_STATE_GATHER_ENV = "VLLM_MUSA_FUSED_GDN_STATE_GATHER"
 _QWEN_GDN_LOCAL_HEAD_COUNTS = (8, 16, 32)
-_BLOCK_SIZE = 256
+_DEFAULT_BLOCK_SIZE = 256
+_SMALL_HEAD_BLOCK_SIZE = 512
 _DEFAULT_ITEMS_PER_PROGRAM = 16
 _SMALL_HEAD_ITEMS_PER_PROGRAM = 8
 
@@ -86,6 +87,7 @@ def fused_gdn_state_gather_mask(
     """Run after ``can_use_fused_gdn_state_gather_mask`` accepts the inputs."""
     num_sequences = state_indices.numel()
     state_size = state[0].numel()
+    block_size = _SMALL_HEAD_BLOCK_SIZE if state.shape[1] == 8 else _DEFAULT_BLOCK_SIZE
     items_per_program = (
         _SMALL_HEAD_ITEMS_PER_PROGRAM
         if state.shape[1] == 8
@@ -96,7 +98,7 @@ def fused_gdn_state_gather_mask(
     )
     grid = (
         num_sequences,
-        triton.cdiv(state_size, _BLOCK_SIZE * items_per_program),
+        triton.cdiv(state_size, block_size * items_per_program),
     )
     _gather_mask_gdn_state_kernel[grid](
         state,
@@ -104,7 +106,7 @@ def fused_gdn_state_gather_mask(
         has_initial_state,
         output,
         state_size=state_size,
-        block_size=_BLOCK_SIZE,
+        block_size=block_size,
         items_per_program=items_per_program,
         num_warps=4,
         num_stages=1,

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -375,10 +375,31 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
                 # exact zero to avoid MATE NaNs on long prefills.
                 g = torch.exp(g).clamp_min(1e-30)
 
-            state_indices = non_spec_state_indices_tensor.to(torch.int64)
-            initial_state = ssm_state[state_indices].to(torch.float32)
+            fused_initial_state = None
             if has_initial_state is not None:
-                initial_state[~has_initial_state, ...] = 0
+                from vllm_musa.jit_kernel.gdn_state_gather_mask import (
+                    can_use_fused_gdn_state_gather_mask,
+                    fused_gdn_state_gather_mask,
+                )
+
+                if can_use_fused_gdn_state_gather_mask(
+                    ssm_state,
+                    non_spec_state_indices_tensor,
+                    has_initial_state,
+                ):
+                    fused_initial_state = fused_gdn_state_gather_mask(
+                        ssm_state,
+                        non_spec_state_indices_tensor,
+                        has_initial_state,
+                    )
+
+            state_indices = non_spec_state_indices_tensor.to(torch.int64)
+            if fused_initial_state is None:
+                initial_state = ssm_state[state_indices].to(torch.float32)
+                if has_initial_state is not None:
+                    initial_state[~has_initial_state, ...] = 0
+            else:
+                initial_state = fused_initial_state
             # mate compiles the GDN kernel against this dtype; int32 indexing is
             # cheaper and the offsets are bounded by the per-forward token cap.
             cu_seqlens = non_spec_query_start_loc.to(torch.int32)

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -392,6 +392,9 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
                         non_spec_state_indices_tensor,
                         has_initial_state,
                     )
+                    logger.info_once(
+                        "Using fused MUSA Qwen GDN prefill state gather and mask."
+                    )
 
             state_indices = non_spec_state_indices_tensor.to(torch.int64)
             if fused_initial_state is None:

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -387,14 +387,21 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
                     non_spec_state_indices_tensor,
                     has_initial_state,
                 ):
-                    fused_initial_state = fused_gdn_state_gather_mask(
-                        ssm_state,
-                        non_spec_state_indices_tensor,
-                        has_initial_state,
-                    )
-                    logger.info_once(
-                        "Using fused MUSA Qwen GDN prefill state gather and mask."
-                    )
+                    try:
+                        fused_initial_state = fused_gdn_state_gather_mask(
+                            ssm_state,
+                            non_spec_state_indices_tensor,
+                            has_initial_state,
+                        )
+                        logger.info_once(
+                            "Using fused MUSA Qwen GDN prefill state gather and mask."
+                        )
+                    except Exception as exc:
+                        _log_once(
+                            "warning",
+                            "fused GDN state gather failed (%s); using indexed gather",
+                            exc,
+                        )
 
             state_indices = non_spec_state_indices_tensor.to(torch.int64)
             if fused_initial_state is None:


### PR DESCRIPTION
## Status: NO-GO performance experiment

Do not merge this Draft as a performance change. The exact PR head makes the
isolated gather/mask operation faster, but regresses warmed TTFT in both
counter-balanced serving pairs.

The branch is kept open temporarily so the implementation and evidence can be
reviewed while the next round profiles the integration overhead.

## Change

- Add a MUSA Triton kernel that combines Qwen3.5/3.6 GDN prefill fp32 state
  gather and initial-state zeroing.
- Gate it to contiguous fp32 state, int32 indices, bool mask, local heads
  8/16/32, 128x128 state dimensions, and BS64. Other shapes use the original
  path.
- Tune local-head-8 separately and keep
  `VLLM_MUSA_FUSED_GDN_STATE_GATHER=0` as a kill switch.
- If the fused compile/launch fails, fall back locally to indexed gather while
  preserving MATE prefill.

## Exact-head warmed serving result

SHA `19a445e892c7224397bbb53ca32074452ee2df67`, Qwen3.5-35B-A3B BF16,
TP4, BS64, 4k input / 256 output, FLASH_ATTN_3,
FULL_AND_PIECEWISE, control-candidate-candidate-control order, three warmed
repetitions per leg.

| pair | control TTFT | candidate TTFT | delta |
| --- | ---: | ---: | ---: |
| A1 vs B1 | 3562.617 ms | 3580.579 ms | **+0.504%** |
| A2 vs B2 | 3577.425 ms | 3589.751 ms | **+0.345%** |
| pooled | 3570.021 ms | 3585.165 ms | **+0.424% (+15.14 ms)** |

Pooled TPOT regressed `+0.181%`; output throughput decreased `0.246%`.
Every repetition completed 64/64 requests with identical input ordering.

JIT/compile time is warmup by policy. Stabilization and the non-performance
measure are excluded from every number above.

## Exact-head kernel result

Cold-cache ABBA, 20 repetitions, BS64, all rows exact-output correct:

| local heads | geomean | minimum across masks |
| ---: | ---: | ---: |
| 8 | 1.433x | 1.095x |
| 16 | 1.604x | 1.165x |
| 32 | 1.834x | 1.439x |
| overall | **1.615x** | **1.095x** |

The standalone kernel win does not survive the production integration. The
next step is to trace host/launch/graph-path overhead, not to merge this PR.

## Validation

- Ruff, formatting, py_compile, source contract tests: passed.
- GPU exact-output smoke: heads 8/16/32, supported and fallback batches, three
  mask modes, kill switch, and fused-failure fallback: passed.
- Serving semantic receipt: 64/64 for all 12 warmed performance results.
- Final evidence archive SHA256:
  `f1385eddf3e229c5906a1c2f9040624212f152c12ec7432e07bd8ed2ec020c95`.
- Warmed analysis SHA256:
  `618b9d5e5956237e3defe7123eac343893ed65e868edde0f95f879fad8512f8a`.
- Kernel analysis SHA256:
  `4ec28ae8650b98b92f850a119d1f0214994d529d07dcc3b85c11199641534e2c`.

The earlier directional `-0.323%` result was collected on the #158 stack in
candidate-control-candidate-control order with only two pairs. It is
superseded by the exact-head, balanced evidence above.

## Stack

This Draft is based on #147, already merged into `v0.24.0-dev`. It changes only
vLLM-MUSA; it does not modify vLLM-Omni.
