### PR TITLE
perf(musa): eliminate Qwen3.5/3.6 prefill attention output copies

### DIFF
--- a/tests/test_qwen_next_attention_return.py
+++ b/tests/test_qwen_next_attention_return.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime contracts for Qwen3.5/3.6 attention return-through."""
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+qwen3_5 = pytest.importorskip("vllm.model_executor.models.qwen3_5")
+qwen3_next = pytest.importorskip("vllm.model_executor.models.qwen3_next")
+qwen_gdn = pytest.importorskip(
+    "vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn"
+)
+
+
+class _Projection:
+    def __init__(self, scale: float = 1.0) -> None:
+        self.scale = scale
+        self.last_output = None
+
+    def __call__(self, hidden_states):
+        self.last_output = hidden_states * self.scale
+        return self.last_output, None
+
+
+def test_full_attention_returns_projection_or_preserves_output_buffer() -> None:
+    projection = _Projection(scale=2.0)
+    attention = SimpleNamespace(
+        qkv_proj=lambda hidden_states: (hidden_states, None),
+        _project_qkv_gate=lambda qkv, positions: (qkv, qkv, qkv, None),
+        attn=lambda query, key, value: query + key + value,
+        o_proj=projection,
+    )
+    hidden_states = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    positions = torch.arange(3)
+
+    returned = qwen3_next.Qwen3NextAttention.forward(
+        attention, positions, None, hidden_states
+    )
+    assert returned is projection.last_output
+    assert torch.equal(returned, hidden_states * 6)
+
+    output = torch.full_like(hidden_states, -1)
+    output_ptr = output.data_ptr()
+    result = qwen3_next.Qwen3NextAttention.forward(
+        attention, positions, output, hidden_states
+    )
+    assert result is None
+    assert output.data_ptr() == output_ptr
+    assert torch.equal(output, hidden_states * 6)
+
+
+def test_gdn_projection_returns_projection_or_preserves_output_buffer() -> None:
+    projection = _Projection(scale=3.0)
+    attention = SimpleNamespace(
+        norm=lambda core, gate: core + gate,
+        out_proj=projection,
+    )
+    core = torch.arange(24, dtype=torch.float32).reshape(3, 2, 4)
+    gate = torch.ones_like(core)
+    expected = (core + gate).flatten(-2) * 3
+
+    returned = qwen_gdn.QwenGatedDeltaNetAttention._output_projection(
+        attention, core, gate, None, 3
+    )
+    assert returned is projection.last_output
+    assert torch.equal(returned, expected)
+
+    output = torch.full((5, 8), -1.0)
+    output_ptr = output.data_ptr()
+    result = qwen_gdn.QwenGatedDeltaNetAttention._output_projection(
+        attention, core, gate, output, 3
+    )
+    assert result is None
+    assert output.data_ptr() == output_ptr
+    assert torch.equal(output[:3], expected)
+    assert torch.equal(output[3:], torch.full((2, 8), -1.0))
+
+
+@pytest.mark.parametrize(
+    ("layer_type", "attribute"),
+    (("linear_attention", "linear_attn"), ("full_attention", "self_attn")),
+)
+@pytest.mark.parametrize(
+    ("enabled", "num_tokens", "is_prefill", "expects_return"),
+    (
+        (True, 1024, True, True),
+        (True, 1023, True, False),
+        (True, 2048, False, False),
+        (False, 1024, True, False),
+    ),
+)
+def test_decoder_return_gate_preserves_parity_and_projection_lifetime(
+    monkeypatch,
+    layer_type: str,
+    attribute: str,
+    enabled: bool,
+    num_tokens: int,
+    is_prefill: bool,
+    expects_return: bool,
+) -> None:
+    hidden_states = torch.arange(num_tokens * 2, dtype=torch.float32).reshape(
+        num_tokens, 2
+    )
+    projected = hidden_states + 7
+
+    class _Attention:
+        def __init__(self) -> None:
+            self.output = object()
+
+        def __call__(self, *, output, **kwargs):
+            self.output = output
+            if output is None:
+                return projected
+            output.copy_(projected)
+            return None
+
+    attention = _Attention()
+    layer = SimpleNamespace(
+        layer_type=layer_type,
+        _musa_return_attention_output=enabled,
+        _musa_attention_metadata_prefix="model.layers.0.attention",
+        input_layernorm=lambda states: states,
+        post_attention_layernorm=lambda states, residual: (states, residual),
+        mlp=lambda states: states,
+        layer_scale=False,
+    )
+    setattr(layer, attribute, attention)
+    monkeypatch.setattr(
+        qwen3_next, "_is_musa_qwen_next_prefill", lambda prefix: is_prefill
+    )
+
+    returned, residual = qwen3_next.Qwen3NextDecoderLayer.forward(
+        layer, hidden_states, None, positions=torch.arange(num_tokens)
+    )
+    assert residual is hidden_states
+    assert torch.equal(returned, projected)
+    assert (attention.output is None) is expects_return
+    assert (returned is projected) is expects_return
+
+
+def test_prefill_gate_uses_layer_phase_metadata(monkeypatch) -> None:
+    prefix = "model.layers.0.self_attn.attn"
+    monkeypatch.setattr(qwen3_next, "is_forward_context_available", lambda: True)
+
+    def set_metadata(metadata) -> None:
+        monkeypatch.setattr(
+            qwen3_next,
+            "get_forward_context",
+            lambda: SimpleNamespace(attn_metadata=metadata),
+        )
+
+    set_metadata({prefix: SimpleNamespace(num_prefills=1)})
+    assert qwen3_next._is_musa_qwen_next_prefill(prefix)
+
+    for metadata in (
+        {prefix: SimpleNamespace(num_prefills=0)},
+        {"another.layer": SimpleNamespace(num_prefills=1)},
+        [{prefix: SimpleNamespace(num_prefills=1)}],
+    ):
+        set_metadata(metadata)
+        assert not qwen3_next._is_musa_qwen_next_prefill(prefix)
+
+    monkeypatch.setattr(qwen3_next, "is_forward_context_available", lambda: False)
+    assert not qwen3_next._is_musa_qwen_next_prefill(prefix)
+
+
+@pytest.mark.parametrize("disabled_value", ("0", "false", "off", "no"))
+def test_static_gate_honors_environment(monkeypatch, disabled_value: str) -> None:
+    model_config = SimpleNamespace(dtype=torch.bfloat16)
+    vllm_config = SimpleNamespace(
+        model_config=model_config,
+        quant_config=None,
+        lora_config=None,
+    )
+    config = SimpleNamespace(hidden_size=5120)
+    monkeypatch.setattr(qwen3_next.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(qwen3_next, "get_tensor_model_parallel_world_size", lambda: 2)
+
+    monkeypatch.delenv(qwen3_next.MUSA_QWEN_NEXT_RETURN_ATTN_OUTPUT_ENV, raising=False)
+    assert qwen3_next._use_musa_qwen_next_return_attention_output(vllm_config, config)
+
+    monkeypatch.setenv(qwen3_next.MUSA_QWEN_NEXT_RETURN_ATTN_OUTPUT_ENV, disabled_value)
+    assert not qwen3_next._use_musa_qwen_next_return_attention_output(
+        vllm_config, config
+    )
+
+
+@pytest.mark.parametrize(
+    ("layer_type", "expected_prefix"),
+    (
+        ("linear_attention", "model.layers.0.linear_attn"),
+        ("full_attention", "model.layers.0.self_attn.attn"),
+    ),
+)
+def test_qwen35_custom_init_sets_return_gate_and_metadata_prefix(
+    monkeypatch, layer_type: str, expected_prefix: str
+) -> None:
+    config = SimpleNamespace(
+        model_type="qwen3_5_text",
+        hidden_size=5120,
+        intermediate_size=1024,
+        hidden_act="silu",
+        rms_norm_eps=1e-6,
+        layer_scale=False,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=config,
+            dtype=torch.bfloat16,
+        ),
+        cache_config=None,
+        quant_config=None,
+        lora_config=None,
+    )
+    seen = []
+    monkeypatch.setattr(
+        qwen3_5,
+        "_use_musa_qwen_next_return_attention_output",
+        lambda actual_vllm_config, actual_config: seen.append(
+            (actual_vllm_config, actual_config)
+        )
+        or True,
+    )
+    monkeypatch.setattr(
+        qwen3_5, "QwenGatedDeltaNetAttention", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(qwen3_5, "Qwen3NextAttention", lambda *args, **kwargs: object())
+    monkeypatch.setattr(qwen3_5, "Qwen3NextMLP", lambda *args, **kwargs: object())
+    monkeypatch.setattr(qwen3_5, "Qwen3_5RMSNorm", lambda *args, **kwargs: object())
+
+    layer = qwen3_5.Qwen3_5DecoderLayer(
+        vllm_config, layer_type, prefix="model.layers.0"
+    )
+
+    assert seen == [(vllm_config, config)]
+    assert layer._musa_return_attention_output
+    assert layer._musa_attention_metadata_prefix == expected_prefix

--- a/tests/test_qwen_next_attention_return_source.py
+++ b/tests/test_qwen_next_attention_return_source.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Source contract for the Qwen3.5/3.6 prefill return-through path."""
+"""Packaging contracts for the Qwen3.5/3.6 return-through patch."""
 
 from pathlib import Path
 
@@ -8,12 +8,24 @@ PATCH = (
     ROOT
     / "vllm_musa/patches/series/0099-perf-musa-return-Qwen-attention-projection-outputs.patch"
 )
-MUSA_GDN = (
-    ROOT / "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
-)
+MUSA_GDN = ROOT / "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
 
 
-def test_return_through_is_exactly_gated() -> None:
+def test_patch_uses_canonical_format_patch_headers() -> None:
+    source = PATCH.read_text()
+
+    assert source.startswith(
+        "From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001\n"
+    )
+    assert (
+        "Subject: [PATCH] perf(musa): return Qwen attention projection outputs"
+        in source
+    )
+    assert "Subject: [PATCH " not in source
+    assert not source.rstrip().endswith("2.34.1")
+
+
+def test_patch_carries_phase_gate_and_both_qwen_initializers() -> None:
     source = PATCH.read_text()
 
     assert "vllm/model_executor/models/qwen3_5.py" in source
@@ -25,22 +37,14 @@ def test_return_through_is_exactly_gated() -> None:
     assert "config.hidden_size == 5120" in source
     assert "get_tensor_model_parallel_world_size() == 2" in source
     assert "hidden_states.shape[0] >= 1024" in source
+    assert "_is_musa_qwen_next_prefill(self._musa_attention_metadata_prefix)" in source
     assert source.count("_use_musa_qwen_next_return_attention_output(") >= 3
-
-
-def test_full_and_gdn_attention_return_projection_without_copy() -> None:
-    source = PATCH.read_text()
-
-    assert source.count("if output is None:") == 2
-    assert source.count("return projected") == 2
-    assert "None if return_attention_output else torch.empty_like(hidden_states)" in source
-    assert "returned_attention_output" in source
-    assert "output[:] = projected" in source
-    assert "output[:num_tokens] = projected" in source
 
 
 def test_musa_gdn_oot_propagates_returned_projection() -> None:
     source = MUSA_GDN.read_text()
 
     assert "output: torch.Tensor | None" in source
-    assert "return self._output_projection(core_attn_out, z, output, num_tokens)" in source
+    assert (
+        "return self._output_projection(core_attn_out, z, output, num_tokens)" in source
+    )

--- a/tests/test_qwen_next_attention_return_source.py
+++ b/tests/test_qwen_next_attention_return_source.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source contract for the Qwen3.5/3.6 prefill return-through path."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = (
+    ROOT
+    / "vllm_musa/patches/series/0099-perf-musa-return-Qwen-attention-projection-outputs.patch"
+)
+MUSA_GDN = (
+    ROOT / "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
+)
+
+
+def test_return_through_is_exactly_gated() -> None:
+    source = PATCH.read_text()
+
+    assert "vllm/model_executor/models/qwen3_5.py" in source
+    assert "VLLM_MUSA_QWEN_NEXT_RETURN_ATTN_OUTPUT" in source
+    assert "current_platform.is_musa()" in source
+    assert "model_config.dtype == torch.bfloat16" in source
+    assert "quant_config is None" in source
+    assert 'getattr(vllm_config, "lora_config", None) is None' in source
+    assert "config.hidden_size == 5120" in source
+    assert "get_tensor_model_parallel_world_size() == 2" in source
+    assert "hidden_states.shape[0] >= 1024" in source
+    assert source.count("_use_musa_qwen_next_return_attention_output(") >= 3
+
+
+def test_full_and_gdn_attention_return_projection_without_copy() -> None:
+    source = PATCH.read_text()
+
+    assert source.count("if output is None:") == 2
+    assert source.count("return projected") == 2
+    assert "None if return_attention_output else torch.empty_like(hidden_states)" in source
+    assert "returned_attention_output" in source
+    assert "output[:] = projected" in source
+    assert "output[:num_tokens] = projected" in source
+
+
+def test_musa_gdn_oot_propagates_returned_projection() -> None:
+    source = MUSA_GDN.read_text()
+
+    assert "output: torch.Tensor | None" in source
+    assert "return self._output_projection(core_attn_out, z, output, num_tokens)" in source

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -68,8 +68,8 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
     def forward_cuda(
         self,
         hidden_states: torch.Tensor,
-        output: torch.Tensor,
-    ) -> None:
+        output: torch.Tensor | None,
+    ) -> torch.Tensor | None:
         # MUSA: Qwen3.5 GDN forward with a single fused z/b/a split kernel
         # (contiguous z/b/a in one launch) replacing the strided-z output-proj
         # copy + b/a contiguous copies. mixed_qkv stays a strided view (conv/MATE
@@ -120,7 +120,7 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
             layer_name=_encode_layer_name(self.prefix),
         )
 
-        self._output_projection(core_attn_out, z, output, num_tokens)
+        return self._output_projection(core_attn_out, z, output, num_tokens)
 
     def _get_gdn_attention_metadata(self, mixed_qkv: torch.Tensor):
         from vllm.forward_context import get_forward_context

--- a/vllm_musa/patches/series/0099-perf-musa-return-Qwen-attention-projection-outputs.patch
+++ b/vllm_musa/patches/series/0099-perf-musa-return-Qwen-attention-projection-outputs.patch
@@ -1,13 +1,13 @@
-From 6f7f82fa52c48dfd09e02fbdefff6321316cd28f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: musa <musa@local>
-Date: Sat, 1 Aug 2026 17:44:03 +0800
-Subject: [PATCH 99/99] perf(musa): return Qwen attention projection outputs
+Date: Sat, 1 Aug 2026 19:53:33 +0800
+Subject: [PATCH] perf(musa): return Qwen attention projection outputs
 
 ---
- .../layers/mamba/gdn/qwen_gdn_linear_attn.py  | 16 ++++--
- vllm/model_executor/models/qwen3_5.py         |  4 ++
- vllm/model_executor/models/qwen3_next.py      | 55 +++++++++++++++++--
- 3 files changed, 63 insertions(+), 12 deletions(-)
+ .../layers/mamba/gdn/qwen_gdn_linear_attn.py  | 16 ++--
+ vllm/model_executor/models/qwen3_5.py         |  8 ++
+ vllm/model_executor/models/qwen3_next.py      | 82 +++++++++++++++++--
+ 3 files changed, 94 insertions(+), 12 deletions(-)
 
 diff --git a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
 index 06bfe5c5de..e270e62f89 100644
@@ -22,7 +22,7 @@ index 06bfe5c5de..e270e62f89 100644
      ):
 -        self._forward_method(hidden_states, output)
 +        return self._forward_method(hidden_states, output)
-
+ 
      def _output_projection(
          self,
          core_attn_out: torch.Tensor,
@@ -42,7 +42,7 @@ index 06bfe5c5de..e270e62f89 100644
 +            return projected
 +        output[:num_tokens] = projected
 +        return None
-
+ 
      def forward_hip(
          self,
 @@ -908,7 +912,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
@@ -60,38 +60,58 @@ index 06bfe5c5de..e270e62f89 100644
          # ============================================================
 -        self._output_projection(core_attn_out, z, output, num_tokens)
 +        return self._output_projection(core_attn_out, z, output, num_tokens)
-
+ 
      def forward_xpu(
          self,
 diff --git a/vllm/model_executor/models/qwen3_5.py b/vllm/model_executor/models/qwen3_5.py
-index 43b9004638..8885730e6a 100644
+index 43b9004638..a703d883a8 100644
 --- a/vllm/model_executor/models/qwen3_5.py
 +++ b/vllm/model_executor/models/qwen3_5.py
-@@ -88,6 +88,7 @@ from .qwen3_next import (
+@@ -88,6 +88,8 @@ from .qwen3_next import (
      Qwen3NextModel,
      Qwen3NextSparseMoeBlock,
      QwenNextMixtureOfExperts,
++    _musa_qwen_next_attention_metadata_prefix,
 +    _use_musa_qwen_next_return_attention_output,
  )
  from .qwen3_vl import (
      Qwen3_VisionTransformer,
-@@ -136,6 +137,9 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
-
+@@ -136,6 +138,12 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
+ 
          self.layer_type = layer_type
          self.layer_idx = extract_layer_index(prefix)
 +        self._musa_return_attention_output = (
 +            _use_musa_qwen_next_return_attention_output(vllm_config, config)
 +        )
-
++        self._musa_attention_metadata_prefix = (
++            _musa_qwen_next_attention_metadata_prefix(layer_type, prefix)
++        )
+ 
          if self.layer_type == "linear_attention":
              self.linear_attn = QwenGatedDeltaNetAttention(
 diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/models/qwen3_next.py
-index d73dfa9e42..17b9e12e20 100644
+index d73dfa9e42..353c9fe31e 100644
 --- a/vllm/model_executor/models/qwen3_next.py
 +++ b/vllm/model_executor/models/qwen3_next.py
-@@ -268,6 +268,33 @@ class Qwen3NextSparseMoeBlock(nn.Module):
-
-
+@@ -8,6 +8,7 @@ from itertools import islice
+ 
+ import torch
+ from torch import nn
++from transformers import PretrainedConfig
+ 
+ from vllm import ir
+ from vllm._aiter_ops import rocm_aiter_ops
+@@ -24,6 +25,7 @@ from vllm.distributed import (
+     get_tensor_model_parallel_world_size,
+     tensor_model_parallel_all_gather,
+ )
++from vllm.forward_context import get_forward_context, is_forward_context_available
+ from vllm.logger import init_logger
+ from vllm.model_executor.layers.attention import Attention
+ from vllm.model_executor.layers.fused_moe import (
+@@ -268,6 +270,53 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+ 
+ 
  MUSA_FUSED_QK_MROPE_ENV = "VLLM_MUSA_FUSED_QK_MROPE"
 +MUSA_QWEN_NEXT_RETURN_ATTN_OUTPUT_ENV = (
 +    "VLLM_MUSA_QWEN_NEXT_RETURN_ATTN_OUTPUT"
@@ -99,7 +119,7 @@ index d73dfa9e42..17b9e12e20 100644
 +
 +
 +def _use_musa_qwen_next_return_attention_output(
-+    vllm_config: VllmConfig, config: Qwen3NextConfig
++    vllm_config: VllmConfig, config: PretrainedConfig
 +) -> bool:
 +    model_config = vllm_config.model_config
 +    enabled = (
@@ -120,10 +140,30 @@ index d73dfa9e42..17b9e12e20 100644
 +        )
 +    return enabled
 +
-
++
++def _musa_qwen_next_attention_metadata_prefix(
++    layer_type: str, prefix: str
++) -> str:
++    if layer_type == "linear_attention":
++        return f"{prefix}.linear_attn"
++    if layer_type == "full_attention":
++        return f"{prefix}.self_attn.attn"
++    raise ValueError(f"Invalid layer_type {layer_type}")
++
++
++def _is_musa_qwen_next_prefill(attention_metadata_prefix: str) -> bool:
++    if not is_forward_context_available():
++        return False
++    attn_metadata = get_forward_context().attn_metadata
++    if not isinstance(attn_metadata, dict):
++        return False
++    layer_metadata = attn_metadata.get(attention_metadata_prefix)
++    return getattr(layer_metadata, "num_prefills", 0) > 0
++
+ 
  _MUSA_MROPE_COS_SIN_CACHE: dict[tuple[int, torch.dtype], torch.Tensor] = {}
-
-@@ -545,7 +572,7 @@ class Qwen3NextAttention(nn.Module):
+ 
+@@ -545,7 +594,7 @@ class Qwen3NextAttention(nn.Module):
      def forward(
          self,
          positions: torch.Tensor,
@@ -132,7 +172,7 @@ index d73dfa9e42..17b9e12e20 100644
          hidden_states: torch.Tensor,
      ):
          qkv, _ = self.qkv_proj(hidden_states)
-@@ -557,7 +584,11 @@ class Qwen3NextAttention(nn.Module):
+@@ -557,7 +606,11 @@ class Qwen3NextAttention(nn.Module):
              # this multiply, then flatten the fresh contiguous result for o_proj.
              attn_output = attn_output.view_as(gate) * torch.sigmoid(gate)
              attn_output = attn_output.view(-1, self.q_size)
@@ -142,26 +182,31 @@ index d73dfa9e42..17b9e12e20 100644
 +            return projected
 +        output[:] = projected
 +        return None
-
-
+ 
+ 
  class Qwen3NextDecoderLayer(nn.Module):
-@@ -576,6 +607,9 @@ class Qwen3NextDecoderLayer(nn.Module):
-
+@@ -576,6 +629,12 @@ class Qwen3NextDecoderLayer(nn.Module):
+ 
          self.layer_type = layer_type
          self.layer_idx = extract_layer_index(prefix)
 +        self._musa_return_attention_output = (
 +            _use_musa_qwen_next_return_attention_output(vllm_config, config)
 +        )
-
++        self._musa_attention_metadata_prefix = (
++            _musa_qwen_next_attention_metadata_prefix(layer_type, prefix)
++        )
+ 
          if self.layer_type == "linear_attention":
              self.linear_attn = QwenGatedDeltaNetAttention(
-@@ -652,21 +686,30 @@ class Qwen3NextDecoderLayer(nn.Module):
+@@ -652,21 +711,32 @@ class Qwen3NextDecoderLayer(nn.Module):
          else:
              hidden_states, residual = self.input_layernorm(hidden_states, residual)
-
+ 
 -        self_attention_output = torch.empty_like(hidden_states)
 +        return_attention_output = (
-+            self._musa_return_attention_output and hidden_states.shape[0] >= 1024
++            self._musa_return_attention_output
++            and hidden_states.shape[0] >= 1024
++            and _is_musa_qwen_next_prefill(self._musa_attention_metadata_prefix)
 +        )
 +        self_attention_output = (
 +            None if return_attention_output else torch.empty_like(hidden_states)
@@ -187,8 +232,6 @@ index d73dfa9e42..17b9e12e20 100644
 +            if return_attention_output
 +            else self_attention_output
 +        )
-
+ 
          if self.layer_scale:
              if len(hidden_states.shape) == 2:
---
-2.34.1

--- a/vllm_musa/patches/series/0099-perf-musa-return-Qwen-attention-projection-outputs.patch
+++ b/vllm_musa/patches/series/0099-perf-musa-return-Qwen-attention-projection-outputs.patch
@@ -1,0 +1,194 @@
+From 6f7f82fa52c48dfd09e02fbdefff6321316cd28f Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sat, 1 Aug 2026 17:44:03 +0800
+Subject: [PATCH 99/99] perf(musa): return Qwen attention projection outputs
+
+---
+ .../layers/mamba/gdn/qwen_gdn_linear_attn.py  | 16 ++++--
+ vllm/model_executor/models/qwen3_5.py         |  4 ++
+ vllm/model_executor/models/qwen3_next.py      | 55 +++++++++++++++++--
+ 3 files changed, 63 insertions(+), 12 deletions(-)
+
+diff --git a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+index 06bfe5c5de..e270e62f89 100644
+--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
++++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+@@ -844,15 +844,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
+     def forward(
+         self,
+         hidden_states: torch.Tensor,
+-        output: torch.Tensor,
++        output: torch.Tensor | None,
+     ):
+-        self._forward_method(hidden_states, output)
++        return self._forward_method(hidden_states, output)
+
+     def _output_projection(
+         self,
+         core_attn_out: torch.Tensor,
+         z: torch.Tensor,
+-        output: torch.Tensor,
++        output: torch.Tensor | None,
+         num_tokens: int,
+     ):
+         """Part 3: RMSNormGated + output linear projection.
+@@ -866,7 +866,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
+         core_attn_out = self.norm(core_attn_out, z)
+         core_attn_out = core_attn_out.reshape(z_shape_og)
+         core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
+-        output[:num_tokens], _ = self.out_proj(core_attn_out)
++        projected, _ = self.out_proj(core_attn_out)
++        if output is None:
++            return projected
++        output[:num_tokens] = projected
++        return None
+
+     def forward_hip(
+         self,
+@@ -908,7 +912,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
+     def forward_cuda(
+         self,
+         hidden_states: torch.Tensor,
+-        output: torch.Tensor,
++        output: torch.Tensor | None,
+     ):
+         """
+         Forward pass with three parts:
+@@ -964,7 +968,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
+         # ============================================================
+         # Part 3: Output Projection
+         # ============================================================
+-        self._output_projection(core_attn_out, z, output, num_tokens)
++        return self._output_projection(core_attn_out, z, output, num_tokens)
+
+     def forward_xpu(
+         self,
+diff --git a/vllm/model_executor/models/qwen3_5.py b/vllm/model_executor/models/qwen3_5.py
+index 43b9004638..8885730e6a 100644
+--- a/vllm/model_executor/models/qwen3_5.py
++++ b/vllm/model_executor/models/qwen3_5.py
+@@ -88,6 +88,7 @@ from .qwen3_next import (
+     Qwen3NextModel,
+     Qwen3NextSparseMoeBlock,
+     QwenNextMixtureOfExperts,
++    _use_musa_qwen_next_return_attention_output,
+ )
+ from .qwen3_vl import (
+     Qwen3_VisionTransformer,
+@@ -136,6 +137,9 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
+
+         self.layer_type = layer_type
+         self.layer_idx = extract_layer_index(prefix)
++        self._musa_return_attention_output = (
++            _use_musa_qwen_next_return_attention_output(vllm_config, config)
++        )
+
+         if self.layer_type == "linear_attention":
+             self.linear_attn = QwenGatedDeltaNetAttention(
+diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/models/qwen3_next.py
+index d73dfa9e42..17b9e12e20 100644
+--- a/vllm/model_executor/models/qwen3_next.py
++++ b/vllm/model_executor/models/qwen3_next.py
+@@ -268,6 +268,33 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+
+
+ MUSA_FUSED_QK_MROPE_ENV = "VLLM_MUSA_FUSED_QK_MROPE"
++MUSA_QWEN_NEXT_RETURN_ATTN_OUTPUT_ENV = (
++    "VLLM_MUSA_QWEN_NEXT_RETURN_ATTN_OUTPUT"
++)
++
++
++def _use_musa_qwen_next_return_attention_output(
++    vllm_config: VllmConfig, config: Qwen3NextConfig
++) -> bool:
++    model_config = vllm_config.model_config
++    enabled = (
++        current_platform.is_musa()
++        and os.environ.get(
++            MUSA_QWEN_NEXT_RETURN_ATTN_OUTPUT_ENV, "1"
++        ).strip().lower()
++        not in ("0", "false", "off", "no")
++        and model_config.dtype == torch.bfloat16
++        and vllm_config.quant_config is None
++        and getattr(vllm_config, "lora_config", None) is None
++        and config.hidden_size == 5120
++        and get_tensor_model_parallel_world_size() == 2
++    )
++    if enabled:
++        logger.info_once(
++            "Using MUSA Qwen3.5/3.6 large-prefill attention return-through."
++        )
++    return enabled
++
+
+ _MUSA_MROPE_COS_SIN_CACHE: dict[tuple[int, torch.dtype], torch.Tensor] = {}
+
+@@ -545,7 +572,7 @@ class Qwen3NextAttention(nn.Module):
+     def forward(
+         self,
+         positions: torch.Tensor,
+-        output: torch.Tensor,
++        output: torch.Tensor | None,
+         hidden_states: torch.Tensor,
+     ):
+         qkv, _ = self.qkv_proj(hidden_states)
+@@ -557,7 +584,11 @@ class Qwen3NextAttention(nn.Module):
+             # this multiply, then flatten the fresh contiguous result for o_proj.
+             attn_output = attn_output.view_as(gate) * torch.sigmoid(gate)
+             attn_output = attn_output.view(-1, self.q_size)
+-        output[:], _ = self.o_proj(attn_output)
++        projected, _ = self.o_proj(attn_output)
++        if output is None:
++            return projected
++        output[:] = projected
++        return None
+
+
+ class Qwen3NextDecoderLayer(nn.Module):
+@@ -576,6 +607,9 @@ class Qwen3NextDecoderLayer(nn.Module):
+
+         self.layer_type = layer_type
+         self.layer_idx = extract_layer_index(prefix)
++        self._musa_return_attention_output = (
++            _use_musa_qwen_next_return_attention_output(vllm_config, config)
++        )
+
+         if self.layer_type == "linear_attention":
+             self.linear_attn = QwenGatedDeltaNetAttention(
+@@ -652,21 +686,30 @@ class Qwen3NextDecoderLayer(nn.Module):
+         else:
+             hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+-        self_attention_output = torch.empty_like(hidden_states)
++        return_attention_output = (
++            self._musa_return_attention_output and hidden_states.shape[0] >= 1024
++        )
++        self_attention_output = (
++            None if return_attention_output else torch.empty_like(hidden_states)
++        )
+         if self.layer_type == "linear_attention":
+-            self.linear_attn(
++            returned_attention_output = self.linear_attn(
+                 hidden_states=hidden_states,
+                 output=self_attention_output,
+             )
+         elif self.layer_type == "full_attention":
+-            self.self_attn(
++            returned_attention_output = self.self_attn(
+                 hidden_states=hidden_states,
+                 output=self_attention_output,
+                 positions=positions,
+             )
+         else:
+             raise ValueError("Invalid layer_type")
+-        hidden_states = self_attention_output
++        hidden_states = (
++            returned_attention_output
++            if return_attention_output
++            else self_attention_output
++        )
+
+         if self.layer_scale:
+             if len(hidden_states.shape) == 2:
+--
+2.34.1

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -15,7 +15,7 @@ is pre-patched.
   sequence and patches removed from the commit stack cannot leave stale files.
   Author headers are normalized to the synthetic `musa <musa@local>` identity.
 
-Currently **101 patches** — the MUSA source edits against the immutable vLLM commit
+Currently **102 patches** — the MUSA source edits against the immutable vLLM commit
 recorded as `VLLM_COMMIT` in `third_party/PINS` (release label `v0.24.0`), applied
 at build. Runtime object/registration patches (which patch live objects at import)
 are kept separately in `vllm_musa/patches/`, not in this build-time series. Run


### PR DESCRIPTION
## Summary

- return Qwen3.5/3.6 dense attention projection results directly to the decoder
  instead of copying them into a freshly allocated hidden-state buffer;
- cover both full attention and MUSA GDN output projection;
- gate the optimization to large BF16 TP2 prefill (`hidden_size=5120`,
  `tokens>=1024`, no quantization/LoRA), with
  `VLLM_MUSA_QWEN_NEXT_RETURN_ATTN_OUTPUT=0` as the kill switch.

## Why

The Qwen3.5-27B TP2 prefill trace contained one `[8192,5120]` BF16
`triton_poi_fused_copy__1` after every attention output projection.  The copy
only moved the already reduced projection result into the buffer consumed by
post-attention norm.

The candidate changes the handoff, not the projection, custom all-reduce,
barrier, attention backend, or sampling path.

## Mechanism evidence

Qwen3.5-27B BF16, TP2, BS64 4k-to-1, normal compile and FlashAttention3:

| rank | control target copy | candidate target copy | total kernel count |
|---|---:|---:|---:|
| 0 | 1771 launches / 236.232 ms | 0 | 41,363 -> 39,529 |
| 1 | 1929 launches / 257.194 ms | 0 | 45,087 -> 43,193 |

CAR launch counts remain window-equivalent and no replacement D2D or
functionalization copy-back appeared.

## Warmed serving evidence

All legs below ran on the same isolated S5000 node in C1-B1-B2-C2 order, with
three repetitions per leg. JIT and graph compilation were warmup-only.

| cell | control TTFT | candidate TTFT | delta |
|---|---:|---:|---:|
| BS64 pair 1 | 16634.887 ms | 16493.167 ms | **-0.852%** |
| BS64 pair 2 | 16628.653 ms | 16510.313 ms | **-0.712%** |
| BS64 pooled | 16631.770 ms | 16501.740 ms | **-0.782% / -130.030 ms** |
| BS16 confirmation | 4812.063 ms | 4782.690 ms | **-0.610% / -29.373 ms** |

## Validation

- `ruff check` passed for changed Python/test files;
- source-contract tests: `3 passed`;
- exact vLLM patch series applied to pinned vLLM
  `ee0da84ab9e04ac7610e28580af62c365e898389`;
- all BS64/BS16 serving legs completed the expected request and token counts;
- Qwen3.6-27B (`qwen3_5_text`, hidden size 5120) activated the same gate and
  completed a BS16 4k-to-1 serving smoke with three successful repetitions;
- seeded 4k-to-16 semantic receipts passed and prompt contracts matched; the
  15 decode iterations also exercised the `<1024`-token fallback path.

Known limitation: ordered sampled-output hashes are not stable across independent
control server startups in this harness (3/16 control-control rows differ), so
they are not used as a bitwise parity claim.

## Evidence artifacts

- profile bundle SHA256:
  `5d2c7647dbf9b41c88c065a45e159158ce87a7de940eba85c233102b5a296564`
- serving bundle SHA256:
  `2ea1a894e0a16ea02c8b20616754c1660ad661b2a712eb0c7f4f501f15471e62`

Tracking: MUSA-60043 Round50.
