### PR TITLE
perf(musa): batch unfiltered seeded Qwen sampling

### DIFF
--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -491,6 +491,84 @@ def test_qwen_legacy_gumbel_gate_and_generator_handoff(monkeypatch) -> None:
     ] * rows
 
 
+def test_qwen_legacy_gumbel_accepts_unfiltered_seeded_rows(monkeypatch) -> None:
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    rows = 16
+    logits = torch.randn((rows, 248320))
+    metadata = _legacy_gumbel_metadata(rows, top_k=None)
+    for generator in metadata.generators.values():
+        generator.set_offset(64)
+
+    assert _can_use_qwen_legacy_gumbel(
+        logits,
+        metadata,
+        "raw_logprobs",
+        None,
+        False,
+    )
+
+    filter_args = []
+
+    def fake_apply_top_k_top_p(logits_arg, top_k_arg, top_p_arg):
+        filter_args.append((top_k_arg, top_p_arg))
+        return logits_arg
+
+    monkeypatch.setattr(sampler, "_apply_top_k_top_p", fake_apply_top_k_top_p)
+    monkeypatch.setattr(
+        sampler.vllm_worker_sampler,
+        "gumbel_sample",
+        lambda *args, **kwargs: torch.arange(rows, dtype=torch.int64),
+    )
+
+    sampled = sampler.sample_qwen_legacy_gumbel_partitioned(
+        logits,
+        metadata.generators,
+        None,
+    )
+
+    assert sampled is not None
+    assert sampled.tolist() == list(range(rows))
+    assert filter_args == [(None, None)]
+    assert [generator.get_offset() for generator in metadata.generators.values()] == [
+        68
+    ] * rows
+
+
+def test_qwen_legacy_gumbel_rejects_small_unfiltered_batches(monkeypatch) -> None:
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    rows = 15
+    logits = torch.randn((rows, 248320))
+    metadata = _legacy_gumbel_metadata(rows, top_k=None)
+
+    assert not _can_use_qwen_legacy_gumbel(
+        logits,
+        metadata,
+        "raw_logprobs",
+        None,
+        False,
+    )
+
+
+def test_qwen_legacy_gumbel_waits_for_unfiltered_seed_offsets(monkeypatch) -> None:
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    rows = 16
+    logits = torch.randn((rows, 248320))
+    metadata = _legacy_gumbel_metadata(rows, top_k=None)
+    for generator in metadata.generators.values():
+        generator.set_offset(60)
+
+    assert not _can_use_qwen_legacy_gumbel(
+        logits,
+        metadata,
+        "raw_logprobs",
+        None,
+        False,
+    )
+
+
 def test_qwen_legacy_gumbel_gate_fails_closed(monkeypatch) -> None:
     monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
     monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 
 _SAMPLING_EPS = 1e-5
 _MUSA_QWEN_SAMPLER_VOCAB_SIZES = frozenset((151936, 152064, 248320))
+# Keep chunked-prefill and first-token response draining on the original path.
+_QWEN_LEGACY_UNFILTERED_GUMBEL_MIN_ROWS = 16
+_QWEN_LEGACY_UNFILTERED_GUMBEL_MIN_OFFSET = 64
 
 
 def _is_qwen_sampler_vocab(logits: torch.Tensor) -> bool:
@@ -613,13 +616,21 @@ def can_use_qwen_legacy_gumbel(
     ):
         return False
     top_k = sampling_metadata.top_k
-    if (
-        top_k is None
-        or top_k.ndim != 1
-        or top_k.numel() != logits.shape[0]
-        or sampling_metadata.top_p is not None
+    if sampling_metadata.top_p is not None or (
+        top_k is not None and (top_k.ndim != 1 or top_k.numel() != logits.shape[0])
     ):
         return False
+    if top_k is None and logits.shape[0] < _QWEN_LEGACY_UNFILTERED_GUMBEL_MIN_ROWS:
+        return False
+    if top_k is None:
+        generator_state = _get_qwen_legacy_generator_state_for_rows(
+            sampling_metadata.generators,
+            list(range(logits.shape[0])),
+        )
+        if generator_state is None or min(generator_state[1]) < (
+            _QWEN_LEGACY_UNFILTERED_GUMBEL_MIN_OFFSET
+        ):
+            return False
 
     spec_token_ids = getattr(sampling_metadata, "spec_token_ids", None)
     if spec_token_ids and any(spec_token_ids):
@@ -726,7 +737,7 @@ def _sample_qwen_legacy_gumbel_filtered(
 def sample_qwen_legacy_gumbel_partitioned(
     logits: torch.Tensor,
     generators: dict[int, torch.Generator],
-    top_k: torch.Tensor,
+    top_k: torch.Tensor | None,
 ) -> torch.Tensor | None:
     """Use Gumbel for seeded rows and preserve multinomial for unseeded rows."""
     rows = logits.shape[0]


### PR DESCRIPTION
## Summary

- extend the existing fail-closed Qwen legacy Gumbel path to unfiltered
  per-request seeded sampling (`top_k=None`, `top_p=None`)
- batch the per-row sampling work instead of launching one
  `sampleMultinomialOnce` kernel per request
- keep chunked prefill and first-token response draining on the old path by
  requiring at least 16 rows and generator offsets >=64
- preserve every existing Qwen/vocab/dtype/logprob/spec/generator fallback

This is based directly on the post-#147 merge commit `c13c3a38a`.

## Why

Qwen3.5-27B BF16 TP1, BS16, 4096->1024, explicit request seeds:

- control trace: 2048 `sampleMultinomialOnce` launches / 430.17 ms over 128
  steady decode steps (5.95% of device time)
- candidate trace: zero `sampleMultinomialOnce`; 128 batched Gumbel launches /
  24.10 ms
- total device kernel time: 7230.73 -> 6743.38 ms (-6.74%)

The initial broad prototype regressed TTFT during chunked prefill.  The final
rows/offset warm gate removes that regression while retaining long-decode
benefit.

## Serving A/B

Same S5000/GPU/source/image, profiler disabled, C-B-B-C.  Capture ladder is
`[1,2,4,8,16,32,64]` and FlashAttention 3 remains selected.

| Metric | Control mean | Candidate mean | Delta |
|---|---:|---:|---:|
| Mean TTFT | 6404.44 ms | 6401.19 ms | -0.05% |
| Median TTFT | 6565.51 ms | 6557.97 ms | -0.11% |
| Mean TPOT | 61.203 ms | 60.082 ms | -1.83% |
| Median TPOT | 61.053 ms | 59.936 ms | -1.83% |
| Output throughput | 236.773 tok/s | 240.773 tok/s | +1.69% |

The exploratory lease was one non-isolated S5000, so these results establish
direction and mechanism for Draft review rather than a final release claim.

## Validation

- 8-GiB cold-L2 A-B-B-A full-operation probe at rows 4/16/32: candidate
  `-87.7%/-95.8%/-96.9%`
- deterministic equal seed/offset MUSA operation smoke: pass
- exact generator offset advance (`+4`) and token-range checks: pass
- final 128-step trace: exact `generation_16(16)`, replacement mechanism pass
- `python -m pytest -q tests/test_sampler_cpu_state_fast_paths.py`: 47 passed
- Ruff check/format, `py_compile`, and `git diff --check`: pass

Local evidence summary:
`generated/MUSA-60043/round58-seeded-unfiltered-gumbel/round58-result.md`.
