### PR TITLE
perf(musa): enable gated width4 GDN prefill split for TP1

### DIFF
--- a/tests/test_causal_conv1d_mixed_dtype.py
+++ b/tests/test_causal_conv1d_mixed_dtype.py
@@ -5,6 +5,46 @@ pytest.importorskip("tilelang")
 causal_conv1d = pytest.importorskip("vllm_musa.jit_kernel.tilelang.causal_conv1d")
 
 
+def _prefill_gate(**overrides):
+    kwargs = {
+        "width": 4,
+        "dim": 10240,
+        "dtype": torch.bfloat16,
+        "max_seq_len": 4096,
+        "batch_size": 2,
+        "has_conv_states": True,
+        "has_cache_indices": True,
+        "cache_indices_stride": 1,
+        "x_inner_stride": 1,
+        "out_inner_stride": 1,
+        "weight_inner_stride": 1,
+    }
+    kwargs.update(overrides)
+    return causal_conv1d._should_use_width4_prefill_split(**kwargs)
+
+
+def test_prefill_split_gate_accepts_validated_tp1_width(monkeypatch):
+    monkeypatch.setattr(causal_conv1d, "_ENABLE_WIDTH4_PREFILL_SPLIT", True)
+    assert _prefill_gate(dim=10240)
+
+
+def test_prefill_split_gate_rejects_tp4_and_small_prefill(monkeypatch):
+    monkeypatch.setattr(causal_conv1d, "_ENABLE_WIDTH4_PREFILL_SPLIT", True)
+    assert not _prefill_gate(dim=2048)
+    assert not _prefill_gate(dim=2560)
+    assert not _prefill_gate(dim=12288)
+    assert not _prefill_gate(dim=8192)
+    assert not _prefill_gate(max_seq_len=2048)
+    assert not _prefill_gate(batch_size=1)
+    assert not _prefill_gate(cache_indices_stride=2)
+    assert not _prefill_gate(dtype=torch.float16)
+
+
+def test_prefill_split_gate_honors_kill_switch(monkeypatch):
+    monkeypatch.setattr(causal_conv1d, "_ENABLE_WIDTH4_PREFILL_SPLIT", False)
+    assert not _prefill_gate()
+
+
 def test_decode_kernel_keeps_supported_mixed_dtypes(monkeypatch):
     captured = {}
 

--- a/tests/test_musa_environ.py
+++ b/tests/test_musa_environ.py
@@ -1,0 +1,8 @@
+from vllm_musa.utils.environ import envs
+
+
+def test_qwen_gdn_width4_split_env_bool_contract():
+    with envs.VLLM_MUSA_QWEN_GDN_WIDTH4_PREFILL_SPLIT.override("yes"):
+        assert envs.VLLM_MUSA_QWEN_GDN_WIDTH4_PREFILL_SPLIT.get() is True
+    with envs.VLLM_MUSA_QWEN_GDN_WIDTH4_PREFILL_SPLIT.override("off"):
+        assert envs.VLLM_MUSA_QWEN_GDN_WIDTH4_PREFILL_SPLIT.get() is False

--- a/vllm_musa/jit_kernel/tilelang/causal_conv1d.py
+++ b/vllm_musa/jit_kernel/tilelang/causal_conv1d.py
@@ -5,6 +5,7 @@ import functools
 import tilelang
 import tilelang.language as T
 import torch
+from vllm.logger import init_logger
 
 from vllm_musa.jit_kernel.tilelang.utils import (
     MUSA_COMMON_PASS_CONFIGS,
@@ -12,6 +13,7 @@ from vllm_musa.jit_kernel.tilelang.utils import (
     storage_window,
     tilelang_dtype,
 )
+from vllm_musa.utils.environ import envs
 
 PAD_SLOT_ID = -1  # MUSA: match vllm mamba causal_conv1d PAD_SLOT_ID
 NULL_BLOCK_ID = 0  # MUSA: match vllm mamba causal_conv1d NULL_BLOCK_ID
@@ -25,7 +27,43 @@ def register_custom_op(fn=None, **_kw):
 
 
 _LOG2E = 1.4426950408889634
-_ENABLE_WIDTH4_PREFILL_SPLIT = False
+_ENABLE_WIDTH4_PREFILL_SPLIT = envs.VLLM_MUSA_QWEN_GDN_WIDTH4_PREFILL_SPLIT.get()
+_WIDTH4_PREFILL_SPLIT_DIMS = frozenset((10240,))
+_WIDTH4_PREFILL_SPLIT_LOGGED = False
+logger = init_logger(__name__)
+
+
+def _should_use_width4_prefill_split(
+    *,
+    width: int,
+    dim: int,
+    dtype: torch.dtype,
+    max_seq_len: int,
+    batch_size: int,
+    has_conv_states: bool,
+    has_cache_indices: bool,
+    cache_indices_stride: int,
+    x_inner_stride: int,
+    out_inner_stride: int,
+    weight_inner_stride: int,
+) -> bool:
+    return (
+        _ENABLE_WIDTH4_PREFILL_SPLIT
+        and width == 4
+        and dtype is torch.bfloat16
+        # The split is beneficial only once the local channel width is large
+        # enough to amortize its two launches on MP31.
+        and dim in _WIDTH4_PREFILL_SPLIT_DIMS
+        and max_seq_len >= 4096
+        and batch_size > 1
+        and has_conv_states
+        and has_cache_indices
+        and cache_indices_stride == 1
+        and x_inner_stride == 1
+        and out_inner_stride == 1
+        and weight_inner_stride == 1
+    )
+
 
 _CAUSAL_CONV1D_PASS_CONFIGS = dict(MUSA_COMMON_PASS_CONFIGS)
 for _key, _value in (
@@ -1285,17 +1323,25 @@ def _causal_conv1d_fwd_impl(
         )
         return out
 
-    if (
-        _ENABLE_WIDTH4_PREFILL_SPLIT
-        and width == 4
-        and max_seq_len >= 128
-        and query_start_loc.numel() > 2
-        and conv_states is not None
-        and cache_indices is not None
-        and x.stride(0) == 1
-        and out.stride(0) == 1
-        and weight.stride(1) == 1
+    if _should_use_width4_prefill_split(
+        width=width,
+        dim=dim,
+        dtype=x.dtype,
+        max_seq_len=max_seq_len,
+        batch_size=query_start_loc.numel() - 1,
+        has_conv_states=conv_states is not None,
+        has_cache_indices=cache_indices is not None,
+        cache_indices_stride=(
+            cache_indices.stride(0) if cache_indices is not None else 1
+        ),
+        x_inner_stride=x.stride(0),
+        out_inner_stride=out.stride(0),
+        weight_inner_stride=weight.stride(1),
     ):
+        global _WIDTH4_PREFILL_SPLIT_LOGGED
+        if not _WIDTH4_PREFILL_SPLIT_LOGGED:
+            logger.info_once("MUSA width-4 causal-conv prefill split active")
+            _WIDTH4_PREFILL_SPLIT_LOGGED = True
         _causal_conv1d_prefill_width4_kernel(
             dtype,
             cache_indices_dtype,

--- a/vllm_musa/utils/environ.py
+++ b/vllm_musa/utils/environ.py
@@ -97,6 +97,7 @@ class Envs:
     VLLM_MUSA_ENABLE_JIT_TOPK = EnvBool(True)
     VLLM_MUSA_SEEDED_MULTINOMIAL = EnvBool(True)
     VLLM_MUSA_RESHAPE_CACHE_FLASH = EnvBool(True)
+    VLLM_MUSA_QWEN_GDN_WIDTH4_PREFILL_SPLIT = EnvBool(True)
 
 
 envs = Envs()


### PR DESCRIPTION
## Summary

Enable the existing width-4 causal-conv prefill prologue/body split for wide
single-card Qwen GDN shapes. The split is now guarded by an explicit helper:
BF16 width 4, exact validated local dimension `dim=10240`, at least two
sequences, `max_seq_len>=4096`, valid cache/state and unit inner strides
(including contiguous `cache_indices`). It is enabled by default for that exact
shape family and
can be disabled with `VLLM_MUSA_QWEN_GDN_WIDTH4_PREFILL_SPLIT=0`.

This branch is based on the merged #147 base (`c13c3a38`). It does not modify
vLLM-Omni and does not depend on the open #157/#160 drafts. Submitted commit:
`5a7674310`.

## Why

The generic prefill kernel was 2.62% of the fresh Qwen3.5-27B TP1 BS64
device-time profile. The specialized kernels already existed in vLLM-MUSA but
were permanently disabled. The gate keeps the path off for TP4 geometries where
the second launch is not amortized, and keeps BS1 on the existing fallback.

## Evidence (S5000, TP1)

Image digest:
`sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`

Model: `/mnt/nfs/models/Qwen3.5-27B-BF16`, BF16, BS64, 4096 -> 1,
`max_num_batched_tokens=8192`, FA3, `FULL_AND_PIECEWISE`.

| Exact operation shape | Generic (us) | Split (us) | Delta |
|---|---:|---:|---:|
| TP1 dense `dim=10240,parent=16384` | 462.644 | 324.353 | -29.891% |
| TP1 MoE geometry `dim=8192,parent=12288` | 374.241 | 277.681 | -25.801% |
| TP4 MoE `dim=2048,parent=3072` (gate off) | 103.243 | 103.199 | -0.043% |

The TP1 dense operation result passed BF16 output tolerance and exact state
update comparison with mixed initial-state flags. The formal serving protocol
was C1(control), B1(candidate), B2(candidate), C2(control), three performance
repetitions per leg on the same leased GPU:

| Arm | n | Mean TTFT (ms) | Request throughput (req/s) |
|---|---:|---:|---:|
| Control (C1+C2) | 6 | 21344.917 | 1.609618 |
| Candidate (B1+B2) | 6 | 21147.126 | 1.626970 |

Pooled TTFT delta is **-0.927%** (-197.8 ms); paired bootstrap 95% CI is
[-221.1, -179.9] ms. Request throughput improves 1.078%. Every candidate leg
hit the specialized-branch marker; every control leg verified the marker was
absent. BS16 default-on compiled/FA3 semantic smoke also passed.

Non-contiguous `cache_indices` are explicitly rejected by the split gate and
fall back to the existing generic kernel, matching the generic kernel's stride
contract; the gate test covers this case. The switch is registered through the
repository `EnvBool` surface, so `yes/on/true` and `no/off/false` follow the
same contract as other vLLM-MUSA flags.

## Validation

- `ruff check`, `ruff format --check`, `py_compile`: pass.
- Gate assertions for TP1 width, short-prefill/BS1 fallback, BF16 dtype,
  non-contiguous cache indices, and kill switch: pass on MUSA runtime.
- Existing pytest module: not run in the supplied image because pytest is not
  installed; local collection is skipped for the same optional dependency.
- Pending before merge: CI pytest, TP1 MoE `dim=8192` serving evidence (the
  corresponding weights were not staged on the leased host), Qwen3.5/3.6
  sibling smoke, and a TP4 end-to-end no-regression leg.

## Risk / rollback

The implementation is a dispatch gate around existing kernels; generic fallback
is retained. Set `VLLM_MUSA_QWEN_GDN_WIDTH4_PREFILL_SPLIT=0` to disable it
without changing model or serving arguments.
