### PR TITLE
refactor(musa): centralize Qwen and DeepSeek-V4 optimization contracts

### DIFF
--- a/csrc/musa/fused_add_rmsnorm.mu
+++ b/csrc/musa/fused_add_rmsnorm.mu
@@ -126,13 +126,15 @@ __global__ void __launch_bounds__(BLOCK_X, 1) fused_add_rmsnorm_kernel(
 template <typename T>
 void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
                                 int rows, int hidden_size, float epsilon,
-                                musaStream_t stream) {
+                                musaStream_t stream, int requested_block) {
   const int vec_hidden_size = hidden_size / 8;
 
-  static const int forced_block = []() {
+  static const int env_forced_block = []() {
     const char* env = std::getenv("VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X");
     return env == nullptr ? 0 : std::atoi(env);
   }();
+  const int forced_block =
+      env_forced_block > 0 ? env_forced_block : requested_block;
 
   int block_x;
   if (forced_block > 0) {
@@ -202,7 +204,8 @@ void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
 }  // namespace vllm_musa
 
 void musa_fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
-                             torch::Tensor& weight, double epsilon) {
+                             torch::Tensor& weight, double epsilon,
+                             int64_t block_x) {
   TORCH_CHECK(input.device().is_privateuseone(), "input must be a MUSA tensor");
   TORCH_CHECK(residual.device().is_privateuseone(),
               "residual must be a MUSA tensor");
@@ -234,13 +237,13 @@ void musa_fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
         static_cast<__half*>(input.data_ptr()),
         static_cast<__half*>(residual.data_ptr()),
         static_cast<const __half*>(weight.data_ptr()), rows, hidden_size,
-        static_cast<float>(epsilon), stream);
+        static_cast<float>(epsilon), stream, static_cast<int>(block_x));
   } else if (input.scalar_type() == at::ScalarType::BFloat16) {
     vllm_musa::dispatch_fused_add_rmsnorm<__mt_bfloat16>(
         static_cast<__mt_bfloat16*>(input.data_ptr()),
         static_cast<__mt_bfloat16*>(residual.data_ptr()),
         static_cast<const __mt_bfloat16*>(weight.data_ptr()), rows, hidden_size,
-        static_cast<float>(epsilon), stream);
+        static_cast<float>(epsilon), stream, static_cast<int>(block_x));
   } else {
     TORCH_CHECK(false, "only fp16 and bf16 are supported");
   }

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -800,7 +800,9 @@ void musa_fused_gemv_moe(
     bool mul_routed_weight,
     int64_t topk,
     bool use_int4_w4a16,
-    bool use_swigelu) {
+    bool use_swigelu,
+    int64_t requested_block_n,
+    int64_t requested_block_k) {
 
     TORCH_CHECK(A.dim() == 2, "A must be dim 2.")
     TORCH_CHECK(B.dim() == 3, "B must be dim 3.")
@@ -897,6 +899,29 @@ void musa_fused_gemv_moe(
         fallback_config = BlockConfig{128, 1, -1.0f, false};
     }
     BlockConfig forced_config{0, 0, 0.f, false};
+    BlockConfig requested_config{0, 0, 0.f, false};
+    TORCH_CHECK(
+        (requested_block_n == 0) == (requested_block_k == 0),
+        "requested GEMV block must provide both block_n and block_k, got ",
+        requested_block_n, "x", requested_block_k);
+    if (requested_block_n != 0) {
+        TORCH_CHECK(
+            requested_block_n > 0 && requested_block_k > 0 &&
+                requested_block_n * requested_block_k <= 512,
+            "requested GEMV block must use positive sizes with block_n * "
+            "block_k <= 512, got ",
+            requested_block_n, "x", requested_block_k);
+        requested_config = BlockConfig{
+            static_cast<int>(requested_block_n),
+            static_cast<int>(requested_block_k),
+            0.f,
+            true};
+        TORCH_CHECK(
+            IsForcedBlockConfigValid(requested_config, nr_n, hidden_size, vlen),
+            "requested GEMV block=", requested_block_n, "x",
+            requested_block_k, " is invalid for nr_n=", nr_n,
+            ", hidden_size=", hidden_size, ", vlen=", vlen);
+    }
     BlockConfig qwen_fp8_moe_config{32, 4, 0.f, true};
     BlockConfig deepseek_fp8_w1_config{32, 4, 0.f, true};
     BlockConfig deepseek_v4_fp8_moe_config =
@@ -923,6 +948,11 @@ void musa_fused_gemv_moe(
             forced_config.block_k, " is invalid for nr_n=", nr_n,
             ", hidden_size=", hidden_size, ", vlen=", vlen);
         best_config = &forced_config;
+    } else if (requested_config.valid) {
+        // The model-contract path passes this as a graph-static scalar. Keep
+        // the explicit environment override above for A/B diagnostics and
+        // preserve the DSV4 one-token split-tile rule ahead of both choices.
+        best_config = &requested_config;
     } else if (ShouldUseQwenFp8Moe32x4(
                    current_arch,
                    is_fp8,

--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -17,7 +17,9 @@ void musa_fused_gemv_moe(
     bool mul_routed_weight,
     int64_t topk,
     bool use_int4_w4a16,
-    bool use_swigelu);
+    bool use_swigelu,
+    int64_t block_n,
+    int64_t block_k);
 
 void musa_fused_gemv(
     torch::Tensor &A,

--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -35,7 +35,8 @@ void musa_fused_add_rms_norm(
     torch::Tensor &input,
     torch::Tensor &residual,
     torch::Tensor &weight,
-    double eps);
+    double eps,
+    int64_t block_x);
 
 void musa_reshape_and_cache_flash_nhd(
     torch::Tensor &key,

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -13,7 +13,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
   musa_ops.def(
       "musa_fused_gemv_moe(Tensor! A, Tensor! B, Tensor! C, Tensor? A_scale, Tensor? B_scale,"
       "Tensor! topk_weights, Tensor! topk_ids, bool mul_routed_weight, int topk, bool use_int4_w4a16,"
-      "bool use_swigelu) -> ()");
+      "bool use_swigelu, int block_n=0, int block_k=0) -> ()");
   musa_ops.impl("musa_fused_gemv_moe", torch::kMUSA, &musa_fused_gemv_moe);
 
   musa_ops.def(

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -24,7 +24,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
 
   musa_ops.def(
       "musa_fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, "
-      "float eps) -> ()");
+      "float eps, int block_x=0) -> ()");
   musa_ops.impl("musa_fused_add_rms_norm", torch::kMUSA,
                 &musa_fused_add_rms_norm);
 

--- a/tests/jit_kernel/test_fa3_metadata.py
+++ b/tests/jit_kernel/test_fa3_metadata.py
@@ -18,6 +18,8 @@ def _make_builder(flash_attn):
     builder.dcp_rank = 0
     builder.cp_kv_cache_interleave_size = 1
     builder.reorder_batch_threshold = 1
+    builder.num_speculative_tokens = 0
+    builder.decode_threshold = 1
     builder.use_full_cuda_graph = True
     builder.max_cudagraph_size = 8
     builder.max_num_splits = 32

--- a/tests/jit_kernel/test_fa3_metadata.py
+++ b/tests/jit_kernel/test_fa3_metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
 from types import SimpleNamespace
 
 import pytest
@@ -9,6 +10,13 @@ import torch
 
 from tests.qwen_contract_test_utils import qwen_sampler
 from vllm_musa.jit_kernel import fa3_metadata
+
+
+def _mate_scheduler_golden_is_current() -> bool:
+    try:
+        return version("mate").split("+", 1)[0] == "0.2.4"
+    except PackageNotFoundError:
+        return False
 
 
 def _make_builder(flash_attn):
@@ -426,6 +434,13 @@ def test_qwen_single_request_fa3_scheduler_lookup_launches_once(monkeypatch):
     ],
 )
 @pytest.mark.parametrize("seq_len", [1, 64, 65, 384, 385, 4096])
+@pytest.mark.skipif(
+    not _mate_scheduler_golden_is_current(),
+    reason=(
+        "FA3 scheduler golden values are tied to MATE 0.2.4; MATE 0.2.5 "
+        "is fail-closed by the production scheduler gate"
+    ),
+)
 def test_qwen_single_request_fa3_scheduler_lookup_values(
     seq_len,
     num_heads_q,

--- a/tests/jit_kernel/test_fa3_metadata.py
+++ b/tests/jit_kernel/test_fa3_metadata.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from qwen_contract_test_utils import qwen_sampler
 from vllm_musa.jit_kernel import fa3_metadata
 
 
@@ -33,7 +34,7 @@ def _make_builder(flash_attn):
     builder.block_size = 64
     builder.kv_cache_dtype = torch.bfloat16
     builder.model_config = SimpleNamespace(dtype=torch.bfloat16)
-    builder._musa_qwen_family = True
+    builder._musa_optimization_contract = qwen_sampler()._musa_optimization_contract
     builder.cache_config = SimpleNamespace(cache_dtype="auto")
     return builder
 

--- a/tests/jit_kernel/test_fa3_metadata.py
+++ b/tests/jit_kernel/test_fa3_metadata.py
@@ -6,8 +6,8 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-
 from qwen_contract_test_utils import qwen_sampler
+
 from vllm_musa.jit_kernel import fa3_metadata
 
 

--- a/tests/jit_kernel/test_fa3_metadata.py
+++ b/tests/jit_kernel/test_fa3_metadata.py
@@ -6,8 +6,8 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from qwen_contract_test_utils import qwen_sampler
 
+from tests.qwen_contract_test_utils import qwen_sampler
 from vllm_musa.jit_kernel import fa3_metadata
 
 

--- a/tests/qwen_contract_test_utils.py
+++ b/tests/qwen_contract_test_utils.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from vllm_musa.optimization_contract import resolve_optimization_contract
+
+
+def qwen_sampler(*, enabled: bool = True, legacy: bool = True):
+    architecture = "Qwen3ForCausalLM" if enabled else "LlamaForCausalLM"
+    model_type = "qwen3" if enabled else "llama"
+    contract = resolve_optimization_contract(
+        SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=[architecture],
+                hf_text_config=SimpleNamespace(
+                    model_type=model_type,
+                    vocab_size=151936,
+                ),
+                dtype="bfloat16",
+                quantization=None,
+            ),
+            parallel_config=SimpleNamespace(
+                tensor_parallel_size=1,
+                pipeline_parallel_size=1,
+                data_parallel_size=1,
+                decode_context_parallel_size=1,
+            ),
+            cache_config=SimpleNamespace(cache_dtype="auto", block_size=64),
+            speculative_config=None,
+            quant_config=None,
+        )
+    )
+    if not legacy:
+        contract = resolve_optimization_contract(
+            SimpleNamespace(
+                model_config=SimpleNamespace(
+                    architectures=["Qwen3_5ForCausalLM"],
+                    hf_text_config=SimpleNamespace(
+                        model_type="qwen3_5_text",
+                        vocab_size=248320,
+                    ),
+                    dtype="bfloat16",
+                    quantization=None,
+                )
+            )
+        )
+    return SimpleNamespace(_musa_optimization_contract=contract)

--- a/tests/qwen_contract_test_utils.py
+++ b/tests/qwen_contract_test_utils.py
@@ -43,3 +43,26 @@ def qwen_sampler(*, enabled: bool = True, legacy: bool = True):
             )
         )
     return SimpleNamespace(_musa_optimization_contract=contract)
+
+
+def qwen_hybrid_contract():
+    return resolve_optimization_contract(
+        SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=["Qwen3_5ForConditionalGeneration"],
+                hf_text_config=SimpleNamespace(
+                    model_type="qwen3_5_text",
+                    vocab_size=248320,
+                ),
+                dtype="bfloat16",
+                quantization=None,
+                is_hybrid=True,
+            ),
+            parallel_config=SimpleNamespace(
+                tensor_parallel_size=1,
+                pipeline_parallel_size=1,
+                data_parallel_size=1,
+                decode_context_parallel_size=1,
+            ),
+        )
+    )

--- a/tests/test_deepseek_v4_contract_source.py
+++ b/tests/test_deepseek_v4_contract_source.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _source(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_platform_uses_contract_without_model_derived_kernel_envs() -> None:
+    source = _source("vllm_musa/platform.py")
+
+    assert "DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256" in source
+    assert "_is_deepseek_v4_model" not in source
+    assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in source
+    assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in source
+
+
+def test_shared_mlp_and_rmsnorm_bind_instance_contracts() -> None:
+    linear = _source("vllm_musa/model_executor/layers/linear.py")
+    layernorm = _source("vllm_musa/model_executor/layers/layernorm.py")
+    model_patch = _source(
+        "vllm_musa/patches/series/"
+        "0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch"
+    )
+
+    assert "DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8" in linear
+    assert "prefers_optimization(" in linear
+    assert "bind_optimization_contract(self.down_proj" in model_patch
+    assert "bind_optimization_contract(self" in layernorm
+    assert "DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256" in layernorm
+    assert "block_x=256" in layernorm
+
+
+def test_sparse_indexer_contract_keeps_glm_entry_shape_local() -> None:
+    patch = _source(
+        "vllm_musa/patches/series/"
+        "0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch"
+    )
+
+    assert "DEEPSEEK_V4_NATIVE_SPARSE_INDEXER" in patch
+    assert "DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER" in patch
+    assert "use_musa_materialized_prefill" in patch
+    assert "q_quant.shape[1] == 32" in patch
+    assert "and self.use_musa_native_indexer" in patch
+
+
+def test_fused_add_rmsnorm_argument_is_graph_static_and_env_override_wins() -> None:
+    schema = _source("csrc/musa/torch_bindings.cpp")
+    kernel = _source("csrc/musa/fused_add_rmsnorm.mu")
+
+    assert "float eps, int block_x=0) -> ()" in schema
+    assert "int requested_block" in kernel
+    assert "env_forced_block > 0 ? env_forced_block : requested_block" in kernel
+
+
+def test_deepseek_tp8_moe_tile_is_selected_by_exact_runtime_shape() -> None:
+    source = _source("vllm_musa/model_executor/layers/fused_moe/fused_moe.py")
+
+    assert "is_deepseek_v4_flash_tp8_shape" in source
+    assert 'gemv_block = "16x8" if is_deepseek_v4_flash_tp8_shape else "auto"' in source
+    assert 'os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK")' in source

--- a/tests/test_deepseek_v4_contract_source.py
+++ b/tests/test_deepseek_v4_contract_source.py
@@ -60,3 +60,16 @@ def test_deepseek_tp8_moe_tile_is_selected_by_exact_runtime_shape() -> None:
     assert "is_deepseek_v4_flash_tp8_shape" in source
     assert 'gemv_block = "16x8" if is_deepseek_v4_flash_tp8_shape else "auto"' in source
     assert 'os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK")' in source
+
+
+def test_custom_all_reduce_uses_contract_identity_and_dynamic_capture_guard() -> None:
+    source = _source(
+        "vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py"
+    )
+
+    assert "DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD" in source
+    assert "contract.model.family is not ModelFamily.DEEPSEEK_V4" in source
+    assert "contract.supports(" in source
+    assert "cudagraph_capture_sizes" in source
+    assert '"DeepseekV4" in str(arch)' not in source
+    assert 'getattr(hf_config, "model_type", None)' not in source

--- a/tests/test_deepseek_v4_contract_source.py
+++ b/tests/test_deepseek_v4_contract_source.py
@@ -9,8 +9,10 @@ def _source(path: str) -> str:
 
 def test_platform_uses_contract_without_model_derived_kernel_envs() -> None:
     source = _source("vllm_musa/platform.py")
+    policy = _source("vllm_musa/optimization_contract/policy.py")
 
-    assert "DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256" in source
+    assert "DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256" in policy
+    assert "deepseek_v4_flashmla_sparse_page_size" in policy
     assert "_is_deepseek_v4_model" not in source
     assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in source
     assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in source

--- a/tests/test_deepseek_v4_fused_add_rmsnorm.py
+++ b/tests/test_deepseek_v4_fused_add_rmsnorm.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+requires_musa = pytest.mark.skipif(
+    not hasattr(torch, "musa") or not torch.musa.is_available(),
+    reason="requires a MUSA device",
+)
+
+
+def _reference(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    residual_fp32 = x.float() + residual.float()
+    residual_out = residual_fp32.to(x.dtype)
+    normalized = residual_fp32 * torch.rsqrt(
+        residual_fp32.pow(2).mean(dim=-1, keepdim=True) + eps
+    )
+    return (normalized * weight.float()).to(x.dtype), residual_out
+
+
+@requires_musa
+@pytest.mark.parametrize("rows", [1, 4, 16, 64, 4096, 4100])
+def test_explicit_block256_matches_fp32_sum_reference(rows: int) -> None:
+    from vllm_musa import _custom_ops as musa_ops
+
+    torch.manual_seed(60083 + rows)
+    eps = 1e-6
+    x = torch.randn((rows, 4096), device="musa", dtype=torch.bfloat16)
+    residual = torch.randn_like(x)
+    weight = torch.randn((4096,), device="musa", dtype=torch.bfloat16)
+    expected, expected_residual = _reference(x, residual, weight, eps)
+
+    musa_ops.musa_fused_add_rms_norm(
+        x,
+        residual,
+        weight,
+        eps,
+        block_x=256,
+    )
+    torch.musa.synchronize()
+
+    torch.testing.assert_close(x.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(
+        residual.float(),
+        expected_residual.float(),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+@requires_musa
+def test_explicit_block256_replays_with_new_inputs() -> None:
+    eps = 1e-6
+    static_x = torch.empty((1, 4096), device="musa", dtype=torch.bfloat16)
+    static_residual = torch.empty_like(static_x)
+    weight = torch.randn((4096,), device="musa", dtype=torch.bfloat16)
+
+    warmup_stream = torch.musa.Stream()
+    warmup_stream.wait_stream(torch.musa.current_stream())
+    with torch.musa.stream(warmup_stream):
+        for seed in (3, 5, 7):
+            torch.manual_seed(seed)
+            static_x.copy_(torch.randn_like(static_x))
+            static_residual.copy_(torch.randn_like(static_residual))
+            torch.ops._C_musa_ops.musa_fused_add_rms_norm(
+                static_x,
+                static_residual,
+                weight,
+                eps,
+                256,
+            )
+    torch.musa.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.musa.MUSAGraph()
+    with torch.musa.graph(graph):
+        torch.ops._C_musa_ops.musa_fused_add_rms_norm(
+            static_x,
+            static_residual,
+            weight,
+            eps,
+            256,
+        )
+
+    for seed in (11, 13, 17):
+        torch.manual_seed(seed)
+        next_x = torch.randn_like(static_x)
+        next_residual = torch.randn_like(static_residual)
+        expected, expected_residual = _reference(next_x, next_residual, weight, eps)
+        static_x.copy_(next_x)
+        static_residual.copy_(next_residual)
+
+        graph.replay()
+        torch.musa.synchronize()
+
+        torch.testing.assert_close(
+            static_x.float(), expected.float(), rtol=2e-2, atol=2e-2
+        )
+        torch.testing.assert_close(
+            static_residual.float(),
+            expected_residual.float(),
+            rtol=0.0,
+            atol=0.0,
+        )

--- a/tests/test_deepseek_v4_gemv_contract_source.py
+++ b/tests/test_deepseek_v4_gemv_contract_source.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_deepseek_v4_gemv_contract_source.py
+++ b/tests/test_deepseek_v4_gemv_contract_source.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _source(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_contract_selected_gemv_block_reaches_custom_op_schema() -> None:
+    bindings = _source("csrc/musa/torch_bindings.cpp")
+    custom_ops = _source("vllm_musa/_custom_ops.py")
+    fused_moe = _source("vllm_musa/model_executor/layers/fused_moe/fused_moe.py")
+
+    assert "bool use_swigelu, int block_n=0, int block_k=0) -> ()" in bindings
+    assert "block_n: int = 0" in custom_ops
+    assert "block_k: int = 0" in custom_ops
+    assert "block_n,\n        block_k," in custom_ops
+    assert "_requested_gemv_block(shape)" in fused_moe
+    assert "block_n=gemv_block_n" in fused_moe
+    assert "block_k=gemv_block_k" in fused_moe
+
+
+def test_requested_tile_preserves_dsv4_and_environment_precedence() -> None:
+    gemv = _source("csrc/musa/gemv.mu")
+    moe = gemv[gemv.index("void musa_fused_gemv_moe(") :]
+    dispatch = moe[moe.index("BlockConfig forced_config") : moe.index("switch (")]
+
+    assert "int64_t requested_block_n" in gemv
+    assert "int64_t requested_block_k" in gemv
+    assert dispatch.index("ShouldUseDeepSeekV4Fp8MoeSplitTile(") < dispatch.index(
+        "ParseForcedBlockConfig(&forced_config)"
+    )
+    assert dispatch.index("ParseForcedBlockConfig(&forced_config)") < dispatch.index(
+        "requested_config.valid"
+    )
+    assert "requested GEMV block must provide both block_n and block_k" in gemv
+
+
+def test_contract_selector_does_not_forward_explicit_environment_override() -> None:
+    fused_moe = _source("vllm_musa/model_executor/layers/fused_moe/fused_moe.py")
+
+    helper = fused_moe[
+        fused_moe.index("def _requested_gemv_block(") : fused_moe.index(
+            "def _tensors_share_device("
+        )
+    ]
+    assert "os.environ.get(_GEMV_MOE_BLOCK_ENV) is not None" in helper
+    assert 'shape.gemv_block != "16x8"' in helper
+    assert "return 0, 0" in helper

--- a/tests/test_deepseek_v4_gemv_numeric.py
+++ b/tests/test_deepseek_v4_gemv_numeric.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_musa")
+
+
+requires_mp31 = pytest.mark.skipif(
+    not hasattr(torch, "musa")
+    or not torch.musa.is_available()
+    or tuple(torch.musa.get_device_capability()) != (3, 1),
+    reason="requires an mp31 MUSA device",
+)
+
+
+@requires_mp31
+@pytest.mark.parametrize("rows", [1, 2, 3, 4, 5])
+def test_requested_16x8_gemv_matches_reference(rows: int) -> None:
+    from vllm_musa import _custom_ops as musa_ops
+
+    vllm_musa = pytest.importorskip("vllm_musa")
+    vllm_musa.register_custom_ops()
+    torch.manual_seed(60083 + rows)
+
+    hidden_size = 128
+    output_size = 32
+    a = torch.randn((rows, hidden_size), device="musa", dtype=torch.bfloat16)
+    b = torch.randn(
+        (1, output_size, hidden_size), device="musa", dtype=torch.bfloat16
+    )
+    c = torch.empty((rows, output_size), device="musa", dtype=torch.bfloat16)
+    topk_weights = torch.ones((rows, 1), device="musa", dtype=torch.float32)
+    topk_ids = torch.zeros((rows, 1), device="musa", dtype=torch.int32)
+
+    musa_ops.musa_fused_gemv_moe(
+        a,
+        b,
+        c,
+        None,
+        None,
+        topk_weights,
+        topk_ids,
+        False,
+        1,
+        False,
+        False,
+        block_n=16,
+        block_k=8,
+    )
+    torch.musa.synchronize()
+
+    expected = torch.matmul(a.float(), b[0].float().transpose(0, 1)).to(
+        torch.bfloat16
+    )
+    torch.testing.assert_close(c.float(), expected.float(), rtol=2e-2, atol=2e-2)
+
+
+@requires_mp31
+def test_requested_gemv_block_is_graph_static() -> None:
+    from vllm_musa import _custom_ops as musa_ops
+
+    vllm_musa = pytest.importorskip("vllm_musa")
+    vllm_musa.register_custom_ops()
+
+    rows, hidden_size, output_size = 1, 128, 32
+    a = torch.empty((rows, hidden_size), device="musa", dtype=torch.bfloat16)
+    b = torch.randn(
+        (1, output_size, hidden_size), device="musa", dtype=torch.bfloat16
+    )
+    c = torch.empty((rows, output_size), device="musa", dtype=torch.bfloat16)
+    topk_weights = torch.ones((rows, 1), device="musa", dtype=torch.float32)
+    topk_ids = torch.zeros((rows, 1), device="musa", dtype=torch.int32)
+
+    warmup = torch.musa.Stream()
+    warmup.wait_stream(torch.musa.current_stream())
+    with torch.musa.stream(warmup):
+        for seed in (3, 5, 7):
+            torch.manual_seed(seed)
+            a.copy_(torch.randn_like(a))
+            musa_ops.musa_fused_gemv_moe(
+                a,
+                b,
+                c,
+                None,
+                None,
+                topk_weights,
+                topk_ids,
+                False,
+                1,
+                False,
+                False,
+                block_n=16,
+                block_k=8,
+            )
+    torch.musa.current_stream().wait_stream(warmup)
+
+    graph = torch.musa.MUSAGraph()
+    with torch.musa.graph(graph):
+        musa_ops.musa_fused_gemv_moe(
+            a,
+            b,
+            c,
+            None,
+            None,
+            topk_weights,
+            topk_ids,
+            False,
+            1,
+            False,
+            False,
+            block_n=16,
+            block_k=8,
+        )
+
+    for seed in (11, 13, 17):
+        torch.manual_seed(seed)
+        next_a = torch.randn_like(a)
+        expected = torch.matmul(next_a.float(), b[0].float().transpose(0, 1)).to(
+            torch.bfloat16
+        )
+        a.copy_(next_a)
+        graph.replay()
+        torch.musa.synchronize()
+        torch.testing.assert_close(c.float(), expected.float(), rtol=2e-2, atol=2e-2)

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -100,6 +100,15 @@ def test_flash_base_tp4_is_supported_but_not_tp8_preferred() -> None:
     assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
 
 
+def test_model_config_without_execution_topology_is_support_only() -> None:
+    config = _flash_base_config()
+
+    contract = resolve_optimization_contract(model_config=config.model_config)
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
+    assert not contract.preferred_features
+
+
 def test_incomplete_deepseek_identity_fails_closed() -> None:
     config = _flash_base_config()
     config.model_config.architectures = []

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -84,12 +84,18 @@ def test_flash_base_tp8_resolves_validated_profile() -> None:
     assert contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
     )
+    assert contract.supports(
+        OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD
+    )
 
 
 def test_flash_base_tp4_is_supported_but_not_tp8_preferred() -> None:
     contract = resolve_optimization_contract(_flash_base_config(tp=4))
 
     assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert contract.supports(
+        OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD
+    )
     assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from vllm_musa.optimization_contract import (
+    ModelFamily,
+    ModelRole,
+    OptimizationFeature,
+    bind_optimization_contract,
+    resolve_optimization_contract,
+)
+
+
+def _flash_base_config(*, tp: int = 8, speculative: bool = False):
+    text_config = SimpleNamespace(
+        architectures=["DeepseekV4ForCausalLM"],
+        model_type="deepseek_v4",
+        hidden_size=4096,
+        num_hidden_layers=43,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        head_dim=512,
+        vocab_size=129280,
+        n_routed_experts=256,
+        num_experts_per_tok=6,
+        n_shared_experts=1,
+        moe_intermediate_size=2048,
+        expert_dtype="fp8",
+        hidden_act="silu",
+        swiglu_limit=10.0,
+        index_topk=512,
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        },
+    )
+    model_config = SimpleNamespace(
+        architectures=["DeepseekV4ForCausalLM"],
+        hf_text_config=text_config,
+        hf_config=text_config,
+        dtype="bfloat16",
+        quantization="deepseek_v4_fp8",
+        use_mla=True,
+        is_hybrid=False,
+        is_moe=True,
+        enforce_eager=False,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=tp,
+            pipeline_parallel_size=1,
+            data_parallel_size=1,
+            decode_context_parallel_size=1,
+        ),
+        cache_config=SimpleNamespace(cache_dtype="fp8", block_size=64),
+        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        attention_config=SimpleNamespace(backend="FLASHMLA"),
+        compilation_config=SimpleNamespace(
+            mode="NONE",
+            cudagraph_mode="FULL_DECODE_ONLY",
+        ),
+        speculative_config=object() if speculative else None,
+        quant_config=SimpleNamespace(weight_block_size=[128, 128]),
+    )
+
+
+def test_flash_base_tp8_resolves_validated_profile() -> None:
+    contract = resolve_optimization_contract(_flash_base_config())
+
+    assert contract.model.family is ModelFamily.DEEPSEEK_V4
+    assert contract.model.role is ModelRole.TEXT
+    assert contract.model.uses_mla is True
+    assert contract.profile == "deepseek_v4.tp8_flash_base"
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER
+    )
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256)
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
+def test_flash_base_tp4_is_supported_but_not_tp8_preferred() -> None:
+    contract = resolve_optimization_contract(_flash_base_config(tp=4))
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
+
+
+def test_incomplete_deepseek_identity_fails_closed() -> None:
+    config = _flash_base_config()
+    config.model_config.architectures = []
+    config.model_config.hf_text_config.architectures = []
+    config.model_config.hf_config.architectures = []
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.model.family is ModelFamily.DEEPSEEK_V4
+    assert contract.profile == "deepseek_v4.unvalidated"
+    assert not contract.supported_features
+    assert not contract.preferred_features
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hidden_size", 7168),
+        ("num_hidden_layers", 44),
+        ("num_attention_heads", 32),
+        ("num_key_value_heads", 2),
+        ("head_dim", 256),
+        ("vocab_size", 129281),
+        ("n_routed_experts", 384),
+        ("num_experts_per_tok", 8),
+        ("n_shared_experts", 2),
+        ("moe_intermediate_size", 3072),
+        ("expert_dtype", "bf16"),
+        ("hidden_act", "gelu"),
+        ("swiglu_limit", 0.0),
+        ("index_topk", 1024),
+    ],
+)
+def test_one_field_model_mismatch_disables_flash_base_features(
+    field: str,
+    value: object,
+) -> None:
+    config = _flash_base_config()
+    setattr(config.model_config.hf_text_config, field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.model.family is ModelFamily.DEEPSEEK_V4
+    assert not contract.supported_features
+    assert not contract.preferred_features
+
+
+def test_model_config_use_mla_takes_precedence_over_missing_hf_fact() -> None:
+    config = _flash_base_config()
+    assert not hasattr(config.model_config.hf_text_config, "use_mla")
+    assert not hasattr(config.model_config.hf_text_config, "kv_lora_rank")
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.model.uses_mla is True
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
+
+
+def test_speculative_execution_keeps_support_but_disables_tp8_preferences() -> None:
+    contract = resolve_optimization_contract(_flash_base_config(speculative=True))
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+
+
+@pytest.mark.parametrize(
+    ("owner", "field", "value"),
+    [
+        ("cache_config", "cache_dtype", "auto"),
+        ("scheduler_config", "max_num_seqs", 4),
+        ("attention_config", "backend", "FLASH_ATTN"),
+        ("compilation_config", "mode", "VLLM_COMPILE"),
+        ("compilation_config", "cudagraph_mode", "PIECEWISE"),
+    ],
+)
+def test_one_field_execution_mismatch_disables_tp8_profile(
+    owner: str,
+    field: str,
+    value: object,
+) -> None:
+    config = _flash_base_config()
+    setattr(getattr(config, owner), field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
+def test_batch_invariant_is_snapshotted_as_an_execution_fact(monkeypatch) -> None:
+    fake_vllm = ModuleType("vllm")
+    fake_envs = ModuleType("vllm.envs")
+    fake_envs.VLLM_BATCH_INVARIANT = True
+    fake_vllm.envs = fake_envs
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+    monkeypatch.setitem(sys.modules, "vllm.envs", fake_envs)
+
+    contract = resolve_optimization_contract(_flash_base_config())
+
+    assert contract.execution.batch_invariant_enabled is True
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+
+
+def test_contract_binds_to_runtime_owner_once_resolved() -> None:
+    owner = SimpleNamespace()
+
+    contract = bind_optimization_contract(owner, _flash_base_config())
+
+    assert owner._musa_optimization_contract is contract
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -130,6 +130,90 @@ def test_incomplete_deepseek_identity_fails_closed() -> None:
 
 
 @pytest.mark.parametrize(
+    ("owner", "field", "value", "expected_supported"),
+    [
+        ("model_config", "architectures", ["Qwen3ForCausalLM"], frozenset()),
+        ("text_config", "model_type", "qwen3", frozenset()),
+        (
+            "model_config",
+            "dtype",
+            "float16",
+            frozenset(
+                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+            ),
+        ),
+        (
+            "model_config",
+            "quantization",
+            "compressed-tensors",
+            frozenset(
+                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+            ),
+        ),
+        (
+            "model_config",
+            "use_mla",
+            False,
+            frozenset(
+                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+            ),
+        ),
+    ],
+)
+def test_identity_and_model_traits_fail_closed(
+    owner: str,
+    field: str,
+    value: object,
+    expected_supported: frozenset[OptimizationFeature],
+) -> None:
+    config = _flash_base_config()
+    target = (
+        config.model_config.hf_text_config
+        if owner == "text_config"
+        else config.model_config
+    )
+    setattr(target, field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.supported_features == expected_supported
+    assert not contract.preferred_features
+
+
+def test_hybrid_deepseek_v4_does_not_enable_flash_base_features() -> None:
+    config = _flash_base_config()
+    config.model_config.is_hybrid = True
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.supported_features == frozenset(
+        {
+            OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD,
+            OptimizationFeature.HYBRID_SEPARATE_MAMBA_POOL,
+        }
+    )
+    assert contract.preferred_features == frozenset(
+        {OptimizationFeature.HYBRID_SEPARATE_MAMBA_POOL}
+    )
+
+
+def test_non_block128_quantization_fails_closed() -> None:
+    config = _flash_base_config()
+    config.quant_config.weight_block_size = [64, 128]
+    config.model_config.hf_text_config.quantization_config["weight_block_size"] = [
+        64,
+        128,
+    ]
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.supported_features == frozenset(
+        {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+    )
+    assert not contract.preferred_features
+
+
+@pytest.mark.parametrize(
     ("field", "value"),
     [
         ("hidden_size", 7168),
@@ -158,7 +242,9 @@ def test_one_field_model_mismatch_disables_flash_base_features(
     contract = resolve_optimization_contract(config)
 
     assert contract.model.family is ModelFamily.DEEPSEEK_V4
-    assert not contract.supported_features
+    assert contract.supported_features == frozenset(
+        {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+    )
     assert not contract.preferred_features
 
 
@@ -205,6 +291,46 @@ def test_one_field_execution_mismatch_disables_tp8_profile(
 
     assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("pipeline_parallel_size", 2),
+        ("data_parallel_size", 2),
+        ("decode_context_parallel_size", 2),
+    ],
+)
+def test_non_reference_parallel_topology_disables_tp8_profile(
+    field: str,
+    value: int,
+) -> None:
+    config = _flash_base_config()
+    setattr(config.parallel_config, field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
+def test_pooling_and_missing_quant_runtime_disable_tp8_profile() -> None:
+    config = _flash_base_config()
+    config.quant_config = None
+
+    contract = resolve_optimization_contract(config, is_pooling_model=True)
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
     )

--- a/tests/test_deepseek_v4_swiglu_fp8_fusion.py
+++ b/tests/test_deepseek_v4_swiglu_fp8_fusion.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""S5000 correctness coverage for the DeepSeek-V4 shared-MLP fusion."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+pytest.importorskip("torchada")
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_musa")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _musa_device() -> Iterator[None]:
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+    torch.musa.set_device(0)
+
+    from vllm.platforms import current_platform
+
+    import vllm_musa
+
+    if not current_platform.is_device_capability((3, 1)):
+        pytest.skip("the fused clamp-SwiGLU group-quant kernel requires mp31")
+    vllm_musa.register_custom_ops()
+    yield
+
+
+def _quant_outputs(rows: int, hidden: int = 256):
+    q = torch.empty((rows, hidden), device="musa", dtype=torch.float8_e4m3fn)
+    s = torch.empty((rows, hidden // 128), device="musa", dtype=torch.float32)
+    return q, s
+
+
+def _materialized_activation(gate_up, limit: float = 10.0):
+    hidden = gate_up.shape[-1] // 2
+    gate = torch.clamp(gate_up[..., :hidden], max=limit)
+    up = torch.clamp(gate_up[..., hidden:], min=-limit, max=limit)
+    return gate * torch.sigmoid(gate) * up
+
+
+@pytest.mark.parametrize("rows", [1, 4, 16, 64, 4096, 4100])
+def test_clamp_swiglu_group_quant_is_bit_exact(rows: int) -> None:
+    torch.manual_seed(60156 + rows)
+    gate_up = torch.randn((rows, 512), device="musa", dtype=torch.bfloat16)
+    boundary = torch.tensor(
+        [
+            float("-inf"),
+            -20.0,
+            -10.0,
+            -0.0,
+            0.0,
+            10.0,
+            20.0,
+            float("inf"),
+        ],
+        device="musa",
+        dtype=torch.bfloat16,
+    )
+    gate_up[0, :8] = boundary
+    gate_up[0, 256:264] = boundary.flip(0)
+
+    reference_q, reference_s = _quant_outputs(rows)
+    fused_q, fused_s = _quant_outputs(rows)
+    activated = _materialized_activation(gate_up)
+    torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+        activated,
+        reference_q,
+        reference_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+    )
+    torch.ops._C_musa_ops.silu_and_mul_clamp_per_token_group_fp8_quant(
+        gate_up,
+        fused_q,
+        fused_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+        10.0,
+    )
+    torch.musa.synchronize()
+
+    assert torch.equal(
+        reference_q.view(torch.uint8).cpu(), fused_q.view(torch.uint8).cpu()
+    )
+    assert torch.equal(
+        reference_s.view(torch.int32).cpu(), fused_s.view(torch.int32).cpu()
+    )
+
+
+@pytest.mark.parametrize("rows", [1, 4, 64])
+def test_bit_exact_quantization_preserves_bf16_down_projection(rows: int) -> None:
+    torch.manual_seed(60256 + rows)
+    gate_up = torch.randn((rows, 512), device="musa", dtype=torch.bfloat16)
+    reference_q, reference_s = _quant_outputs(rows)
+    fused_q, fused_s = _quant_outputs(rows)
+
+    torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+        _materialized_activation(gate_up),
+        reference_q,
+        reference_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+    )
+    torch.ops._C_musa_ops.silu_and_mul_clamp_per_token_group_fp8_quant(
+        gate_up,
+        fused_q,
+        fused_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+        10.0,
+    )
+
+    reference_dequant = reference_q.float() * reference_s.repeat_interleave(128, -1)
+    fused_dequant = fused_q.float() * fused_s.repeat_interleave(128, -1)
+    weight = torch.randn((4096, 256), device="musa", dtype=torch.bfloat16)
+    reference_out = (reference_dequant @ weight.float().T).to(torch.bfloat16)
+    fused_out = (fused_dequant @ weight.float().T).to(torch.bfloat16)
+    torch.musa.synchronize()
+
+    assert torch.equal(reference_out, fused_out)
+
+
+def test_clamp_swiglu_group_quant_replays_with_new_inputs() -> None:
+    gate_up = torch.empty((1, 512), device="musa", dtype=torch.bfloat16)
+    fused_q, fused_s = _quant_outputs(1)
+
+    warmup_stream = torch.musa.Stream()
+    warmup_stream.wait_stream(torch.musa.current_stream())
+    with torch.musa.stream(warmup_stream):
+        for seed in (23, 29, 31):
+            torch.manual_seed(seed)
+            gate_up.copy_(torch.randn_like(gate_up))
+            torch.ops._C_musa_ops.silu_and_mul_clamp_per_token_group_fp8_quant(
+                gate_up,
+                fused_q,
+                fused_s,
+                128,
+                1e-10,
+                -448.0,
+                448.0,
+                10.0,
+            )
+    torch.musa.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.musa.MUSAGraph()
+    with torch.musa.graph(graph):
+        torch.ops._C_musa_ops.silu_and_mul_clamp_per_token_group_fp8_quant(
+            gate_up,
+            fused_q,
+            fused_s,
+            128,
+            1e-10,
+            -448.0,
+            448.0,
+            10.0,
+        )
+
+    for seed in (37, 41, 43):
+        torch.manual_seed(seed)
+        next_gate_up = torch.randn_like(gate_up)
+        reference_q, reference_s = _quant_outputs(1)
+        torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+            _materialized_activation(next_gate_up),
+            reference_q,
+            reference_s,
+            128,
+            1e-10,
+            -448.0,
+            448.0,
+        )
+        gate_up.copy_(next_gate_up)
+
+        graph.replay()
+        torch.musa.synchronize()
+
+        assert torch.equal(
+            reference_q.view(torch.uint8).cpu(), fused_q.view(torch.uint8).cpu()
+        )
+        assert torch.equal(
+            reference_s.view(torch.int32).cpu(), fused_s.view(torch.int32).cpu()
+        )

--- a/tests/test_deepseek_v4_swiglu_fp8_fusion.py
+++ b/tests/test_deepseek_v4_swiglu_fp8_fusion.py
@@ -56,12 +56,13 @@ def test_clamp_swiglu_group_quant_is_bit_exact(rows: int) -> None:
             10.0,
             20.0,
             float("inf"),
+            float("nan"),
         ],
         device="musa",
         dtype=torch.bfloat16,
     )
-    gate_up[0, :8] = boundary
-    gate_up[0, 256:264] = boundary.flip(0)
+    gate_up[0, :9] = boundary
+    gate_up[0, 256:265] = boundary.flip(0)
 
     reference_q, reference_s = _quant_outputs(rows)
     fused_q, fused_s = _quant_outputs(rows)

--- a/tests/test_flash_attn_scheduler_fast_path.py
+++ b/tests/test_flash_attn_scheduler_fast_path.py
@@ -6,9 +6,9 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from qwen_contract_test_utils import qwen_sampler
 
 import vllm_musa.v1.attention.backends.flash_attn as flash_attn
+from tests.qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.attention.backends.flash_attn import (
     FlashAttentionMetadataBuilder,
     _is_musa_qwen_text_generation_architecture,

--- a/tests/test_flash_attn_scheduler_fast_path.py
+++ b/tests/test_flash_attn_scheduler_fast_path.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 import vllm_musa.v1.attention.backends.flash_attn as flash_attn
+from qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.attention.backends.flash_attn import (
     FlashAttentionMetadataBuilder,
     _is_musa_qwen_text_generation_architecture,
@@ -122,7 +123,9 @@ def _make_graph_size_64_builder(*, is_qwen_family: bool):
     builder.kv_cache_dtype = torch.bfloat16
     builder.model_config = SimpleNamespace(dtype=torch.bfloat16)
     builder.cache_config = SimpleNamespace(cache_dtype="auto")
-    builder._musa_qwen_family = is_qwen_family
+    builder._musa_optimization_contract = qwen_sampler(
+        enabled=is_qwen_family
+    )._musa_optimization_contract
     builder._use_qwen_single_request_scheduler_lookup = True
     builder._sm_count_query_succeeded = True
     builder._cu_seqlens_k_buffer = torch.empty(65, dtype=torch.int32)

--- a/tests/test_flash_attn_scheduler_fast_path.py
+++ b/tests/test_flash_attn_scheduler_fast_path.py
@@ -6,9 +6,9 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from qwen_contract_test_utils import qwen_sampler
 
 import vllm_musa.v1.attention.backends.flash_attn as flash_attn
-from qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.attention.backends.flash_attn import (
     FlashAttentionMetadataBuilder,
     _is_musa_qwen_text_generation_architecture,

--- a/tests/test_fused_moe_chunking.py
+++ b/tests/test_fused_moe_chunking.py
@@ -524,6 +524,7 @@ def test_musa_dispatcher_routes_forced_backends(monkeypatch):
     assert native_calls[0][1] == {
         "inplace": False,
         "_allow_deepgemm_prefill": False,
+        "_gemv_block": (16, 8),
     }
 
     grouped_calls = []

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -140,7 +140,8 @@ class TestMUSAPlatformBase:
     def test_gated_qkv_inductor_priority_excludes_routed_moe(self):
         from vllm.config.compilation import CompilationMode
 
-        from vllm_musa.platform import MUSAPlatformBase, _has_routed_experts
+        from vllm_musa.optimization_contract.policy import model_has_routed_experts
+        from vllm_musa.platform import MUSAPlatformBase
 
         compilation_config = SimpleNamespace(
             backend="inductor",
@@ -155,18 +156,18 @@ class TestMUSAPlatformBase:
         )
         priority = MUSAPlatformBase.get_default_ir_op_priority(dense_config)
         assert priority.gated_qkv_rms_norm_rope == ["musa_inductor", "native"]
-        assert not _has_routed_experts(dense_model)
+        assert not model_has_routed_experts(dense_model)
 
         authoritative_moe = SimpleNamespace(
             is_moe=True,
             hf_text_config=SimpleNamespace(model_type="heterogeneous_blocks"),
         )
-        assert _has_routed_experts(authoritative_moe)
+        assert model_has_routed_experts(authoritative_moe)
         authoritative_dense = SimpleNamespace(
             is_moe=False,
             hf_text_config=SimpleNamespace(num_experts=8),
         )
-        assert not _has_routed_experts(authoritative_dense)
+        assert not model_has_routed_experts(authoritative_dense)
 
         for expert_count_name in (
             "num_experts",
@@ -183,7 +184,7 @@ class TestMUSAPlatformBase:
             )
             priority = MUSAPlatformBase.get_default_ir_op_priority(moe_config)
             assert priority.gated_qkv_rms_norm_rope == ["native"]
-            assert _has_routed_experts(moe_model)
+            assert model_has_routed_experts(moe_model)
 
         compilation_config.mode = CompilationMode.NONE
         priority = MUSAPlatformBase.get_default_ir_op_priority(dense_config)
@@ -256,7 +257,13 @@ class TestMUSAPlatformBase:
     def test_qwen2_rope_kv_fusion_exact_config_gate(self):
         import torch
 
-        from vllm_musa.platform import _is_qwen2_rope_kv_fusion_config
+        from vllm_musa.optimization_contract import policy
+        from vllm_musa.optimization_contract.types import OptimizationFeature
+
+        def is_eligible(config):
+            return policy.prefers_feature(
+                config, OptimizationFeature.QWEN2_ROPE_KV_PRESPLIT
+            )
 
         def make_config(model_type: str, kv_heads, intermediate_size):
             return SimpleNamespace(
@@ -283,22 +290,28 @@ class TestMUSAPlatformBase:
                 speculative_config=None,
             )
 
-        assert not _is_qwen2_rope_kv_fusion_config(make_config("qwen2", None, None))
-        assert _is_qwen2_rope_kv_fusion_config(make_config("cosyvoice3", None, None))
+        assert not is_eligible(make_config("qwen2", None, None))
+        assert is_eligible(make_config("cosyvoice3", None, None))
         config = make_config("qwen2", 2, 4864)
-        assert _is_qwen2_rope_kv_fusion_config(config)
+        assert is_eligible(config)
         config.cache_config = SimpleNamespace(cache_dtype="bfloat16", block_size=64)
-        assert _is_qwen2_rope_kv_fusion_config(config)
+        assert is_eligible(config)
         config.cache_config.block_size = 128
-        assert not _is_qwen2_rope_kv_fusion_config(config)
+        assert not is_eligible(config)
         config.cache_config.block_size = 64
         config.quant_config = object()
-        assert not _is_qwen2_rope_kv_fusion_config(config)
+        assert not is_eligible(config)
 
     def test_qwen3_qk_rope_kv_fusion_exact_config_gate(self):
         import torch
 
-        from vllm_musa.platform import _is_qwen3_qk_rope_kv_fusion_config
+        from vllm_musa.optimization_contract import policy
+        from vllm_musa.optimization_contract.types import OptimizationFeature
+
+        def is_eligible(config):
+            return policy.prefers_feature(
+                config, OptimizationFeature.QWEN3_QK_ROPE_KV_PRESPLIT
+            )
 
         def make_config(
             *,
@@ -357,10 +370,10 @@ class TestMUSAPlatformBase:
             num_attention_heads=32,
         )
 
-        assert _is_qwen3_qk_rope_kv_fusion_config(qwen3_0_6b)
-        assert _is_qwen3_qk_rope_kv_fusion_config(qwen3_8b)
+        assert is_eligible(qwen3_0_6b)
+        assert is_eligible(qwen3_8b)
 
-        assert not _is_qwen3_qk_rope_kv_fusion_config(
+        assert not is_eligible(
             make_config(
                 hidden_size=1024,
                 intermediate_size=3072,
@@ -370,7 +383,7 @@ class TestMUSAPlatformBase:
                 architecture="Qwen2ForCausalLM",
             )
         )
-        assert not _is_qwen3_qk_rope_kv_fusion_config(
+        assert not is_eligible(
             make_config(
                 hidden_size=2048,
                 intermediate_size=6144,
@@ -382,7 +395,7 @@ class TestMUSAPlatformBase:
                 architecture="Qwen3_5ForCausalLM",
             )
         )
-        assert not _is_qwen3_qk_rope_kv_fusion_config(
+        assert not is_eligible(
             make_config(
                 hidden_size=4096,
                 intermediate_size=12288,
@@ -391,7 +404,7 @@ class TestMUSAPlatformBase:
                 tensor_parallel_size=2,
             )
         )
-        assert not _is_qwen3_qk_rope_kv_fusion_config(
+        assert not is_eligible(
             make_config(
                 hidden_size=4096,
                 intermediate_size=12288,
@@ -400,7 +413,7 @@ class TestMUSAPlatformBase:
                 quantization="fp8",
             )
         )
-        assert not _is_qwen3_qk_rope_kv_fusion_config(
+        assert not is_eligible(
             make_config(
                 hidden_size=4096,
                 intermediate_size=12288,
@@ -409,7 +422,7 @@ class TestMUSAPlatformBase:
                 quant_config=object(),
             )
         )
-        assert not _is_qwen3_qk_rope_kv_fusion_config(
+        assert not is_eligible(
             make_config(
                 hidden_size=4096,
                 intermediate_size=12288,

--- a/tests/test_musa_jit_custom_all_reduce_graph.py
+++ b/tests/test_musa_jit_custom_all_reduce_graph.py
@@ -11,36 +11,112 @@ custom_ar = pytest.importorskip(
 )
 
 
+def _deepseek_v4_config(capture_sizes: tuple[object, ...]) -> SimpleNamespace:
+    text_config = SimpleNamespace(
+        model_type="deepseek_v4",
+        architectures=("DeepseekV4ForCausalLM",),
+        hidden_size=4096,
+        num_hidden_layers=43,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        head_dim=512,
+        vocab_size=129280,
+        n_routed_experts=256,
+        num_experts_per_tok=6,
+        n_shared_experts=1,
+        moe_intermediate_size=2048,
+        expert_dtype="fp8",
+        hidden_act="silu",
+        swiglu_limit=10.0,
+        index_topk=512,
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        },
+    )
+    model_config = SimpleNamespace(
+        architectures=("DeepseekV4ForCausalLM",),
+        hf_config=text_config,
+        hf_text_config=text_config,
+        dtype="bfloat16",
+        quantization="deepseek_v4_fp8",
+        use_mla=True,
+        is_hybrid=False,
+        is_moe=True,
+        enforce_eager=False,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=8,
+            pipeline_parallel_size=1,
+            data_parallel_size=1,
+            decode_context_parallel_size=1,
+        ),
+        cache_config=SimpleNamespace(cache_dtype="fp8", block_size=64),
+        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        attention_config=SimpleNamespace(backend="FLASHMLA"),
+        compilation_config=SimpleNamespace(
+            mode="NONE",
+            cudagraph_mode="FULL_DECODE_ONLY",
+            cudagraph_capture_sizes=capture_sizes,
+        ),
+        speculative_config=None,
+        quant_config=SimpleNamespace(weight_block_size=[128, 128]),
+    )
+
+
 @pytest.mark.parametrize(
-    ("model_type", "architectures", "capture_sizes", "expected"),
+    ("capture_sizes", "expected"),
     [
-        ("deepseek_v4", ("DeepseekV4ForCausalLM",), (1,), True),
-        ("deepseek_v4", ("DeepseekV4ForCausalLM",), (1, 2, 4), False),
-        (None, ("DeepseekV4ForCausalLM",), (1, 2, 4), False),
-        ("qwen3", ("Qwen3ForCausalLM",), (1, 2, 4), True),
+        ((1,), True),
+        ((1, 2, 4), False),
+        ((), False),
+        ((1, "invalid"), False),
     ],
 )
-def test_graph_registered_inputs_model_gate(
-    monkeypatch, model_type, architectures, capture_sizes, expected
-):
-    model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(
-            model_type=model_type,
-            architectures=architectures,
-        ),
-        architectures=architectures,
-    )
+def test_graph_registered_inputs_preserve_deepseek_capture_guard(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_sizes: tuple[object, ...],
+    expected: bool,
+) -> None:
+    vllm_config = _deepseek_v4_config(capture_sizes)
     monkeypatch.setattr(
         "vllm.config.get_current_vllm_config_or_none",
-        lambda: SimpleNamespace(
-            model_config=model_config,
-            compilation_config=SimpleNamespace(
-                cudagraph_capture_sizes=capture_sizes,
-            ),
-        ),
+        lambda: vllm_config,
     )
 
     assert custom_ar._use_graph_registered_inputs_for_current_model() is expected
+
+
+@pytest.mark.parametrize(
+    ("model_type", "architectures", "model_field", "model_value"),
+    [
+        ("deepseek_v4", ("Qwen3ForCausalLM",), None, None),
+        ("qwen3", ("FakeDeepseekV4ForCausalLM",), None, None),
+        ("deepseek_v4", ("DeepseekV4ForCausalLM",), "hidden_size", 7168),
+    ],
+)
+def test_graph_registered_inputs_reject_incomplete_deepseek_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+    architectures: tuple[str, ...],
+    model_field: str | None,
+    model_value: object,
+) -> None:
+    vllm_config = _deepseek_v4_config((1, 2, 4))
+    text_config = vllm_config.model_config.hf_text_config
+    text_config.model_type = model_type
+    text_config.architectures = architectures
+    vllm_config.model_config.architectures = architectures
+    if model_field is not None:
+        setattr(text_config, model_field, model_value)
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config_or_none",
+        lambda: vllm_config,
+    )
+
+    assert custom_ar._use_graph_registered_inputs_for_current_model() is True
 
 
 def test_register_graph_buffers_populates_persistent_rank_data(monkeypatch):

--- a/tests/test_musa_jit_custom_all_reduce_graph.py
+++ b/tests/test_musa_jit_custom_all_reduce_graph.py
@@ -90,33 +90,43 @@ def test_graph_registered_inputs_preserve_deepseek_capture_guard(
 
 
 @pytest.mark.parametrize(
-    ("model_type", "architectures", "model_field", "model_value"),
+    ("model_type", "architectures", "expected"),
     [
-        ("deepseek_v4", ("Qwen3ForCausalLM",), None, None),
-        ("qwen3", ("FakeDeepseekV4ForCausalLM",), None, None),
-        ("deepseek_v4", ("DeepseekV4ForCausalLM",), "hidden_size", 7168),
+        ("deepseek_v4", ("Qwen3ForCausalLM",), False),
+        ("qwen3", ("DeepseekV4ForCausalLM",), False),
+        ("qwen3", ("FakeDeepseekV4ForCausalLM",), True),
     ],
 )
-def test_graph_registered_inputs_reject_incomplete_deepseek_identity(
+def test_graph_registered_inputs_fail_closed_for_partial_deepseek_identity(
     monkeypatch: pytest.MonkeyPatch,
     model_type: str,
     architectures: tuple[str, ...],
-    model_field: str | None,
-    model_value: object,
+    expected: bool,
 ) -> None:
     vllm_config = _deepseek_v4_config((1, 2, 4))
     text_config = vllm_config.model_config.hf_text_config
     text_config.model_type = model_type
     text_config.architectures = architectures
     vllm_config.model_config.architectures = architectures
-    if model_field is not None:
-        setattr(text_config, model_field, model_value)
     monkeypatch.setattr(
         "vllm.config.get_current_vllm_config_or_none",
         lambda: vllm_config,
     )
 
-    assert custom_ar._use_graph_registered_inputs_for_current_model() is True
+    assert custom_ar._use_graph_registered_inputs_for_current_model() is expected
+
+
+def test_graph_registered_inputs_guard_all_exact_deepseek_v4_configs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vllm_config = _deepseek_v4_config((1, 2, 4))
+    vllm_config.model_config.hf_text_config.hidden_size = 7168
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config_or_none",
+        lambda: vllm_config,
+    )
+
+    assert custom_ar._use_graph_registered_inputs_for_current_model() is False
 
 
 def test_register_graph_buffers_populates_persistent_rank_data(monkeypatch):

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -681,6 +681,8 @@ class TestMUSANativeKernelReviewHardening:
         # (avoid brittle cross-literal substring matching).
         assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X must be one of" in source
         assert "128, 256, 512, or 1024" in source
+        assert "int requested_block" in source
+        assert "env_forced_block > 0 ? env_forced_block : requested_block" in source
 
     def test_fused_rmsnorm_qwen2_small_hidden_uses_256_threads(self):
         source = (
@@ -733,9 +735,33 @@ class TestMUSAPlatformDefaults:
     ):
         from types import SimpleNamespace
 
+        is_deepseek_v4 = architectures == ["DeepseekV4ForCausalLM"]
+        if is_deepseek_v4 and attention_backend is None:
+            attention_backend = "FLASHMLA"
+        if is_deepseek_v4 and cudagraph_mode is None:
+            cudagraph_mode = "FULL_DECODE_ONLY"
+        if is_deepseek_v4 and quantization_config is None:
+            quantization_config = {
+                "quant_method": "fp8",
+                "weight_block_size": [128, 128],
+            }
         hf_config = SimpleNamespace(
             architectures=architectures,
+            model_type="deepseek_v4" if is_deepseek_v4 else None,
             quantization_config=quantization_config,
+            hidden_size=4096 if is_deepseek_v4 else None,
+            num_hidden_layers=43 if is_deepseek_v4 else None,
+            num_attention_heads=64 if is_deepseek_v4 else None,
+            num_key_value_heads=1 if is_deepseek_v4 else None,
+            head_dim=512 if is_deepseek_v4 else None,
+            vocab_size=129280 if is_deepseek_v4 else None,
+            n_routed_experts=256 if is_deepseek_v4 else None,
+            num_experts_per_tok=6 if is_deepseek_v4 else None,
+            n_shared_experts=1 if is_deepseek_v4 else None,
+            moe_intermediate_size=2048 if is_deepseek_v4 else None,
+            expert_dtype="fp8" if is_deepseek_v4 else None,
+            hidden_act="silu" if is_deepseek_v4 else None,
+            swiglu_limit=10.0 if is_deepseek_v4 else None,
         )
         if index_topk is not None:
             hf_config.index_topk = index_topk
@@ -743,22 +769,32 @@ class TestMUSAPlatformDefaults:
             model_config=SimpleNamespace(
                 architectures=architectures,
                 hf_config=hf_config,
+                hf_text_config=hf_config,
+                dtype="bfloat16",
                 quantization=quantization,
                 use_mla=use_mla,
+                is_hybrid=False,
+                is_moe=is_deepseek_v4,
+                enforce_eager=False,
                 is_mm_prefix_lm=False,
             ),
             parallel_config=SimpleNamespace(
                 tensor_parallel_size=tensor_parallel_size,
                 worker_cls="auto",
             ),
-            cache_config=SimpleNamespace(block_size=cache_block_size),
+            cache_config=SimpleNamespace(
+                block_size=cache_block_size,
+                cache_dtype="fp8" if is_deepseek_v4 else "auto",
+            ),
             scheduler_config=SimpleNamespace(
                 is_multimodal_model=False,
                 disable_chunked_mm_input=False,
+                max_num_seqs=1 if is_deepseek_v4 else 64,
             ),
             attention_config=SimpleNamespace(backend=attention_backend),
             compilation_config=SimpleNamespace(
                 custom_ops=[],
+                mode="NONE",
                 cudagraph_mode=cudagraph_mode,
                 max_cudagraph_capture_size=max_cudagraph_capture_size,
                 cudagraph_capture_sizes=cudagraph_capture_sizes,
@@ -852,7 +888,7 @@ class TestMUSAPlatformDefaults:
         assert vllm_config.compilation_config.max_cudagraph_capture_size == 512
         assert vllm_config.compilation_config.cudagraph_capture_sizes == [1, 2, 4, 8]
 
-    def test_deepseek_v4_defaults_moe_gemv_block32x8(self):
+    def test_deepseek_v4_does_not_default_generic_kernel_envs(self):
         from vllm_musa.platform import MUSAPlatformBase
 
         vllm_config = self._make_vllm_config(
@@ -860,13 +896,13 @@ class TestMUSAPlatformDefaults:
         )
 
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV", None)
             os.environ.pop("VLLM_MUSA_GEMV_MOE_BLOCK", None)
+            os.environ.pop("VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X", None)
 
             MUSAPlatformBase.check_and_update_config(vllm_config)
 
-            assert "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV" not in os.environ
-            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "32x8"
+            assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in os.environ
+            assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in os.environ
 
     def test_deepseek_v4_preserves_user_moe_gemv_block(self):
         from vllm_musa.platform import MUSAPlatformBase
@@ -906,12 +942,18 @@ class TestMUSAPlatformDefaults:
 
             assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in os.environ
 
-    def test_deepseek_v4_tp8_uses_validated_defaults_without_profile_env(self):
+    def test_deepseek_v4_tp8_uses_contract_without_profile_env(self):
+        from vllm_musa.optimization_contract import (
+            OptimizationFeature,
+            resolve_optimization_contract,
+        )
         from vllm_musa.platform import MUSAPlatformBase
 
         vllm_config = self._make_vllm_config(
             architectures=["DeepseekV4ForCausalLM"],
             tensor_parallel_size=8,
+            use_mla=True,
+            index_topk=512,
         )
 
         with patch.dict(os.environ, {}, clear=False):
@@ -928,8 +970,15 @@ class TestMUSAPlatformDefaults:
 
             MUSAPlatformBase.check_and_update_config(vllm_config)
 
-            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "16x8"
-            assert os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] == "256"
+            contract = resolve_optimization_contract(vllm_config)
+            assert contract.prefers(
+                OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+            )
+            assert contract.prefers(
+                OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+            )
+            assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in os.environ
+            assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in os.environ
             assert "VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE" not in os.environ
             assert (
                 os.environ.get("VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE")

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -36,6 +36,7 @@ class TestCustomOpsRuntimePatches:
         # the dflash fallback is now the vllm._custom_ops cat-6 object
         # patch; load + apply() it and assert it rebinds to the _shared helpers.
         import vllm
+
         from vllm_musa.patches import _get_patch_files, _load_patch_module, _shared
 
         vllm_ops = ModuleType("vllm._custom_ops")
@@ -145,17 +146,15 @@ class TestCompilationBackendPatch:
         )
 
     def test_qwen2_presplit_keeps_baseline_split_and_hashes_helper(self, monkeypatch):
-        from vllm_musa import platform
         from vllm_musa.compilation import qwen2_rope_kv_presplit as presplit
+        from vllm_musa.optimization_contract import policy
         from vllm_musa.patches import _get_patch_files, _load_patch_module
 
         patch_file = next(
             f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
         )
         patch_module = _load_patch_module(patch_file)
-        monkeypatch.setattr(
-            platform, "_is_qwen2_rope_kv_fusion_config", lambda _config: True
-        )
+        monkeypatch.setattr(policy, "prefers_feature", lambda *_args: True)
         monkeypatch.setattr(
             presplit, "qwen2_rope_kv_backend_supported", lambda _config: True
         )
@@ -190,17 +189,15 @@ class TestCompilationBackendPatch:
         )
 
     def test_qwen2_presplit_mismatch_keeps_baseline_config(self, monkeypatch):
-        from vllm_musa import platform
         from vllm_musa.compilation import qwen2_rope_kv_presplit as presplit
+        from vllm_musa.optimization_contract import policy
         from vllm_musa.patches import _get_patch_files, _load_patch_module
 
         patch_file = next(
             f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
         )
         patch_module = _load_patch_module(patch_file)
-        monkeypatch.setattr(
-            platform, "_is_qwen2_rope_kv_fusion_config", lambda _config: True
-        )
+        monkeypatch.setattr(policy, "prefers_feature", lambda *_args: True)
         monkeypatch.setattr(
             presplit, "qwen2_rope_kv_backend_supported", lambda _config: True
         )
@@ -222,17 +219,15 @@ class TestCompilationBackendPatch:
         assert compilation_config.traced_files == set()
 
     def test_qwen2_presplit_rejects_unsupported_attention_backend(self, monkeypatch):
-        from vllm_musa import platform
         from vllm_musa.compilation import qwen2_rope_kv_presplit as presplit
+        from vllm_musa.optimization_contract import policy
         from vllm_musa.patches import _get_patch_files, _load_patch_module
 
         patch_file = next(
             f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
         )
         patch_module = _load_patch_module(patch_file)
-        monkeypatch.setattr(
-            platform, "_is_qwen2_rope_kv_fusion_config", lambda _config: True
-        )
+        monkeypatch.setattr(policy, "prefers_feature", lambda *_args: True)
         monkeypatch.setattr(
             presplit, "qwen2_rope_kv_backend_supported", lambda _config: False
         )
@@ -256,17 +251,15 @@ class TestCompilationBackendPatch:
         monkeypatch,
         text_config_source: str,
     ):
-        from vllm_musa import platform
         from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
+        from vllm_musa.optimization_contract import policy
         from vllm_musa.patches import _get_patch_files, _load_patch_module
 
         patch_file = next(
             f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
         )
         patch_module = _load_patch_module(patch_file)
-        monkeypatch.setattr(
-            platform, "_is_qwen3_qk_rope_kv_fusion_config", lambda _config: True
-        )
+        monkeypatch.setattr(policy, "prefers_feature", lambda *_args: True)
         monkeypatch.setattr(
             presplit,
             "qwen3_qk_rope_kv_backend_supported",
@@ -310,17 +303,15 @@ class TestCompilationBackendPatch:
         )
 
     def test_qwen3_presplit_missing_layer_count_is_fail_closed(self, monkeypatch):
-        from vllm_musa import platform
         from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
+        from vllm_musa.optimization_contract import policy
         from vllm_musa.patches import _get_patch_files, _load_patch_module
 
         patch_file = next(
             f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
         )
         patch_module = _load_patch_module(patch_file)
-        monkeypatch.setattr(
-            platform, "_is_qwen3_qk_rope_kv_fusion_config", lambda _config: True
-        )
+        monkeypatch.setattr(policy, "prefers_feature", lambda *_args: True)
 
         def unexpected_backend_check(*_args, **_kwargs):
             pytest.fail("backend support must not run without a layer count")
@@ -348,17 +339,15 @@ class TestCompilationBackendPatch:
         assert compilation_config.traced_files == set()
 
     def test_qwen3_presplit_site_mismatch_is_atomic(self, monkeypatch):
-        from vllm_musa import platform
         from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
+        from vllm_musa.optimization_contract import policy
         from vllm_musa.patches import _get_patch_files, _load_patch_module
 
         patch_file = next(
             f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
         )
         patch_module = _load_patch_module(patch_file)
-        monkeypatch.setattr(
-            platform, "_is_qwen3_qk_rope_kv_fusion_config", lambda _config: True
-        )
+        monkeypatch.setattr(policy, "prefers_feature", lambda *_args: True)
         monkeypatch.setattr(
             presplit,
             "qwen3_qk_rope_kv_backend_supported",
@@ -396,17 +385,15 @@ class TestCompilationBackendPatch:
         assert compilation_config.traced_files == set()
 
     def test_qwen3_presplit_rejects_unsupported_attention_backend(self, monkeypatch):
-        from vllm_musa import platform
         from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
+        from vllm_musa.optimization_contract import policy
         from vllm_musa.patches import _get_patch_files, _load_patch_module
 
         patch_file = next(
             f for m, f in _get_patch_files() if m == "vllm.compilation.backends"
         )
         patch_module = _load_patch_module(patch_file)
-        monkeypatch.setattr(
-            platform, "_is_qwen3_qk_rope_kv_fusion_config", lambda _config: True
-        )
+        monkeypatch.setattr(policy, "prefers_feature", lambda *_args: True)
         monkeypatch.setattr(
             presplit,
             "qwen3_qk_rope_kv_backend_supported",
@@ -517,9 +504,9 @@ class TestMUSAFlashAttentionReshapeCache:
     """
 
     def _load_fa_utils_with_musa_platform(self, monkeypatch, musa_ops_namespace):
+        import vllm
         import vllm.platforms as vllm_platforms
 
-        import vllm
         import vllm_musa
 
         monkeypatch.setenv("VLLM_MUSA_RESHAPE_CACHE_FLASH", "1")
@@ -1077,9 +1064,7 @@ class TestMUSAPlatformDefaults:
             assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "32x8"
             assert os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] == "128"
 
-    def test_update_block_size_for_backend_defaults_and_hybrid_modes(
-        self, monkeypatch
-    ):
+    def test_update_block_size_for_backend_defaults_and_hybrid_modes(self, monkeypatch):
         # The MUSA platform seeds a 64-element KV page for non-hybrid,
         # non-user-specified configs so paged FMHA/MLA decode takes the TME
         # bulk-gather path. Fixed-page kernels and explicit user overrides are
@@ -1254,7 +1239,11 @@ class TestMUSAFp8MoEPadding:
         monkeypatch.setattr(
             musa_fp8,
             "_ORIGINAL_FP8_MOE_MAYBE_ROUNDUP_SIZES",
-            lambda self, hidden_size, intermediate_size_per_partition, act_dtype, moe_parallel_config: (
+            lambda self,
+            hidden_size,
+            intermediate_size_per_partition,
+            act_dtype,
+            moe_parallel_config: (
                 hidden_size,
                 intermediate_size_per_partition,
             ),

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -735,11 +735,14 @@ class TestMUSAPlatformDefaults:
     ):
         from types import SimpleNamespace
 
+        from vllm.config import CUDAGraphMode
+        from vllm.config.compilation import CompilationMode
+
         is_deepseek_v4 = architectures == ["DeepseekV4ForCausalLM"]
         if is_deepseek_v4 and attention_backend is None:
             attention_backend = "FLASHMLA"
         if is_deepseek_v4 and cudagraph_mode is None:
-            cudagraph_mode = "FULL_DECODE_ONLY"
+            cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
         if is_deepseek_v4 and quantization_config is None:
             quantization_config = {
                 "quant_method": "fp8",
@@ -780,6 +783,9 @@ class TestMUSAPlatformDefaults:
             ),
             parallel_config=SimpleNamespace(
                 tensor_parallel_size=tensor_parallel_size,
+                pipeline_parallel_size=1,
+                data_parallel_size=1,
+                decode_context_parallel_size=1,
                 worker_cls="auto",
             ),
             cache_config=SimpleNamespace(
@@ -792,9 +798,12 @@ class TestMUSAPlatformDefaults:
                 max_num_seqs=1 if is_deepseek_v4 else 64,
             ),
             attention_config=SimpleNamespace(backend=attention_backend),
+            quant_config=SimpleNamespace(weight_block_size=[128, 128])
+            if is_deepseek_v4
+            else None,
             compilation_config=SimpleNamespace(
                 custom_ops=[],
-                mode="NONE",
+                mode=CompilationMode.NONE if is_deepseek_v4 else "NONE",
                 cudagraph_mode=cudagraph_mode,
                 max_cudagraph_capture_size=max_cudagraph_capture_size,
                 cudagraph_capture_sizes=cudagraph_capture_sizes,

--- a/tests/test_qwen_contract_source.py
+++ b/tests/test_qwen_contract_source.py
@@ -42,7 +42,8 @@ def test_qwen_patch_consumers_bind_contract_features() -> None:
     assert "+    return True" in mamba_pool
 
 
-def test_deepseek_provider_is_not_registered_yet() -> None:
+def test_deepseek_provider_is_registered_explicitly() -> None:
     providers = _source("vllm_musa/optimization_contract/providers.py")
     assert "resolve_qwen_contract" in providers
-    assert "resolve_deepseek" not in providers
+    assert "resolve_deepseek_v4_contract" in providers
+    assert "resolve_deepseek_v4_contract," in providers

--- a/tests/test_qwen_contract_source.py
+++ b/tests/test_qwen_contract_source.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MUSA_ROOT = ROOT / "vllm_musa"
+
+
+def _source(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_qwen_model_specific_env_gates_are_removed() -> None:
+    forbidden = {
+        "VLLM_MUSA_MOE_SHARED_EXPERT_FUSION",
+        "VLLM_MUSA_FUSED_QK_MROPE",
+        "VLLM_MUSA_MAMBA_SEPARATE_POOL",
+    }
+    production_sources = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in MUSA_ROOT.rglob("*")
+        if path.suffix in {".py", ".patch"}
+    )
+    assert forbidden.isdisjoint(production_sources)
+
+
+def test_qwen_patch_consumers_bind_contract_features() -> None:
+    shared_expert = _source(
+        "vllm_musa/patches/series/"
+        "0076-MUSA-model-fold-the-Qwen3.5-shared-expert-into-fused.patch"
+    )
+    fused_mrope = _source(
+        "vllm_musa/patches/series/"
+        "0087-MUSA-fuse-QK-RMSNorm-and-MRoPE-for-interleaved-MRoPE.patch"
+    )
+    mamba_pool = _source(
+        "vllm_musa/patches/series/0083-MUSA-vllm.v1.core.kv_cache_utils.patch"
+    )
+
+    assert "QWEN35_SHARED_EXPERT_FOLD" in shared_expert
+    assert "QWEN35_INTERLEAVED_MROPE_QK" in fused_mrope
+    assert "def musa_mamba_separate_pool_enabled" in mamba_pool
+    assert "+    return True" in mamba_pool
+
+
+def test_deepseek_provider_is_not_registered_yet() -> None:
+    providers = _source("vllm_musa/optimization_contract/providers.py")
+    assert "resolve_qwen_contract" in providers
+    assert "resolve_deepseek" not in providers

--- a/tests/test_qwen_contract_source.py
+++ b/tests/test_qwen_contract_source.py
@@ -19,7 +19,8 @@ def test_qwen_model_specific_env_gates_are_removed() -> None:
         for path in MUSA_ROOT.rglob("*")
         if path.suffix in {".py", ".patch"}
     )
-    assert forbidden.isdisjoint(production_sources)
+    for gate in forbidden:
+        assert gate not in production_sources
 
 
 def test_qwen_patch_consumers_bind_contract_features() -> None:

--- a/tests/test_qwen_fused_next_input_ids.py
+++ b/tests/test_qwen_fused_next_input_ids.py
@@ -8,7 +8,7 @@ import numpy as np
 import torchada  # noqa: F401
 import torch
 
-from qwen_contract_test_utils import qwen_sampler
+from tests.qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.worker import qwen_fused_next_input_ids as fused_inputs
 
 

--- a/tests/test_qwen_fused_next_input_ids.py
+++ b/tests/test_qwen_fused_next_input_ids.py
@@ -8,6 +8,7 @@ import numpy as np
 import torchada  # noqa: F401
 import torch
 
+from qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.worker import qwen_fused_next_input_ids as fused_inputs
 
 
@@ -17,7 +18,7 @@ def make_runner(capacity: int = 8, *, is_qwen_family: bool = True):
             input_ids=torch.zeros(capacity, dtype=torch.int32)
         ),
         model_state=SimpleNamespace(num_new_sampled_tokens_per_step=1),
-        sampler=SimpleNamespace(_musa_qwen_family=is_qwen_family),
+        sampler=qwen_sampler(enabled=is_qwen_family),
         use_pp=False,
     )
 

--- a/tests/test_qwen_gdn_decode_output.py
+++ b/tests/test_qwen_gdn_decode_output.py
@@ -10,7 +10,7 @@ import torch
 
 # isort: on
 
-from qwen_contract_test_utils import qwen_hybrid_contract, qwen_sampler
+from tests.qwen_contract_test_utils import qwen_hybrid_contract, qwen_sampler
 from vllm_musa.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
 
 

--- a/tests/test_qwen_gdn_decode_output.py
+++ b/tests/test_qwen_gdn_decode_output.py
@@ -10,10 +10,13 @@ import torch
 
 # isort: on
 
+from qwen_contract_test_utils import qwen_hybrid_contract, qwen_sampler
 from vllm_musa.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
 
 
-def _fake_attention() -> gdn.MusaQwenGatedDeltaNetAttention:
+def _fake_attention(
+    *, separate_pool: bool = True
+) -> gdn.MusaQwenGatedDeltaNetAttention:
     attention = object.__new__(gdn.MusaQwenGatedDeltaNetAttention)
     attention.key_dim = 4
     attention.value_dim = 4
@@ -28,6 +31,11 @@ def _fake_attention() -> gdn.MusaQwenGatedDeltaNetAttention:
     attention.kv_cache = (
         torch.zeros(2, 4, 1),
         torch.zeros(4, 2, 2, 2, dtype=torch.float32),
+    )
+    attention._musa_optimization_contract = (
+        qwen_hybrid_contract()
+        if separate_pool
+        else qwen_sampler(enabled=False)._musa_optimization_contract
     )
     return attention
 
@@ -72,8 +80,6 @@ def test_mate_decode_writes_caller_output_and_ignores_decoy(monkeypatch) -> None
 
     monkeypatch.setattr(gdn, "gated_delta_rule_decode", fake_decode)
     monkeypatch.setattr(gdn, "_MATE_GDN_DECODE_HAS_OUTPUT", True)
-    monkeypatch.setenv("VLLM_MUSA_MAMBA_SEPARATE_POOL", "1")
-
     assert attention._try_mate_decode(mixed_qkv, b, a, core_attn_out, metadata)
 
     assert captured["output"].shape == (num_tokens, 1, 2, 2)
@@ -100,8 +106,6 @@ def test_mate_decode_legacy_api_copies_returned_output(monkeypatch) -> None:
 
     monkeypatch.setattr(gdn, "gated_delta_rule_decode", fake_decode)
     monkeypatch.setattr(gdn, "_MATE_GDN_DECODE_HAS_OUTPUT", False)
-    monkeypatch.setenv("VLLM_MUSA_MAMBA_SEPARATE_POOL", "1")
-
     assert attention._try_mate_decode(mixed_qkv, b, a, core_attn_out, metadata)
 
     assert "output" not in captured
@@ -111,7 +115,7 @@ def test_mate_decode_legacy_api_copies_returned_output(monkeypatch) -> None:
 def test_mate_decode_gather_scatter_reuses_output_and_updates_active_state(
     monkeypatch,
 ) -> None:
-    attention = _fake_attention()
+    attention = _fake_attention(separate_pool=False)
     num_tokens = 2
     mixed_qkv = torch.randn(num_tokens, 12)
     a = torch.ones(num_tokens, 2)
@@ -128,8 +132,6 @@ def test_mate_decode_gather_scatter_reuses_output_and_updates_active_state(
 
     monkeypatch.setattr(gdn, "gated_delta_rule_decode", fake_decode)
     monkeypatch.setattr(gdn, "_MATE_GDN_DECODE_HAS_OUTPUT", True)
-    monkeypatch.setenv("VLLM_MUSA_MAMBA_SEPARATE_POOL", "0")
-
     assert attention._try_mate_decode(mixed_qkv, b, a, core_attn_out, metadata)
 
     assert torch.equal(core_attn_out, torch.full_like(core_attn_out, 7))
@@ -155,8 +157,6 @@ def test_mate_decode_output_reuse_only_writes_decode_prefix(monkeypatch) -> None
 
     monkeypatch.setattr(gdn, "gated_delta_rule_decode", fake_decode)
     monkeypatch.setattr(gdn, "_MATE_GDN_DECODE_HAS_OUTPUT", True)
-    monkeypatch.setenv("VLLM_MUSA_MAMBA_SEPARATE_POOL", "1")
-
     assert attention._try_mate_decode(mixed_qkv, b, a, core_attn_out, metadata)
 
     assert torch.equal(core_attn_out[:num_decode_tokens], torch.full((2, 2, 2), 7.0))

--- a/tests/test_qwen_identity_logits_view.py
+++ b/tests/test_qwen_identity_logits_view.py
@@ -3,12 +3,13 @@ from types import SimpleNamespace
 import numpy as np
 import torch
 
+from qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.worker import qwen_identity_logits_view as identity_view
 
 
 def make_runner(architecture: str = "Qwen3ForCausalLM", sampled_tokens: int = 1):
     return SimpleNamespace(
-        sampler=SimpleNamespace(_musa_qwen_family=architecture.startswith("Qwen")),
+        sampler=qwen_sampler(enabled=architecture.startswith("Qwen")),
         model_state=SimpleNamespace(num_new_sampled_tokens_per_step=sampled_tokens),
     )
 

--- a/tests/test_qwen_identity_logits_view.py
+++ b/tests/test_qwen_identity_logits_view.py
@@ -2,8 +2,8 @@ from types import SimpleNamespace
 
 import numpy as np
 import torch
-
 from qwen_contract_test_utils import qwen_sampler
+
 from vllm_musa.v1.worker import qwen_identity_logits_view as identity_view
 
 

--- a/tests/test_qwen_identity_logits_view.py
+++ b/tests/test_qwen_identity_logits_view.py
@@ -2,8 +2,8 @@ from types import SimpleNamespace
 
 import numpy as np
 import torch
-from qwen_contract_test_utils import qwen_sampler
 
+from tests.qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.worker import qwen_identity_logits_view as identity_view
 
 

--- a/tests/test_qwen_optimization_contract.py
+++ b/tests/test_qwen_optimization_contract.py
@@ -295,6 +295,9 @@ def test_qwen35_dense_gdn_and_moe_prefill_static_contracts() -> None:
     dense_contract = resolve_optimization_contract(dense)
     assert dense_contract.model.gdn_conv_dim == 10240
     assert dense_contract.prefers(OptimizationFeature.QWEN35_GDN_WIDTH4_PREFILL)
+    assert dense_contract.prefers(OptimizationFeature.QWEN35_INTERLEAVED_MROPE_QK)
+    assert dense_contract.prefers(OptimizationFeature.HYBRID_SEPARATE_MAMBA_POOL)
+    assert not dense_contract.prefers(OptimizationFeature.QWEN35_SHARED_EXPERT_FOLD)
 
     moe = _config(
         architecture="Qwen3_5MoeForConditionalGeneration",
@@ -313,6 +316,8 @@ def test_qwen35_dense_gdn_and_moe_prefill_static_contracts() -> None:
     moe_contract = resolve_optimization_contract(moe)
     assert moe_contract.model.gdn_conv_dim == 8192
     assert moe_contract.prefers(OptimizationFeature.QWEN35_MOE_BF16_PREFILL)
+    assert moe_contract.prefers(OptimizationFeature.QWEN35_SHARED_EXPERT_FOLD)
+    assert moe_contract.prefers(OptimizationFeature.QWEN35_INTERLEAVED_MROPE_QK)
     assert not moe_contract.prefers(OptimizationFeature.QWEN35_GDN_WIDTH4_PREFILL)
 
 

--- a/tests/test_qwen_optimization_contract.py
+++ b/tests/test_qwen_optimization_contract.py
@@ -1,0 +1,337 @@
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_musa.optimization_contract import (
+    ModelFamily,
+    ModelRole,
+    OptimizationFeature,
+    resolve_optimization_contract,
+)
+
+
+def _config(
+    *,
+    architecture: str,
+    model_type: str,
+    dtype: object = "bfloat16",
+    quantization: str | None = None,
+    hidden_size: int | None = None,
+    intermediate_size: int | None = None,
+    num_hidden_layers: int | None = None,
+    num_attention_heads: int | None = None,
+    num_key_value_heads: int | None = None,
+    head_dim: int | None = None,
+    num_experts: int | None = None,
+    num_experts_per_tok: int | None = None,
+    moe_intermediate_size: int | None = None,
+    linear_num_key_heads: int | None = None,
+    linear_num_value_heads: int | None = None,
+    linear_key_head_dim: int | None = None,
+    linear_value_head_dim: int | None = None,
+    linear_conv_kernel_dim: int | None = None,
+    tp: int = 1,
+    pp: int = 1,
+    dp: int = 1,
+    dcp: int = 1,
+    speculative: bool = False,
+    cache_dtype: object = "auto",
+    cache_block_size: int | None = 64,
+    enforce_eager: bool = False,
+):
+    text_config = SimpleNamespace(
+        model_type=model_type,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+        head_dim=head_dim,
+        num_experts=num_experts,
+        num_experts_per_tok=num_experts_per_tok,
+        moe_intermediate_size=moe_intermediate_size,
+        linear_num_key_heads=linear_num_key_heads,
+        linear_num_value_heads=linear_num_value_heads,
+        linear_key_head_dim=linear_key_head_dim,
+        linear_value_head_dim=linear_value_head_dim,
+        linear_conv_kernel_dim=linear_conv_kernel_dim,
+        quantization_config=(
+            {"quant_method": quantization} if quantization is not None else None
+        ),
+    )
+    model_config = SimpleNamespace(
+        architectures=[architecture],
+        hf_text_config=text_config,
+        hf_config=text_config,
+        dtype=dtype,
+        quantization=quantization,
+        enforce_eager=enforce_eager,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=tp,
+            pipeline_parallel_size=pp,
+            data_parallel_size=dp,
+            decode_context_parallel_size=dcp,
+        ),
+        cache_config=SimpleNamespace(
+            cache_dtype=cache_dtype,
+            block_size=cache_block_size,
+        ),
+        scheduler_config=SimpleNamespace(max_num_seqs=64),
+        speculative_config=object() if speculative else None,
+        quant_config=object() if quantization not in (None, "none") else None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("architecture", "model_type", "family", "role"),
+    [
+        ("Qwen2ForCausalLM", "qwen2", ModelFamily.QWEN2, ModelRole.TEXT),
+        ("Qwen3ForCausalLM", "qwen3", ModelFamily.QWEN3, ModelRole.TEXT),
+        (
+            "Qwen3_5ForConditionalGeneration",
+            "qwen3_5_text",
+            ModelFamily.QWEN35_36,
+            ModelRole.TEXT,
+        ),
+        (
+            "Qwen3_5MoeForConditionalGeneration",
+            "qwen3_5_moe_text",
+            ModelFamily.QWEN35_36,
+            ModelRole.TEXT,
+        ),
+        (
+            "CosyVoice3Model",
+            "cosyvoice3",
+            ModelFamily.QWEN2,
+            ModelRole.COSYVOICE_TALKER,
+        ),
+    ],
+)
+def test_resolves_qwen_family_without_model_name(
+    architecture: str,
+    model_type: str,
+    family: ModelFamily,
+    role: ModelRole,
+) -> None:
+    contract = resolve_optimization_contract(
+        _config(architecture=architecture, model_type=model_type)
+    )
+    assert contract.model.family is family
+    assert contract.model.role is role
+
+
+@pytest.mark.parametrize(
+    "architecture",
+    [
+        "Qwen3VLForConditionalGeneration",
+        "Qwen3OmniMoeForConditionalGeneration",
+        "DeepseekV4ForCausalLM",
+        "LlamaForCausalLM",
+    ],
+)
+def test_unknown_or_future_families_fail_closed(architecture: str) -> None:
+    contract = resolve_optimization_contract(
+        _config(architecture=architecture, model_type="unknown")
+    )
+    assert contract.model.family is ModelFamily.UNKNOWN
+    assert not contract.supported_features
+    assert not contract.preferred_features
+
+
+def test_deepseek_v4_facts_are_normalized_without_enabling_a_provider() -> None:
+    text_config = SimpleNamespace(
+        model_type="deepseek_v4",
+        kv_lora_rank=512,
+        index_topk=2048,
+        quantization_config={"weight_block_size": [128, 128]},
+    )
+    contract = resolve_optimization_contract(
+        SimpleNamespace(
+            model_config=SimpleNamespace(
+                architectures=["DeepseekV4ForCausalLM"],
+                hf_text_config=text_config,
+                hf_config=text_config,
+                dtype="bfloat16",
+                quantization="fp8",
+            ),
+            parallel_config=SimpleNamespace(
+                tensor_parallel_size=8,
+                pipeline_parallel_size=1,
+                data_parallel_size=1,
+                decode_context_parallel_size=1,
+            ),
+            attention_config=SimpleNamespace(backend="FLASHMLA"),
+            compilation_config=SimpleNamespace(
+                mode="NONE",
+                cudagraph_mode="FULL_DECODE_ONLY",
+            ),
+            quant_config=None,
+        )
+    )
+    assert contract.model.family is ModelFamily.UNKNOWN
+    assert contract.model.uses_mla is True
+    assert contract.model.index_topk == 2048
+    assert contract.model.quant_block_shape == (128, 128)
+    assert contract.execution.attention_backend == "flashmla"
+    assert contract.execution.cudagraph_mode == "full_decode_only"
+    assert not contract.preferred_features
+
+
+def test_qwen_runner_and_fa3_architecture_sets_preserve_current_scope() -> None:
+    causal_variant = resolve_optimization_contract(
+        _config(
+            architecture="Qwen3_5ForCausalLM",
+            model_type="qwen3_5_text",
+        )
+    )
+    assert causal_variant.prefers(OptimizationFeature.QWEN_V2_SAMPLING)
+    assert not causal_variant.prefers(OptimizationFeature.QWEN_LEGACY_SAMPLING)
+    assert not causal_variant.prefers(OptimizationFeature.QWEN_FA3_SCHEDULER)
+
+    conditional_variant = resolve_optimization_contract(
+        _config(
+            architecture="Qwen3_5ForConditionalGeneration",
+            model_type="qwen3_5_text",
+        )
+    )
+    assert conditional_variant.prefers(OptimizationFeature.QWEN_V2_SAMPLING)
+    assert conditional_variant.prefers(OptimizationFeature.QWEN_LEGACY_SAMPLING)
+    assert conditional_variant.prefers(OptimizationFeature.QWEN_FA3_SCHEDULER)
+
+    cosyvoice = resolve_optimization_contract(
+        _config(architecture="CosyVoice3Model", model_type="cosyvoice3")
+    )
+    assert cosyvoice.prefers(OptimizationFeature.QWEN_FA3_SCHEDULER)
+    assert not cosyvoice.prefers(OptimizationFeature.QWEN_V2_SAMPLING)
+
+
+def test_exact_qwen3_dense_fp8_contract() -> None:
+    config = _config(
+        architecture="Qwen3ForCausalLM",
+        model_type="qwen3",
+        quantization="fp8",
+        hidden_size=4096,
+        intermediate_size=12288,
+        num_hidden_layers=36,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=128,
+    )
+    contract = resolve_optimization_contract(config)
+    assert contract.prefers(OptimizationFeature.QWEN3_DENSE_FP8_POST_GRAD_FUSIONS)
+
+    config.parallel_config.tensor_parallel_size = 2
+    contract = resolve_optimization_contract(config)
+    assert not contract.supports(OptimizationFeature.QWEN3_DENSE_FP8_POST_GRAD_FUSIONS)
+
+
+@pytest.mark.parametrize(
+    "geometry",
+    [
+        (1024, 3072, 28, 16, 8, 128),
+        (4096, 12288, 36, 32, 8, 128),
+    ],
+)
+def test_exact_qwen3_qk_rope_kv_contract(geometry: tuple[int, ...]) -> None:
+    contract = resolve_optimization_contract(
+        _config(
+            architecture="Qwen3ForCausalLM",
+            model_type="qwen3",
+            hidden_size=geometry[0],
+            intermediate_size=geometry[1],
+            num_hidden_layers=geometry[2],
+            num_attention_heads=geometry[3],
+            num_key_value_heads=geometry[4],
+            head_dim=geometry[5],
+        )
+    )
+    assert contract.prefers(OptimizationFeature.QWEN3_QK_ROPE_KV_PRESPLIT)
+
+
+def test_exact_qwen2_and_cosyvoice_rope_kv_contracts() -> None:
+    qwen2 = _config(
+        architecture="Qwen2ForCausalLM",
+        model_type="qwen2",
+        hidden_size=896,
+        intermediate_size=4864,
+        num_hidden_layers=24,
+        num_attention_heads=14,
+        num_key_value_heads=2,
+    )
+    assert resolve_optimization_contract(qwen2).prefers(
+        OptimizationFeature.QWEN2_ROPE_KV_PRESPLIT
+    )
+
+    cosyvoice = _config(
+        architecture="CosyVoice3Model",
+        model_type="cosyvoice3",
+        hidden_size=896,
+        intermediate_size=None,
+        num_hidden_layers=24,
+        num_attention_heads=14,
+        num_key_value_heads=None,
+    )
+    assert resolve_optimization_contract(cosyvoice).prefers(
+        OptimizationFeature.QWEN2_ROPE_KV_PRESPLIT
+    )
+
+
+def test_qwen35_dense_gdn_and_moe_prefill_static_contracts() -> None:
+    dense = _config(
+        architecture="Qwen3_5ForConditionalGeneration",
+        model_type="qwen3_5_text",
+        hidden_size=5120,
+        intermediate_size=17408,
+        num_experts=None,
+        linear_num_key_heads=16,
+        linear_num_value_heads=48,
+        linear_key_head_dim=128,
+        linear_value_head_dim=128,
+        linear_conv_kernel_dim=4,
+    )
+    dense_contract = resolve_optimization_contract(dense)
+    assert dense_contract.model.gdn_conv_dim == 10240
+    assert dense_contract.prefers(OptimizationFeature.QWEN35_GDN_WIDTH4_PREFILL)
+
+    moe = _config(
+        architecture="Qwen3_5MoeForConditionalGeneration",
+        model_type="qwen3_5_moe_text",
+        hidden_size=2048,
+        num_experts=256,
+        num_experts_per_tok=8,
+        moe_intermediate_size=512,
+        linear_num_key_heads=16,
+        linear_num_value_heads=32,
+        linear_key_head_dim=128,
+        linear_value_head_dim=128,
+        linear_conv_kernel_dim=4,
+        tp=4,
+    )
+    moe_contract = resolve_optimization_contract(moe)
+    assert moe_contract.model.gdn_conv_dim == 8192
+    assert moe_contract.prefers(OptimizationFeature.QWEN35_MOE_BF16_PREFILL)
+    assert not moe_contract.prefers(OptimizationFeature.QWEN35_GDN_WIDTH4_PREFILL)
+
+
+def test_static_contract_rejects_one_field_mismatches() -> None:
+    config = _config(
+        architecture="Qwen3ForCausalLM",
+        model_type="qwen3",
+        hidden_size=4096,
+        intermediate_size=12288,
+        num_hidden_layers=36,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=128,
+    )
+    config.speculative_config = object()
+    contract = resolve_optimization_contract(config)
+    assert not contract.prefers(OptimizationFeature.QWEN3_QK_ROPE_KV_PRESPLIT)
+
+    config.speculative_config = None
+    config.cache_config.block_size = 16
+    contract = resolve_optimization_contract(config)
+    assert not contract.prefers(OptimizationFeature.QWEN3_QK_ROPE_KV_PRESPLIT)

--- a/tests/test_qwen_optimization_contract.py
+++ b/tests/test_qwen_optimization_contract.py
@@ -124,6 +124,66 @@ def test_resolves_qwen_family_without_model_name(
 
 
 @pytest.mark.parametrize(
+    "checkpoint",
+    [
+        "Qwen3.5-35B-A3B",
+        "Qwen3.6-35B-A3B",
+    ],
+)
+def test_qwen35_and_qwen36_share_the_current_hf_schema(checkpoint: str) -> None:
+    """Both released checkpoints use the Qwen3.5 HF architecture/schema."""
+    contract = resolve_optimization_contract(
+        _config(
+            architecture="Qwen3_5MoeForConditionalGeneration",
+            model_type="qwen3_5_moe",
+            hidden_size=2048,
+            num_experts=256,
+            num_experts_per_tok=8,
+            moe_intermediate_size=512,
+            linear_num_key_heads=16,
+            linear_num_value_heads=32,
+            linear_key_head_dim=128,
+            linear_value_head_dim=128,
+            linear_conv_kernel_dim=4,
+            tp=4,
+        )
+    )
+
+    assert contract.model.family is ModelFamily.QWEN35_36, checkpoint
+    assert contract.prefers(OptimizationFeature.QWEN35_MOE_BF16_PREFILL)
+    assert contract.prefers(OptimizationFeature.QWEN35_SHARED_EXPERT_FOLD)
+    assert contract.prefers(OptimizationFeature.QWEN35_INTERLEAVED_MROPE_QK)
+
+
+def test_future_distinct_qwen36_schema_fails_closed() -> None:
+    contract = resolve_optimization_contract(
+        _config(
+            architecture="Qwen3_6MoeForConditionalGeneration",
+            model_type="qwen3_6_moe",
+            hidden_size=2048,
+            num_experts=256,
+            num_experts_per_tok=8,
+            moe_intermediate_size=512,
+            linear_num_key_heads=16,
+            linear_num_value_heads=32,
+            linear_key_head_dim=128,
+            linear_value_head_dim=128,
+            linear_conv_kernel_dim=4,
+            tp=4,
+        )
+    )
+
+    assert contract.model.family is ModelFamily.UNKNOWN
+    for feature in (
+        OptimizationFeature.QWEN35_MOE_BF16_PREFILL,
+        OptimizationFeature.QWEN35_SHARED_EXPERT_FOLD,
+        OptimizationFeature.QWEN35_INTERLEAVED_MROPE_QK,
+    ):
+        assert not contract.supports(feature)
+        assert not contract.prefers(feature)
+
+
+@pytest.mark.parametrize(
     "architecture",
     [
         "Qwen3VLForConditionalGeneration",
@@ -184,7 +244,9 @@ def test_deepseek_v4_incomplete_facts_are_normalized_but_fail_closed() -> None:
     assert contract.model.quant_block_shape == (128, 128)
     assert contract.execution.attention_backend == "flashmla"
     assert contract.execution.cudagraph_mode == "full_decode_only"
-    assert not contract.supported_features
+    assert contract.supported_features == frozenset(
+        {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+    )
     assert not contract.preferred_features
 
 

--- a/tests/test_qwen_optimization_contract.py
+++ b/tests/test_qwen_optimization_contract.py
@@ -141,6 +141,14 @@ def test_unknown_or_future_families_fail_closed(architecture: str) -> None:
     assert not contract.preferred_features
 
 
+def test_supported_and_preferred_feature_sets_are_independent() -> None:
+    contract = resolve_optimization_contract(
+        _config(architecture="Qwen3ForCausalLM", model_type="qwen3")
+    )
+    assert contract.supported_features == contract.preferred_features
+    assert contract.supported_features is not contract.preferred_features
+
+
 def test_deepseek_v4_facts_are_normalized_without_enabling_a_provider() -> None:
     text_config = SimpleNamespace(
         model_type="deepseek_v4",

--- a/tests/test_qwen_optimization_contract.py
+++ b/tests/test_qwen_optimization_contract.py
@@ -128,7 +128,6 @@ def test_resolves_qwen_family_without_model_name(
     [
         "Qwen3VLForConditionalGeneration",
         "Qwen3OmniMoeForConditionalGeneration",
-        "DeepseekV4ForCausalLM",
         "LlamaForCausalLM",
     ],
 )
@@ -149,7 +148,7 @@ def test_supported_and_preferred_feature_sets_are_independent() -> None:
     assert contract.supported_features is not contract.preferred_features
 
 
-def test_deepseek_v4_facts_are_normalized_without_enabling_a_provider() -> None:
+def test_deepseek_v4_incomplete_facts_are_normalized_but_fail_closed() -> None:
     text_config = SimpleNamespace(
         model_type="deepseek_v4",
         kv_lora_rank=512,
@@ -179,12 +178,13 @@ def test_deepseek_v4_facts_are_normalized_without_enabling_a_provider() -> None:
             quant_config=None,
         )
     )
-    assert contract.model.family is ModelFamily.UNKNOWN
+    assert contract.model.family is ModelFamily.DEEPSEEK_V4
     assert contract.model.uses_mla is True
     assert contract.model.index_topk == 2048
     assert contract.model.quant_block_shape == (128, 128)
     assert contract.execution.attention_backend == "flashmla"
     assert contract.execution.cudagraph_mode == "full_decode_only"
+    assert not contract.supported_features
     assert not contract.preferred_features
 
 

--- a/tests/test_qwen_sample_input_views.py
+++ b/tests/test_qwen_sample_input_views.py
@@ -2,8 +2,8 @@ from types import SimpleNamespace
 
 import numpy as np
 import torch
-
 from qwen_contract_test_utils import qwen_sampler
+
 from vllm_musa.optimization_contract import OptimizationFeature
 from vllm_musa.v1.sample import qwen_sample_input_views as sample_views
 

--- a/tests/test_qwen_sample_input_views.py
+++ b/tests/test_qwen_sample_input_views.py
@@ -3,6 +3,8 @@ from types import SimpleNamespace
 import numpy as np
 import torch
 
+from qwen_contract_test_utils import qwen_sampler
+from vllm_musa.optimization_contract import OptimizationFeature
 from vllm_musa.v1.sample import qwen_sample_input_views as sample_views
 
 
@@ -23,12 +25,14 @@ def make_batch(batch_size: int = 4, padded: int = 8):
 def select(monkeypatch, batch=None, *, is_qwen_family=True, **kwargs):
     monkeypatch.setattr(
         "vllm_musa.v1.sample.topk_topp_sampler.can_use_qwen_v2_unfiltered_gumbel",
-        lambda sampler, *args, **kw: sampler._musa_qwen_family,
+        lambda sampler, *args, **kw: sampler._musa_optimization_contract.prefers(
+            OptimizationFeature.QWEN_V2_SAMPLING
+        ),
     )
     batch = batch or make_batch()
     logits = torch.zeros(batch.num_reqs, 16, dtype=torch.bfloat16)
     return sample_views._select_qwen_sample_input_views(
-        SimpleNamespace(_musa_qwen_family=is_qwen_family),
+        qwen_sampler(enabled=is_qwen_family),
         logits,
         batch,
         torch.arange(batch.num_reqs, dtype=torch.int32),

--- a/tests/test_qwen_sample_input_views.py
+++ b/tests/test_qwen_sample_input_views.py
@@ -2,8 +2,8 @@ from types import SimpleNamespace
 
 import numpy as np
 import torch
-from qwen_contract_test_utils import qwen_sampler
 
+from tests.qwen_contract_test_utils import qwen_sampler
 from vllm_musa.optimization_contract import OptimizationFeature
 from vllm_musa.v1.sample import qwen_sample_input_views as sample_views
 

--- a/tests/test_qwen_sampler_model_traits_source.py
+++ b/tests/test_qwen_sampler_model_traits_source.py
@@ -1,4 +1,4 @@
-"""Source contract for attribute-gated Qwen sampler fast paths."""
+"""Source contract for contract-bound Qwen sampler fast paths."""
 
 from pathlib import Path
 
@@ -19,24 +19,14 @@ AUTO_FAST_PATH_SOURCES = (
 )
 
 
-def test_sampler_traits_are_derived_from_model_architecture() -> None:
+def test_sampler_traits_are_resolved_by_the_contract() -> None:
     source = PATCH.read_text()
 
     assert "VLLM_MUSA_QWEN" not in source
-    assert (
-        "+        self.sampler._musa_qwen_family = is_musa_qwen_text_generation"
-        in source
-    )
-    assert "+            qwen_sampling_architectures = {" in source
-    assert "+            self.sampler._musa_qwen_family = any(" in source
-    for architecture in (
-        "Qwen2ForCausalLM",
-        "Qwen3ForCausalLM",
-        "Qwen3MoeForCausalLM",
-        "Qwen3_5ForConditionalGeneration",
-        "Qwen3_5MoeForConditionalGeneration",
-    ):
-        assert architecture in source
+    assert "resolve_optimization_contract" in source
+    assert "_musa_optimization_contract" in source
+    assert "QWEN_LEGACY_SAMPLING" in source
+    assert "_musa_qwen_family" not in source
 
 
 def test_both_runner_generations_propagate_qwen_traits() -> None:
@@ -56,10 +46,11 @@ def test_followup_qwen_fast_paths_use_model_traits_without_env_flags() -> None:
     sources = {path: path.read_text() for path in AUTO_FAST_PATH_SOURCES}
 
     assert all("VLLM_MUSA_QWEN" not in source for source in sources.values())
-    assert "_musa_qwen_family" in sources[AUTO_FAST_PATH_SOURCES[0]]
-    assert "_musa_qwen_family" in sources[AUTO_FAST_PATH_SOURCES[1]]
-    assert "_musa_qwen_family" in sources[AUTO_FAST_PATH_SOURCES[2]]
-    assert "_musa_qwen_family" in sources[AUTO_FAST_PATH_SOURCES[3]]
+    assert "prefers_optimization" in sources[AUTO_FAST_PATH_SOURCES[0]]
+    assert "QWEN_UNIFORM_SAMPLE_COUNTS" in sources[AUTO_FAST_PATH_SOURCES[1]]
+    assert "QWEN_SAMPLE_INPUT_VIEWS" in sources[AUTO_FAST_PATH_SOURCES[2]]
+    assert "QWEN_UNIFORM_DECODE_VIEWS" in sources[AUTO_FAST_PATH_SOURCES[3]]
+    assert "_is_qwen_runner" in sources[AUTO_FAST_PATH_SOURCES[4]]
     assert "_is_qwen_runner(runner)" in sources[AUTO_FAST_PATH_SOURCES[4]]
     assert "worker_cls.sample = _worker_sample" in sources[AUTO_FAST_PATH_SOURCES[0]]
     assert "_worker_sample_unfiltered_gumbel" not in sources[AUTO_FAST_PATH_SOURCES[0]]

--- a/tests/test_qwen_uniform_sample_counts.py
+++ b/tests/test_qwen_uniform_sample_counts.py
@@ -9,7 +9,7 @@ import numpy as np
 import torchada  # noqa: F401
 import torch
 
-from qwen_contract_test_utils import qwen_sampler
+from tests.qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.sample import uniform_sample_counts as sample_counts
 
 

--- a/tests/test_qwen_uniform_sample_counts.py
+++ b/tests/test_qwen_uniform_sample_counts.py
@@ -9,6 +9,7 @@ import numpy as np
 import torchada  # noqa: F401
 import torch
 
+from qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.sample import uniform_sample_counts as sample_counts
 
 
@@ -30,7 +31,7 @@ def install_test_gates(monkeypatch) -> None:
 
 def test_qwen_uniform_sample_counts_accepts_and_reuses(monkeypatch) -> None:
     install_test_gates(monkeypatch)
-    sampler = SimpleNamespace(_musa_qwen_family=True)
+    sampler = qwen_sampler()
     logits = torch.empty((4, 151936), dtype=torch.bfloat16)
     first = sample_counts.select_qwen_uniform_sample_counts(
         sampler, logits, make_batch()
@@ -58,7 +59,7 @@ def test_qwen_uniform_sample_counts_accepts_supported_qwen_vocab_sizes(
     monkeypatch.setattr(sample_counts, "is_musa_tensor", lambda _tensor: True)
     for vocab_size in (151936, 248320):
         output = sample_counts.select_qwen_uniform_sample_counts(
-            SimpleNamespace(_musa_qwen_family=True),
+            qwen_sampler(),
             torch.empty((2, vocab_size), dtype=torch.bfloat16),
             make_batch(2),
         )
@@ -67,7 +68,7 @@ def test_qwen_uniform_sample_counts_accepts_supported_qwen_vocab_sizes(
 
     assert (
         sample_counts.select_qwen_uniform_sample_counts(
-            SimpleNamespace(_musa_qwen_family=True),
+            qwen_sampler(),
             torch.empty((2, 32000), dtype=torch.bfloat16),
             make_batch(2),
         )
@@ -77,7 +78,7 @@ def test_qwen_uniform_sample_counts_accepts_supported_qwen_vocab_sizes(
 
 def test_qwen_uniform_sample_counts_grows_and_changes_dtype(monkeypatch) -> None:
     install_test_gates(monkeypatch)
-    sampler = SimpleNamespace(_musa_qwen_family=True)
+    sampler = qwen_sampler()
     logits = torch.empty((4, 151936), dtype=torch.bfloat16)
     first = sample_counts.select_qwen_uniform_sample_counts(
         sampler, logits, make_batch()
@@ -118,7 +119,7 @@ def test_qwen_uniform_sample_counts_bound_hook(monkeypatch) -> None:
         raising=False,
     )
     sampler = sample_counts.Sampler.__new__(sample_counts.Sampler)
-    sampler._musa_qwen_family = True
+    sampler._musa_optimization_contract = qwen_sampler()._musa_optimization_contract
     logits = torch.empty((4, 151936), dtype=torch.bfloat16)
 
     counts = sampler._musa_select_num_sampled_and_rejected(logits, make_batch())
@@ -153,7 +154,7 @@ def test_qwen_uniform_sample_counts_fails_closed(monkeypatch) -> None:
     for candidate_logits, batch in cases:
         assert (
             sample_counts.select_qwen_uniform_sample_counts(
-                SimpleNamespace(_musa_qwen_family=True), candidate_logits, batch
+                qwen_sampler(), candidate_logits, batch
             )
             is None
         )
@@ -163,7 +164,7 @@ def test_qwen_uniform_sample_counts_rejects_non_qwen_trait(monkeypatch) -> None:
     logits = torch.empty((4, 151936), dtype=torch.bfloat16)
     assert (
         sample_counts.select_qwen_uniform_sample_counts(
-            SimpleNamespace(_musa_qwen_family=False), logits, make_batch()
+            qwen_sampler(enabled=False), logits, make_batch()
         )
         is None
     )
@@ -177,9 +178,7 @@ def test_qwen_uniform_sample_counts_rejects_unsupported_count_dtype(
     batch.seq_lens = batch.seq_lens.to(torch.float32)
     logits = torch.empty((2, 151936), dtype=torch.bfloat16)
     assert (
-        sample_counts.select_qwen_uniform_sample_counts(
-            SimpleNamespace(_musa_qwen_family=True), logits, batch
-        )
+        sample_counts.select_qwen_uniform_sample_counts(qwen_sampler(), logits, batch)
         is None
     )
 
@@ -201,7 +200,7 @@ def test_qwen_async_output_patch_is_tag_gated() -> None:
 def test_qwen_uniform_count_host_tag_is_automatic(monkeypatch) -> None:
     install_test_gates(monkeypatch)
     output = sample_counts.select_qwen_uniform_sample_counts(
-        SimpleNamespace(_musa_qwen_family=True),
+        qwen_sampler(),
         torch.empty((2, 151936), dtype=torch.bfloat16),
         make_batch(2),
     )

--- a/tests/test_qwen_unit_temperature_source.py
+++ b/tests/test_qwen_unit_temperature_source.py
@@ -24,25 +24,16 @@ def test_qwen_unit_temperature_metadata_gate_is_fail_closed() -> None:
     assert "temperature_cpu == np.float32(1.0)" in source
     assert "VLLM_MUSA_QWEN_SKIP_UNIT_TEMPERATURE" not in source
     assert "uniform_temperature=uniform_temperature" in source
-    assert "current_platform.is_musa()" in source
-    assert "not self.is_pooling_model" in source
-    assert "self.speculative_config is None" in source
-    for architecture in (
-        "Qwen2ForCausalLM",
-        "Qwen2MoeForCausalLM",
-        "Qwen3ForCausalLM",
-        "Qwen3MoeForCausalLM",
-        "Qwen3_5ForConditionalGeneration",
-        "Qwen3_5MoeForConditionalGeneration",
-    ):
-        assert architecture in source
+    assert "resolve_optimization_contract" in source
+    assert "QWEN_LEGACY_SAMPLING" in source
 
 
 def test_qwen_unit_temperature_sampler_keeps_original_fallback() -> None:
     source = SAMPLER.read_text()
 
     assert "def _can_skip_legacy_qwen_unit_temperature" in source
-    assert 'getattr(sampler, "_musa_qwen_skip_unit_temperature", False)' in source
+    assert "prefers_optimization" in source
+    assert "QWEN_LEGACY_SAMPLING" in source
     assert 'getattr(sampling_metadata, "all_random", False)' in source
     assert "_is_qwen_sampler_vocab(logits)" in source
     assert 'sampling_metadata, "uniform_temperature", None' in source

--- a/tests/test_rms_deepgemm_fusion.py
+++ b/tests/test_rms_deepgemm_fusion.py
@@ -149,8 +149,8 @@ def test_default_auto_scope_is_evaluated_per_config(
     validated = object()
     other = object()
     monkeypatch.setattr(
-        "vllm_musa.platform._is_validated_qwen3_8b_fp8_single_gpu",
-        lambda config: config is validated,
+        "vllm_musa.optimization_contract.policy.prefers_feature",
+        lambda config, _feature: config is validated,
     )
 
     assert _rms_deepgemm_fusion_requested(validated)

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -434,6 +434,57 @@ def test_qwen_legacy_unfiltered_gumbel_rejects_non_qwen_trait(monkeypatch) -> No
     )
 
 
+def test_qwen_sharded_logits_postcondition_recomputes_full_logits(monkeypatch) -> None:
+    rows = 32
+    hidden_states = torch.empty((rows, 2048), dtype=torch.bfloat16)
+    local_logits = torch.empty((rows, 10), dtype=torch.bfloat16)
+    full_logits = torch.empty((rows, 248320), dtype=torch.bfloat16)
+    processor = SimpleNamespace(
+        org_vocab_size=248320,
+        scale=1.0,
+        soft_cap=None,
+        use_all_gather=True,
+        _musa_skip_tp_gather=False,
+    )
+    calls = []
+
+    class FakeModel:
+        def compute_logits(self, _hidden_states):
+            calls.append(processor._musa_skip_tp_gather)
+            return local_logits if len(calls) == 1 else full_logits
+
+    fake_sampler = SimpleNamespace(
+        logprobs_mode="raw_logprobs",
+        use_fp64_gumbel=False,
+    )
+    monkeypatch.setattr(
+        sampler,
+        "can_use_qwen_legacy_unfiltered_metadata",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(sampler, "prefers_optimization", lambda *args: True)
+    monkeypatch.setattr(sampler, "get_pp_group", lambda: SimpleNamespace(world_size=1))
+    monkeypatch.setattr(sampler, "_musa_jit_pair_gather_available", lambda: True)
+    monkeypatch.setattr(
+        sampler, "_find_logits_processor", lambda _model: (processor, None)
+    )
+    monkeypatch.setattr(sampler, "get_tensor_model_parallel_world_size", lambda: 4)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+
+    logits, used_sharded = sampler.musa_compute_logits_if_eligible(
+        FakeModel(),
+        hidden_states,
+        SimpleNamespace(),
+        fake_sampler,
+    )
+
+    assert logits is full_logits
+    assert not used_sharded
+    assert calls == [True, False]
+    assert processor._musa_skip_tp_gather is False
+    assert fake_sampler._musa_qwen_sharded_logits is False
+
+
 def _can_use_qwen_legacy_gumbel(*args, **kwargs) -> bool:
     return sampler.can_use_qwen_legacy_gumbel(*args, **kwargs, is_qwen_family=True)
 
@@ -540,6 +591,26 @@ def test_qwen_legacy_gumbel_accepts_unfiltered_seeded_rows(monkeypatch) -> None:
     assert [generator.get_offset() for generator in metadata.generators.values()] == [
         68
     ] * rows
+
+
+def test_qwen_legacy_gumbel_rejects_partial_unfiltered_generators(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(sampler.current_platform, "is_musa", lambda: True)
+    monkeypatch.setattr(sampler, "is_musa_tensor", lambda _tensor: True)
+    rows = 16
+    logits = torch.randn((rows, 248320))
+    metadata = _legacy_gumbel_metadata(rows, top_k=None)
+    metadata.generators = {0: metadata.generators[0]}
+    metadata.generators[0].set_offset(64)
+
+    assert not _can_use_qwen_legacy_gumbel(
+        logits,
+        metadata,
+        "raw_logprobs",
+        None,
+        False,
+    )
 
 
 def test_qwen_legacy_gumbel_rejects_small_unfiltered_batches(monkeypatch) -> None:

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -18,7 +18,7 @@ import torch
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.worker.gpu_input_batch import InputBatch
 
-from qwen_contract_test_utils import qwen_sampler
+from tests.qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.sample import topk_topp_sampler as sampler
 
 requires_musa = pytest.mark.skipif(

--- a/tests/test_sampler_cpu_state_fast_paths.py
+++ b/tests/test_sampler_cpu_state_fast_paths.py
@@ -18,6 +18,7 @@ import torch
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.worker.gpu_input_batch import InputBatch
 
+from qwen_contract_test_utils import qwen_sampler
 from vllm_musa.v1.sample import topk_topp_sampler as sampler
 
 requires_musa = pytest.mark.skipif(
@@ -71,7 +72,7 @@ def test_uniform_sampler_metadata_patch_is_active_and_qwen_gated() -> None:
 
 
 def test_legacy_qwen_unit_temperature_skip_is_exact_and_vocab_gated() -> None:
-    enabled_sampler = SimpleNamespace(_musa_qwen_skip_unit_temperature=True)
+    enabled_sampler = qwen_sampler()
     metadata = SimpleNamespace(all_random=True, uniform_temperature=1.0)
     assert sampler._can_skip_legacy_qwen_unit_temperature(
         enabled_sampler, torch.empty((4, 248320)), metadata
@@ -98,7 +99,7 @@ def test_legacy_qwen_unit_temperature_skip_is_exact_and_vocab_gated() -> None:
     )
     metadata.all_random = True
     assert not sampler._can_skip_legacy_qwen_unit_temperature(
-        SimpleNamespace(_musa_qwen_skip_unit_temperature=False),
+        qwen_sampler(enabled=False),
         torch.empty((4, 248320)),
         metadata,
     )
@@ -120,7 +121,7 @@ def test_legacy_sample_skips_only_cpu_proven_qwen_unit_temperature(
             forward=SimpleNamespace(__name__="forward_native")
         ),
         use_fp64_gumbel=False,
-        _musa_qwen_skip_unit_temperature=True,
+        _musa_optimization_contract=qwen_sampler()._musa_optimization_contract,
     )
     metadata = SimpleNamespace(
         all_greedy=False,
@@ -150,7 +151,9 @@ def test_legacy_sample_skips_only_cpu_proven_qwen_unit_temperature(
     sampler._sample(fake_sampler, torch.empty((4, 32000)), metadata)
     assert len(temperature_calls) == 2
 
-    fake_sampler._musa_qwen_skip_unit_temperature = False
+    fake_sampler._musa_optimization_contract = qwen_sampler(
+        enabled=False
+    )._musa_optimization_contract
     sampler._sample(fake_sampler, torch.empty((4, 248320)), metadata)
     assert len(temperature_calls) == 3
 
@@ -190,7 +193,9 @@ def _gumbel_gate_sampler(
         num_speculative_tokens=num_speculative_tokens,
         use_fp64_gumbel=use_fp64_gumbel,
         logprobs_mode=logprobs_mode,
-        _musa_qwen_family=is_qwen_family,
+        _musa_optimization_contract=qwen_sampler(
+            enabled=is_qwen_family
+        )._musa_optimization_contract,
     )
 
 
@@ -210,7 +215,9 @@ def _unfiltered_gumbel_gate_sampler(
         num_speculative_tokens=1,
         use_fp64_gumbel=False,
         logprobs_mode="raw_logprobs",
-        _musa_qwen_family=is_qwen_family,
+        _musa_optimization_contract=qwen_sampler(
+            enabled=is_qwen_family
+        )._musa_optimization_contract,
         logit_bias_state=SimpleNamespace(use_logit_bias=np.zeros(rows, dtype=np.bool_)),
         penalties_state=SimpleNamespace(use_penalty=np.zeros(rows, dtype=np.bool_)),
         bad_words_state=SimpleNamespace(
@@ -1200,7 +1207,8 @@ def test_seeded_large_uniform_top_k_top_p_uses_cpu_scalar(monkeypatch) -> None:
         apply_min_p=lambda *_args: None,
     )
     fake_sampler = SimpleNamespace(
-        sampling_states=sampling_states, _musa_qwen_family=True
+        sampling_states=sampling_states,
+        _musa_optimization_contract=qwen_sampler()._musa_optimization_contract,
     )
     mapping = torch.arange(rows, dtype=torch.int64)
     mapping_np = np.arange(rows, dtype=np.int64)
@@ -1235,7 +1243,8 @@ def test_seeded_small_batch_qwen_vocab_uses_cpu_scalar(monkeypatch) -> None:
         apply_min_p=lambda *_args: None,
     )
     fake_sampler = SimpleNamespace(
-        sampling_states=sampling_states, _musa_qwen_family=True
+        sampling_states=sampling_states,
+        _musa_optimization_contract=qwen_sampler()._musa_optimization_contract,
     )
     mapping = torch.arange(rows, dtype=torch.int64)
     mapping_np = np.arange(rows, dtype=np.int64)
@@ -1302,7 +1311,8 @@ def test_non_qwen_vocab_keeps_tensor_top_k_path(monkeypatch) -> None:
         apply_min_p=lambda *_args: None,
     )
     fake_sampler = SimpleNamespace(
-        sampling_states=sampling_states, _musa_qwen_family=True
+        sampling_states=sampling_states,
+        _musa_optimization_contract=qwen_sampler()._musa_optimization_contract,
     )
     mapping = torch.arange(rows, dtype=torch.int64)
     mapping_np = np.arange(rows, dtype=np.int64)

--- a/tests/test_silu_deepgemm_fusion.py
+++ b/tests/test_silu_deepgemm_fusion.py
@@ -145,12 +145,12 @@ def _validated_qwen3_config(**overrides):
     ],
 )
 def test_validated_qwen3_8b_auto_scope(overrides) -> None:
-    from vllm_musa.platform import _is_validated_qwen3_8b_fp8_single_gpu
+    from vllm_musa.optimization_contract import policy
+    from vllm_musa.optimization_contract.types import OptimizationFeature
 
-    assert _is_validated_qwen3_8b_fp8_single_gpu(_validated_qwen3_config())
-    assert not _is_validated_qwen3_8b_fp8_single_gpu(
-        _validated_qwen3_config(**overrides)
-    )
+    feature = OptimizationFeature.QWEN3_DENSE_FP8_POST_GRAD_FUSIONS
+    assert policy.prefers_feature(_validated_qwen3_config(), feature)
+    assert not policy.prefers_feature(_validated_qwen3_config(**overrides), feature)
 
 
 def test_default_auto_scope_is_evaluated_per_config() -> None:

--- a/tests/test_silu_deepgemm_fusion_source.py
+++ b/tests/test_silu_deepgemm_fusion_source.py
@@ -64,14 +64,23 @@ def test_pass_manager_uses_independent_standard_fusion_flags():
     assert "self.pass_config.fuse_act_quant" not in rms_block
 
 
-def test_platform_auto_enablement_is_limited_to_the_validated_scope():
-    source = (ROOT / "vllm_musa" / "platform.py").read_text()
+def test_contract_auto_enablement_is_limited_to_the_validated_scope():
+    platform_source = (ROOT / "vllm_musa" / "platform.py").read_text()
+    qwen_source = (ROOT / "vllm_musa" / "optimization_contract" / "qwen.py").read_text()
+    policy_source = (
+        ROOT / "vllm_musa" / "optimization_contract" / "policy.py"
+    ).read_text()
 
-    assert "def _is_validated_qwen3_8b_fp8_single_gpu(" in source
-    assert 'tuple(architectures or ()) == ("Qwen3ForCausalLM",)' in source
-    assert 'getattr(hf_text_config, "hidden_size", None) == 4096' in source
-    assert 'getattr(hf_text_config, "intermediate_size", None) == 12288' in source
-    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION" not in source
+    assert "def _is_validated_qwen3_8b_fp8_single_gpu(" not in platform_source
+    assert "def _is_qwen2_rope_kv_fusion_config(" not in platform_source
+    assert "def _is_qwen3_qk_rope_kv_fusion_config(" not in platform_source
+    assert "def _has_routed_experts(" not in platform_source
+    assert "def _deepseek_v4_flashmla_sparse_block_size(" not in platform_source
+    assert "def prefers_feature(" in policy_source
+    assert "def deepseek_v4_flashmla_sparse_page_size(" in policy_source
+    assert "== (4096, 12288, 36)" in qwen_source
+    assert "model.hidden_size == 2048" in qwen_source
+    assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION" not in platform_source
 
     environ_source = (ROOT / "vllm_musa" / "utils" / "environ.py").read_text()
     assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION" not in environ_source
@@ -82,7 +91,8 @@ def test_platform_auto_enablement_is_limited_to_the_validated_scope():
     assert "def _silu_deepgemm_fusion_requested(" in pass_manager_source
     assert "VLLM_MUSA_SILU_DEEPGEMM_FUSION" not in pass_manager_source
     assert "VLLM_MUSA_CUSTOM_OP_USE_NATIVE" not in pass_manager_source
-    assert "_is_validated_qwen3_8b_fp8_single_gpu(config)" in pass_manager_source
+    assert "policy.prefers_feature(" in pass_manager_source
+    assert "QWEN3_DENSE_FP8_POST_GRAD_FUSIONS" in pass_manager_source
     assert "_has_validated_musa_device_capability()" in pass_manager_source
     assert "torch.musa.current_device()" in pass_manager_source
     assert "torch.musa.get_device_capability(device_id)" in pass_manager_source

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -142,12 +142,14 @@ def musa_fused_add_rms_norm(
     residual: torch.Tensor,
     weight: torch.Tensor,
     eps: float,
+    block_x: int = 0,
 ) -> None:
     return torch.ops._C_musa_ops.musa_fused_add_rms_norm(
         input,
         residual,
         weight,
         eps,
+        block_x,
     )
 
 

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -31,6 +31,8 @@ def musa_fused_gemv_moe(
     topk: int,
     use_int4_w4a16: bool,
     use_swigelu: bool,
+    block_n: int = 0,
+    block_k: int = 0,
 ) -> None:
     return torch.ops._C_musa_ops.musa_fused_gemv_moe(
         A,
@@ -44,6 +46,8 @@ def musa_fused_gemv_moe(
         topk,
         use_int4_w4a16,
         use_swigelu,
+        block_n,
+        block_k,
     )
 
 

--- a/vllm_musa/compilation/passes/pass_manager.py
+++ b/vllm_musa/compilation/passes/pass_manager.py
@@ -39,15 +39,21 @@ def _is_dense_model(config: VllmConfig) -> bool:
 
 
 def _silu_deepgemm_fusion_requested(config: VllmConfig) -> bool:
-    from vllm_musa.platform import _is_validated_qwen3_8b_fp8_single_gpu
+    from vllm_musa.optimization_contract import policy
+    from vllm_musa.optimization_contract.types import OptimizationFeature
 
-    return _is_validated_qwen3_8b_fp8_single_gpu(config)
+    return policy.prefers_feature(
+        config, OptimizationFeature.QWEN3_DENSE_FP8_POST_GRAD_FUSIONS
+    )
 
 
 def _rms_deepgemm_fusion_requested(config: VllmConfig) -> bool:
-    from vllm_musa.platform import _is_validated_qwen3_8b_fp8_single_gpu
+    from vllm_musa.optimization_contract import policy
+    from vllm_musa.optimization_contract.types import OptimizationFeature
 
-    return _is_validated_qwen3_8b_fp8_single_gpu(config)
+    return policy.prefers_feature(
+        config, OptimizationFeature.QWEN3_DENSE_FP8_POST_GRAD_FUSIONS
+    )
 
 
 class MusaPostGradPassManager(PostGradPassManager):

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -12,6 +12,11 @@ from vllm.logger import init_logger
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_musa.jit_kernel.csrc import allreduce as jit_ar
+from vllm_musa.optimization_contract import (
+    ModelFamily,
+    OptimizationFeature,
+    resolve_optimization_contract,
+)
 from vllm_musa.utils.environ import envs
 
 logger = init_logger(__name__)
@@ -35,18 +40,11 @@ def _use_graph_registered_inputs_for_current_model() -> bool:
     except (ImportError, RuntimeError):
         return True
 
-    model_config = getattr(vllm_config, "model_config", None)
-    if model_config is None:
-        return True
-
-    hf_config = getattr(model_config, "hf_config", None)
-    architectures = getattr(model_config, "architectures", None)
-    if architectures is None and hf_config is not None:
-        architectures = getattr(hf_config, "architectures", None)
-    is_deepseek_v4 = getattr(hf_config, "model_type", None) == "deepseek_v4" or any(
-        "DeepseekV4" in str(arch) for arch in architectures or ()
-    )
-    if not is_deepseek_v4:
+    contract = resolve_optimization_contract(vllm_config)
+    feature = OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD
+    if contract.model.family is not ModelFamily.DEEPSEEK_V4 or not contract.supports(
+        feature
+    ):
         return True
 
     compilation_config = getattr(vllm_config, "compilation_config", None)

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -42,10 +42,10 @@ def _use_graph_registered_inputs_for_current_model() -> bool:
 
     contract = resolve_optimization_contract(vllm_config)
     feature = OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD
-    if contract.model.family is not ModelFamily.DEEPSEEK_V4 or not contract.supports(
-        feature
-    ):
+    if contract.model.family is not ModelFamily.DEEPSEEK_V4:
         return True
+    if not contract.supports(feature):
+        return False
 
     compilation_config = getattr(vllm_config, "compilation_config", None)
     capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None)

--- a/vllm_musa/jit_kernel/tilelang/causal_conv1d.py
+++ b/vllm_musa/jit_kernel/tilelang/causal_conv1d.py
@@ -1210,6 +1210,7 @@ def _causal_conv1d_fwd_impl(
     cache_index_mapping: torch.Tensor | None = None,
     activation: str | bool | None = "silu",
     pad_slot_id: int = PAD_SLOT_ID,
+    allow_width4_prefill_split: bool = False,
 ) -> torch.Tensor:
     if isinstance(activation, bool) and activation:
         activation = "silu"
@@ -1320,7 +1321,7 @@ def _causal_conv1d_fwd_impl(
         )
         return out
 
-    if _should_use_width4_prefill_split(
+    if allow_width4_prefill_split and _should_use_width4_prefill_split(
         width=width,
         dim=dim,
         dtype=x.dtype,
@@ -1532,6 +1533,7 @@ def causal_conv1d_fwd(
     activation: str | bool | None = "silu",
     pad_slot_id: int = PAD_SLOT_ID,
     cache_index_mapping: torch.Tensor | None = None,
+    allow_width4_prefill_split: bool = False,
 ) -> torch.Tensor:
     if isinstance(seq_lens_cpu, torch.Tensor) and seq_lens_cpu.device.type != "cpu":
         # Backward-compatible positional form used by the generic mamba wrapper:
@@ -1562,6 +1564,7 @@ def causal_conv1d_fwd(
         cache_index_mapping=cache_index_mapping,
         activation=activation,
         pad_slot_id=pad_slot_id,
+        allow_width4_prefill_split=allow_width4_prefill_split,
     )
 
 
@@ -1577,6 +1580,7 @@ def causal_conv1d_fn(
     activation: str | bool | None = "silu",
     pad_slot_id: int = PAD_SLOT_ID,
     cache_index_mapping: torch.Tensor | None = None,
+    allow_width4_prefill_split: bool = False,
     **_: object,
 ) -> torch.Tensor:
     return causal_conv1d_fwd(
@@ -1591,6 +1595,7 @@ def causal_conv1d_fn(
         cache_index_mapping=cache_index_mapping,
         activation=activation,
         pad_slot_id=pad_slot_id,
+        allow_width4_prefill_split=allow_width4_prefill_split,
     )
 
 
@@ -1606,6 +1611,7 @@ def musa_tilelang_causal_conv1d_fn(
     pad_slot_id=PAD_SLOT_ID,
     cache_index_mapping=None,
     metadata=None,
+    allow_width4_prefill_split=False,
     **_,
 ):
     """Drop-in for vllm Triton causal_conv1d_fn (prefill). Synthesizes
@@ -1630,6 +1636,7 @@ def musa_tilelang_causal_conv1d_fn(
         activation=activation,
         pad_slot_id=pad_slot_id,
         cache_index_mapping=cache_index_mapping,
+        allow_width4_prefill_split=allow_width4_prefill_split,
     )
     return out.to(orig_dtype)
 

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 
 from vllm_musa import _custom_ops as musa_ops
+from vllm_musa.jit_kernel.csrc.moe import maybe_fast_moe_sum
 from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (
     MusaFusedMoeBackend,
     MusaFusedMoeShape,
@@ -35,7 +36,7 @@ from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (
     select_fused_moe_backend,
     thresholds_for_shape,
 )
-from vllm_musa.jit_kernel.csrc.moe import maybe_fast_moe_sum
+from vllm_musa.optimization_contract import matches_qwen35_moe_bf16_prefill_layer
 
 logger = init_logger(__name__)
 
@@ -84,6 +85,8 @@ def _env_flag_disabled(name: str) -> bool:
 
 
 _MOE_SHAPE_INVENTORY_ENABLED = _env_flag_enabled(_MOE_SHAPE_INVENTORY_ENV)
+
+
 def _env_int(name: str, default: int) -> int:
     try:
         return int(os.environ.get(name, default))
@@ -546,20 +549,14 @@ def _is_calibrated_qwen_moe_bf16_prefill_shape(
     global_num_experts: int | None,
 ) -> bool:
     """Match the TP4 Qwen3.5/3.6-35B-A3B BF16 prefill shape."""
-    return (
-        global_num_experts == 256
-        and hidden_states.ndim == 2
-        and hidden_states.dtype == torch.bfloat16
-        and w1.dtype == torch.bfloat16
-        and w2.dtype == torch.bfloat16
-        and hidden_states.shape[0] >= _DEEPGEMM_BF16_PREFILL_MIN_TOKENS
-        and hidden_states.shape[1] == 2048
-        and w1.shape == (256, 256, 2048)
-        and w2.shape == (256, 2048, 128)
-        and topk_weights.ndim == 2
-        and topk_ids.ndim == 2
-        and topk_weights.shape == topk_ids.shape
-        and topk_ids.shape[1] == 8
+    return matches_qwen35_moe_bf16_prefill_layer(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        global_num_experts,
+        min_tokens=_DEEPGEMM_BF16_PREFILL_MIN_TOKENS,
     )
 
 
@@ -946,9 +943,7 @@ def _moe_deepgemm_bf16_prefill_impl(
         (src2dst_numel + E * (block_m - 1) + block_m - 1) // block_m
     ) * block_m
 
-    hidden_perm = torch.empty(
-        (all_tokens, K), device=device, dtype=hidden_states.dtype
-    )
+    hidden_perm = torch.empty((all_tokens, K), device=device, dtype=hidden_states.dtype)
     m_indices = torch.empty(all_tokens, device=device, dtype=torch.int32)
     src2dst = torch.empty(src2dst_numel, device=device, dtype=torch.int32)
     topk_ids_for_combine = torch.empty_like(topk_ids)
@@ -969,9 +964,7 @@ def _moe_deepgemm_bf16_prefill_impl(
     )
 
     with mk_alignment_scope(block_m):
-        mm1_out = torch.empty(
-            (all_tokens, N), device=device, dtype=hidden_states.dtype
-        )
+        mm1_out = torch.empty((all_tokens, N), device=device, dtype=hidden_states.dtype)
         deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
             hidden_perm,
             w1,
@@ -985,9 +978,7 @@ def _moe_deepgemm_bf16_prefill_impl(
         )
         torch.ops._C.silu_and_mul(act_out, mm1_out)
 
-        mm2_out = torch.empty(
-            (all_tokens, K), device=device, dtype=hidden_states.dtype
-        )
+        mm2_out = torch.empty((all_tokens, K), device=device, dtype=hidden_states.dtype)
         deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
             act_out,
             w2,

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -1366,6 +1366,22 @@ def _musa_fused_moe_shape(
 ) -> MusaFusedMoeShape:
     block_n = block_shape[0] if block_shape else 0
     block_k = block_shape[1] if block_shape and len(block_shape) > 1 else 0
+    gemv_block = os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK")
+    if gemv_block is None:
+        # DeepSeek-V4 Flash TP8 has a unique per-rank routed-expert shape.
+        # Keep this launch choice op-local: the generic env remains an explicit
+        # diagnostic override, while the normal path no longer receives a
+        # process-global model-derived default from platform.py.
+        is_deepseek_v4_flash_tp8_shape = (
+            w1.shape[0] == 256
+            and w1.shape[1] == 512
+            and w2.shape[2] == 256
+            and hidden_states.shape[1] == 4096
+            and topk_ids.shape[1] == 6
+            and block_n == 128
+            and block_k == 128
+        )
+        gemv_block = "16x8" if is_deepseek_v4_flash_tp8_shape else "auto"
     return MusaFusedMoeShape(
         device_capability=device_capability,
         multiprocessor_count=multiprocessor_count,
@@ -1383,7 +1399,7 @@ def _musa_fused_moe_shape(
         scale_dtype=str(w1_scale.dtype) if w1_scale is not None else "none",
         w1_scale_shape=tuple(w1_scale.shape) if w1_scale is not None else (),
         w2_scale_shape=tuple(w2_scale.shape) if w2_scale is not None else (),
-        gemv_block=os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK", "auto"),
+        gemv_block=gemv_block,
         graph_mode="capture" if stream_is_capturing else "eager",
     )
 

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -66,6 +66,7 @@ _DEEPGEMM_BF16_PREFILL_MIN_TOKENS = 1024
 _DEEPGEMM_BF16_PREFILL_WARNED = False
 _MUSA_GROUPED_GEMM_AVAILABLE = True
 _MUSA_FUSED_MOE_REQUESTED_BACKEND = parse_dispatch_backend()
+_GEMV_MOE_BLOCK_ENV = "VLLM_MUSA_GEMV_MOE_BLOCK"
 
 
 def _env_flag_enabled(name: str) -> bool:
@@ -92,6 +93,25 @@ def _env_int(name: str, default: int) -> int:
         return int(os.environ.get(name, default))
     except ValueError:
         return default
+
+
+def _requested_gemv_block(shape: MusaFusedMoeShape | None) -> tuple[int, int]:
+    """Return a graph-static tile request for a contract-selected GEMV shape.
+
+    The legacy environment override remains owned by the C++ op.  Passing
+    zeroes here lets that override (and the one-token DeepSeek-V4 split-tile
+    rule) retain their existing precedence.  Only a selector produced by the
+    Python policy, with no explicit environment override, is forwarded.
+    """
+
+    if shape is None or os.environ.get(_GEMV_MOE_BLOCK_ENV) is not None:
+        return 0, 0
+    # The only contract-backed scalar today is the DeepSeek-V4 TP8 profile.
+    # Keep unknown policy labels on the C++ heuristic until they have their
+    # own kernel evidence.
+    if shape.gemv_block != "16x8":
+        return 0, 0
+    return 16, 8
 
 
 def _tensors_share_device(
@@ -1477,6 +1497,7 @@ def fused_experts_impl(
     *,
     inplace: bool = False,
     _allow_deepgemm_prefill: bool = True,
+    _gemv_block: tuple[int, int] = (0, 0),
 ) -> torch.Tensor:
     # Check constraints.
     if use_int4_w4a16:
@@ -1636,6 +1657,7 @@ def fused_experts_impl(
         "Triton MoE JSON config lookup.",
         scope="global",
     )
+    gemv_block_n, gemv_block_k = _gemv_block
     CHUNK_SIZE = 16384
     M = min(num_tokens, CHUNK_SIZE)
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
@@ -1670,6 +1692,8 @@ def fused_experts_impl(
             topk_ids.shape[1],
             use_int4_w4a16,
             use_swigelu=True,
+            block_n=gemv_block_n,
+            block_k=gemv_block_k,
         )
         musa_ops.musa_fused_gemv_moe(
             curr_intermediate_cache2,
@@ -1683,6 +1707,8 @@ def fused_experts_impl(
             1,
             use_int4_w4a16,
             use_swigelu=False,
+            block_n=gemv_block_n,
+            block_k=gemv_block_k,
         )
         # ========================== END ====================
         moe_sum_input = curr_intermediate_cache3.view(*curr_intermediate_cache3.size())
@@ -1730,6 +1756,7 @@ def _musa_fused_experts_impl_dispatch(
     backend = MusaFusedMoeBackend.UPSTREAM
     policy = None
     shape = None
+    requested_gemv_block = (0, 0)
 
     # Skip all shape construction and capture queries for non-FP8 callers and
     # for the explicit rollback path. This wrapper sits on every MoE layer.
@@ -1850,6 +1877,8 @@ def _musa_fused_experts_impl_dispatch(
                     requested=_MUSA_FUSED_MOE_REQUESTED_BACKEND,
                     thresholds=policy,
                 )
+                if backend == MusaFusedMoeBackend.GEMV:
+                    requested_gemv_block = _requested_gemv_block(shape)
 
     # Native GEMV records inside ``fused_experts_impl`` after expanding any
     # per-tensor scales.  Record every other dispatcher outcome here so the
@@ -1925,6 +1954,12 @@ def _musa_fused_experts_impl_dispatch(
         if grouped_output is not None:
             return grouped_output
     elif backend == MusaFusedMoeBackend.GEMV:
+        gemv_kwargs = {
+            "inplace": False,
+            "_allow_deepgemm_prefill": False,
+        }
+        if requested_gemv_block != (0, 0):
+            gemv_kwargs["_gemv_block"] = requested_gemv_block
         return fused_experts_impl(
             hidden_states,
             w1,
@@ -1950,8 +1985,7 @@ def _musa_fused_experts_impl_dispatch(
             block_shape,
             w1_bias,
             w2_bias,
-            inplace=False,
-            _allow_deepgemm_prefill=False,
+            **gemv_kwargs,
         )
 
     prefer_upstream_qwen_prefill = (

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -98,7 +98,7 @@ def _env_int(name: str, default: int) -> int:
 def _requested_gemv_block(shape: MusaFusedMoeShape | None) -> tuple[int, int]:
     """Return a graph-static tile request for a contract-selected GEMV shape.
 
-    The legacy environment override remains owned by the C++ op.  Passing
+    The explicit environment override remains owned by the C++ op. Passing
     zeroes here lets that override (and the one-token DeepSeek-V4 split-tile
     rule) retain their existing precedence.  Only a selector produced by the
     Python policy, with no explicit environment override, is forwarded.
@@ -106,9 +106,8 @@ def _requested_gemv_block(shape: MusaFusedMoeShape | None) -> tuple[int, int]:
 
     if shape is None or os.environ.get(_GEMV_MOE_BLOCK_ENV) is not None:
         return 0, 0
-    # The only contract-backed scalar today is the DeepSeek-V4 TP8 profile.
-    # Keep unknown policy labels on the C++ heuristic until they have their
-    # own kernel evidence.
+    # Only the DeepSeek-V4 TP8 profile has end-to-end evidence for this scalar.
+    # Unknown policy labels stay on the C++ heuristic.
     if shape.gemv_block != "16x8":
         return 0, 0
     return 16, 8
@@ -1388,10 +1387,9 @@ def _musa_fused_moe_shape(
     block_k = block_shape[1] if block_shape and len(block_shape) > 1 else 0
     gemv_block = os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK")
     if gemv_block is None:
-        # DeepSeek-V4 Flash TP8 has a unique per-rank routed-expert shape.
-        # Keep this launch choice op-local: the generic env remains an explicit
-        # diagnostic override, while the normal path no longer receives a
-        # process-global model-derived default from platform.py.
+        # DeepSeek-V4 Flash TP8 has a unique per-rank routed-expert shape. The
+        # explicit generic override wins in C++; otherwise this label forwards
+        # the validated 16x8 tile for multi-token GEMV dispatch.
         is_deepseek_v4_flash_tp8_shape = (
             w1.shape[0] == 256
             and w1.shape[1] == 512

--- a/vllm_musa/model_executor/layers/layernorm.py
+++ b/vllm_musa/model_executor/layers/layernorm.py
@@ -3,9 +3,14 @@
 
 import torch
 import torch.nn as nn
+from vllm.config import get_current_vllm_config_or_none
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm, RMSNormGated
 
 from vllm_musa.jit_kernel.csrc import norm as musa_jit_norm
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    bind_optimization_contract,
+)
 from vllm_musa.utils.environ import envs
 
 
@@ -31,6 +36,17 @@ def _can_use_musa_jit_rmsnorm(
 
 @RMSNorm.register_oot
 class MusaRMSNorm(RMSNorm):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        var_hidden_size: int | None = None,
+        has_weight: bool = True,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__(hidden_size, eps, var_hidden_size, has_weight, dtype)
+        bind_optimization_contract(self, get_current_vllm_config_or_none())
+
     def forward_oot(
         self,
         x: torch.Tensor,
@@ -43,6 +59,36 @@ class MusaRMSNorm(RMSNorm):
             return self.forward_native(x, residual)
 
         if residual is not None:
+            contract = self._musa_optimization_contract
+            weight = self.weight.data
+            if (
+                envs.VLLM_MUSA_FUSED_ADD_RMSNORM.get()
+                and contract.prefers(
+                    OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+                )
+                and x.device.type == "musa"
+                and x.dim() == 2
+                and residual.shape == x.shape
+                and x.shape[1] == 4096
+                and weight.shape == (4096,)
+                and x.dtype == torch.bfloat16
+                and residual.dtype == x.dtype
+                and weight.dtype == x.dtype
+                and x.is_contiguous()
+                and residual.is_contiguous()
+                and weight.is_contiguous()
+            ):
+                from vllm_musa import _custom_ops as musa_ops
+
+                musa_ops.musa_fused_add_rms_norm(
+                    x,
+                    residual,
+                    weight,
+                    self.variance_epsilon,
+                    block_x=256,
+                )
+                return x, residual
+
             # All residual calls use IR. It validates donation and selects the
             # measured JIT kernel, the broad C-extension kernel, or native.
             return self.forward_native(x, residual)

--- a/vllm_musa/model_executor/layers/linear.py
+++ b/vllm_musa/model_executor/layers/linear.py
@@ -6,6 +6,11 @@ from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.model_executor.layers.linear import RowParallelLinear
 from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
 
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    prefers_optimization,
+)
+
 
 def _deepgemm_block_fp8(quant_method) -> bool:
     # MUSA: the DeepGemm block-FP8 kernel writes the GEMM result into a caller
@@ -32,7 +37,10 @@ class MusaRowParallelLinear(RowParallelLinear):
         activation and linear path unchanged.
         """
         fast = (
-            not envs.VLLM_BATCH_INVARIANT
+            prefers_optimization(
+                self,
+                OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8,
+            )
             and self.input_is_parallel
             and _deepgemm_block_fp8(self.quant_method)
             and self.bias is None

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -263,9 +263,9 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
         # whole-pool contiguity copy.
         if ssm_state.dtype == torch.float32:
             try:
-                import os as _os
-
-                _musa_sep = _os.environ.get("VLLM_MUSA_MAMBA_SEPARATE_POOL", "1") == "1"
+                _musa_sep = self._musa_optimization_contract.prefers(
+                    OptimizationFeature.HYBRID_SEPARATE_MAMBA_POOL
+                )
                 # MUSA: write the mate decode output straight into the
                 # preallocated core_attn_out buffer (bf16) to skip a per-layer copy.
                 _out_view = core_attn_out[:num_decode_tokens].view(

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -13,6 +13,11 @@ from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     QwenGatedDeltaNetAttention,
 )
 
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    resolve_optimization_contract,
+)
+
 logger = init_logger(__name__)
 
 _MATE_GDN_PREFILL_HAS_OUTPUT = (
@@ -40,6 +45,16 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
     Keeps upstream construction and the qwen_gdn_attention_core call chain, but
     routes the core recurrent path through MATE kernels when available.
     """
+
+    def __init__(
+        self,
+        config,
+        vllm_config,
+        prefix: str = "",
+        gqa_interleaved_layout: bool = False,
+    ) -> None:
+        super().__init__(config, vllm_config, prefix, gqa_interleaved_layout)
+        self._musa_optimization_contract = resolve_optimization_contract(vllm_config)
 
     def _forward_core(
         self,
@@ -433,9 +448,16 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
             causal_conv1d_update,
         )
 
+        causal_conv1d_kwargs = {}
         try:
             from vllm_musa.jit_kernel.tilelang.causal_conv1d import (
                 musa_tilelang_causal_conv1d_fn as causal_conv1d_fn,
+            )
+
+            causal_conv1d_kwargs["allow_width4_prefill_split"] = (
+                self._musa_optimization_contract.prefers(
+                    OptimizationFeature.QWEN35_GDN_WIDTH4_PREFILL
+                )
             )
         except Exception:
             pass  # MUSA: fall back to Triton causal_conv1d_fn on import failure
@@ -507,6 +529,7 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
             cache_indices=non_spec_state_indices_tensor,
             query_start_loc=non_spec_query_start_loc,
             metadata=attn_metadata,
+            **causal_conv1d_kwargs,
         ).transpose(0, 1)
 
         query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)

--- a/vllm_musa/optimization_contract/__init__.py
+++ b/vllm_musa/optimization_contract/__init__.py
@@ -1,5 +1,9 @@
 from .qwen import matches_qwen35_moe_bf16_prefill_layer
-from .resolver import prefers_optimization, resolve_optimization_contract
+from .resolver import (
+    bind_optimization_contract,
+    prefers_optimization,
+    resolve_optimization_contract,
+)
 from .types import (
     ExecutionSignature,
     ModelFamily,
@@ -16,6 +20,7 @@ __all__ = [
     "ModelSignature",
     "MusaOptimizationContract",
     "OptimizationFeature",
+    "bind_optimization_contract",
     "matches_qwen35_moe_bf16_prefill_layer",
     "prefers_optimization",
     "resolve_optimization_contract",

--- a/vllm_musa/optimization_contract/__init__.py
+++ b/vllm_musa/optimization_contract/__init__.py
@@ -1,5 +1,5 @@
-from .resolver import prefers_optimization, resolve_optimization_contract
 from .qwen import matches_qwen35_moe_bf16_prefill_layer
+from .resolver import prefers_optimization, resolve_optimization_contract
 from .types import (
     ExecutionSignature,
     ModelFamily,

--- a/vllm_musa/optimization_contract/__init__.py
+++ b/vllm_musa/optimization_contract/__init__.py
@@ -1,0 +1,22 @@
+from .resolver import prefers_optimization, resolve_optimization_contract
+from .qwen import matches_qwen35_moe_bf16_prefill_layer
+from .types import (
+    ExecutionSignature,
+    ModelFamily,
+    ModelRole,
+    ModelSignature,
+    MusaOptimizationContract,
+    OptimizationFeature,
+)
+
+__all__ = [
+    "ExecutionSignature",
+    "ModelFamily",
+    "ModelRole",
+    "ModelSignature",
+    "MusaOptimizationContract",
+    "OptimizationFeature",
+    "matches_qwen35_moe_bf16_prefill_layer",
+    "prefers_optimization",
+    "resolve_optimization_contract",
+]

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -57,6 +57,7 @@ def _matches_tp8_reference(execution: ExecutionSignature) -> bool:
         and execution.data_parallel_size == 1
         and execution.decode_context_parallel_size == 1
         and not execution.has_speculative_config
+        and execution.has_quant_config
         and not execution.is_pooling_model
         and execution.cache_dtype == "fp8"
         and execution.max_num_seqs == 1
@@ -81,6 +82,9 @@ def resolve_deepseek_v4_contract(
     supported: set[OptimizationFeature] = set()
     preferred: set[OptimizationFeature] = set()
 
+    if _has_complete_identity(model):
+        supported.add(OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD)
+
     if _matches_flash_base(model):
         supported.update(
             {
@@ -89,7 +93,6 @@ def resolve_deepseek_v4_contract(
                 OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
-                OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD,
             }
         )
         if execution.has_parallel_config:

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -91,12 +91,13 @@ def resolve_deepseek_v4_contract(
                 OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
             }
         )
-        preferred.update(
-            {
-                OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER,
-                OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
-            }
-        )
+        if execution.has_parallel_config:
+            preferred.update(
+                {
+                    OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER,
+                    OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
+                }
+            )
         if _matches_tp8_reference(execution):
             preferred.update(
                 {

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -89,6 +89,7 @@ def resolve_deepseek_v4_contract(
                 OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
+                OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD,
             }
         )
         if execution.has_parallel_config:

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from .types import (
+    ExecutionSignature,
+    ModelFamily,
+    ModelRole,
+    ModelSignature,
+    MusaOptimizationContract,
+    OptimizationFeature,
+)
+
+_DEEPSEEK_V4_ARCHITECTURES = ("DeepseekV4ForCausalLM",)
+_DEEPSEEK_V4_QUANTIZATION = frozenset({"fp8", "deepseek_v4_fp8"})
+
+
+def _has_complete_identity(model: ModelSignature) -> bool:
+    architectures = model.outer_architectures or model.architectures
+    return (
+        architectures == _DEEPSEEK_V4_ARCHITECTURES
+        and model.model_type == "deepseek_v4"
+    )
+
+
+def _matches_flash_base(model: ModelSignature) -> bool:
+    return (
+        _has_complete_identity(model)
+        and model.dtype == "bfloat16"
+        and model.quantization in _DEEPSEEK_V4_QUANTIZATION
+        and model.hidden_size == 4096
+        and model.num_hidden_layers == 43
+        and model.num_attention_heads == 64
+        and model.num_key_value_heads == 1
+        and model.head_dim == 512
+        and model.vocab_size == 129280
+        and model.num_experts == 256
+        and model.num_experts_per_tok == 6
+        and model.num_shared_experts == 1
+        and model.moe_intermediate_size == 2048
+        and model.expert_dtype == "fp8"
+        and model.hidden_act == "silu"
+        and model.swiglu_limit == 10.0
+        and model.quant_block_shape == (128, 128)
+        and model.has_routed_experts is True
+        and model.uses_mla is True
+        and model.index_topk == 512
+        and model.is_hybrid is False
+    )
+
+
+def _matches_tp8_reference(execution: ExecutionSignature) -> bool:
+    return (
+        execution.has_parallel_config
+        and execution.tensor_parallel_size == 8
+        and execution.pipeline_parallel_size == 1
+        and execution.data_parallel_size == 1
+        and execution.decode_context_parallel_size == 1
+        and not execution.has_speculative_config
+        and not execution.is_pooling_model
+        and execution.cache_dtype == "fp8"
+        and execution.max_num_seqs == 1
+        and execution.attention_backend == "flashmla"
+        and execution.compilation_mode == "none"
+        and execution.cudagraph_mode == "full_decode_only"
+    )
+
+
+def resolve_deepseek_v4_contract(
+    model: ModelSignature,
+    execution: ExecutionSignature,
+) -> MusaOptimizationContract | None:
+    architectures = model.outer_architectures or model.architectures
+    if (
+        "DeepseekV4ForCausalLM" not in architectures
+        and model.model_type != "deepseek_v4"
+    ):
+        return None
+
+    model = replace(model, family=ModelFamily.DEEPSEEK_V4, role=ModelRole.TEXT)
+    supported: set[OptimizationFeature] = set()
+    preferred: set[OptimizationFeature] = set()
+
+    if _matches_flash_base(model):
+        supported.update(
+            {
+                OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8,
+                OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER,
+                OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
+                OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
+                OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
+            }
+        )
+        preferred.update(
+            {
+                OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER,
+                OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
+            }
+        )
+        if _matches_tp8_reference(execution):
+            preferred.update(
+                {
+                    OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
+                    OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
+                }
+            )
+            if not execution.batch_invariant_enabled:
+                preferred.add(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+
+    profile = (
+        "deepseek_v4.tp8_flash_base"
+        if _matches_flash_base(model) and _matches_tp8_reference(execution)
+        else "deepseek_v4.unvalidated"
+    )
+    return MusaOptimizationContract(
+        model=model,
+        execution=execution,
+        profile=profile,
+        supported_features=frozenset(supported),
+        preferred_features=frozenset(preferred),
+    )

--- a/vllm_musa/optimization_contract/policy.py
+++ b/vllm_musa/optimization_contract/policy.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract-backed policy queries used by platform consumers.
+
+Model eligibility belongs to the optimization-contract package.  Keeping these
+small queries here prevents the platform module from becoming a registry of
+model-name and shape predicates while preserving the dynamic guards in each
+consumer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .resolver import resolve_optimization_contract
+from .types import OptimizationFeature
+
+
+def prefers_feature(vllm_config: Any, feature: OptimizationFeature) -> bool:
+    """Return whether a config's frozen contract prefers ``feature``."""
+    return resolve_optimization_contract(vllm_config).prefers(feature)
+
+
+def model_has_routed_experts(model_config: Any | None) -> bool:
+    """Return whether a lightweight model config has routed experts.
+
+    The platform no longer owns this predicate; this compatibility query is
+    kept for tests and older consumers while the resolver remains the source
+    of truth for complete ``VllmConfig`` objects.
+    """
+    if model_config is None:
+        return False
+    is_model_moe = getattr(model_config, "is_model_moe", None)
+    if callable(is_model_moe):
+        try:
+            return bool(is_model_moe())
+        except (AttributeError, TypeError, ValueError):
+            return False
+    is_moe = getattr(model_config, "is_moe", None)
+    if is_moe is not None:
+        return bool(is_moe)
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    if hf_text_config is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        hf_text_config = getattr(hf_config, "text_config", hf_config)
+    expert_values = [
+        getattr(hf_text_config, name, None)
+        for name in (
+            "num_experts",
+            "moe_num_experts",
+            "n_routed_experts",
+            "num_local_experts",
+        )
+    ]
+    if any(value is not None for value in expert_values):
+        return any(bool(value) for value in expert_values)
+    architectures = getattr(model_config, "architectures", None)
+    if architectures is None:
+        architectures = getattr(hf_text_config, "architectures", None)
+    return any(
+        "moe" in str(architecture).lower() for architecture in architectures or ()
+    )
+
+
+def deepseek_v4_flashmla_sparse_page_size(vllm_config: Any) -> int:
+    """Return the contract-selected sparse FlashMLA page size."""
+    if prefers_feature(
+        vllm_config,
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
+    ):
+        return 256
+    return 64

--- a/vllm_musa/optimization_contract/providers.py
+++ b/vllm_musa/optimization_contract/providers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from .deepseek_v4 import resolve_deepseek_v4_contract
 from .qwen import resolve_qwen_contract
 from .types import ExecutionSignature, ModelSignature, MusaOptimizationContract
 
@@ -10,6 +11,10 @@ ContractProvider = Callable[
     MusaOptimizationContract | None,
 ]
 
-# Keep provider registration explicit. DeepSeek-V4 will be added here only
-# after its merged policy has an isolated evidence and migration pass.
-CONTRACT_PROVIDERS: tuple[ContractProvider, ...] = (resolve_qwen_contract,)
+# Keep provider registration explicit. Providers must fail closed when their
+# exact family metadata is incomplete so one family cannot enable another's
+# fast paths.
+CONTRACT_PROVIDERS: tuple[ContractProvider, ...] = (
+    resolve_deepseek_v4_contract,
+    resolve_qwen_contract,
+)

--- a/vllm_musa/optimization_contract/providers.py
+++ b/vllm_musa/optimization_contract/providers.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .qwen import resolve_qwen_contract
+from .types import ExecutionSignature, ModelSignature, MusaOptimizationContract
+
+ContractProvider = Callable[
+    [ModelSignature, ExecutionSignature],
+    MusaOptimizationContract | None,
+]
+
+# Keep provider registration explicit. DeepSeek-V4 will be added here only
+# after its merged policy has an isolated evidence and migration pass.
+CONTRACT_PROVIDERS: tuple[ContractProvider, ...] = (resolve_qwen_contract,)

--- a/vllm_musa/optimization_contract/qwen.py
+++ b/vllm_musa/optimization_contract/qwen.py
@@ -36,12 +36,20 @@ QWEN_LEGACY_SAMPLING_ARCHITECTURES = frozenset(
 QWEN_FA3_ARCHITECTURES = frozenset(
     {*QWEN_LEGACY_SAMPLING_ARCHITECTURES, "CosyVoice3Model"}
 )
-_QWEN35_ARCHITECTURES = frozenset(
+_QWEN35_36_ARCHITECTURES = frozenset(
     {
         "Qwen3_5ForConditionalGeneration",
         "Qwen3_5MoeForConditionalGeneration",
         "Qwen3_5ForCausalLM",
         "Qwen3_5MoeForCausalLM",
+    }
+)
+_QWEN35_36_MODEL_TYPES = frozenset(
+    {
+        "qwen3_5",
+        "qwen3_5_text",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
     }
 )
 
@@ -232,12 +240,13 @@ def resolve_qwen_contract(
     if "CosyVoice3Model" in architectures or model.model_type == "cosyvoice3":
         family = ModelFamily.QWEN2
         role = ModelRole.COSYVOICE_TALKER
-    elif architectures & _QWEN35_ARCHITECTURES or model.model_type in {
-        "qwen3_5",
-        "qwen3_5_text",
-        "qwen3_5_moe",
-        "qwen3_5_moe_text",
-    }:
+    # Current Qwen3.6 checkpoints deliberately reuse the Qwen3.5 HF schema:
+    # Qwen3_5[Moe]ForConditionalGeneration with qwen3_5[_moe][_text].
+    # A future Qwen3.6 schema change fails closed until explicitly added.
+    elif (
+        architectures & _QWEN35_36_ARCHITECTURES
+        or model.model_type in _QWEN35_36_MODEL_TYPES
+    ):
         family = ModelFamily.QWEN35_36
         role = ModelRole.TEXT
     elif (

--- a/vllm_musa/optimization_contract/qwen.py
+++ b/vllm_musa/optimization_contract/qwen.py
@@ -287,6 +287,11 @@ def resolve_qwen_contract(
         preferred.add(OptimizationFeature.QWEN35_GDN_WIDTH4_PREFILL)
     if _qwen35_moe_prefill_preferred(model, execution):
         preferred.add(OptimizationFeature.QWEN35_MOE_BF16_PREFILL)
+    if model.family is ModelFamily.QWEN35_36:
+        if model.has_routed_experts is True:
+            preferred.add(OptimizationFeature.QWEN35_SHARED_EXPERT_FOLD)
+        if model.dtype == "bfloat16":
+            preferred.add(OptimizationFeature.QWEN35_INTERLEAVED_MROPE_QK)
 
     if model.vocab_size in (151936, 152064, 248320):
         if OptimizationFeature.QWEN_V2_SAMPLING in preferred:
@@ -307,8 +312,7 @@ def resolve_qwen_contract(
             )
         if (
             OptimizationFeature.QWEN_LEGACY_SAMPLING in preferred
-            and
-            execution.tensor_parallel_size == 4
+            and execution.tensor_parallel_size == 4
             and execution.pipeline_parallel_size == 1
         ):
             preferred.add(OptimizationFeature.QWEN_TP4_SHARDED_GUMBEL)

--- a/vllm_musa/optimization_contract/qwen.py
+++ b/vllm_musa/optimization_contract/qwen.py
@@ -321,11 +321,13 @@ def resolve_qwen_contract(
             preferred.add(OptimizationFeature.QWEN_TP4_SHARDED_GUMBEL)
 
     profile = f"{family.value}.{'moe' if model.has_routed_experts else role.value}"
-    features = frozenset(preferred)
     return MusaOptimizationContract(
         model=model,
         execution=execution,
         profile=profile,
-        supported_features=features,
-        preferred_features=features,
+        # Keep the two sets independent even while the first Qwen rollout
+        # promotes every proven feature automatically. Future providers can
+        # expose a supported-but-not-yet-preferred implementation safely.
+        supported_features=frozenset(preferred),
+        preferred_features=frozenset(preferred),
     )

--- a/vllm_musa/optimization_contract/qwen.py
+++ b/vllm_musa/optimization_contract/qwen.py
@@ -274,7 +274,8 @@ def resolve_qwen_contract(
             execution.has_parallel_config
             and not execution.has_speculative_config
             and _single_device(execution, include_dcp=True)
-            and (execution.max_num_seqs is None or execution.max_num_seqs > 0)
+            and execution.max_num_seqs is not None
+            and execution.max_num_seqs > 0
         ):
             preferred.add(OptimizationFeature.QWEN_FA3_SINGLE_REQUEST_METADATA)
     if _qwen2_rope_kv_preferred(model, execution):

--- a/vllm_musa/optimization_contract/qwen.py
+++ b/vllm_musa/optimization_contract/qwen.py
@@ -66,21 +66,24 @@ def matches_qwen35_moe_bf16_prefill_layer(
     def dtype_name(value) -> str:
         return str(value).lower().removeprefix("torch.")
 
-    return (
-        global_num_experts == 256
-        and hidden_states.ndim == 2
-        and dtype_name(hidden_states.dtype) == "bfloat16"
-        and dtype_name(w1.dtype) == "bfloat16"
-        and dtype_name(w2.dtype) == "bfloat16"
-        and hidden_states.shape[0] >= min_tokens
-        and hidden_states.shape[1] == 2048
-        and tuple(w1.shape) == (256, 256, 2048)
-        and tuple(w2.shape) == (256, 2048, 128)
-        and topk_weights.ndim == 2
-        and topk_ids.ndim == 2
-        and topk_weights.shape == topk_ids.shape
-        and topk_ids.shape[1] == 8
-    )
+    try:
+        return (
+            global_num_experts == 256
+            and hidden_states.ndim == 2
+            and dtype_name(hidden_states.dtype) == "bfloat16"
+            and dtype_name(w1.dtype) == "bfloat16"
+            and dtype_name(w2.dtype) == "bfloat16"
+            and hidden_states.shape[0] >= min_tokens
+            and hidden_states.shape[1] == 2048
+            and tuple(w1.shape) == (256, 256, 2048)
+            and tuple(w2.shape) == (256, 2048, 128)
+            and topk_weights.ndim == 2
+            and topk_ids.ndim == 2
+            and topk_weights.shape == topk_ids.shape
+            and topk_ids.shape[1] == 8
+        )
+    except (AttributeError, IndexError, TypeError, ValueError):
+        return False
 
 
 def _has_architecture(model: ModelSignature, allowed: frozenset[str]) -> bool:

--- a/vllm_musa/optimization_contract/qwen.py
+++ b/vllm_musa/optimization_contract/qwen.py
@@ -198,6 +198,7 @@ def _qwen35_gdn_prefill_preferred(
         and model.dtype == "bfloat16"
         and model.gdn_conv_width == 4
         and model.gdn_conv_dim == 10240
+        and execution.has_parallel_config
         and execution.tensor_parallel_size == 1
     )
 
@@ -214,6 +215,7 @@ def _qwen35_moe_prefill_preferred(
         and model.num_experts == 256
         and model.num_experts_per_tok == 8
         and model.moe_intermediate_size == 512
+        and execution.has_parallel_config
         and execution.tensor_parallel_size == 4
         and execution.pipeline_parallel_size == 1
     )

--- a/vllm_musa/optimization_contract/qwen.py
+++ b/vllm_musa/optimization_contract/qwen.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from .types import (
+    ExecutionSignature,
+    ModelFamily,
+    ModelRole,
+    ModelSignature,
+    MusaOptimizationContract,
+    OptimizationFeature,
+)
+
+QWEN_V2_SAMPLING_ARCHITECTURES = frozenset(
+    {
+        "Qwen2ForCausalLM",
+        "Qwen2MoeForCausalLM",
+        "Qwen3ForCausalLM",
+        "Qwen3MoeForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3_5ForCausalLM",
+        "Qwen3_5MoeForCausalLM",
+    }
+)
+QWEN_LEGACY_SAMPLING_ARCHITECTURES = frozenset(
+    {
+        "Qwen2ForCausalLM",
+        "Qwen2MoeForCausalLM",
+        "Qwen3ForCausalLM",
+        "Qwen3MoeForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    }
+)
+QWEN_FA3_ARCHITECTURES = frozenset(
+    {*QWEN_LEGACY_SAMPLING_ARCHITECTURES, "CosyVoice3Model"}
+)
+_QWEN35_ARCHITECTURES = frozenset(
+    {
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3_5ForCausalLM",
+        "Qwen3_5MoeForCausalLM",
+    }
+)
+
+
+def matches_qwen35_moe_bf16_prefill_layer(
+    hidden_states,
+    w1,
+    w2,
+    topk_weights,
+    topk_ids,
+    global_num_experts: int | None,
+    *,
+    min_tokens: int,
+) -> bool:
+    """Match the layer-bound Qwen3.5/3.6-35B-A3B prefill signature.
+
+    The caller is the generic fused-MoE custom-op boundary, so tensor and
+    layout checks remain here rather than attempting to recover model config
+    from global runtime state on every token.
+    """
+
+    def dtype_name(value) -> str:
+        return str(value).lower().removeprefix("torch.")
+
+    return (
+        global_num_experts == 256
+        and hidden_states.ndim == 2
+        and dtype_name(hidden_states.dtype) == "bfloat16"
+        and dtype_name(w1.dtype) == "bfloat16"
+        and dtype_name(w2.dtype) == "bfloat16"
+        and hidden_states.shape[0] >= min_tokens
+        and hidden_states.shape[1] == 2048
+        and tuple(w1.shape) == (256, 256, 2048)
+        and tuple(w2.shape) == (256, 2048, 128)
+        and topk_weights.ndim == 2
+        and topk_ids.ndim == 2
+        and topk_weights.shape == topk_ids.shape
+        and topk_ids.shape[1] == 8
+    )
+
+
+def _has_architecture(model: ModelSignature, allowed: frozenset[str]) -> bool:
+    architectures = model.outer_architectures or model.architectures
+    return any(architecture in allowed for architecture in architectures)
+
+
+def _single_device(execution: ExecutionSignature, *, include_dcp: bool) -> bool:
+    sizes = (
+        execution.tensor_parallel_size,
+        execution.pipeline_parallel_size,
+        execution.data_parallel_size,
+    )
+    if include_dcp:
+        sizes = (*sizes, execution.decode_context_parallel_size)
+    return all(size == 1 for size in sizes)
+
+
+def _cache_supports_fused_qwen_attention(execution: ExecutionSignature) -> bool:
+    return execution.cache_dtype in (None, "auto", "bfloat16") and (
+        execution.cache_block_size in (None, 64)
+    )
+
+
+def _qwen2_rope_kv_preferred(
+    model: ModelSignature,
+    execution: ExecutionSignature,
+) -> bool:
+    if model.family is not ModelFamily.QWEN2:
+        return False
+    if model.model_type not in ("qwen2", "cosyvoice3"):
+        return False
+    if model.model_type == "qwen2":
+        if model.num_key_value_heads != 2 or model.intermediate_size != 4864:
+            return False
+    elif model.num_key_value_heads not in (None, 2) or model.intermediate_size not in (
+        None,
+        4864,
+    ):
+        return False
+    return (
+        model.hidden_size == 896
+        and model.num_hidden_layers == 24
+        and model.num_attention_heads == 14
+        and model.dtype == "bfloat16"
+        and model.quantization in (None, "none")
+        and not execution.has_quant_config
+        and not execution.has_speculative_config
+        and execution.has_parallel_config
+        and _cache_supports_fused_qwen_attention(execution)
+        and not model.enforce_eager
+        and _single_device(execution, include_dcp=True)
+    )
+
+
+def _qwen3_rope_kv_preferred(
+    model: ModelSignature,
+    execution: ExecutionSignature,
+) -> bool:
+    geometry = (
+        model.hidden_size,
+        model.intermediate_size,
+        model.num_hidden_layers,
+        model.num_attention_heads,
+        model.num_key_value_heads,
+        model.head_dim,
+    )
+    return (
+        model.architectures == ("Qwen3ForCausalLM",)
+        and model.model_type == "qwen3"
+        and geometry
+        in {
+            (1024, 3072, 28, 16, 8, 128),
+            (4096, 12288, 36, 32, 8, 128),
+        }
+        and model.dtype == "bfloat16"
+        and model.quantization in (None, "none")
+        and not execution.has_quant_config
+        and not execution.has_speculative_config
+        and execution.has_parallel_config
+        and _cache_supports_fused_qwen_attention(execution)
+        and not model.enforce_eager
+        and _single_device(execution, include_dcp=True)
+    )
+
+
+def _qwen3_dense_fp8_fusions_preferred(
+    model: ModelSignature,
+    execution: ExecutionSignature,
+) -> bool:
+    return (
+        model.architectures == ("Qwen3ForCausalLM",)
+        and model.model_type == "qwen3"
+        and model.has_routed_experts is False
+        and (
+            model.hidden_size,
+            model.intermediate_size,
+            model.num_hidden_layers,
+        )
+        == (4096, 12288, 36)
+        and model.quantization == "fp8"
+        and model.dtype == "bfloat16"
+        and not execution.has_speculative_config
+        and _single_device(execution, include_dcp=False)
+    )
+
+
+def _qwen35_gdn_prefill_preferred(
+    model: ModelSignature,
+    execution: ExecutionSignature,
+) -> bool:
+    return (
+        model.family is ModelFamily.QWEN35_36
+        and model.has_routed_experts is False
+        and model.dtype == "bfloat16"
+        and model.gdn_conv_width == 4
+        and model.gdn_conv_dim == 10240
+        and execution.tensor_parallel_size == 1
+    )
+
+
+def _qwen35_moe_prefill_preferred(
+    model: ModelSignature,
+    execution: ExecutionSignature,
+) -> bool:
+    return (
+        model.family is ModelFamily.QWEN35_36
+        and model.has_routed_experts is True
+        and model.dtype == "bfloat16"
+        and model.hidden_size == 2048
+        and model.num_experts == 256
+        and model.num_experts_per_tok == 8
+        and model.moe_intermediate_size == 512
+        and execution.tensor_parallel_size == 4
+        and execution.pipeline_parallel_size == 1
+    )
+
+
+def resolve_qwen_contract(
+    model: ModelSignature,
+    execution: ExecutionSignature,
+) -> MusaOptimizationContract | None:
+    architectures = set(model.outer_architectures or model.architectures)
+    if "CosyVoice3Model" in architectures or model.model_type == "cosyvoice3":
+        family = ModelFamily.QWEN2
+        role = ModelRole.COSYVOICE_TALKER
+    elif architectures & _QWEN35_ARCHITECTURES or model.model_type in {
+        "qwen3_5",
+        "qwen3_5_text",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
+    }:
+        family = ModelFamily.QWEN35_36
+        role = ModelRole.TEXT
+    elif (
+        architectures
+        & {
+            "Qwen3ForCausalLM",
+            "Qwen3MoeForCausalLM",
+        }
+        or model.model_type == "qwen3"
+    ):
+        family = ModelFamily.QWEN3
+        role = ModelRole.TEXT
+    elif (
+        architectures
+        & {
+            "Qwen2ForCausalLM",
+            "Qwen2MoeForCausalLM",
+        }
+        or model.model_type == "qwen2"
+    ):
+        family = ModelFamily.QWEN2
+        role = ModelRole.TEXT
+    else:
+        return None
+
+    model = replace(model, family=family, role=role)
+    preferred: set[OptimizationFeature] = set()
+    if _has_architecture(model, QWEN_V2_SAMPLING_ARCHITECTURES):
+        preferred.add(OptimizationFeature.QWEN_V2_SAMPLING)
+    if (
+        _has_architecture(model, QWEN_LEGACY_SAMPLING_ARCHITECTURES)
+        and not execution.has_speculative_config
+        and not execution.is_pooling_model
+    ):
+        preferred.add(OptimizationFeature.QWEN_LEGACY_SAMPLING)
+    if _has_architecture(model, QWEN_FA3_ARCHITECTURES):
+        preferred.add(OptimizationFeature.QWEN_FA3_SCHEDULER)
+        if (
+            execution.has_parallel_config
+            and not execution.has_speculative_config
+            and _single_device(execution, include_dcp=True)
+            and (execution.max_num_seqs is None or execution.max_num_seqs > 0)
+        ):
+            preferred.add(OptimizationFeature.QWEN_FA3_SINGLE_REQUEST_METADATA)
+    if _qwen2_rope_kv_preferred(model, execution):
+        preferred.add(OptimizationFeature.QWEN2_ROPE_KV_PRESPLIT)
+    if _qwen3_rope_kv_preferred(model, execution):
+        preferred.add(OptimizationFeature.QWEN3_QK_ROPE_KV_PRESPLIT)
+    if _qwen3_dense_fp8_fusions_preferred(model, execution):
+        preferred.add(OptimizationFeature.QWEN3_DENSE_FP8_POST_GRAD_FUSIONS)
+    if _qwen35_gdn_prefill_preferred(model, execution):
+        preferred.add(OptimizationFeature.QWEN35_GDN_WIDTH4_PREFILL)
+    if _qwen35_moe_prefill_preferred(model, execution):
+        preferred.add(OptimizationFeature.QWEN35_MOE_BF16_PREFILL)
+
+    if model.vocab_size in (151936, 152064, 248320):
+        if OptimizationFeature.QWEN_V2_SAMPLING in preferred:
+            preferred.update(
+                {
+                    OptimizationFeature.QWEN_V2_GUMBEL,
+                    OptimizationFeature.QWEN_UNIFORM_DECODE_VIEWS,
+                    OptimizationFeature.QWEN_UNIFORM_SAMPLE_COUNTS,
+                    OptimizationFeature.QWEN_SAMPLE_INPUT_VIEWS,
+                }
+            )
+        if OptimizationFeature.QWEN_LEGACY_SAMPLING in preferred:
+            preferred.update(
+                {
+                    OptimizationFeature.QWEN_LEGACY_GUMBEL,
+                    OptimizationFeature.QWEN_TP_LOGITS_IPC_GATHER,
+                }
+            )
+        if (
+            OptimizationFeature.QWEN_LEGACY_SAMPLING in preferred
+            and
+            execution.tensor_parallel_size == 4
+            and execution.pipeline_parallel_size == 1
+        ):
+            preferred.add(OptimizationFeature.QWEN_TP4_SHARDED_GUMBEL)
+
+    profile = f"{family.value}.{'moe' if model.has_routed_experts else role.value}"
+    features = frozenset(preferred)
+    return MusaOptimizationContract(
+        model=model,
+        execution=execution,
+        profile=profile,
+        supported_features=features,
+        preferred_features=features,
+    )

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -297,4 +297,4 @@ def resolve_optimization_contract(
 
 def prefers_optimization(owner: Any, feature: OptimizationFeature) -> bool:
     contract = getattr(owner, "_musa_optimization_contract", None)
-    return isinstance(contract, MusaOptimizationContract) and contract.prefers(feature)
+    return contract is not None and feature in contract.preferred_features

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -297,4 +297,6 @@ def resolve_optimization_contract(
 
 def prefers_optimization(owner: Any, feature: OptimizationFeature) -> bool:
     contract = getattr(owner, "_musa_optimization_contract", None)
-    return contract is not None and feature in contract.preferred_features
+    return contract is not None and feature in getattr(
+        contract, "preferred_features", ()
+    )

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -349,18 +349,10 @@ def bind_optimization_contract(
 ) -> MusaOptimizationContract:
     """Resolve once and bind an immutable contract to a runtime owner."""
 
-    contract = (
-        getattr(vllm_config, "_musa_optimization_contract", None)
-        if vllm_config is not None
-        else None
+    contract = resolve_optimization_contract(
+        vllm_config,
+        model_config=model_config,
+        is_pooling_model=is_pooling_model,
     )
-    if not isinstance(contract, MusaOptimizationContract):
-        contract = resolve_optimization_contract(
-            vllm_config,
-            model_config=model_config,
-            is_pooling_model=is_pooling_model,
-        )
-        if vllm_config is not None:
-            vllm_config._musa_optimization_contract = contract
     owner._musa_optimization_contract = contract
     return contract

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -51,12 +51,12 @@ def _text_config(model_config: Any) -> Any:
 
 
 def _architectures(model_config: Any, text_config: Any) -> tuple[str, ...]:
-    values = getattr(model_config, "architectures", None)
-    if values is None:
+    values = getattr(model_config, "architectures", None) or None
+    if not values:
         hf_config = getattr(model_config, "hf_config", None)
-        values = getattr(hf_config, "architectures", None)
-    if values is None:
-        values = getattr(text_config, "architectures", None)
+        values = getattr(hf_config, "architectures", None) or None
+    if not values:
+        values = getattr(text_config, "architectures", None) or ()
     return tuple(str(value) for value in values or ())
 
 
@@ -71,7 +71,7 @@ def _outer_model_type(model_config: Any, text_config: Any) -> str | None:
 
 
 def _text_architectures(text_config: Any) -> tuple[str, ...]:
-    values = getattr(text_config, "architectures", None)
+    values = getattr(text_config, "architectures", None) or ()
     return tuple(str(value) for value in values or ())
 
 

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .providers import CONTRACT_PROVIDERS
+from .types import (
+    ExecutionSignature,
+    ModelFamily,
+    ModelRole,
+    ModelSignature,
+    MusaOptimizationContract,
+    OptimizationFeature,
+)
+
+
+def _normalize_dtype(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value).lower().removeprefix("torch.")
+
+
+def _normalize_name(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value).lower().split(".")[-1]
+
+
+def _int_tuple(value: Any) -> tuple[int, ...] | None:
+    if not isinstance(value, (list, tuple)) or not value:
+        return None
+    if not all(isinstance(item, int) and not isinstance(item, bool) for item in value):
+        return None
+    return tuple(value)
+
+
+def _int_attr(config: Any, *names: str) -> int | None:
+    for name in names:
+        value = getattr(config, name, None)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return None
+
+
+def _text_config(model_config: Any) -> Any:
+    text_config = getattr(model_config, "hf_text_config", None)
+    if text_config is not None:
+        return text_config
+    hf_config = getattr(model_config, "hf_config", None)
+    return getattr(hf_config, "text_config", hf_config)
+
+
+def _architectures(model_config: Any, text_config: Any) -> tuple[str, ...]:
+    values = getattr(model_config, "architectures", None)
+    if values is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        values = getattr(hf_config, "architectures", None)
+    if values is None:
+        values = getattr(text_config, "architectures", None)
+    return tuple(str(value) for value in values or ())
+
+
+def _outer_model_type(model_config: Any, text_config: Any) -> str | None:
+    value = getattr(model_config, "model_type", None)
+    if value is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        value = getattr(hf_config, "model_type", None)
+    if value is None:
+        value = getattr(text_config, "model_type", None)
+    return str(value) if value is not None else None
+
+
+def _quantization(model_config: Any, text_config: Any) -> str | None:
+    value = getattr(model_config, "quantization", None)
+    if value is not None:
+        return str(value).lower()
+    quantization_config = getattr(text_config, "quantization_config", None)
+    if isinstance(quantization_config, dict):
+        value = quantization_config.get("quant_method")
+        return str(value).lower() if value is not None else None
+    return None
+
+
+def _has_routed_experts(model_config: Any, text_config: Any) -> bool | None:
+    is_model_moe = getattr(model_config, "is_model_moe", None)
+    if callable(is_model_moe):
+        try:
+            return bool(is_model_moe())
+        except (AttributeError, TypeError, ValueError):
+            return None
+    if bool(getattr(model_config, "is_moe", False)):
+        return True
+    expert_values = [
+        getattr(text_config, name, None)
+        for name in (
+            "num_experts",
+            "moe_num_experts",
+            "n_routed_experts",
+            "num_local_experts",
+        )
+    ]
+    if any(value is not None for value in expert_values):
+        return any(bool(value) for value in expert_values)
+    return False
+
+
+def _gdn_conv_signature(text_config: Any) -> tuple[int | None, int | None]:
+    width = _int_attr(text_config, "linear_conv_kernel_dim")
+    key_heads = _int_attr(text_config, "linear_num_key_heads")
+    value_heads = _int_attr(text_config, "linear_num_value_heads")
+    key_dim = _int_attr(text_config, "linear_key_head_dim")
+    value_dim = _int_attr(text_config, "linear_value_head_dim")
+    if None in (key_heads, value_heads, key_dim, value_dim):
+        return width, None
+    return width, 2 * key_heads * key_dim + value_heads * value_dim
+
+
+def _model_signature(model_config: Any, vllm_config: Any | None) -> ModelSignature:
+    text_config = _text_config(model_config)
+    gdn_width, gdn_dim = _gdn_conv_signature(text_config)
+    architectures = _architectures(model_config, text_config)
+    quant_config = getattr(vllm_config, "quant_config", None)
+    quantization_config = getattr(text_config, "quantization_config", None)
+    quant_block_shape = _int_tuple(getattr(quant_config, "weight_block_size", None))
+    if quant_block_shape is None and isinstance(quantization_config, dict):
+        quant_block_shape = _int_tuple(
+            quantization_config.get("weight_block_size")
+            or quantization_config.get("weight_block_shape")
+        )
+    uses_mla = getattr(text_config, "use_mla", None)
+    if not isinstance(uses_mla, bool):
+        uses_mla = getattr(text_config, "kv_lora_rank", None) is not None
+    return ModelSignature(
+        family=ModelFamily.UNKNOWN,
+        role=ModelRole.UNKNOWN,
+        architectures=architectures,
+        model_type=getattr(text_config, "model_type", None),
+        dtype=_normalize_dtype(getattr(model_config, "dtype", None)),
+        quantization=_quantization(model_config, text_config),
+        hidden_size=_int_attr(text_config, "hidden_size"),
+        intermediate_size=_int_attr(text_config, "intermediate_size"),
+        num_hidden_layers=_int_attr(text_config, "num_hidden_layers"),
+        num_attention_heads=_int_attr(text_config, "num_attention_heads"),
+        num_key_value_heads=_int_attr(text_config, "num_key_value_heads"),
+        head_dim=_int_attr(text_config, "head_dim"),
+        vocab_size=_int_attr(text_config, "vocab_size"),
+        num_experts=_int_attr(
+            text_config,
+            "num_experts",
+            "moe_num_experts",
+            "n_routed_experts",
+            "num_local_experts",
+        ),
+        num_experts_per_tok=_int_attr(
+            text_config,
+            "num_experts_per_tok",
+            "num_experts_per_token",
+            "top_k",
+        ),
+        moe_intermediate_size=_int_attr(text_config, "moe_intermediate_size"),
+        gdn_conv_width=gdn_width,
+        gdn_conv_dim=gdn_dim,
+        has_routed_experts=_has_routed_experts(model_config, text_config),
+        enforce_eager=bool(getattr(model_config, "enforce_eager", False)),
+        outer_architectures=architectures,
+        outer_model_type=_outer_model_type(model_config, text_config),
+        uses_mla=uses_mla,
+        index_topk=_int_attr(text_config, "index_topk"),
+        quant_block_shape=quant_block_shape,
+    )
+
+
+def _execution_signature(
+    vllm_config: Any | None,
+    *,
+    is_pooling_model: bool,
+) -> ExecutionSignature:
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    cache_config = getattr(vllm_config, "cache_config", None)
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    attention_config = getattr(vllm_config, "attention_config", None)
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+
+    def size(name: str) -> int:
+        value = getattr(parallel_config, name, 1)
+        return value if isinstance(value, int) and value > 0 else 1
+
+    block_size = getattr(cache_config, "block_size", None)
+    return ExecutionSignature(
+        tensor_parallel_size=size("tensor_parallel_size"),
+        pipeline_parallel_size=size("pipeline_parallel_size"),
+        data_parallel_size=size("data_parallel_size"),
+        decode_context_parallel_size=size("decode_context_parallel_size"),
+        has_speculative_config=(
+            getattr(vllm_config, "speculative_config", None) is not None
+        ),
+        has_quant_config=getattr(vllm_config, "quant_config", None) is not None,
+        is_pooling_model=is_pooling_model,
+        has_parallel_config=parallel_config is not None,
+        cache_dtype=_normalize_dtype(getattr(cache_config, "cache_dtype", "auto")),
+        cache_block_size=(
+            block_size
+            if isinstance(block_size, int) and not isinstance(block_size, bool)
+            else None
+        ),
+        max_num_seqs=_int_attr(scheduler_config, "max_num_seqs"),
+        attention_backend=_normalize_name(getattr(attention_config, "backend", None)),
+        compilation_mode=_normalize_name(getattr(compilation_config, "mode", None)),
+        cudagraph_mode=_normalize_name(
+            getattr(compilation_config, "cudagraph_mode", None)
+        ),
+    )
+
+
+def resolve_optimization_contract(
+    vllm_config: Any | None = None,
+    *,
+    model_config: Any | None = None,
+    is_pooling_model: bool = False,
+) -> MusaOptimizationContract:
+    if model_config is None:
+        model_config = getattr(vllm_config, "model_config", None)
+    execution = _execution_signature(
+        vllm_config,
+        is_pooling_model=is_pooling_model,
+    )
+    if model_config is None:
+        model = ModelSignature(
+            family=ModelFamily.UNKNOWN,
+            role=ModelRole.UNKNOWN,
+            architectures=(),
+            model_type=None,
+            dtype=None,
+            quantization=None,
+            hidden_size=None,
+            intermediate_size=None,
+            num_hidden_layers=None,
+            num_attention_heads=None,
+            num_key_value_heads=None,
+            head_dim=None,
+            vocab_size=None,
+            num_experts=None,
+            num_experts_per_tok=None,
+            moe_intermediate_size=None,
+            gdn_conv_width=None,
+            gdn_conv_dim=None,
+            has_routed_experts=False,
+            enforce_eager=False,
+            outer_architectures=(),
+            outer_model_type=None,
+            uses_mla=None,
+            index_topk=None,
+            quant_block_shape=None,
+        )
+    else:
+        model = _model_signature(model_config, vllm_config)
+
+    for provider in CONTRACT_PROVIDERS:
+        contract = provider(model, execution)
+        if contract is not None:
+            return contract
+    return MusaOptimizationContract(
+        model=model,
+        execution=execution,
+        profile="unknown",
+        supported_features=frozenset(),
+        preferred_features=frozenset(),
+    )
+
+
+def prefers_optimization(owner: Any, feature: OptimizationFeature) -> bool:
+    contract = getattr(owner, "_musa_optimization_contract", None)
+    return isinstance(contract, MusaOptimizationContract) and contract.prefers(feature)

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -42,6 +42,22 @@ def _int_attr(config: Any, *names: str) -> int | None:
     return None
 
 
+def _float_attr(config: Any, *names: str) -> float | None:
+    for name in names:
+        value = getattr(config, name, None)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return None
+
+
+def _str_attr(config: Any, *names: str) -> str | None:
+    for name in names:
+        value = getattr(config, name, None)
+        if value is not None:
+            return str(value).lower()
+    return None
+
+
 def _text_config(model_config: Any) -> Any:
     text_config = getattr(model_config, "hf_text_config", None)
     if text_config is not None:
@@ -132,7 +148,9 @@ def _model_signature(model_config: Any, vllm_config: Any | None) -> ModelSignatu
             quantization_config.get("weight_block_size")
             or quantization_config.get("weight_block_shape")
         )
-    uses_mla = getattr(text_config, "use_mla", None)
+    uses_mla = getattr(model_config, "use_mla", None)
+    if not isinstance(uses_mla, bool):
+        uses_mla = getattr(text_config, "use_mla", None)
     if not isinstance(uses_mla, bool):
         uses_mla = getattr(text_config, "kv_lora_rank", None) is not None
     is_hybrid = getattr(model_config, "is_hybrid", None)
@@ -170,7 +188,15 @@ def _model_signature(model_config: Any, vllm_config: Any | None) -> ModelSignatu
             "num_experts_per_token",
             "top_k",
         ),
+        num_shared_experts=_int_attr(
+            text_config,
+            "num_shared_experts",
+            "n_shared_experts",
+        ),
         moe_intermediate_size=_int_attr(text_config, "moe_intermediate_size"),
+        expert_dtype=_str_attr(text_config, "expert_dtype"),
+        hidden_act=_str_attr(text_config, "hidden_act"),
+        swiglu_limit=_float_attr(text_config, "swiglu_limit"),
         gdn_conv_width=gdn_width,
         gdn_conv_dim=gdn_dim,
         has_routed_experts=_has_routed_experts(model_config, text_config),
@@ -201,6 +227,13 @@ def _execution_signature(
         return value if isinstance(value, int) and value > 0 else 1
 
     block_size = getattr(cache_config, "block_size", None)
+    try:
+        import vllm.envs as vllm_envs
+
+        batch_invariant_enabled = bool(vllm_envs.VLLM_BATCH_INVARIANT)
+    except (AttributeError, ImportError):
+        batch_invariant_enabled = False
+
     return ExecutionSignature(
         tensor_parallel_size=size("tensor_parallel_size"),
         pipeline_parallel_size=size("pipeline_parallel_size"),
@@ -224,6 +257,7 @@ def _execution_signature(
         cudagraph_mode=_normalize_name(
             getattr(compilation_config, "cudagraph_mode", None)
         ),
+        batch_invariant_enabled=batch_invariant_enabled,
     )
 
 
@@ -256,7 +290,11 @@ def resolve_optimization_contract(
             vocab_size=None,
             num_experts=None,
             num_experts_per_tok=None,
+            num_shared_experts=None,
             moe_intermediate_size=None,
+            expert_dtype=None,
+            hidden_act=None,
+            swiglu_limit=None,
             gdn_conv_width=None,
             gdn_conv_dim=None,
             has_routed_experts=False,
@@ -300,3 +338,29 @@ def prefers_optimization(owner: Any, feature: OptimizationFeature) -> bool:
     return contract is not None and feature in getattr(
         contract, "preferred_features", ()
     )
+
+
+def bind_optimization_contract(
+    owner: Any,
+    vllm_config: Any | None = None,
+    *,
+    model_config: Any | None = None,
+    is_pooling_model: bool = False,
+) -> MusaOptimizationContract:
+    """Resolve once and bind an immutable contract to a runtime owner."""
+
+    contract = (
+        getattr(vllm_config, "_musa_optimization_contract", None)
+        if vllm_config is not None
+        else None
+    )
+    if not isinstance(contract, MusaOptimizationContract):
+        contract = resolve_optimization_contract(
+            vllm_config,
+            model_config=model_config,
+            is_pooling_model=is_pooling_model,
+        )
+        if vllm_config is not None:
+            vllm_config._musa_optimization_contract = contract
+    owner._musa_optimization_contract = contract
+    return contract

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from .providers import CONTRACT_PROVIDERS
@@ -69,6 +70,11 @@ def _outer_model_type(model_config: Any, text_config: Any) -> str | None:
     return str(value) if value is not None else None
 
 
+def _text_architectures(text_config: Any) -> tuple[str, ...]:
+    values = getattr(text_config, "architectures", None)
+    return tuple(str(value) for value in values or ())
+
+
 def _quantization(model_config: Any, text_config: Any) -> str | None:
     value = getattr(model_config, "quantization", None)
     if value is not None:
@@ -129,6 +135,14 @@ def _model_signature(model_config: Any, vllm_config: Any | None) -> ModelSignatu
     uses_mla = getattr(text_config, "use_mla", None)
     if not isinstance(uses_mla, bool):
         uses_mla = getattr(text_config, "kv_lora_rank", None) is not None
+    is_hybrid = getattr(model_config, "is_hybrid", None)
+    if callable(is_hybrid):
+        try:
+            is_hybrid = bool(is_hybrid())
+        except (AttributeError, TypeError, ValueError):
+            is_hybrid = None
+    if not isinstance(is_hybrid, bool) and gdn_dim is not None:
+        is_hybrid = True
     return ModelSignature(
         family=ModelFamily.UNKNOWN,
         role=ModelRole.UNKNOWN,
@@ -162,10 +176,12 @@ def _model_signature(model_config: Any, vllm_config: Any | None) -> ModelSignatu
         has_routed_experts=_has_routed_experts(model_config, text_config),
         enforce_eager=bool(getattr(model_config, "enforce_eager", False)),
         outer_architectures=architectures,
+        text_architectures=_text_architectures(text_config),
         outer_model_type=_outer_model_type(model_config, text_config),
         uses_mla=uses_mla,
         index_topk=_int_attr(text_config, "index_topk"),
         quant_block_shape=quant_block_shape,
+        is_hybrid=is_hybrid if isinstance(is_hybrid, bool) else None,
     )
 
 
@@ -246,10 +262,12 @@ def resolve_optimization_contract(
             has_routed_experts=False,
             enforce_eager=False,
             outer_architectures=(),
+            text_architectures=(),
             outer_model_type=None,
             uses_mla=None,
             index_topk=None,
             quant_block_shape=None,
+            is_hybrid=None,
         )
     else:
         model = _model_signature(model_config, vllm_config)
@@ -257,14 +275,24 @@ def resolve_optimization_contract(
     for provider in CONTRACT_PROVIDERS:
         contract = provider(model, execution)
         if contract is not None:
-            return contract
-    return MusaOptimizationContract(
-        model=model,
-        execution=execution,
-        profile="unknown",
-        supported_features=frozenset(),
-        preferred_features=frozenset(),
-    )
+            break
+    else:
+        contract = MusaOptimizationContract(
+            model=model,
+            execution=execution,
+            profile="unknown",
+            supported_features=frozenset(),
+            preferred_features=frozenset(),
+        )
+
+    if model.is_hybrid is True:
+        feature = OptimizationFeature.HYBRID_SEPARATE_MAMBA_POOL
+        contract = replace(
+            contract,
+            supported_features=contract.supported_features | {feature},
+            preferred_features=contract.preferred_features | {feature},
+        )
+    return contract
 
 
 def prefers_optimization(owner: Any, feature: OptimizationFeature) -> bool:

--- a/vllm_musa/optimization_contract/types.py
+++ b/vllm_musa/optimization_contract/types.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 class ModelFamily(str, Enum):
     UNKNOWN = "unknown"
+    DEEPSEEK_V4 = "deepseek_v4"
     QWEN2 = "qwen2"
     QWEN3 = "qwen3"
     QWEN35_36 = "qwen3.5_3.6"
@@ -18,6 +19,15 @@ class ModelRole(str, Enum):
 
 
 class OptimizationFeature(str, Enum):
+    DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8 = "deepseek_v4.shared_mlp_clamp_fp8"
+    DEEPSEEK_V4_NATIVE_SPARSE_INDEXER = "deepseek_v4.native_sparse_indexer"
+    DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER = (
+        "deepseek_v4.materialized_prefill_indexer"
+    )
+    DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256 = "deepseek_v4.tp8_flashmla_sparse_page256"
+    DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256 = (
+        "deepseek_v4.tp8_fused_add_rmsnorm_block256"
+    )
     QWEN_V2_SAMPLING = "qwen.v2_sampling"
     QWEN_LEGACY_SAMPLING = "qwen.legacy_sampling"
     QWEN_FA3_SCHEDULER = "qwen.fa3_scheduler"
@@ -56,7 +66,11 @@ class ModelSignature:
     vocab_size: int | None
     num_experts: int | None
     num_experts_per_tok: int | None
+    num_shared_experts: int | None
     moe_intermediate_size: int | None
+    expert_dtype: str | None
+    hidden_act: str | None
+    swiglu_limit: float | None
     gdn_conv_width: int | None
     gdn_conv_dim: int | None
     has_routed_experts: bool | None
@@ -86,6 +100,7 @@ class ExecutionSignature:
     attention_backend: str | None = None
     compilation_mode: str | None = None
     cudagraph_mode: str | None = None
+    batch_invariant_enabled: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_musa/optimization_contract/types.py
+++ b/vllm_musa/optimization_contract/types.py
@@ -34,6 +34,9 @@ class OptimizationFeature(str, Enum):
     QWEN_V2_GUMBEL = "qwen.v2_gumbel"
     QWEN_TP_LOGITS_IPC_GATHER = "qwen.tp_logits_ipc_gather"
     QWEN_TP4_SHARDED_GUMBEL = "qwen.tp4_sharded_gumbel"
+    QWEN35_SHARED_EXPERT_FOLD = "qwen3.5_3.6.shared_expert_fold"
+    QWEN35_INTERLEAVED_MROPE_QK = "qwen3.5_3.6.interleaved_mrope_qk"
+    HYBRID_SEPARATE_MAMBA_POOL = "hybrid.separate_mamba_pool"
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,10 +62,12 @@ class ModelSignature:
     has_routed_experts: bool | None
     enforce_eager: bool
     outer_architectures: tuple[str, ...] = ()
+    text_architectures: tuple[str, ...] = ()
     outer_model_type: str | None = None
     uses_mla: bool | None = None
     index_topk: int | None = None
     quant_block_shape: tuple[int, ...] | None = None
+    is_hybrid: bool | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_musa/optimization_contract/types.py
+++ b/vllm_musa/optimization_contract/types.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ModelFamily(str, Enum):
+    UNKNOWN = "unknown"
+    QWEN2 = "qwen2"
+    QWEN3 = "qwen3"
+    QWEN35_36 = "qwen3.5_3.6"
+
+
+class ModelRole(str, Enum):
+    UNKNOWN = "unknown"
+    TEXT = "text_generation"
+    COSYVOICE_TALKER = "cosyvoice_talker"
+
+
+class OptimizationFeature(str, Enum):
+    QWEN_V2_SAMPLING = "qwen.v2_sampling"
+    QWEN_LEGACY_SAMPLING = "qwen.legacy_sampling"
+    QWEN_FA3_SCHEDULER = "qwen.fa3_scheduler"
+    QWEN_FA3_SINGLE_REQUEST_METADATA = "qwen.fa3_single_request_metadata"
+    QWEN2_ROPE_KV_PRESPLIT = "qwen2.rope_kv_presplit"
+    QWEN3_QK_ROPE_KV_PRESPLIT = "qwen3.qk_rope_kv_presplit"
+    QWEN3_DENSE_FP8_POST_GRAD_FUSIONS = "qwen3.dense_fp8_post_grad_fusions"
+    QWEN35_GDN_WIDTH4_PREFILL = "qwen3.5_3.6.gdn_width4_prefill"
+    QWEN35_MOE_BF16_PREFILL = "qwen3.5_3.6.moe_bf16_prefill"
+    QWEN_UNIFORM_DECODE_VIEWS = "qwen.uniform_decode_views"
+    QWEN_UNIFORM_SAMPLE_COUNTS = "qwen.uniform_sample_counts"
+    QWEN_SAMPLE_INPUT_VIEWS = "qwen.sample_input_views"
+    QWEN_LEGACY_GUMBEL = "qwen.legacy_gumbel"
+    QWEN_V2_GUMBEL = "qwen.v2_gumbel"
+    QWEN_TP_LOGITS_IPC_GATHER = "qwen.tp_logits_ipc_gather"
+    QWEN_TP4_SHARDED_GUMBEL = "qwen.tp4_sharded_gumbel"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelSignature:
+    family: ModelFamily
+    role: ModelRole
+    architectures: tuple[str, ...]
+    model_type: str | None
+    dtype: str | None
+    quantization: str | None
+    hidden_size: int | None
+    intermediate_size: int | None
+    num_hidden_layers: int | None
+    num_attention_heads: int | None
+    num_key_value_heads: int | None
+    head_dim: int | None
+    vocab_size: int | None
+    num_experts: int | None
+    num_experts_per_tok: int | None
+    moe_intermediate_size: int | None
+    gdn_conv_width: int | None
+    gdn_conv_dim: int | None
+    has_routed_experts: bool | None
+    enforce_eager: bool
+    outer_architectures: tuple[str, ...] = ()
+    outer_model_type: str | None = None
+    uses_mla: bool | None = None
+    index_topk: int | None = None
+    quant_block_shape: tuple[int, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionSignature:
+    tensor_parallel_size: int
+    pipeline_parallel_size: int
+    data_parallel_size: int
+    decode_context_parallel_size: int
+    has_speculative_config: bool
+    has_quant_config: bool
+    is_pooling_model: bool
+    has_parallel_config: bool
+    cache_dtype: str | None
+    cache_block_size: int | None
+    max_num_seqs: int | None
+    attention_backend: str | None = None
+    compilation_mode: str | None = None
+    cudagraph_mode: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MusaOptimizationContract:
+    model: ModelSignature
+    execution: ExecutionSignature
+    profile: str
+    supported_features: frozenset[OptimizationFeature]
+    preferred_features: frozenset[OptimizationFeature]
+
+    def supports(self, feature: OptimizationFeature) -> bool:
+        return feature in self.supported_features
+
+    def prefers(self, feature: OptimizationFeature) -> bool:
+        return feature in self.preferred_features

--- a/vllm_musa/optimization_contract/types.py
+++ b/vllm_musa/optimization_contract/types.py
@@ -28,6 +28,9 @@ class OptimizationFeature(str, Enum):
     DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256 = (
         "deepseek_v4.tp8_fused_add_rmsnorm_block256"
     )
+    DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD = (
+        "deepseek_v4.car_graph_input_capture_guard"
+    )
     QWEN_V2_SAMPLING = "qwen.v2_sampling"
     QWEN_LEGACY_SAMPLING = "qwen.legacy_sampling"
     QWEN_FA3_SCHEDULER = "qwen.fa3_scheduler"

--- a/vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch
+++ b/vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch
@@ -24,7 +24,7 @@ index fe2b268cd..eadc6f533 100644
  from vllm import _custom_ops as ops
  from vllm._aiter_ops import rocm_aiter_ops
  from vllm.compilation.breakable_cudagraph import eager_break_during_capture
-@@ -31,6 +34,1311 @@ from vllm.v1.worker.workspace import current_workspace_manager
+@@ -31,6 +34,1291 @@ from vllm.v1.worker.workspace import current_workspace_manager
  
  logger = init_logger(__name__)
  
@@ -1316,7 +1316,7 @@ index fe2b268cd..eadc6f533 100644
  RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
  
  # MXFP4 layout: 2 values packed per byte, ue8m0 (1-byte) scale per block of 32.
-@@ -452,17 +1760,19 @@ class SparseAttnIndexer(CustomOp):
+@@ -452,19 +1740,21 @@ class SparseAttnIndexer(CustomOp):
          max_total_seq_len: int,
          topk_indices_buffer: torch.Tensor,
          skip_k_cache_insert: bool = False,
@@ -1338,7 +1338,7 @@ index fe2b268cd..eadc6f533 100644
          if current_platform.is_cuda() and not has_deep_gemm():
              raise RuntimeError(
                  "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
-@@ -482,6 +1790,46 @@ class SparseAttnIndexer(CustomOp):
+@@ -482,6 +1772,42 @@ class SparseAttnIndexer(CustomOp):
              return self.forward_cuda(hidden_states, q_quant, k, weights)
          elif current_platform.is_rocm():
              return self.forward_hip(hidden_states, q_quant, k, weights)

--- a/vllm_musa/patches/series/0017-MUSA-vllm.models.deepseek_v4.nvidia.model.patch
+++ b/vllm_musa/patches/series/0017-MUSA-vllm.models.deepseek_v4.nvidia.model.patch
@@ -4,27 +4,14 @@ Date: Wed, 3 Jun 2026 11:47:35 +0000
 Subject: [PATCH] MUSA: vllm.models.deepseek_v4.nvidia.model
 
 ---
- vllm/models/deepseek_v4/nvidia/model.py | 19 ++++++++++++++++++-
- 1 file changed, 18 insertions(+), 1 deletion(-)
+ vllm/models/deepseek_v4/nvidia/model.py | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/vllm/models/deepseek_v4/nvidia/model.py b/vllm/models/deepseek_v4/nvidia/model.py
 index aa60ad34c..ce73743da 100644
 --- a/vllm/models/deepseek_v4/nvidia/model.py
 +++ b/vllm/models/deepseek_v4/nvidia/model.py
-@@ -1,5 +1,5 @@
- # SPDX-License-Identifier: Apache-2.0
- # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
- import typing
- from collections.abc import Callable, Iterable, MutableSequence, Sequence
- from itertools import islice
-@@ -70,6 +70,7 @@ from vllm.utils.math_utils import cdiv
- from vllm.v1.attention.backends.registry import AttentionBackendEnum
- 
- 
- class DeepseekV4MLP(nn.Module):
-     def __init__(
-         self,
-@@ -945,7 +953,16 @@ class DeepseekV4Model(nn.Module):
+@@ -945,7 +945,15 @@ class DeepseekV4Model(nn.Module):
          # DeepseekV4Attention.attn_gemm_parallel_execute
          # (compressor kv_score, indexer.weights_proj, indexer.compressor
          # kv_score). fused_wqa_wkv stays on the default stream.

--- a/vllm_musa/patches/series/0076-MUSA-model-fold-the-Qwen3.5-shared-expert-into-fused.patch
+++ b/vllm_musa/patches/series/0076-MUSA-model-fold-the-Qwen3.5-shared-expert-into-fused.patch
@@ -23,7 +23,7 @@ diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/mode
 index acce2a767..de163b0e6 100644
 --- a/vllm/model_executor/models/qwen3_next.py
 +++ b/vllm/model_executor/models/qwen3_next.py
-@@ -88,6 +89,42 @@
+@@ -88,6 +89,39 @@
  KVCache = tuple[torch.Tensor, torch.Tensor]
  
  
@@ -63,7 +63,7 @@ index acce2a767..de163b0e6 100644
  class Qwen3NextSparseMoeBlock(nn.Module):
      def __init__(self, vllm_config: VllmConfig, prefix: str = ""):
          super().__init__()
-@@ -159,8 +196,24 @@
+@@ -159,8 +196,31 @@
                  prefix=f"{prefix}.shared_expert",
              )
  

--- a/vllm_musa/patches/series/0076-MUSA-model-fold-the-Qwen3.5-shared-expert-into-fused.patch
+++ b/vllm_musa/patches/series/0076-MUSA-model-fold-the-Qwen3.5-shared-expert-into-fused.patch
@@ -14,7 +14,7 @@ producing numerically equivalent output from a single kernel.
 
 The fold appends one expert to the routed stack, so it stays off under expert
 parallelism and EPLB, whose expert_map is built for the unfolded count.
-Set VLLM_MUSA_MOE_SHARED_EXPERT_FUSION=0 to disable.
+The MUSA optimization contract selects the fold for Qwen3.5/3.6 MoE models.
 ---
  vllm/model_executor/models/qwen3_next.py | 60 +++---
  1 file changed, 59 insertions(+), 1 deletions(-)
@@ -23,21 +23,10 @@ diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/mode
 index acce2a767..de163b0e6 100644
 --- a/vllm/model_executor/models/qwen3_next.py
 +++ b/vllm/model_executor/models/qwen3_next.py
-@@ -2,6 +2,7 @@
- # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
- """Inference-only Qwen3Next model."""
- 
-+import os
- from collections.abc import Iterable
- from itertools import islice
- 
 @@ -88,6 +89,42 @@
  KVCache = tuple[torch.Tensor, torch.Tensor]
  
  
-+MUSA_SHARED_EXPERT_FUSION_ENV = "VLLM_MUSA_MOE_SHARED_EXPERT_FUSION"
-+
-+
 +def _musa_linear_is_block_fp8(linear: nn.Module) -> bool:
 +    method = getattr(linear, "quant_method", None)
 +    if method is None or not getattr(method, "block_quant", False):
@@ -84,10 +73,17 @@ index acce2a767..de163b0e6 100644
 +        # weight format the routed expert stack can absorb. The fold appends one
 +        # expert to the routed stack, which an expert-parallel expert_map built for
 +        # the unfolded count would not know about.
++        from vllm_musa.optimization_contract import (
++            OptimizationFeature,
++            resolve_optimization_contract,
++        )
++
++        optimization_contract = resolve_optimization_contract(vllm_config)
 +        self._musa_shared_fold = (
 +            getattr(torch.version, "musa", None) is not None
-+            and os.environ.get(MUSA_SHARED_EXPERT_FUSION_ENV, "1").strip().lower()
-+            not in ("0", "false", "off", "no")
++            and optimization_contract.prefers(
++                OptimizationFeature.QWEN35_SHARED_EXPERT_FOLD
++            )
 +            and self.ep_size <= 1
 +            and not self.enable_eplb
 +            and config.shared_expert_intermediate_size == config.moe_intermediate_size

--- a/vllm_musa/patches/series/0082-MUSA-vllm.v1.kv_cache_interface.patch
+++ b/vllm_musa/patches/series/0082-MUSA-vllm.v1.kv_cache_interface.patch
@@ -14,7 +14,7 @@ diff --git a/vllm/v1/kv_cache_interface.py b/vllm/v1/kv_cache_interface.py
 
 
  @dataclass
-@@ -895,6 +896,11 @@
+@@ -895,6 +896,12 @@
      see `_get_kv_cache_config_uniform_page_size` for more details.
      """
 

--- a/vllm_musa/patches/series/0082-MUSA-vllm.v1.kv_cache_interface.patch
+++ b/vllm_musa/patches/series/0082-MUSA-vllm.v1.kv_cache_interface.patch
@@ -19,7 +19,7 @@ diff --git a/vllm/v1/kv_cache_interface.py b/vllm/v1/kv_cache_interface.py
      """
 
 +    # MUSA: block count of the separate mamba state pool when
-+    # VLLM_MUSA_MAMBA_SEPARATE_POOL is on. None = mamba shares the
++    # dedicated Mamba-pool policy is selected. None = mamba shares the
 +    # attention pool (upstream behavior). The count is per Mamba group;
 +    # each group owns a separate BlockPool/address space.
 +    musa_mamba_num_blocks: int | None = None

--- a/vllm_musa/patches/series/0083-MUSA-vllm.v1.core.kv_cache_utils.patch
+++ b/vllm_musa/patches/series/0083-MUSA-vllm.v1.core.kv_cache_utils.patch
@@ -8,7 +8,7 @@ never bind, and keep them out of the attention pool's proportional shrink. The
 mamba groups then own small contiguous block-id spaces and mate's GDN decode
 updates the recurrent state in place instead of gathering and scattering it.
 
-On by default; set VLLM_MUSA_MAMBA_SEPARATE_POOL=0 to fall back to the shared pool.
+Hybrid models select the dedicated pool automatically from the resolved policy.
 ---
  vllm/v1/core/kv_cache_utils.py | 80 ++++++++
  1 file changed, 80 insertions(+), 0 deletions(-)
@@ -23,8 +23,8 @@ index 3ea89d5af..c8425baa5 100644
  
 +def musa_mamba_separate_pool_enabled() -> bool:
 +    """MUSA: give mamba state its own contiguous BlockPool so mate's GDN
-+    decode runs in place (no gather/scatter). On by default."""
-+    return os.environ.get("VLLM_MUSA_MAMBA_SEPARATE_POOL", "1") == "1"
++    decode runs in place (no gather/scatter)."""
++    return True
 +
 +
 +def _musa_has_mamba_and_attention(kv_cache_groups) -> bool:

--- a/vllm_musa/patches/series/0083-MUSA-vllm.v1.core.kv_cache_utils.patch
+++ b/vllm_musa/patches/series/0083-MUSA-vllm.v1.core.kv_cache_utils.patch
@@ -17,7 +17,7 @@ diff --git a/vllm/v1/core/kv_cache_utils.py b/vllm/v1/core/kv_cache_utils.py
 index 3ea89d5af..c8425baa5 100644
 --- a/vllm/v1/core/kv_cache_utils.py
 +++ b/vllm/v1/core/kv_cache_utils.py
-@@ -1357,6 +1357,69 @@
+@@ -1357,6 +1357,74 @@
  _get_kv_cache_config_deepseek_v4 = _get_kv_cache_config_packed
  
  

--- a/vllm_musa/patches/series/0084-MUSA-vllm.v1.core.kv_cache_coordinator.patch
+++ b/vllm_musa/patches/series/0084-MUSA-vllm.v1.core.kv_cache_coordinator.patch
@@ -18,7 +18,7 @@ diff --git a/vllm/v1/core/kv_cache_coordinator.py b/vllm/v1/core/kv_cache_coordi
      SingleTypeKVCacheManager,
      get_manager_for_kv_cache_spec,
  )
-@@ -96,6 +98,22 @@
+@@ -96,6 +98,26 @@
              metrics_collector=metrics_collector,
          )
 

--- a/vllm_musa/patches/series/0087-MUSA-fuse-QK-RMSNorm-and-MRoPE-for-interleaved-MRoPE.patch
+++ b/vllm_musa/patches/series/0087-MUSA-fuse-QK-RMSNorm-and-MRoPE-for-interleaved-MRoPE.patch
@@ -9,7 +9,7 @@ keeps routed MoE on native, so they otherwise run the eager rotary path and
 issue a long tail of elementwise kernels.
 
 The IR operation stays as the fallback for every shape this kernel declines.
-Set VLLM_MUSA_FUSED_QK_MROPE=0 to disable.
+The MUSA optimization contract selects the Qwen3.5/3.6 BF16 scope.
 ---
  vllm/model_executor/models/qwen3_next.py | 77 +++---
  1 file changed, 77 insertions(+), 0 deletions(-)
@@ -22,8 +22,6 @@ index f7907f3c4..d73dfa9e4 100644
          return final_hidden_states.view(orig_shape)
  
  
-+MUSA_FUSED_QK_MROPE_ENV = "VLLM_MUSA_FUSED_QK_MROPE"
-+
 +_MUSA_MROPE_COS_SIN_CACHE: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 +
 +
@@ -56,11 +54,20 @@ index f7907f3c4..d73dfa9e4 100644
 +        # MUSA: interleaved-MRoPE models reject the text-only NeoX fusion above
 +        # and the IR provider keeps routed MoE on native, leaving the eager
 +        # rotary path. Fuse QK-RMSNorm + MRoPE for them in one kernel.
++        from vllm_musa.optimization_contract import (
++            OptimizationFeature,
++            resolve_optimization_contract,
++        )
++
++        optimization_contract = resolve_optimization_contract(
++            model_config=model_config
++        )
 +        self._musa_fused_qk_mrope = (
 +            self.attn_output_gate
 +            and current_platform.is_musa()
-+            and os.environ.get(MUSA_FUSED_QK_MROPE_ENV, "1").strip().lower()
-+            not in ("0", "false", "off", "no")
++            and optimization_contract.prefers(
++                OptimizationFeature.QWEN35_INTERLEAVED_MROPE_QK
++            )
 +            and len(self.mrope_section) == 3
 +            and self.mrope_interleaved
 +        )

--- a/vllm_musa/patches/series/0087-MUSA-fuse-QK-RMSNorm-and-MRoPE-for-interleaved-MRoPE.patch
+++ b/vllm_musa/patches/series/0087-MUSA-fuse-QK-RMSNorm-and-MRoPE-for-interleaved-MRoPE.patch
@@ -18,7 +18,7 @@ diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/mode
 index f7907f3c4..d73dfa9e4 100644
 --- a/vllm/model_executor/models/qwen3_next.py
 +++ b/vllm/model_executor/models/qwen3_next.py
-@@ -267,6 +267,30 @@
+@@ -267,6 +267,28 @@
          return final_hidden_states.view(orig_shape)
  
  
@@ -47,7 +47,7 @@ index f7907f3c4..d73dfa9e4 100644
  class Qwen3NextAttention(nn.Module):
      def __init__(
          self,
-@@ -379,6 +403,26 @@
+@@ -379,6 +403,35 @@
          self.mrope_interleaved = bool(
              getattr(self.rotary_emb, "mrope_interleaved", False)
          )

--- a/vllm_musa/patches/series/0090-perf-musa-unify-Qwen-runtime-fast-paths.patch
+++ b/vllm_musa/patches/series/0090-perf-musa-unify-Qwen-runtime-fast-paths.patch
@@ -91,23 +91,16 @@ diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runne
 index 30ca2ddc56..4905fe7516 100644
 --- a/vllm/v1/worker/gpu/model_runner.py
 +++ b/vllm/v1/worker/gpu/model_runner.py
-@@ -341,6 +341,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+@@ -341,6 +341,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                      self.speculative_config,
                      self.device,
                  )
-+            qwen_sampling_architectures = {
-+                "Qwen2ForCausalLM",
-+                "Qwen2MoeForCausalLM",
-+                "Qwen3ForCausalLM",
-+                "Qwen3MoeForCausalLM",
-+                "Qwen3_5ForConditionalGeneration",
-+                "Qwen3_5MoeForConditionalGeneration",
-+                "Qwen3_5ForCausalLM",
-+                "Qwen3_5MoeForCausalLM",
-+            }
-+            self.sampler._musa_qwen_family = any(
-+                architecture in qwen_sampling_architectures
-+                for architecture in (self.model_config.architectures or ())
++            from vllm_musa.optimization_contract import (
++                resolve_optimization_contract,
++            )
++
++            self.sampler._musa_optimization_contract = (
++                resolve_optimization_contract(model_config=self.model_config)
 +            )
              self.prompt_logprobs_worker = PromptLogprobsWorker(self.max_num_reqs)
              self.structured_outputs_worker = StructuredOutputsWorker(
@@ -149,40 +142,35 @@ diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runne
 index c1f1b43606..487ceda13c 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
-@@ -812,6 +812,36 @@ class GPUModelRunner(
+@@ -812,6 +812,31 @@ class GPUModelRunner(
          self.query_pos = self._make_buffer(arange_size, dtype=torch.int64)
          self._arange_scratch = np.empty(arange_size, dtype=np.int64)
 
-+        qwen_text_generation_architectures = {
-+            "Qwen2ForCausalLM",
-+            "Qwen2MoeForCausalLM",
-+            "Qwen3ForCausalLM",
-+            "Qwen3MoeForCausalLM",
-+            "Qwen3_5ForConditionalGeneration",
-+            "Qwen3_5MoeForConditionalGeneration",
-+        }
++        from vllm_musa.optimization_contract import (
++            OptimizationFeature,
++            resolve_optimization_contract,
++        )
++
++        optimization_contract = resolve_optimization_contract(
++            self.vllm_config,
++            is_pooling_model=self.is_pooling_model,
++        )
 +        is_musa_qwen_text_generation = (
 +            current_platform.is_musa()
-+            and not self.is_pooling_model
-+            and self.speculative_config is None
-+            and any(
-+                architecture in qwen_text_generation_architectures
-+                for architecture in (self.model_config.architectures or ())
++            and optimization_contract.prefers(
++                OptimizationFeature.QWEN_LEGACY_SAMPLING
 +            )
 +        )
-+        self.sampler._musa_qwen_family = is_musa_qwen_text_generation
-+        self.sampler.topk_topp_sampler._musa_qwen_family = (
-+            is_musa_qwen_text_generation
++        self.sampler._musa_qwen_legacy_sampling = is_musa_qwen_text_generation
++        self.sampler._musa_optimization_contract = optimization_contract
++        self.sampler.topk_topp_sampler._musa_optimization_contract = (
++            optimization_contract
 +        )
 +        self._musa_qwen_uniform_decode_logits_indices = (
 +            torch.arange(self.max_num_reqs, dtype=torch.int32, device=self.device)
 +            if is_musa_qwen_text_generation
 +            else None
 +        )
-+        self.sampler._musa_qwen_skip_unit_temperature = (
-+            is_musa_qwen_text_generation
-+        )
-+
          # MUSA-3406: reusable CPU/GPU buffers for speculative metadata indices.
          # Avoid per-step torch.from_numpy(...).to(device) pageable uploads in
          # _calc_spec_decode_metadata on the TP8 DeepSeek-V4 decode path.

--- a/vllm_musa/patches/series/0092-MUSA-skip-unused-DeepSeek-V4-recent-indexer-Q-work.patch
+++ b/vllm_musa/patches/series/0092-MUSA-skip-unused-DeepSeek-V4-recent-indexer-Q-work.patch
@@ -7,7 +7,7 @@ diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_exec
 index fff4a1aa..d003219e 100644
 --- a/vllm/model_executor/layers/sparse_attn_indexer.py
 +++ b/vllm/model_executor/layers/sparse_attn_indexer.py
-@@ -1836,6 +1836,66 @@ class SparseAttnIndexer(CustomOp):
+@@ -1836,6 +1836,62 @@ class SparseAttnIndexer(CustomOp):
                  "CUDA, ROCm and XPU platforms."
              )
 
@@ -217,7 +217,7 @@ index e31f9763..e8d1a731 100644
          scheduler_config = self.vllm_config.scheduler_config
          # NOTE(Chen):an estimated max size of flattened_kv. Need to double check.
          self.max_prefill_buffer_size = get_max_prefill_buffer_size(self.vllm_config)
-@@ -332,6 +341,26 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+@@ -332,6 +341,24 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
          if isinstance(self.kv_cache_spec, MLAAttentionSpec):
              self.compress_ratio = self.kv_cache_spec.compress_ratio
 

--- a/vllm_musa/patches/series/0100-perf-musa-sharded-qwen-gumbel.patch
+++ b/vllm_musa/patches/series/0100-perf-musa-sharded-qwen-gumbel.patch
@@ -113,7 +113,7 @@ index f342e99..f51dae0 100644
                      sample_hidden_states = hidden_states[logits_indices]
 -                logits = self.model.compute_logits(sample_hidden_states)
 +                if current_platform.is_musa() and getattr(
-+                    self.sampler, "_musa_qwen_family", False
++                    self.sampler, "_musa_qwen_legacy_sampling", False
 +                ):
 +                    from vllm_musa.v1.sample.topk_topp_sampler import (
 +                        musa_compute_logits_if_eligible,
@@ -145,7 +145,7 @@ index f342e99..f51dae0 100644
                  else:
 -                    logits = self.model.compute_logits(sample_hidden_states)
 +                    if current_platform.is_musa() and getattr(
-+                        self.sampler, "_musa_qwen_family", False
++                        self.sampler, "_musa_qwen_legacy_sampling", False
 +                    ):
 +                        from vllm_musa.v1.sample.topk_topp_sampler import (
 +                            musa_compute_logits_if_eligible,

--- a/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
+++ b/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
@@ -1,0 +1,173 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Mon, 3 Aug 2026 19:17:49 +0800
+Subject: [PATCH 101/101] MUSA: bind DeepSeek-V4 optimization contract
+
+---
+ .../layers/sparse_attn_indexer.py             | 26 +++++++++++++++----
+ vllm/models/deepseek_v4/attention.py          | 19 +++++++++++++-
+ vllm/models/deepseek_v4/nvidia/model.py       |  6 +++++
+ 3 files changed, 45 insertions(+), 6 deletions(-)
+
+diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
+index e21e566f7f..77b78e6e25 100644
+--- a/vllm/model_executor/layers/sparse_attn_indexer.py
++++ b/vllm/model_executor/layers/sparse_attn_indexer.py
+@@ -535,6 +535,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+     topk_indices: torch.Tensor,
+     topk_tokens: int,
+     head_dim: int,
++    allow_deepseek_v4: bool = False,
+ ) -> bool:
+     is_glm52 = (
+         q_quant.ndim == 3
+@@ -549,7 +550,9 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+     implementation_enabled = (
+         is_glm52 and _musa_sparse_indexer_glm52_materialized_enabled()
+     ) or (
+-        is_deepseek_v4 and _musa_sparse_indexer_materialized_prefill_enabled()
++        is_deepseek_v4
++        and allow_deepseek_v4
++        and _musa_sparse_indexer_materialized_prefill_enabled()
+     )
+     if (
+         not implementation_enabled
+@@ -776,6 +779,7 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
+     topk_indices: torch.Tensor,
+     topk_tokens: int,
+     head_dim: int,
++    allow_deepseek_v4_materialized: bool = False,
+ ) -> bool:
+     if (
+         q_quant.ndim == 3
+@@ -851,6 +855,7 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
+         topk_indices[:rows, :topk],
+         topk,
+         head_dim,
++        allow_deepseek_v4_materialized,
+     ):
+         return True
+ 
+@@ -1204,6 +1209,7 @@ def _musa_fill_exact_sparse_indexer_indices(
+     max_model_len: int,
+     topk_indices_buffer: torch.Tensor,
+     use_fp4_cache: bool,
++    use_musa_materialized_prefill: bool = False,
+ ) -> torch.Tensor:
+     if _musa_try_fill_all_sparse_indexer_indices(
+         hidden_states,
+@@ -1270,6 +1276,7 @@ def _musa_fill_exact_sparse_indexer_indices(
+                 topk_indices_buffer[token_start:token_end, :topk_tokens],
+                 topk_tokens,
+                 head_dim,
++                use_musa_materialized_prefill,
+             ):
+                 continue
+             if q_deq is None:
+@@ -1742,6 +1749,7 @@ class SparseAttnIndexer(CustomOp):
+         skip_k_cache_insert: bool = False,
+         use_fp4_cache: bool = False,
+         use_musa_native_indexer: bool = False,
++        use_musa_materialized_prefill: bool = False,
+     ):
+         super().__init__()
+         self.k_cache = k_cache
+@@ -1755,6 +1763,7 @@ class SparseAttnIndexer(CustomOp):
+         self.skip_k_cache_insert = skip_k_cache_insert
+         self.use_fp4_cache = use_fp4_cache
+         self.use_musa_native_indexer = use_musa_native_indexer
++        self.use_musa_materialized_prefill = use_musa_materialized_prefill
+         if current_platform.is_cuda() and not has_deep_gemm():
+             raise RuntimeError(
+                 "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
+@@ -1776,11 +1785,16 @@ class SparseAttnIndexer(CustomOp):
+             current_platform.is_musa()
+             and (
+                 self.use_musa_native_indexer
+-                or os.getenv(
+-                    "VLLM_MUSA_ENABLE_GLM52_SPARSE_INDEXER_MUSA_IMPL",
+-                    "1",
++                or (
++                    not isinstance(q_quant, tuple)
++                    and q_quant.ndim == 3
++                    and q_quant.shape[1] == 32
++                    and os.getenv(
++                        "VLLM_MUSA_ENABLE_GLM52_SPARSE_INDEXER_MUSA_IMPL",
++                        "1",
++                    )
++                    == "1"
+                 )
+-                == "1"
+                 or os.getenv(
+                     "VLLM_MUSA_ENABLE_TORCH_SPARSE_ATTN_INDEXER_FALLBACK",
+                     "0",
+@@ -1800,6 +1814,7 @@ class SparseAttnIndexer(CustomOp):
+                     self.max_model_len,
+                     self.topk_indices_buffer,
+                     self.use_fp4_cache,
++                    self.use_musa_materialized_prefill,
+                 )
+             except NotImplementedError:
+                 return _musa_fill_recent_sparse_indexer_indices(
+@@ -1824,6 +1839,7 @@ class SparseAttnIndexer(CustomOp):
+         """
+         return (
+             current_platform.is_musa()
++            and self.use_musa_native_indexer
+             and _musa_sparse_indexer_is_current_stream_capturing()
+             and not _musa_sparse_indexer_graph_exact_decode_enabled()
+         )
+diff --git a/vllm/models/deepseek_v4/attention.py b/vllm/models/deepseek_v4/attention.py
+index 34842fc34e..b2d29e1973 100644
+--- a/vllm/models/deepseek_v4/attention.py
++++ b/vllm/models/deepseek_v4/attention.py
+@@ -874,6 +874,22 @@ class DeepseekV4Indexer(nn.Module):
+             use_fp4_cache=self.use_fp4_kv,
+         )
+ 
++        use_musa_native_indexer = False
++        use_musa_materialized_prefill = False
++        if current_platform.is_musa():
++            from vllm_musa.optimization_contract import (
++                OptimizationFeature,
++                resolve_optimization_contract,
++            )
++
++            optimization_contract = resolve_optimization_contract(vllm_config)
++            use_musa_native_indexer = optimization_contract.prefers(
++                OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER
++            )
++            use_musa_materialized_prefill = optimization_contract.prefers(
++                OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER
++            )
++
+         self.indexer_op = SparseAttnIndexer(
+             self.k_cache,
+             self.quant_block_size,
+@@ -885,7 +901,8 @@ class DeepseekV4Indexer(nn.Module):
+             self.topk_indices_buffer,
+             skip_k_cache_insert=True,
+             use_fp4_cache=self.use_fp4_kv,
+-            use_musa_native_indexer=True,
++            use_musa_native_indexer=use_musa_native_indexer,
++            use_musa_materialized_prefill=use_musa_materialized_prefill,
+         )
+ 
+         # None on ROCm — maybe_execute_in_parallel falls back to sequential.
+diff --git a/vllm/models/deepseek_v4/nvidia/model.py b/vllm/models/deepseek_v4/nvidia/model.py
+index d334a1d7bf..a58cf0f2b0 100644
+--- a/vllm/models/deepseek_v4/nvidia/model.py
++++ b/vllm/models/deepseek_v4/nvidia/model.py
+@@ -114,6 +114,12 @@ class DeepseekV4MLP(nn.Module):
+             disable_tp=is_sequence_parallel,
+             prefix=f"{prefix}.down_proj",
+         )
++        if current_platform.is_musa():
++            from vllm.config import get_current_vllm_config
++
++            from vllm_musa.optimization_contract import bind_optimization_contract
++
++            bind_optimization_contract(self.down_proj, get_current_vllm_config())
+         if hidden_act != "silu":
+             raise ValueError(
+                 f"Unsupported activation: {hidden_act}. Only silu is supported for now."

--- a/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
+++ b/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
@@ -163,11 +163,11 @@ index d334a1d7bf..a58cf0f2b0 100644
              prefix=f"{prefix}.down_proj",
          )
 +        if current_platform.is_musa():
-+            from vllm.config import get_current_vllm_config
++            from vllm.config import get_current_vllm_config_or_none
 +
 +            from vllm_musa.optimization_contract import bind_optimization_contract
 +
-+            bind_optimization_contract(self.down_proj, get_current_vllm_config())
++            bind_optimization_contract(self.down_proj, get_current_vllm_config_or_none())
          if hidden_act != "silu":
              raise ValueError(
                  f"Unsupported activation: {hidden_act}. Only silu is supported for now."

--- a/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
+++ b/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
@@ -1,88 +1,49 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: musa <musa@local>
 Date: Mon, 3 Aug 2026 19:17:49 +0800
-Subject: [PATCH 101/101] MUSA: bind DeepSeek-V4 optimization contract
+Subject: [PATCH] MUSA: bind DeepSeek-V4 optimization contract
 
----
- .../layers/sparse_attn_indexer.py             | 26 +++++++++++++++----
- vllm/models/deepseek_v4/attention.py          | 19 +++++++++++++-
- vllm/models/deepseek_v4/nvidia/model.py       |  6 +++++
- 3 files changed, 45 insertions(+), 6 deletions(-)
 
 diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
-index e21e566f7f..77b78e6e25 100644
+index e21e566f7..77b78e6e2 100644
 --- a/vllm/model_executor/layers/sparse_attn_indexer.py
 +++ b/vllm/model_executor/layers/sparse_attn_indexer.py
-@@ -535,6 +535,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
-     topk_indices: torch.Tensor,
-     topk_tokens: int,
+@@ -537,2 +537,3 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
      head_dim: int,
 +    allow_deepseek_v4: bool = False,
  ) -> bool:
-     is_glm52 = (
-         q_quant.ndim == 3
-@@ -549,7 +550,9 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
-     implementation_enabled = (
-         is_glm52 and _musa_sparse_indexer_glm52_materialized_enabled()
+@@ -551,3 +552,5 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
      ) or (
 -        is_deepseek_v4 and _musa_sparse_indexer_materialized_prefill_enabled()
 +        is_deepseek_v4
 +        and allow_deepseek_v4
 +        and _musa_sparse_indexer_materialized_prefill_enabled()
      )
-     if (
-         not implementation_enabled
-@@ -776,6 +779,7 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
-     topk_indices: torch.Tensor,
-     topk_tokens: int,
+@@ -778,2 +781,3 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
      head_dim: int,
 +    allow_deepseek_v4_materialized: bool = False,
  ) -> bool:
-     if (
-         q_quant.ndim == 3
-@@ -851,6 +855,7 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
-         topk_indices[:rows, :topk],
-         topk,
+@@ -853,2 +857,3 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
          head_dim,
 +        allow_deepseek_v4_materialized,
      ):
-         return True
- 
-@@ -1204,6 +1209,7 @@ def _musa_fill_exact_sparse_indexer_indices(
-     max_model_len: int,
-     topk_indices_buffer: torch.Tensor,
+@@ -1206,2 +1211,3 @@ def _musa_fill_exact_sparse_indexer_indices(
      use_fp4_cache: bool,
 +    use_musa_materialized_prefill: bool = False,
  ) -> torch.Tensor:
-     if _musa_try_fill_all_sparse_indexer_indices(
-         hidden_states,
-@@ -1270,6 +1276,7 @@ def _musa_fill_exact_sparse_indexer_indices(
-                 topk_indices_buffer[token_start:token_end, :topk_tokens],
-                 topk_tokens,
+@@ -1272,2 +1278,3 @@ def _musa_fill_exact_sparse_indexer_indices(
                  head_dim,
 +                use_musa_materialized_prefill,
              ):
-                 continue
-             if q_deq is None:
-@@ -1742,6 +1749,7 @@ class SparseAttnIndexer(CustomOp):
-         skip_k_cache_insert: bool = False,
-         use_fp4_cache: bool = False,
+@@ -1744,2 +1751,3 @@ class SparseAttnIndexer(CustomOp):
          use_musa_native_indexer: bool = False,
 +        use_musa_materialized_prefill: bool = False,
      ):
-         super().__init__()
-         self.k_cache = k_cache
-@@ -1755,6 +1763,7 @@ class SparseAttnIndexer(CustomOp):
-         self.skip_k_cache_insert = skip_k_cache_insert
-         self.use_fp4_cache = use_fp4_cache
+@@ -1757,2 +1765,3 @@ class SparseAttnIndexer(CustomOp):
          self.use_musa_native_indexer = use_musa_native_indexer
 +        self.use_musa_materialized_prefill = use_musa_materialized_prefill
          if current_platform.is_cuda() and not has_deep_gemm():
-             raise RuntimeError(
-                 "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
-@@ -1776,11 +1785,16 @@ class SparseAttnIndexer(CustomOp):
-             current_platform.is_musa()
-             and (
+@@ -1778,7 +1787,12 @@ class SparseAttnIndexer(CustomOp):
                  self.use_musa_native_indexer
 -                or os.getenv(
 -                    "VLLM_MUSA_ENABLE_GLM52_SPARSE_INDEXER_MUSA_IMPL",
@@ -99,32 +60,19 @@ index e21e566f7f..77b78e6e25 100644
                  )
 -                == "1"
                  or os.getenv(
-                     "VLLM_MUSA_ENABLE_TORCH_SPARSE_ATTN_INDEXER_FALLBACK",
-                     "0",
-@@ -1800,6 +1814,7 @@ class SparseAttnIndexer(CustomOp):
-                     self.max_model_len,
-                     self.topk_indices_buffer,
+@@ -1802,2 +1816,3 @@ class SparseAttnIndexer(CustomOp):
                      self.use_fp4_cache,
 +                    self.use_musa_materialized_prefill,
                  )
-             except NotImplementedError:
-                 return _musa_fill_recent_sparse_indexer_indices(
-@@ -1824,6 +1839,7 @@ class SparseAttnIndexer(CustomOp):
-         """
-         return (
+@@ -1826,2 +1841,3 @@ class SparseAttnIndexer(CustomOp):
              current_platform.is_musa()
 +            and self.use_musa_native_indexer
              and _musa_sparse_indexer_is_current_stream_capturing()
-             and not _musa_sparse_indexer_graph_exact_decode_enabled()
-         )
 diff --git a/vllm/models/deepseek_v4/attention.py b/vllm/models/deepseek_v4/attention.py
-index 34842fc34e..b2d29e1973 100644
+index 34842fc34..b2d29e197 100644
 --- a/vllm/models/deepseek_v4/attention.py
 +++ b/vllm/models/deepseek_v4/attention.py
-@@ -874,6 +874,22 @@ class DeepseekV4Indexer(nn.Module):
-             use_fp4_cache=self.use_fp4_kv,
-         )
- 
+@@ -877 +877,17 @@ class DeepseekV4Indexer(nn.Module):
 +        use_musa_native_indexer = False
 +        use_musa_materialized_prefill = False
 +        if current_platform.is_musa():
@@ -142,25 +90,17 @@ index 34842fc34e..b2d29e1973 100644
 +            )
 +
          self.indexer_op = SparseAttnIndexer(
-             self.k_cache,
-             self.quant_block_size,
-@@ -885,7 +901,8 @@ class DeepseekV4Indexer(nn.Module):
-             self.topk_indices_buffer,
-             skip_k_cache_insert=True,
+@@ -887,3 +903,4 @@ class DeepseekV4Indexer(nn.Module):
              use_fp4_cache=self.use_fp4_kv,
 -            use_musa_native_indexer=True,
 +            use_musa_native_indexer=use_musa_native_indexer,
 +            use_musa_materialized_prefill=use_musa_materialized_prefill,
          )
- 
-         # None on ROCm — maybe_execute_in_parallel falls back to sequential.
 diff --git a/vllm/models/deepseek_v4/nvidia/model.py b/vllm/models/deepseek_v4/nvidia/model.py
-index d334a1d7bf..a58cf0f2b0 100644
+index d334a1d7b..9bed7d80f 100644
 --- a/vllm/models/deepseek_v4/nvidia/model.py
 +++ b/vllm/models/deepseek_v4/nvidia/model.py
-@@ -114,6 +114,12 @@ class DeepseekV4MLP(nn.Module):
-             disable_tp=is_sequence_parallel,
-             prefix=f"{prefix}.down_proj",
+@@ -116,2 +116,8 @@ class DeepseekV4MLP(nn.Module):
          )
 +        if current_platform.is_musa():
 +            from vllm.config import get_current_vllm_config_or_none
@@ -169,5 +109,3 @@ index d334a1d7bf..a58cf0f2b0 100644
 +
 +            bind_optimization_contract(self.down_proj, get_current_vllm_config_or_none())
          if hidden_act != "silu":
-             raise ValueError(
-                 f"Unsupported activation: {hidden_act}. Only silu is supported for now."

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,9 +17,10 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **103 patches**: this branch adds the DeepSeek-V4 shared-expert SwiGLU
-FP8 patch and removes the obsolete auxiliary-overlap patch after making that
-path the model default, so the upstream total remains unchanged. These are MUSA
+Currently **104 patches**: this stack adds one follow-up patch that binds the
+DeepSeek-V4 shared-MLP and sparse-indexer decisions to the MUSA optimization
+contract. The base branch adds the shared-expert SwiGLU FP8 patch and removes
+the obsolete auxiliary-overlap patch, leaving its total unchanged. These are MUSA
 source edits against the immutable vLLM commit recorded as `VLLM_COMMIT` in
 `third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
 object/registration patches (which patch live objects at import) are kept

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,12 +17,10 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **104 patches**: this stack adds one follow-up patch that binds the
-DeepSeek-V4 shared-MLP and sparse-indexer decisions to the MUSA optimization
-contract. The base branch adds the shared-expert SwiGLU FP8 patch and removes
-the obsolete auxiliary-overlap patch, leaving its total unchanged. These are MUSA
-source edits against the immutable vLLM commit recorded as `VLLM_COMMIT` in
-`third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
+Currently **104 patches**. The final patch binds DeepSeek-V4 shared-MLP and
+sparse-indexer policy to the MUSA optimization contract. The series contains
+MUSA source edits against the immutable vLLM commit recorded as `VLLM_COMMIT`
+in `third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
 object/registration patches (which patch live objects at import) are kept
 separately in `vllm_musa/patches/`, not in this build-time series. Run
 `python3 tools/musa_sync.py verify` to replay and verify the complete manifest

--- a/vllm_musa/patches/vllm__compilation__backends.patch.py
+++ b/vllm_musa/patches/vllm__compilation__backends.patch.py
@@ -22,9 +22,12 @@ def _try_qwen2_rope_kv_presplit(backend, graph) -> int:
         return 0
 
     from vllm_musa.compilation import qwen2_rope_kv_presplit as presplit
-    from vllm_musa.platform import _is_qwen2_rope_kv_fusion_config
+    from vllm_musa.optimization_contract import policy
+    from vllm_musa.optimization_contract.types import OptimizationFeature
 
-    if not _is_qwen2_rope_kv_fusion_config(vllm_config):
+    if not policy.prefers_feature(
+        vllm_config, OptimizationFeature.QWEN2_ROPE_KV_PRESPLIT
+    ):
         return 0
 
     if not presplit.qwen2_rope_kv_backend_supported(vllm_config):
@@ -81,9 +84,12 @@ def _try_qwen3_qk_rope_kv_presplit(backend, graph) -> int:
         return 0
 
     from vllm_musa.compilation import qwen3_qk_rope_kv_presplit as presplit
-    from vllm_musa.platform import _is_qwen3_qk_rope_kv_fusion_config
+    from vllm_musa.optimization_contract import policy
+    from vllm_musa.optimization_contract.types import OptimizationFeature
 
-    if not _is_qwen3_qk_rope_kv_fusion_config(vllm_config):
+    if not policy.prefers_feature(
+        vllm_config, OptimizationFeature.QWEN3_QK_ROPE_KV_PRESPLIT
+    ):
         return 0
     model_config = getattr(vllm_config, "model_config", None)
     hf_text_config = getattr(model_config, "hf_text_config", None)

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -696,7 +696,9 @@ class MUSAPlatformBase(Platform):
             and cache_config is not None
             and model_config.is_hybrid
             and cache_config.mamba_cache_mode == "none"
-            and os.environ.get("VLLM_MUSA_MAMBA_SEPARATE_POOL", "1") == "1"
+            and resolve_optimization_contract(vllm_config).prefers(
+                OptimizationFeature.HYBRID_SEPARATE_MAMBA_POOL
+            )
         )
         if separate_mamba_pages:
             backend_cls = cls._find_non_ssm_backend(vllm_config)

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -30,6 +30,7 @@ else:
 import pymtml as pynvml
 
 from vllm_musa.optimization_contract import (
+    ModelFamily,
     OptimizationFeature,
     resolve_optimization_contract,
 )
@@ -39,23 +40,6 @@ logger = init_logger(__name__)
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
-_DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV = "VLLM_MUSA_GEMV_MOE_BLOCK"
-_DEEPSEEK_V4_DEFAULT_GEMV_MOE_BLOCK = "32x8"
-
-
-def _is_deepseek_v4_model(model_config: Any | None) -> bool:
-    if model_config is None:
-        return False
-
-    hf_config = getattr(model_config, "hf_config", None)
-    model_type = getattr(hf_config, "model_type", None)
-    if model_type == "deepseek_v4":
-        return True
-
-    architectures = getattr(model_config, "architectures", None)
-    if architectures is None and hf_config is not None:
-        architectures = getattr(hf_config, "architectures", None)
-    return any("DeepseekV4" in str(arch) for arch in architectures or ())
 
 
 def _has_routed_experts(model_config: Any | None) -> bool:
@@ -115,8 +99,7 @@ def _is_qwen3_qk_rope_kv_fusion_config(vllm_config: Any) -> bool:
 
 
 def _deepseek_v4_flashmla_sparse_block_size(
-    model_config: Any | None,
-    tensor_parallel_size: int | None,
+    vllm_config: Any,
 ) -> int:
     """Return the validated FlashMLA sparse page size for DeepSeek-V4.
 
@@ -124,7 +107,9 @@ def _deepseek_v4_flashmla_sparse_block_size(
     the generic 64-token page for other models and parallel layouts; this is a
     model/shape decision rather than a process-wide environment switch.
     """
-    if _is_deepseek_v4_model(model_config) and tensor_parallel_size == 8:
+    if resolve_optimization_contract(vllm_config).prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    ):
         return 256
     return 64
 
@@ -583,32 +568,6 @@ class MUSAPlatformBase(Platform):
                 FUSED_ADD_RMSNORM_MIN_ROWS - 1,
             )
 
-        if _is_deepseek_v4_model(model_config):
-            # Keep the generic GEMV selector available for other models, but
-            # make the validated DeepSeek-V4 TP8 choice independent of a
-            # DeepSeek-specific profile environment variable. Explicit
-            # generic overrides still win for A/B diagnostics.
-            tensor_parallel_size = getattr(
-                parallel_config, "tensor_parallel_size", None
-            )
-            if (
-                tensor_parallel_size == 8
-                and "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in os.environ
-            ):
-                os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] = "256"
-            if _DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV not in os.environ:
-                os.environ[_DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV] = (
-                    "16x8"
-                    if tensor_parallel_size == 8
-                    else _DEEPSEEK_V4_DEFAULT_GEMV_MOE_BLOCK
-                )
-                logger.info(
-                    "Defaulting DeepSeek-V4 MUSA GEMV/MoE block selector to "
-                    "%s=%s (set it explicitly to override).",
-                    _DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV,
-                    os.environ[_DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV],
-                )
-
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm_musa.worker.MTGPUWorker"
 
@@ -658,8 +617,7 @@ class MUSAPlatformBase(Platform):
                     use_flashmla_sparse = True
 
                 sparse_block_size = _deepseek_v4_flashmla_sparse_block_size(
-                    model_config,
-                    getattr(parallel_config, "tensor_parallel_size", None),
+                    vllm_config,
                 )
                 if use_flashmla_sparse and cache_config.block_size != sparse_block_size:
                     cache_config.block_size = sparse_block_size
@@ -736,7 +694,10 @@ class MUSAPlatformBase(Platform):
             or model_config.is_hybrid
         ):
             return
-        if _is_deepseek_v4_model(model_config):
+        if (
+            resolve_optimization_contract(vllm_config).model.family
+            is ModelFamily.DEEPSEEK_V4
+        ):
             return
         backend_cls = cls._find_non_ssm_backend(vllm_config)
         if backend_cls is None:

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -34,84 +34,13 @@ from vllm_musa.optimization_contract import (
     OptimizationFeature,
     resolve_optimization_contract,
 )
+from vllm_musa.optimization_contract import policy as contract_policy
 from vllm_musa.tuning import FUSED_ADD_RMSNORM_MIN_ROWS
 
 logger = init_logger(__name__)
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
-
-
-def _has_routed_experts(model_config: Any | None) -> bool:
-    """Return whether the text model uses routed MoE experts.
-
-    Real vLLM ``ModelConfig`` objects expose the authoritative ``is_moe``
-    property, including heterogeneous ``block_configs``. The remaining checks
-    only support lightweight config doubles and older integrations.
-    """
-    if model_config is None:
-        return False
-
-    is_moe = getattr(model_config, "is_moe", None)
-    if is_moe is not None:
-        return bool(is_moe)
-
-    hf_text_config = getattr(model_config, "hf_text_config", None)
-    if hf_text_config is None:
-        hf_config = getattr(model_config, "hf_config", None)
-        hf_text_config = getattr(hf_config, "text_config", hf_config)
-    for name in (
-        "num_experts",
-        "moe_num_experts",
-        "n_routed_experts",
-        "num_local_experts",
-    ):
-        if getattr(hf_text_config, name, 0):
-            return True
-
-    architectures = getattr(model_config, "architectures", None)
-    if architectures is None:
-        architectures = getattr(hf_text_config, "architectures", None)
-    return any(
-        "moe" in str(architecture).lower() for architecture in architectures or ()
-    )
-
-
-def _is_validated_qwen3_8b_fp8_single_gpu(vllm_config: Any) -> bool:
-    """Return whether the validated Qwen3-8B FP8 single-GPU scope is selected."""
-    return resolve_optimization_contract(vllm_config).prefers(
-        OptimizationFeature.QWEN3_DENSE_FP8_POST_GRAD_FUSIONS
-    )
-
-
-def _is_qwen2_rope_kv_fusion_config(vllm_config: Any) -> bool:
-    """Return whether the config is eligible for the exact MP31 Qwen2 fusion."""
-    return resolve_optimization_contract(vllm_config).prefers(
-        OptimizationFeature.QWEN2_ROPE_KV_PRESPLIT
-    )
-
-
-def _is_qwen3_qk_rope_kv_fusion_config(vllm_config: Any) -> bool:
-    """Return whether config is in the validated dense Qwen3 TP1 scope."""
-    return resolve_optimization_contract(vllm_config).prefers(
-        OptimizationFeature.QWEN3_QK_ROPE_KV_PRESPLIT
-    )
-
-
-def _deepseek_v4_flashmla_sparse_block_size(
-    vllm_config: Any,
-) -> int:
-    """Return the validated FlashMLA sparse page size for DeepSeek-V4.
-
-    The 256-token page is part of the DeepSeek-V4 TP8 kernel contract.  Keep
-    the generic 64-token page for other models and parallel layouts; this is a
-    model/shape decision rather than a process-wide environment switch.
-    """
-    if resolve_optimization_contract(vllm_config).prefers(
-        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
-    ):
-        return 256
-    return 64
 
 
 @cache
@@ -387,10 +316,10 @@ class MUSAPlatformBase(Platform):
         # MoE on native by default because a 100-prompt Qwen3.6 TP8 sweep
         # regressed 2.81% as eager-faithful BF16 rounding changed expert routes.
         # Users can still explicitly select the generic provider for A/B work.
+        contract = resolve_optimization_contract(vllm_config)
         gated_qkv_rms_norm_rope = (
             ["musa_inductor", "native"]
-            if using_inductor
-            and not _has_routed_experts(getattr(vllm_config, "model_config", None))
+            if using_inductor and contract.model.has_routed_experts is not True
             else ["native"]
         )
         return IrOpPriorityConfig.with_default(
@@ -616,8 +545,8 @@ class MUSAPlatformBase(Platform):
                 if not use_flashmla_sparse:
                     use_flashmla_sparse = True
 
-                sparse_block_size = _deepseek_v4_flashmla_sparse_block_size(
-                    vllm_config,
+                sparse_block_size = (
+                    contract_policy.deepseek_v4_flashmla_sparse_page_size(vllm_config)
                 )
                 if use_flashmla_sparse and cache_config.block_size != sparse_block_size:
                     cache_config.block_size = sparse_block_size

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -29,6 +29,10 @@ else:
 
 import pymtml as pynvml
 
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    resolve_optimization_contract,
+)
 from vllm_musa.tuning import FUSED_ADD_RMSNORM_MIN_ROWS
 
 logger = init_logger(__name__)
@@ -91,152 +95,22 @@ def _has_routed_experts(model_config: Any | None) -> bool:
 
 def _is_validated_qwen3_8b_fp8_single_gpu(vllm_config: Any) -> bool:
     """Return whether the validated Qwen3-8B FP8 single-GPU scope is selected."""
-    model_config = getattr(vllm_config, "model_config", None)
-    if model_config is None or _has_routed_experts(model_config):
-        return False
-
-    hf_text_config = getattr(model_config, "hf_text_config", None)
-    if hf_text_config is None:
-        hf_config = getattr(model_config, "hf_config", None)
-        hf_text_config = getattr(hf_config, "text_config", hf_config)
-    architectures = getattr(model_config, "architectures", None)
-    if architectures is None:
-        architectures = getattr(hf_text_config, "architectures", None)
-
-    quantization = getattr(model_config, "quantization", None)
-    if quantization is None:
-        quantization_config = getattr(hf_text_config, "quantization_config", {})
-        if isinstance(quantization_config, dict):
-            quantization = quantization_config.get("quant_method")
-
-    parallel_config = getattr(vllm_config, "parallel_config", None)
-    single_gpu = all(
-        getattr(parallel_config, name, 1) == 1
-        for name in (
-            "tensor_parallel_size",
-            "pipeline_parallel_size",
-            "data_parallel_size",
-        )
-    )
-    return (
-        tuple(architectures or ()) == ("Qwen3ForCausalLM",)
-        and getattr(hf_text_config, "model_type", None) == "qwen3"
-        and getattr(hf_text_config, "hidden_size", None) == 4096
-        and getattr(hf_text_config, "intermediate_size", None) == 12288
-        and getattr(hf_text_config, "num_hidden_layers", None) == 36
-        and quantization == "fp8"
-        and getattr(model_config, "dtype", None) == torch.bfloat16
-        and single_gpu
-        and getattr(vllm_config, "speculative_config", None) is None
+    return resolve_optimization_contract(vllm_config).prefers(
+        OptimizationFeature.QWEN3_DENSE_FP8_POST_GRAD_FUSIONS
     )
 
 
 def _is_qwen2_rope_kv_fusion_config(vllm_config: Any) -> bool:
     """Return whether the config is eligible for the exact MP31 Qwen2 fusion."""
-    model_config = getattr(vllm_config, "model_config", None)
-    parallel_config = getattr(vllm_config, "parallel_config", None)
-    if model_config is None or parallel_config is None:
-        return False
-
-    hf_text_config = getattr(model_config, "hf_text_config", None)
-    if hf_text_config is None:
-        hf_config = getattr(model_config, "hf_config", None)
-        hf_text_config = getattr(hf_config, "text_config", hf_config)
-    single_gpu = all(
-        getattr(parallel_config, name, 1) == 1
-        for name in (
-            "tensor_parallel_size",
-            "pipeline_parallel_size",
-            "data_parallel_size",
-            "decode_context_parallel_size",
-        )
-    )
-    model_type = getattr(hf_text_config, "model_type", None)
-    # CosyVoice3 exposes its outer multimodal config here.  The actual talker
-    # attention layers are Qwen2-shaped and are checked again by the backend
-    # gate, so accept that wrapper without broadening the tensor-shape scope.
-    if model_type not in ("qwen2", "cosyvoice3"):
-        return False
-    num_key_value_heads = getattr(hf_text_config, "num_key_value_heads", None)
-    intermediate_size = getattr(hf_text_config, "intermediate_size", None)
-    cache_config = getattr(vllm_config, "cache_config", None)
-    cache_dtype = getattr(cache_config, "cache_dtype", "auto")
-    cache_block_size = getattr(cache_config, "block_size", None)
-    if model_type == "qwen2":
-        if num_key_value_heads != 2 or intermediate_size != 4864:
-            return False
-    elif num_key_value_heads not in (None, 2) or intermediate_size not in (None, 4864):
-        return False
-    return (
-        getattr(hf_text_config, "hidden_size", None) == 896
-        and getattr(hf_text_config, "num_hidden_layers", None) == 24
-        and getattr(hf_text_config, "num_attention_heads", None) == 14
-        and getattr(model_config, "dtype", None) == torch.bfloat16
-        and getattr(model_config, "quantization", None) in (None, "none")
-        and getattr(vllm_config, "quant_config", None) is None
-        and getattr(vllm_config, "speculative_config", None) is None
-        # vLLM uses the string spelling for an explicit BF16 cache, while
-        # lightweight test/config objects may carry torch.bfloat16 directly.
-        and cache_dtype in ("auto", "bfloat16", torch.bfloat16)
-        # MUSA's fused kernel is specialized for the FA3 NHD block-64 cache.
-        # Keep None acceptable before cache initialization, but reject an
-        # explicitly incompatible block size before mutating the FX graph.
-        and cache_block_size in (None, 64)
-        and not getattr(model_config, "enforce_eager", False)
-        and single_gpu
+    return resolve_optimization_contract(vllm_config).prefers(
+        OptimizationFeature.QWEN2_ROPE_KV_PRESPLIT
     )
 
 
 def _is_qwen3_qk_rope_kv_fusion_config(vllm_config: Any) -> bool:
     """Return whether config is in the validated dense Qwen3 TP1 scope."""
-    model_config = getattr(vllm_config, "model_config", None)
-    parallel_config = getattr(vllm_config, "parallel_config", None)
-    if model_config is None or parallel_config is None:
-        return False
-
-    hf_text_config = getattr(model_config, "hf_text_config", None)
-    if hf_text_config is None:
-        hf_config = getattr(model_config, "hf_config", None)
-        hf_text_config = getattr(hf_config, "text_config", hf_config)
-    architectures = getattr(model_config, "architectures", None)
-    if architectures is None:
-        architectures = getattr(hf_text_config, "architectures", None)
-
-    cache_config = getattr(vllm_config, "cache_config", None)
-    cache_dtype = getattr(cache_config, "cache_dtype", "auto")
-    cache_block_size = getattr(cache_config, "block_size", None)
-    single_gpu = all(
-        getattr(parallel_config, name, 1) == 1
-        for name in (
-            "tensor_parallel_size",
-            "pipeline_parallel_size",
-            "data_parallel_size",
-            "decode_context_parallel_size",
-        )
-    )
-    exact_geometry = (
-        getattr(hf_text_config, "hidden_size", None),
-        getattr(hf_text_config, "intermediate_size", None),
-        getattr(hf_text_config, "num_hidden_layers", None),
-        getattr(hf_text_config, "num_attention_heads", None),
-        getattr(hf_text_config, "num_key_value_heads", None),
-        getattr(hf_text_config, "head_dim", None),
-    ) in (
-        (1024, 3072, 28, 16, 8, 128),
-        (4096, 12288, 36, 32, 8, 128),
-    )
-    return (
-        tuple(architectures or ()) == ("Qwen3ForCausalLM",)
-        and getattr(hf_text_config, "model_type", None) == "qwen3"
-        and exact_geometry
-        and getattr(model_config, "dtype", None) == torch.bfloat16
-        and getattr(model_config, "quantization", None) in (None, "none")
-        and getattr(vllm_config, "quant_config", None) is None
-        and getattr(vllm_config, "speculative_config", None) is None
-        and cache_dtype in ("auto", "bfloat16", torch.bfloat16)
-        and cache_block_size in (None, 64)
-        and not getattr(model_config, "enforce_eager", False)
-        and single_gpu
+    return resolve_optimization_contract(vllm_config).prefers(
+        OptimizationFeature.QWEN3_QK_ROPE_KV_PRESPLIT
     )
 
 
@@ -1045,7 +919,9 @@ class MUSAPlatformBase(Platform):
 
     @classmethod
     def get_device_communicator_cls(cls) -> str:
-        return "vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
+        return (
+            "vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
+        )
 
     @classmethod
     def supports_fp8(cls) -> bool:

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -45,6 +45,10 @@ from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import AttentionSpec
 
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    resolve_optimization_contract,
+)
 from vllm_musa.v1.attention.backends.fa_utils import (
     flash_attn_supports_fp8,
     get_flash_attn_version,
@@ -62,24 +66,10 @@ if is_flash_attn_varlen_func_available():
 
 logger = init_logger(__name__)
 
-_MUSA_QWEN_TEXT_GENERATION_ARCHITECTURES = frozenset(
-    {
-        "Qwen2ForCausalLM",
-        "Qwen2MoeForCausalLM",
-        "Qwen3ForCausalLM",
-        "Qwen3MoeForCausalLM",
-        "Qwen3_5ForConditionalGeneration",
-        "Qwen3_5MoeForConditionalGeneration",
-        "CosyVoice3Model",
-    }
-)
-
 
 def _is_musa_qwen_text_generation_architecture(model_config: Any) -> bool:
-    architectures = getattr(model_config, "architectures", None) or ()
-    return any(
-        architecture in _MUSA_QWEN_TEXT_GENERATION_ARCHITECTURES
-        for architecture in architectures
+    return resolve_optimization_contract(model_config=model_config).prefers(
+        OptimizationFeature.QWEN_FA3_SCHEDULER
     )
 
 
@@ -120,17 +110,16 @@ def _is_qwen_family_scheduler_lookup_base_config(
     vllm_config: VllmConfig,
 ) -> bool:
     """Check the Qwen FA3 scheduler configuration envelope."""
-    model_config = getattr(vllm_config, "model_config", None)
     scheduler_config = getattr(vllm_config, "scheduler_config", None)
     parallel_config = getattr(vllm_config, "parallel_config", None)
-    if model_config is None or scheduler_config is None or parallel_config is None:
+    if scheduler_config is None or parallel_config is None:
         return False
 
     max_num_seqs = getattr(scheduler_config, "max_num_seqs", None)
-    is_qwen_family = _is_musa_qwen_text_generation_architecture(model_config)
+    contract = resolve_optimization_contract(vllm_config)
 
     return (
-        is_qwen_family
+        contract.prefers(OptimizationFeature.QWEN_FA3_SINGLE_REQUEST_METADATA)
         and isinstance(max_num_seqs, int)
         and max_num_seqs >= 1
         and getattr(vllm_config, "speculative_config", None) is None
@@ -510,9 +499,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
 
         self.max_num_splits = 0  # No upper bound on the number of splits.
         self.aot_schedule = get_flash_attn_version() == 3
-        self._musa_qwen_family = _is_musa_qwen_text_generation_architecture(
-            self.model_config
-        )
+        self._musa_optimization_contract = resolve_optimization_contract(vllm_config)
 
         try:
             from vllm.distributed.parallel_state import get_dcp_group
@@ -725,7 +712,9 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
                 self.model_config.dtype == torch.bfloat16
                 and self.kv_cache_dtype in ("auto", "bfloat16", torch.bfloat16)
             ),
-            is_qwen_family=self._musa_qwen_family,
+            is_qwen_family=self._musa_optimization_contract.prefers(
+                OptimizationFeature.QWEN_FA3_SCHEDULER
+            ),
             use_full_cuda_graph=self.use_full_cuda_graph,
             common_prefix_len=common_prefix_len,
             dcp_world_size=self.dcp_world_size,

--- a/vllm_musa/v1/sample/qwen_sample_input_views.py
+++ b/vllm_musa/v1/sample/qwen_sample_input_views.py
@@ -10,6 +10,11 @@ import torchada  # noqa: F401
 import torch
 # isort: on
 
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    prefers_optimization,
+)
+
 
 def _select_qwen_sample_input_views(
     sampler: Any,
@@ -19,7 +24,10 @@ def _select_qwen_sample_input_views(
     idx_mapping_np: np.ndarray,
     return_logprobs: bool,
 ) -> tuple[torch.Tensor, torch.Tensor] | None:
-    if not getattr(sampler, "_musa_qwen_family", False):
+    if not prefers_optimization(
+        sampler,
+        OptimizationFeature.QWEN_SAMPLE_INPUT_VIEWS,
+    ):
         return None
     if return_logprobs:
         return None

--- a/vllm_musa/v1/sample/topk_topp_sampler.py
+++ b/vllm_musa/v1/sample/topk_topp_sampler.py
@@ -19,6 +19,11 @@ from vllm.distributed import (
 from vllm.platforms import current_platform
 
 from vllm_musa import _custom_ops as _ops
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    prefers_optimization,
+    resolve_optimization_contract,
+)
 from vllm_musa.utils.environ import envs
 
 logger = logging.getLogger(__name__)
@@ -73,7 +78,7 @@ def _can_skip_legacy_qwen_unit_temperature(
 ) -> bool:
     """Use the scheduler's exact CPU hint to avoid a device divide by one."""
     return (
-        getattr(sampler, "_musa_qwen_skip_unit_temperature", False)
+        prefers_optimization(sampler, OptimizationFeature.QWEN_LEGACY_SAMPLING)
         and getattr(sampling_metadata, "all_random", False)
         and _is_qwen_sampler_vocab(logits)
         and getattr(sampling_metadata, "uniform_temperature", None) == np.float32(1.0)
@@ -347,7 +352,7 @@ def _topk_topp_sampler_init(
 ):
     original_init = vllm_topk_topp_sampler.TopKTopPSampler._musa_original_init
     original_init(self, logprobs_mode, use_fp64_gumbel)
-    self._musa_qwen_family = False
+    self._musa_optimization_contract = resolve_optimization_contract()
     if (
         logprobs_mode not in ("processed_logits", "processed_logprobs")
         and current_platform.is_musa()
@@ -602,7 +607,10 @@ def musa_compute_logits_if_eligible(
         getattr(sampler, "logprobs_mode", "raw_logprobs"),
         predict_bonus_token=False,
         use_fp64_gumbel=bool(getattr(sampler, "use_fp64_gumbel", False)),
-        is_qwen_family=bool(getattr(sampler, "_musa_qwen_family", False)),
+        is_qwen_family=prefers_optimization(
+            sampler,
+            OptimizationFeature.QWEN_TP4_SHARDED_GUMBEL,
+        ),
     )
     rows = int(hidden_states.shape[0]) if hidden_states.ndim > 0 else 0
     if (
@@ -645,7 +653,7 @@ def musa_compute_logits_if_eligible(
         or not logits.is_contiguous()
         or logits.stride(-1) != 1
     ):
-        return logits, False
+        return model.compute_logits(hidden_states), False
     sampler._musa_qwen_sharded_logits = True
     sampler._musa_qwen_global_vocab_size = global_vocab
     sampler._musa_qwen_tp_size = tp_size
@@ -851,7 +859,7 @@ def _get_qwen_legacy_generator_state_for_rows(
                 return None
             seeds.append(seed)
             offsets.append(offset)
-    except (AttributeError, RuntimeError, TypeError, ValueError):
+    except (AttributeError, KeyError, RuntimeError, TypeError, ValueError):
         return None
     return seeds, offsets
 
@@ -973,7 +981,10 @@ def _sample(
     sampling_metadata: Any,
     logprobs_mode_override: LogprobsMode | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    is_qwen_family = bool(getattr(self, "_musa_qwen_family", False))
+    is_qwen_family = prefers_optimization(
+        self,
+        OptimizationFeature.QWEN_LEGACY_GUMBEL,
+    )
     logprobs_mode = logprobs_mode_override or self.logprobs_mode
     assert not (sampling_metadata.all_greedy and sampling_metadata.all_random)
     if sampling_metadata.all_random:
@@ -1102,7 +1113,7 @@ def _sampler_forward(
         self.logprobs_mode,
         predict_bonus_token,
         self.use_fp64_gumbel,
-        bool(getattr(self, "_musa_qwen_family", False)),
+        prefers_optimization(self, OptimizationFeature.QWEN_LEGACY_GUMBEL),
         sampler=self,
     ):
         sampled = sample_qwen_legacy_unfiltered_gumbel(self, logits)
@@ -1155,7 +1166,7 @@ def can_use_qwen_v2_gumbel(
 ) -> bool:
     """Gate the pinned V2 Gumbel sampler to one validated Qwen contract."""
     if (
-        not getattr(sampler, "_musa_qwen_family", False)
+        not prefers_optimization(sampler, OptimizationFeature.QWEN_V2_GUMBEL)
         or not current_platform.is_musa()
         or not is_musa_tensor(logits)
     ):
@@ -1200,7 +1211,7 @@ def can_use_qwen_v2_unfiltered_gumbel(
 ) -> bool:
     """Gate direct logits-domain Gumbel to an unfiltered Qwen contract."""
     if (
-        not getattr(sampler, "_musa_qwen_family", False)
+        not prefers_optimization(sampler, OptimizationFeature.QWEN_V2_GUMBEL)
         or not current_platform.is_musa()
         or not is_musa_tensor(logits)
     ):
@@ -1457,7 +1468,7 @@ def _apply_worker_sampling_filters_for_seeded_multinomial(
     use_min_p = np.any(sampler.sampling_states.min_p.np[idx_mapping_np] != 0.0)
     if (
         use_top_k
-        and getattr(sampler, "_musa_qwen_family", False)
+        and prefers_optimization(sampler, OptimizationFeature.QWEN_V2_GUMBEL)
         and _is_uniform_top_k_50(top_k_np)
         and _is_qwen_sampler_vocab(logits)
         and (not use_top_p or logits.shape[0] >= 4)
@@ -1576,7 +1587,7 @@ def _worker_sample(
             self.sampling_states,
             expanded_idx_mapping,
             idx_mapping_np,
-            bool(getattr(self, "_musa_qwen_family", False)),
+            prefers_optimization(self, OptimizationFeature.QWEN_V2_GUMBEL),
         )
         return sampled, processed_logits
 

--- a/vllm_musa/v1/sample/uniform_sample_counts.py
+++ b/vllm_musa/v1/sample/uniform_sample_counts.py
@@ -9,6 +9,10 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    prefers_optimization,
+)
 from vllm_musa.v1.sample.topk_topp_sampler import (
     _is_qwen_sampler_vocab,
     is_musa_tensor,
@@ -23,7 +27,10 @@ def select_qwen_uniform_sample_counts(
     sampler: Any, logits: torch.Tensor, input_batch: Any
 ) -> tuple[torch.Tensor, torch.Tensor] | None:
     """Return cached one/zero counts for non-prefill Qwen decode."""
-    if not getattr(sampler, "_musa_qwen_family", False):
+    if not prefers_optimization(
+        sampler,
+        OptimizationFeature.QWEN_UNIFORM_SAMPLE_COUNTS,
+    ):
         return None
     if not current_platform.is_musa() or not is_musa_tensor(logits):
         return None

--- a/vllm_musa/v1/worker/qwen_identity_logits_view.py
+++ b/vllm_musa/v1/worker/qwen_identity_logits_view.py
@@ -6,6 +6,11 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    prefers_optimization,
+)
+
 logger = init_logger(__name__)
 
 
@@ -14,7 +19,10 @@ def _is_musa_tensor(tensor: torch.Tensor) -> bool:
 
 
 def _is_qwen_runner(runner: Any) -> bool:
-    return bool(getattr(getattr(runner, "sampler", None), "_musa_qwen_family", False))
+    return prefers_optimization(
+        getattr(runner, "sampler", None),
+        OptimizationFeature.QWEN_UNIFORM_DECODE_VIEWS,
+    )
 
 
 def select_qwen_identity_logits_view(


### PR DESCRIPTION
## Summary

This PR centralizes the MUSA model/execution optimization contract for the
Qwen family and DeepSeek-V4 in one stack.

- adds an immutable, family-agnostic contract and provider registry;
- migrates Qwen2/Qwen3/Qwen3.5-Qwen3.6 dense, MoE, GDN, and CosyVoice talker
  selection away from scattered model-name/env gates;
- adds an exact DeepSeek-V4 provider and binds its shared-MLP, sparse-indexer,
  FLASHMLA, custom-all-reduce, RMSNorm, and GEMV policies;
- keeps request/shape/stride/capture/provider checks at their owning consumers;
- fails closed for incomplete or unsupported metadata and preserves the old
  path for non-matching models.

The branch is based on `v0.24.0-dev` after #156 and ends at
`1ff66250d461f4ea208c569131af72d778017ade` (with the DSV4 base at
`4d0572f12c450c24a9bbfc3c7e2b4fae306a9cb9`).

## Review follow-up (`1ff66250d`)

- removed model-specific `_is_*`, routed-expert, and DSV4 page-size predicates
  from `platform.py`;
- moved those queries into `optimization_contract.policy` and updated the
  compilation/patch consumers to query policy directly;
- renamed the Qwen constants to `QWEN35_36_*`;
- added explicit Qwen3.5 and Qwen3.6 HF-schema tests plus a fail-closed test
  for a future distinct `qwen3_6_*` schema.

## Contract design

Static model facts (`ModelSignature`) and runtime facts (`ExecutionSignature`)
are resolved once into a frozen contract. Providers expose supported and
preferred features; consumers bind the contract to their owning model/module.
Kernel tuning values that are selected by the contract are passed explicitly
where possible (for example, the DSV4 GEMV tile), while dynamic shape and graph
guards remain local.

Explicit generic environment overrides remain available for rollback and A/B
experiments; they no longer provide the default model identity decision.

## DeepSeek-V4 performance preservation

The DSV4 work is a refactor on top of #156, not a second claim of the original
fusion uplift. The gate is that contract selection preserves the #156 path.

The exact TP8 workload was measured on one isolated 8 x S5000 node with the
5.2.0-server driver and image
`registry.mthreads.com/mcconline/inference/vllm:v0.24.0-ph1-5.2.0-torch2.9.1.post1-20260725`:

- DeepSeek-V4-Flash-Base; BF16 model; block-FP8 weights; FP8 KV;
  FLASHMLA;
- TP8; max model length 6144; max batched tokens 8195; max sequences 1;
- prefix cache off; async scheduling on; compilation `NONE`;
  `FULL_DECODE_ONLY`, capture sizes `[1]`, copy inputs off;
- random 4096 input / 1024 output tokens; five warmups;
  A1 -> B1 -> B2 -> A2.

| Variant | Output TPS | TTFT | TPOT | E2E |
|---|---:|---:|---:|---:|
| Current control (includes #156) | 50.8624 | 792.99 ms | 18.8067 ms | 20032.20 ms |
| Contract candidate | 50.8604 | 789.75 ms | 18.8105 ms | 20032.94 ms |
| Candidate vs control | -0.004% | -0.409% | +0.021% | +0.004% |

The [#156](https://github.com/MooreThreads/vllm-musa/pull/156) controlled
candidate was 51.0648 tok/s, 779.92 ms TTFT, and 18.7415 ms TPOT. The new
candidate differs by -0.40%, +1.26%, and +0.37%, respectively, within a 3%
repeatability envelope. All four measured requests completed with zero
failures and 1024 output tokens.

## Validation

### Unit, patch, and kernel tests

- contract/patch regression: `171 passed, 2 skipped`;
- DeepSeek-V4 tests: `112 passed`;
- JIT C++ regression: `64 passed`;
- RMSNorm/SwiGLU numeric and graph tests: `17 passed`;
- GEMV numeric and graph replay: `6 passed`;
- all 104 ordered patches replayed cleanly on pinned vLLM
  `ee0da84ab9e04ac7610e28580af62c365e898389`.
- final candidate focused regression on the 5.2.0-server image:
  `178 passed, 2 skipped`; the two graph-rewrite failures reproduce unchanged
  on the unmodified candidate image and are pre-existing compile/cache drift.

### Final-SHA model smokes

- Qwen3-8B BF16: normal `VLLM_COMPILE` + `FULL_DECODE_ONLY` graph,
  FLASH_ATTN, semantic request passed;
- Qwen3-8B-FP8: FLASH_ATTN semantic request passed;
- Qwen3-30B-A3B-FP8: FLASH_ATTN/DeepGEMM MoE semantic request passed;
- DeepSeek-V2-Lite-Chat-FP8: FLASHMLA, six sequential multi-turn requests,
  all HTTP 200, final health passed;
- DeepSeek-V4-Flash-Base: TP8 FLASHMLA semantic request passed, graph capture
  completed, sparse page 256 and GEMV 16x8 paths observed.

The BF16 MoE/MLA fallback smoke stops on
`UnquantizedFusedMoEMethod.is_monolithic`; the same exception reproduces with
the pre-DSV4 control image, so it is an existing stack baseline issue rather
than a regression from this PR.

## Review and merge

This PR now contains both the Qwen and DeepSeek-V4 changes. The former stacked
DSV4 PR (#167) is now an automatically merged/empty consolidation branch.
Review this PR as one contract change; no PR ordering is required after this
fast-forward.

Evidence bundles:

- `generated/musa60083-dsv4-contract/musa60083-dsv4-abba52-final.tgz`
- `generated/musa60083-dsv4-contract/musa60083-dsv4-regression.tgz`
