### PR TITLE
deps: upgrade MATE to 0.2.5 and bundle MUBIN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ dev = [
     "build",
     "twine",
 ]
+# The MUBIN wheel is installed by the MUSA image requirements above. Keep an
+# explicit extra for source/editable installs that want the same offline,
+# pre-generated assembly payload without making runtime fallback impossible.
+offline = ["mate-mubin==0.2.5"]
 
 [project.scripts]
 vllm_collect_env = "vllm_musa:collect_env"

--- a/requirements/musa_private.txt
+++ b/requirements/musa_private.txt
@@ -21,10 +21,11 @@ mate==0.2.5
 # at runtime when this optional package is absent; installing it here keeps the
 # vLLM-MUSA image usable offline and avoids first-request download latency.
 mate-mubin==0.2.5
-flash_attn_3==0.2.4
-flash_mla==0.2.4
-deep-gemm==0.2.4
-sageattention==0.2.4
+# MATE wrappers have an exact mate dependency and must stay on the same release.
+flash_attn_3==0.2.5
+flash_mla==0.2.5
+deep-gemm==0.2.5
+sageattention==0.2.5
 deep_ep==1.1.0+musa5.2.0torch2.9.1.post1s5000
 tilelang_musa==0.1.8+musa.3
 # torch 2.9.1 Inductor reads KernelMetadata.cluster_dims. The MUSA backend in

--- a/requirements/musa_private.txt
+++ b/requirements/musa_private.txt
@@ -16,7 +16,11 @@ torch==2.9.1.post1+musa5.2.0
 torch_musa==2.9.1.post1+musa5.2.0
 torchvision==0.24.1.post1+musa5.2.0
 torchaudio==2.9.1+musa5.2.0
-mate==0.2.4
+mate==0.2.5
+# Pre-generated MATE assembly (MUBIN) objects. MATE can download these lazily
+# at runtime when this optional package is absent; installing it here keeps the
+# vLLM-MUSA image usable offline and avoids first-request download latency.
+mate-mubin==0.2.5
 flash_attn_3==0.2.4
 flash_mla==0.2.4
 deep-gemm==0.2.4

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -327,7 +327,8 @@ class MUSAFlashAttentionBackend(AttentionBackend):
             return torch.float8_e4m3fn
         raise NotImplementedError(
             f"kv_cache_dtype {kv_cache_dtype!r} is not supported for "
-            "FlashAttention on MUSA; mate provides an e4m3 FMHA kernel only."
+            "FlashAttention on MUSA; vLLM query quantization currently emits "
+            "E4M3, while MATE requires matching Q/K/V FP8 dtypes."
         )
 
     @classmethod
@@ -338,7 +339,10 @@ class MUSAFlashAttentionBackend(AttentionBackend):
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype is None:
             return True
-        # MUSA: e4m3 only — mate has no e5m2 FMHA kernel.
+        # MATE 0.2.5 has E5M2 FMHA, but vLLM currently quantizes queries to
+        # E4M3. Enabling an E5M2 KV cache would violate MATE's same-dtype Q/K/V
+        # requirement, so keep the backend gate closed until query quantization
+        # can emit E5M2 for this cache type.
         if kv_cache_dtype in ("fp8", "fp8_e4m3"):
             return flash_attn_supports_fp8()
         return kv_cache_dtype in ["auto", "float16", "bfloat16"]


### PR DESCRIPTION
## Summary

- upgrade `mate` and its wrapper packages from 0.2.4 to 0.2.5
- align `flash_attn_3`, `flash_mla`, `deep-gemm`, and `sageattention` with the
  MATE release they require
- install the optional `mate-mubin==0.2.5` payload in the MUSA image dependency set
- expose an `offline` extra for source/editable installs that want pre-generated MUBIN objects

MATE still supports lazy runtime download when `mate-mubin` is absent. The
image pin avoids that network dependency for offline deployments and removes
first-use artifact download latency.

## Validation

- internal index contains `mate==0.2.5` and `mate-mubin==0.2.5`; downloaded wheel hashes matched the simple-index hashes
- each 0.2.5 wrapper wheel declares the exact dependency `mate==0.2.5`
- runtime probe selected the installed `mate-mubin` package directory through `mate.artifacts.resolve_active_mubin_dir()`
- final package smoke passed for all six 0.2.5 packages, the bundled MUBIN path,
  and a real MUSA tensor operation
- Qwen3.5 matched A/B used the same MTT S5000 host and GPUs 1-4, driver
  5.2.0-server, TP4, normal torch.compile and `FULL_DECODE_ONLY` graph capture,
  exact 4096-token input / 1024-token output, BS 1/4/16/64
- every batch size used one same-batch warmup followed by two measured samples;
  all 1,020 completion requests returned HTTP 200

Median output token throughput (fully aligned 0.2.5 candidate versus the
image-native 0.2.4 stack):

| Model | BS | Baseline tok/s | Candidate tok/s | Delta |
|---|---:|---:|---:|---:|
| Qwen3.5-27B-FP8 dense | 1 | 64.49 | 63.51 | -1.51% |
|  | 4 | 235.44 | 234.98 | -0.20% |
|  | 16 | 681.01 | 693.62 | +1.85% |
|  | 64 | 688.34 | 691.20 | +0.42% |
| Qwen3.5-35B-A3B-BF16 MoE | 1 | 72.41 | 71.37 | -1.44% |
|  | 4 | 308.17 | 302.47 | -1.85% |
|  | 16 | 718.02 | 779.65 | +8.58% |
|  | 64 | 785.91 | 775.23 | -1.36% |

No measured point crosses the -3% regression gate. The MoE BS16 improvement is
directional only because that baseline pair had high variance.

## Caveats

- the requested 20260802 image tag is not present in the registry; the A/B used
  the attested 20260731 v0.24.0 digest
  `sha256:d3bfe984e313f856f55dfa34f69c86699d677be06f3d0d8d2696d87bf4ec4b6f`
- the run was not whole-host isolated: an unrelated process remained idle at
  0% utilization on GPU0; both legs used the same leased GPUs 1-4, so these are
  same-host regression results rather than absolute performance claims
- the staged BF16 MoE checkpoint was used because the FP8 MoE checkpoint is not
  compatible with the chosen TP shape
- both legs used identical capture sizes `1,4,16,64` to avoid the image's known
  default broad-capture startup failure
- MATE 0.2.5 includes an E5M2 FMHA specialization, but `fp8_e5m2` KV cache is
  intentionally not enabled here: vLLM's dynamic query quantizer still emits
  E4M3 while MATE requires matching Q/K/V FP8 dtypes. A hardware probe reached
  the MATE kernel and reproduced that dtype assertion; the stale backend
  comment/error now records the actual integration blocker.

Evidence is tracked under workspace ticket MUSA-60081.
