### PR TITLE
fix(musa): support Qwen Omni ModelOpt FP8 inference

### DIFF
--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -51,6 +51,19 @@ class TestCustomOpsRuntimePatches:
         assert getattr(vllm_ops.rotary_embedding, "_musa_safe_rotary_embedding") is True
 
 
+class TestModelOptFp8CapabilityPatch:
+    def test_modelopt_fp8_uses_musa_capability_floor(self):
+        patch_path = (
+            Path(__file__).parent.parent
+            / "vllm_musa/patches/series/0099-MUSA-allow-ModelOpt-FP8-on-MUSA-capability.patch"
+        )
+        source = patch_path.read_text()
+
+        assert "vllm/model_executor/layers/quantization/modelopt.py" in source
+        assert "-        return 89" in source
+        assert "+        return 31" in source
+
+
 class TestCompilationBackendPatch:
     """Tests for MUSA torch.compile backend compatibility patches."""
 

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -88,6 +88,17 @@ class TestCustomOpsRuntimePatches:
             rtol=0.1,
         )
 
+        saturated, _ = vllm_ops.scaled_fp8_quant(
+            torch.tensor([[1000.0, -1000.0]]),
+            torch.tensor(1.0),
+        )
+        fp8_info = torch.finfo(torch.float8_e4m3fn)
+        torch.testing.assert_close(
+            saturated.float(),
+            torch.tensor([[fp8_info.max, fp8_info.min]]),
+        )
+        assert torch.isfinite(saturated.float()).all()
+
 
 class TestModelOptFp8CapabilityPatch:
     def test_modelopt_fp8_uses_musa_capability_floor(self):

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -50,6 +50,44 @@ class TestCustomOpsRuntimePatches:
         assert vllm_ops.rotary_embedding is _shared.musa_safe_rotary_embedding
         assert getattr(vllm_ops.rotary_embedding, "_musa_safe_rotary_embedding") is True
 
+    def test_static_fp8_fallback_is_registered_on_vllm_custom_ops(self, monkeypatch):
+        import vllm
+
+        from vllm_musa.patches import _get_patch_files, _load_patch_module
+
+        delegated = object()
+        vllm_ops = ModuleType("vllm._custom_ops")
+        vllm_ops.scaled_fp8_quant = lambda *args: delegated
+        monkeypatch.setitem(sys.modules, "vllm._custom_ops", vllm_ops)
+        monkeypatch.setattr(vllm, "_custom_ops", vllm_ops, raising=False)
+
+        patch_file = next(f for m, f in _get_patch_files() if m == "vllm._custom_ops")
+        patch_module = _load_patch_module(patch_file)
+        monkeypatch.setattr(
+            patch_module,
+            "current_platform",
+            SimpleNamespace(fp8_dtype=lambda: torch.float8_e4m3fn),
+        )
+        patch_module.apply()
+
+        assert getattr(vllm_ops.scaled_fp8_quant, "_musa_static_fp8_fallback")
+        assert vllm_ops.scaled_fp8_quant(torch.ones((1, 1))) is delegated
+
+        values = torch.tensor([[2.0, 4.0], [4.0, 4.0]])
+        scale = torch.tensor([1.0, 2.0])
+        quantized, returned_scale = vllm_ops.scaled_fp8_quant(
+            values, scale, group_shape=(-1, 1)
+        )
+
+        assert returned_scale is scale
+        assert quantized.dtype == torch.float8_e4m3fn
+        torch.testing.assert_close(
+            quantized.float(),
+            torch.tensor([[2.0, 2.0], [4.0, 2.0]]),
+            atol=0.1,
+            rtol=0.1,
+        )
+
 
 class TestModelOptFp8CapabilityPatch:
     def test_modelopt_fp8_uses_musa_capability_floor(self):

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -26,6 +26,34 @@ requires_musa = pytest.mark.skipif(
 )
 
 
+def test_legacy_seeded_multinomial_is_limited_to_validated_qwen_vocabs(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(sampler, "musa_seeded_multinomial_enabled", lambda: True)
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    generators = {0: object()}
+
+    assert sampler.can_use_musa_seeded_multinomial(
+        torch.empty((1, 151936)), generators, "raw_logprobs"
+    )
+    assert sampler.can_use_musa_seeded_multinomial(
+        torch.empty((1, 248320)), generators, "raw_logprobs"
+    )
+    assert not sampler.can_use_musa_seeded_multinomial(
+        torch.empty((1, 3072)), generators, "raw_logprobs"
+    )
+    assert not sampler.can_use_musa_seeded_multinomial(
+        torch.empty((1, 4096)), generators, "raw_logprobs"
+    )
+    assert not sampler.can_use_musa_seeded_multinomial(
+        torch.empty((1, 151936)), {}, "raw_logprobs"
+    )
+    assert not sampler.can_use_musa_seeded_multinomial(
+        torch.empty((1, 151936)), generators, "processed_logprobs"
+    )
+
+
 def test_uniform_sampler_metadata_patch_is_active_and_qwen_gated() -> None:
     metadata_fields = {field.name for field in fields(SamplingMetadata)}
     assert "uniform_top_k" in metadata_fields

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -26,7 +26,7 @@ requires_musa = pytest.mark.skipif(
 )
 
 
-def test_legacy_seeded_multinomial_is_limited_to_validated_qwen_vocabs(
+def test_legacy_seeded_multinomial_is_limited_to_qwen_text_vocabs(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(sampler, "musa_seeded_multinomial_enabled", lambda: True)
@@ -38,13 +38,16 @@ def test_legacy_seeded_multinomial_is_limited_to_validated_qwen_vocabs(
         torch.empty((1, 151936)), generators, "raw_logprobs"
     )
     assert sampler.can_use_musa_seeded_multinomial(
+        torch.empty((1, 152064)), generators, "raw_logprobs"
+    )
+    assert sampler.can_use_musa_seeded_multinomial(
         torch.empty((1, 248320)), generators, "raw_logprobs"
     )
     assert not sampler.can_use_musa_seeded_multinomial(
-        torch.empty((1, 3072)), generators, "raw_logprobs"
+        torch.empty((1, 102400)), generators, "raw_logprobs"
     )
     assert not sampler.can_use_musa_seeded_multinomial(
-        torch.empty((1, 4096)), generators, "raw_logprobs"
+        torch.empty((1, 8448)), generators, "raw_logprobs"
     )
     assert not sampler.can_use_musa_seeded_multinomial(
         torch.empty((1, 151936)), {}, "raw_logprobs"

--- a/tests/test_unquantized_fused_moe_import.py
+++ b/tests/test_unquantized_fused_moe_import.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: I001
+
+import torchada  # noqa: F401
+
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+    TritonExperts as UpstreamTritonExperts,
+)
+
+from vllm_musa.model_executor.layers.fused_moe import (
+    unquantized_fused_moe_method,
+)
+
+
+def test_triton_experts_uses_canonical_upstream_module() -> None:
+    assert unquantized_fused_moe_method.TritonExperts is UpstreamTritonExperts

--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -3,10 +3,16 @@ import inspect
 import torch
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
-    TritonExperts,
     UnquantizedFusedMoEMethod,
     fused_experts,
 )
+
+try:
+    from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+        TritonExperts,
+    )
+except ImportError:
+    from vllm.model_executor.layers.fused_moe import TritonExperts
 
 try:
     from vllm.model_executor.layers.fused_moe.experts.fused_batched_moe import (

--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -6,13 +6,9 @@ from vllm.model_executor.layers.fused_moe import (
     UnquantizedFusedMoEMethod,
     fused_experts,
 )
-
-try:
-    from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
-        TritonExperts,
-    )
-except ImportError:
-    from vllm.model_executor.layers.fused_moe import TritonExperts
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+    TritonExperts,
+)
 
 try:
     from vllm.model_executor.layers.fused_moe.experts.fused_batched_moe import (
@@ -104,9 +100,9 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             # to FusedMoE, so the runner never supplies a separate
             # shared_experts_input here; x is the shared expert's input, matching
             # the routed experts it now rides with.
-            assert shared_experts_input is None, (
-                "folded shared expert expects shared_experts=None"
-            )
+            assert (
+                shared_experts_input is None
+            ), "folded shared expert expects shared_experts=None"
             shared_logits, _ = layer._musa_shared_gate(x)
             topk_weights, topk_ids = extend_topk_with_shared(
                 topk_weights,

--- a/vllm_musa/patches/series/0099-MUSA-allow-ModelOpt-FP8-on-MUSA-capability.patch
+++ b/vllm_musa/patches/series/0099-MUSA-allow-ModelOpt-FP8-on-MUSA-capability.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sat, 1 Aug 2026 08:49:31 +0800
+Subject: [PATCH] MUSA: allow ModelOpt FP8 on MUSA capability
+
+---
+ vllm/model_executor/layers/quantization/modelopt.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/vllm/model_executor/layers/quantization/modelopt.py b/vllm/model_executor/layers/quantization/modelopt.py
+index d51a2dd31..c65569cdf 100644
+--- a/vllm/model_executor/layers/quantization/modelopt.py
++++ b/vllm/model_executor/layers/quantization/modelopt.py
+@@ -409,7 +409,7 @@ class ModelOptFp8Config(ModelOptQuantConfigBase):
+ 
+     @classmethod
+     def get_min_capability(cls) -> int:
+-        return 89
++        return 31
+ 
+     @classmethod
+     def override_quantization_method(

--- a/vllm_musa/patches/vllm___custom_ops.patch.py
+++ b/vllm_musa/patches/vllm___custom_ops.patch.py
@@ -1,15 +1,106 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MUSA cat-6 object patch: route direct ``vllm._custom_ops`` rms_norm /
-rotary_embedding calls through MUSA-safe fallbacks for dflash paths (
-was inline ``_patch_vllm_custom_ops_dflash_fallbacks``)."""
+"""MUSA-safe fallbacks for direct ``vllm._custom_ops`` calls."""
 
+from collections.abc import Callable
+
+import torch
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 
 from vllm_musa.patches._shared import musa_safe_rms_norm, musa_safe_rotary_embedding
 
 logger = init_logger(__name__)
 
 PATCHES: list = []
+
+
+def _expand_static_fp8_scale(
+    scale: torch.Tensor,
+    input_shape: tuple[int, int],
+    group_shape: tuple[int, int] | None,
+) -> torch.Tensor:
+    rows, cols = input_shape
+    if scale.numel() == 1:
+        return scale
+    if group_shape is None:
+        if scale.ndim == 1:
+            raise ValueError("A 1D FP8 scale requires an explicit group_shape")
+        return scale
+
+    group_rows, group_cols = group_shape
+    group_rows = rows if group_rows == -1 else group_rows
+    group_cols = cols if group_cols == -1 else group_cols
+    if group_rows <= 0 or group_cols <= 0:
+        raise ValueError(f"Invalid FP8 group shape: {group_shape}")
+
+    if scale.ndim == 1:
+        if group_rows == rows and group_cols == 1:
+            scale = scale.reshape(1, -1)
+        elif group_rows == 1 and group_cols == cols:
+            scale = scale.reshape(-1, 1)
+        else:
+            raise ValueError(
+                "A 1D FP8 scale requires per-channel (-1, 1) or "
+                "per-token (1, -1) group_shape"
+            )
+    if scale.ndim != 2:
+        raise ValueError("MUSA static FP8 fallback expects a scalar, 1D, or 2D scale")
+
+    expected_rows = (rows + group_rows - 1) // group_rows
+    expected_cols = (cols + group_cols - 1) // group_cols
+    if scale.shape != (expected_rows, expected_cols):
+        raise ValueError(
+            f"FP8 scale shape {tuple(scale.shape)} does not match "
+            f"group_shape={group_shape} for input_shape={input_shape}"
+        )
+    return scale.repeat_interleave(group_rows, dim=0).repeat_interleave(
+        group_cols, dim=1
+    )[:rows, :cols]
+
+
+def _make_musa_scaled_fp8_quant(
+    original: Callable,
+) -> Callable:
+    def musa_scaled_fp8_quant(
+        input: torch.Tensor,
+        scale: torch.Tensor | None = None,
+        num_token_padding: int | None = None,
+        scale_ub: torch.Tensor | None = None,
+        use_per_token_if_dynamic: bool = False,
+        output: torch.Tensor | None = None,
+        group_shape: tuple[int, int] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if scale is None:
+            return original(
+                input,
+                scale,
+                num_token_padding,
+                scale_ub,
+                use_per_token_if_dynamic,
+                output,
+                group_shape,
+            )
+
+        if input.ndim != 2:
+            raise ValueError("MUSA static FP8 fallback expects a 2D input")
+        rows, cols = input.shape
+        out_rows = max(rows, num_token_padding or rows)
+        out_dtype = current_platform.fp8_dtype()
+        if output is None:
+            output = torch.empty((out_rows, cols), device=input.device, dtype=out_dtype)
+        elif num_token_padding is not None:
+            raise ValueError("MUSA static FP8 fallback does not support output padding")
+        elif output.dtype != out_dtype:
+            raise ValueError(f"MUSA static FP8 output must have dtype {out_dtype}")
+
+        expanded_scale = _expand_static_fp8_scale(scale, (rows, cols), group_shape)
+        output[:rows].copy_((input / expanded_scale).to(out_dtype))
+        if out_rows > rows:
+            output[rows:].zero_()
+        return output, scale
+
+    setattr(musa_scaled_fp8_quant, "_musa_static_fp8_fallback", True)
+    return musa_scaled_fp8_quant
 
 
 def apply() -> None:
@@ -27,3 +118,7 @@ def apply() -> None:
     if not getattr(current, "_musa_safe_rotary_embedding", False):
         setattr(musa_safe_rotary_embedding, "_musa_safe_rotary_embedding", True)
         vllm_custom_ops.rotary_embedding = musa_safe_rotary_embedding
+
+    current = getattr(vllm_custom_ops, "scaled_fp8_quant", None)
+    if current is not None and not getattr(current, "_musa_static_fp8_fallback", False):
+        vllm_custom_ops.scaled_fp8_quant = _make_musa_scaled_fp8_quant(current)

--- a/vllm_musa/patches/vllm___custom_ops.patch.py
+++ b/vllm_musa/patches/vllm___custom_ops.patch.py
@@ -94,7 +94,12 @@ def _make_musa_scaled_fp8_quant(
             raise ValueError(f"MUSA static FP8 output must have dtype {out_dtype}")
 
         expanded_scale = _expand_static_fp8_scale(scale, (rows, cols), group_shape)
-        output[:rows].copy_((input / expanded_scale).to(out_dtype))
+        fp8_info = torch.finfo(out_dtype)
+        scaled = (input / expanded_scale).clamp(
+            min=fp8_info.min,
+            max=fp8_info.max,
+        )
+        output[:rows].copy_(scaled.to(out_dtype))
         if out_rows > rows:
             output[rows:].zero_()
         return output, scale

--- a/vllm_musa/patches/vllm___custom_ops.patch.py
+++ b/vllm_musa/patches/vllm___custom_ops.patch.py
@@ -61,6 +61,11 @@ def _expand_static_fp8_scale(
 def _make_musa_scaled_fp8_quant(
     original: Callable,
 ) -> Callable:
+    """Wrap vLLM's CUDA-only static FP8 custom op for MUSA.
+
+    Dynamic FP8 quantization continues to use the original vLLM implementation.
+    """
+
     def musa_scaled_fp8_quant(
         input: torch.Tensor,
         scale: torch.Tensor | None = None,

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -19,7 +19,7 @@ from vllm_musa.utils.environ import envs
 logger = logging.getLogger(__name__)
 
 _SAMPLING_EPS = 1e-5
-_MUSA_QWEN_SAMPLER_VOCAB_SIZES = frozenset((151936, 248320))
+_MUSA_QWEN_SAMPLER_VOCAB_SIZES = frozenset((151936, 152064, 248320))
 
 
 def _is_qwen_sampler_vocab(logits: torch.Tensor) -> bool:
@@ -83,7 +83,7 @@ def can_use_musa_seeded_multinomial(
         and musa_seeded_multinomial_enabled()
         and current_platform.is_musa()
         and is_musa_tensor(logits)
-        # MUSA seeded multinomial is validated for Qwen text vocabularies only.
+        # Keep non-Qwen and small codec vocabularies on the upstream sampler.
         and _is_qwen_sampler_vocab(logits)
         and logprobs_mode not in ("processed_logits", "processed_logprobs")
     )

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -72,6 +72,23 @@ def can_use_musa_sampler(
     return logprobs_mode not in ("processed_logits", "processed_logprobs")
 
 
+def can_use_musa_seeded_multinomial(
+    logits: torch.Tensor,
+    generators: dict[int, torch.Generator],
+    logprobs_mode: LogprobsMode,
+) -> bool:
+    """Gate the legacy per-request multinomial path to validated vocabularies."""
+    return (
+        bool(generators)
+        and musa_seeded_multinomial_enabled()
+        and current_platform.is_musa()
+        and is_musa_tensor(logits)
+        # MUSA seeded multinomial is validated for Qwen text vocabularies only.
+        and _is_qwen_sampler_vocab(logits)
+        and logprobs_mode not in ("processed_logits", "processed_logprobs")
+    )
+
+
 def _squeeze_filter_tensor(value: torch.Tensor | None) -> torch.Tensor | None:
     if value is None:
         return None
@@ -273,13 +290,7 @@ def forward_musa(
     p: torch.Tensor | float | None,
     min_p: torch.Tensor | float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    if (
-        generators
-        and musa_seeded_multinomial_enabled()
-        and current_platform.is_musa()
-        and is_musa_tensor(logits)
-        and self.logprobs_mode not in ("processed_logits", "processed_logprobs")
-    ):
+    if can_use_musa_seeded_multinomial(logits, generators, self.logprobs_mode):
         if min_p is not None:
             return self.forward_native(logits, generators, k, p)
         logits = _apply_top_k_top_p(logits, k, p)


### PR DESCRIPTION
## Motivation

Qwen3-Omni ModelOpt FP8 exposed three vLLM-MUSA compatibility gaps:

1. ModelOpt checkpoints were rejected before backend capability selection.
2. Static FP8 activation quantization called a CUDA custom op unavailable on MUSA; unsaturated E4M3 conversion could also turn finite overflow into NaN.
3. Per-request seeded `torch.multinomial` could return an out-of-range token for small talker/code-predictor codec vocabularies.

Qwen2.5-Omni additionally hit the vLLM `TritonExperts` import-path change.

This is the vLLM-MUSA half of [vllm-omni#5671](https://github.com/vllm-project/vllm-omni/pull/5671).

## Changes

- Allow ModelOpt FP8 after checking the active MUSA linear/MoE capabilities.
- Provide a MUSA-only static `scaled_fp8_quant` fallback supporting scalar, per-channel, per-token, and 2-D group scales.
- Clamp static E4M3 input to the finite FP8 range before casting.
- Keep seeded multinomial only for the validated Qwen text vocabularies `151936`, `152064`, and `248320`; Qwen2.5/Qwen3 codec vocabularies and non-Qwen vocabularies retain the upstream sampler.
- Import `TritonExperts` directly from the canonical `experts.triton_moe` location used by the pinned vLLM commit.

Dynamic FP8 quantization still delegates to the original vLLM implementation.

## Validation

Environment:

- Image: `registry.mthreads.com/mcconline/inference/vllm:v0.24.0-ph1-5.2.0-torch2.9.1.post1-20260801`
- Image ID: `sha256:d42fa0763498993717dd2154970866f645fd033d9e5fddf06ddd08e74f2b7442`
- Hardware: 8 x MTT S5000 exclusively leased; model runs used devices 0/1
- MUSA driver/runtime: 5.2.0
- Base: `v0.24.0-dev`
- Tested head: `9b4485177b6b57a4e0e664c8eaa99e2e1c5dd7e1`

Focused tests on the final head:

- Sampler, static-FP8 fallback, ModelOpt capability patch, and canonical import: **48 passed**
- Full `tests/test_patches.py` from the earlier integration gate: **73 passed, 2 skipped, 5 failed**; the same five failures reproduced unchanged at detached baseline `662a52794`.

Model smokes:

| Model/path | Result |
| --- | --- |
| Qwen3-8B-FP8 dense | Semantic `Beijing`; MUSA DeepGEMM FP8; FLASH_ATTN |
| Qwen3-30B-A3B-FP8 MoE | Semantic `Beijing`; MUSA DeepGEMM FP8; FLASH_ATTN |
| DeepSeek-V2-Lite-Chat-FP8 MLA | Five offline requests plus five sequential OpenAI chat requests passed; FLASH_MLA; no non-contiguous/Triton-fallback FP8 crash |
| Qwen3-Omni ModelOpt FP8 on final head | Compiled `FULL_AND_PIECEWISE` request returned `Beijing`; startup 598.64 s; request 2.02 s |
| Qwen2.5-Omni-3B on final head | Eager semantic request returned `Beijing`; all three stages initialized |

The final sampler refinement does not broaden behavior to DeepSeek or other large-vocabulary families. For the issue-2347 models, the text/codec decisions are explicit: Qwen3-Omni `152064 -> seeded`, `3072/2048 -> upstream`; Qwen2.5-Omni `151936 -> seeded`, `8448 -> upstream`. The production DeepSeek V2 sampler path is unchanged.

### Full vLLM-Omni correctness matrix before merge

The final vLLM-MUSA head `9b4485177` was integrated with vLLM-Omni PR #5671 (`8e87b977`) on the v0.24.1 + #5366 + #5164 release stack. The matrix ran on 2 x MTT S5000 with driver/runtime 5.2.0. Server startup alone was not accepted as a pass.

| #2347 model | Execution path | Correctness oracle | Result |
| --- | --- | --- | --- |
| Fun-CosyVoice3-0.5B-2512 | Eager, two-stage TTS | Decodable, finite, non-silent 24kHz WAV | PASS: 110400 frames, 4.60 s, RMS 0.077797 |
| Qwen2.5-Omni-3B | Eager server, all three stages | Semantic response to capital-of-China prompt | PASS: `Beijing` |
| Qwen3-Omni-30B-A3B-Instruct BF16 | `VLLM_COMPILE`, `FULL_AND_PIECEWISE` | Semantic response | PASS: `Beijing`; startup 330.36 s, request 31.05 s |
| Qwen3-Omni-30B-A3B-Instruct ModelOpt FP8 | `VLLM_COMPILE`, `FULL_AND_PIECEWISE` | Semantic response plus stage-local quantization | PASS: `Beijing`; startup 518.55 s, request 1.46 s |
| Qwen-Image | Eager, TP2, 2 denoising steps | Decodable non-uniform PNG | PASS: 256x256 RGB, pixel std 61.34 |
| Qwen-Image-Edit | Eager, TP2, 2 denoising steps | Decodable PNG changed from input | PASS: 1024x1024 RGB, mean absolute input delta 25.99 |
| Wan2.2-T2V-A14B-Diffusers | Eager, TP2, 2 steps | Decodable non-static MP4 | PASS: 5x256x256 RGB, temporal delta 2.36 |
| Wan2.2-I2V-A14B-Diffusers | Eager, TP2, 2 steps | Decodable non-static MP4 | PASS: 5x256x256 RGB, temporal delta 3.36 |

Result: **8/8 supported vLLM-Omni model/configuration gates passed**. The generated WAV, PNG, and MP4 files were decoded and numerically checked after inference. CosyVoice3 used the existing Snake Triton eager fallback; the request and audio correctness oracle passed.

Runtime package highlights: PyTorch/torch-musa `2.9.1.post1+musa5.2.0`, torchada `0.1.77`, diffusers `0.38.0`, cache-dit `1.3.0`, accelerate `1.12.0`, gguf `0.17.1`, and AV `17.1.0`.
