### PR TITLE
refactor(musa): bind DeepSeek-V4 optimizations to model contract

### DIFF
--- a/csrc/musa/fused_add_rmsnorm.mu
+++ b/csrc/musa/fused_add_rmsnorm.mu
@@ -126,13 +126,15 @@ __global__ void __launch_bounds__(BLOCK_X, 1) fused_add_rmsnorm_kernel(
 template <typename T>
 void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
                                 int rows, int hidden_size, float epsilon,
-                                musaStream_t stream) {
+                                musaStream_t stream, int requested_block) {
   const int vec_hidden_size = hidden_size / 8;
 
-  static const int forced_block = []() {
+  static const int env_forced_block = []() {
     const char* env = std::getenv("VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X");
     return env == nullptr ? 0 : std::atoi(env);
   }();
+  const int forced_block =
+      env_forced_block > 0 ? env_forced_block : requested_block;
 
   int block_x;
   if (forced_block > 0) {
@@ -202,7 +204,8 @@ void dispatch_fused_add_rmsnorm(T* input, T* residual, const T* weight,
 }  // namespace vllm_musa
 
 void musa_fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
-                             torch::Tensor& weight, double epsilon) {
+                             torch::Tensor& weight, double epsilon,
+                             int64_t block_x) {
   TORCH_CHECK(input.device().is_privateuseone(), "input must be a MUSA tensor");
   TORCH_CHECK(residual.device().is_privateuseone(),
               "residual must be a MUSA tensor");
@@ -234,13 +237,13 @@ void musa_fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
         static_cast<__half*>(input.data_ptr()),
         static_cast<__half*>(residual.data_ptr()),
         static_cast<const __half*>(weight.data_ptr()), rows, hidden_size,
-        static_cast<float>(epsilon), stream);
+        static_cast<float>(epsilon), stream, static_cast<int>(block_x));
   } else if (input.scalar_type() == at::ScalarType::BFloat16) {
     vllm_musa::dispatch_fused_add_rmsnorm<__mt_bfloat16>(
         static_cast<__mt_bfloat16*>(input.data_ptr()),
         static_cast<__mt_bfloat16*>(residual.data_ptr()),
         static_cast<const __mt_bfloat16*>(weight.data_ptr()), rows, hidden_size,
-        static_cast<float>(epsilon), stream);
+        static_cast<float>(epsilon), stream, static_cast<int>(block_x));
   } else {
     TORCH_CHECK(false, "only fp16 and bf16 are supported");
   }

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -800,7 +800,9 @@ void musa_fused_gemv_moe(
     bool mul_routed_weight,
     int64_t topk,
     bool use_int4_w4a16,
-    bool use_swigelu) {
+    bool use_swigelu,
+    int64_t requested_block_n,
+    int64_t requested_block_k) {
 
     TORCH_CHECK(A.dim() == 2, "A must be dim 2.")
     TORCH_CHECK(B.dim() == 3, "B must be dim 3.")
@@ -897,6 +899,29 @@ void musa_fused_gemv_moe(
         fallback_config = BlockConfig{128, 1, -1.0f, false};
     }
     BlockConfig forced_config{0, 0, 0.f, false};
+    BlockConfig requested_config{0, 0, 0.f, false};
+    TORCH_CHECK(
+        (requested_block_n == 0) == (requested_block_k == 0),
+        "requested GEMV block must provide both block_n and block_k, got ",
+        requested_block_n, "x", requested_block_k);
+    if (requested_block_n != 0) {
+        TORCH_CHECK(
+            requested_block_n > 0 && requested_block_k > 0 &&
+                requested_block_n * requested_block_k <= 512,
+            "requested GEMV block must use positive sizes with block_n * "
+            "block_k <= 512, got ",
+            requested_block_n, "x", requested_block_k);
+        requested_config = BlockConfig{
+            static_cast<int>(requested_block_n),
+            static_cast<int>(requested_block_k),
+            0.f,
+            true};
+        TORCH_CHECK(
+            IsForcedBlockConfigValid(requested_config, nr_n, hidden_size, vlen),
+            "requested GEMV block=", requested_block_n, "x",
+            requested_block_k, " is invalid for nr_n=", nr_n,
+            ", hidden_size=", hidden_size, ", vlen=", vlen);
+    }
     BlockConfig qwen_fp8_moe_config{32, 4, 0.f, true};
     BlockConfig deepseek_fp8_w1_config{32, 4, 0.f, true};
     BlockConfig deepseek_v4_fp8_moe_config =
@@ -923,6 +948,11 @@ void musa_fused_gemv_moe(
             forced_config.block_k, " is invalid for nr_n=", nr_n,
             ", hidden_size=", hidden_size, ", vlen=", vlen);
         best_config = &forced_config;
+    } else if (requested_config.valid) {
+        // The model-contract path passes this as a graph-static scalar. Keep
+        // the explicit environment override above for A/B diagnostics and
+        // preserve the DSV4 one-token split-tile rule ahead of both choices.
+        best_config = &requested_config;
     } else if (ShouldUseQwenFp8Moe32x4(
                    current_arch,
                    is_fp8,

--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -17,7 +17,9 @@ void musa_fused_gemv_moe(
     bool mul_routed_weight,
     int64_t topk,
     bool use_int4_w4a16,
-    bool use_swigelu);
+    bool use_swigelu,
+    int64_t block_n,
+    int64_t block_k);
 
 void musa_fused_gemv(
     torch::Tensor &A,

--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -35,7 +35,8 @@ void musa_fused_add_rms_norm(
     torch::Tensor &input,
     torch::Tensor &residual,
     torch::Tensor &weight,
-    double eps);
+    double eps,
+    int64_t block_x);
 
 void musa_reshape_and_cache_flash_nhd(
     torch::Tensor &key,

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -13,7 +13,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
   musa_ops.def(
       "musa_fused_gemv_moe(Tensor! A, Tensor! B, Tensor! C, Tensor? A_scale, Tensor? B_scale,"
       "Tensor! topk_weights, Tensor! topk_ids, bool mul_routed_weight, int topk, bool use_int4_w4a16,"
-      "bool use_swigelu) -> ()");
+      "bool use_swigelu, int block_n=0, int block_k=0) -> ()");
   musa_ops.impl("musa_fused_gemv_moe", torch::kMUSA, &musa_fused_gemv_moe);
 
   musa_ops.def(

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -24,7 +24,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
 
   musa_ops.def(
       "musa_fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, "
-      "float eps) -> ()");
+      "float eps, int block_x=0) -> ()");
   musa_ops.impl("musa_fused_add_rms_norm", torch::kMUSA,
                 &musa_fused_add_rms_norm);
 

--- a/tests/test_deepseek_v4_contract_source.py
+++ b/tests/test_deepseek_v4_contract_source.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _source(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_platform_uses_contract_without_model_derived_kernel_envs() -> None:
+    source = _source("vllm_musa/platform.py")
+
+    assert "DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256" in source
+    assert "_is_deepseek_v4_model" not in source
+    assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in source
+    assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in source
+
+
+def test_shared_mlp_and_rmsnorm_bind_instance_contracts() -> None:
+    linear = _source("vllm_musa/model_executor/layers/linear.py")
+    layernorm = _source("vllm_musa/model_executor/layers/layernorm.py")
+    model_patch = _source(
+        "vllm_musa/patches/series/"
+        "0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch"
+    )
+
+    assert "DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8" in linear
+    assert "prefers_optimization(" in linear
+    assert "bind_optimization_contract(self.down_proj" in model_patch
+    assert "bind_optimization_contract(self" in layernorm
+    assert "DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256" in layernorm
+    assert "block_x=256" in layernorm
+
+
+def test_sparse_indexer_contract_keeps_glm_entry_shape_local() -> None:
+    patch = _source(
+        "vllm_musa/patches/series/"
+        "0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch"
+    )
+
+    assert "DEEPSEEK_V4_NATIVE_SPARSE_INDEXER" in patch
+    assert "DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER" in patch
+    assert "use_musa_materialized_prefill" in patch
+    assert "q_quant.shape[1] == 32" in patch
+    assert "and self.use_musa_native_indexer" in patch
+
+
+def test_fused_add_rmsnorm_argument_is_graph_static_and_env_override_wins() -> None:
+    schema = _source("csrc/musa/torch_bindings.cpp")
+    kernel = _source("csrc/musa/fused_add_rmsnorm.mu")
+
+    assert "float eps, int block_x=0) -> ()" in schema
+    assert "int requested_block" in kernel
+    assert "env_forced_block > 0 ? env_forced_block : requested_block" in kernel
+
+
+def test_deepseek_tp8_moe_tile_is_selected_by_exact_runtime_shape() -> None:
+    source = _source("vllm_musa/model_executor/layers/fused_moe/fused_moe.py")
+
+    assert "is_deepseek_v4_flash_tp8_shape" in source
+    assert 'gemv_block = "16x8" if is_deepseek_v4_flash_tp8_shape else "auto"' in source
+    assert 'os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK")' in source

--- a/tests/test_deepseek_v4_contract_source.py
+++ b/tests/test_deepseek_v4_contract_source.py
@@ -60,3 +60,16 @@ def test_deepseek_tp8_moe_tile_is_selected_by_exact_runtime_shape() -> None:
     assert "is_deepseek_v4_flash_tp8_shape" in source
     assert 'gemv_block = "16x8" if is_deepseek_v4_flash_tp8_shape else "auto"' in source
     assert 'os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK")' in source
+
+
+def test_custom_all_reduce_uses_contract_identity_and_dynamic_capture_guard() -> None:
+    source = _source(
+        "vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py"
+    )
+
+    assert "DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD" in source
+    assert "contract.model.family is not ModelFamily.DEEPSEEK_V4" in source
+    assert "contract.supports(" in source
+    assert "cudagraph_capture_sizes" in source
+    assert '"DeepseekV4" in str(arch)' not in source
+    assert 'getattr(hf_config, "model_type", None)' not in source

--- a/tests/test_deepseek_v4_fused_add_rmsnorm.py
+++ b/tests/test_deepseek_v4_fused_add_rmsnorm.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+requires_musa = pytest.mark.skipif(
+    not hasattr(torch, "musa") or not torch.musa.is_available(),
+    reason="requires a MUSA device",
+)
+
+
+def _reference(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    residual_fp32 = x.float() + residual.float()
+    residual_out = residual_fp32.to(x.dtype)
+    normalized = residual_fp32 * torch.rsqrt(
+        residual_fp32.pow(2).mean(dim=-1, keepdim=True) + eps
+    )
+    return (normalized * weight.float()).to(x.dtype), residual_out
+
+
+@requires_musa
+@pytest.mark.parametrize("rows", [1, 4, 16, 64, 4096, 4100])
+def test_explicit_block256_matches_fp32_sum_reference(rows: int) -> None:
+    from vllm_musa import _custom_ops as musa_ops
+
+    torch.manual_seed(60083 + rows)
+    eps = 1e-6
+    x = torch.randn((rows, 4096), device="musa", dtype=torch.bfloat16)
+    residual = torch.randn_like(x)
+    weight = torch.randn((4096,), device="musa", dtype=torch.bfloat16)
+    expected, expected_residual = _reference(x, residual, weight, eps)
+
+    musa_ops.musa_fused_add_rms_norm(
+        x,
+        residual,
+        weight,
+        eps,
+        block_x=256,
+    )
+    torch.musa.synchronize()
+
+    torch.testing.assert_close(x.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(
+        residual.float(),
+        expected_residual.float(),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+@requires_musa
+def test_explicit_block256_replays_with_new_inputs() -> None:
+    eps = 1e-6
+    static_x = torch.empty((1, 4096), device="musa", dtype=torch.bfloat16)
+    static_residual = torch.empty_like(static_x)
+    weight = torch.randn((4096,), device="musa", dtype=torch.bfloat16)
+
+    warmup_stream = torch.musa.Stream()
+    warmup_stream.wait_stream(torch.musa.current_stream())
+    with torch.musa.stream(warmup_stream):
+        for seed in (3, 5, 7):
+            torch.manual_seed(seed)
+            static_x.copy_(torch.randn_like(static_x))
+            static_residual.copy_(torch.randn_like(static_residual))
+            torch.ops._C_musa_ops.musa_fused_add_rms_norm(
+                static_x,
+                static_residual,
+                weight,
+                eps,
+                256,
+            )
+    torch.musa.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.musa.MUSAGraph()
+    with torch.musa.graph(graph):
+        torch.ops._C_musa_ops.musa_fused_add_rms_norm(
+            static_x,
+            static_residual,
+            weight,
+            eps,
+            256,
+        )
+
+    for seed in (11, 13, 17):
+        torch.manual_seed(seed)
+        next_x = torch.randn_like(static_x)
+        next_residual = torch.randn_like(static_residual)
+        expected, expected_residual = _reference(next_x, next_residual, weight, eps)
+        static_x.copy_(next_x)
+        static_residual.copy_(next_residual)
+
+        graph.replay()
+        torch.musa.synchronize()
+
+        torch.testing.assert_close(
+            static_x.float(), expected.float(), rtol=2e-2, atol=2e-2
+        )
+        torch.testing.assert_close(
+            static_residual.float(),
+            expected_residual.float(),
+            rtol=0.0,
+            atol=0.0,
+        )

--- a/tests/test_deepseek_v4_gemv_contract_source.py
+++ b/tests/test_deepseek_v4_gemv_contract_source.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_deepseek_v4_gemv_contract_source.py
+++ b/tests/test_deepseek_v4_gemv_contract_source.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _source(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_contract_selected_gemv_block_reaches_custom_op_schema() -> None:
+    bindings = _source("csrc/musa/torch_bindings.cpp")
+    custom_ops = _source("vllm_musa/_custom_ops.py")
+    fused_moe = _source("vllm_musa/model_executor/layers/fused_moe/fused_moe.py")
+
+    assert "bool use_swigelu, int block_n=0, int block_k=0) -> ()" in bindings
+    assert "block_n: int = 0" in custom_ops
+    assert "block_k: int = 0" in custom_ops
+    assert "block_n,\n        block_k," in custom_ops
+    assert "_requested_gemv_block(shape)" in fused_moe
+    assert "block_n=gemv_block_n" in fused_moe
+    assert "block_k=gemv_block_k" in fused_moe
+
+
+def test_requested_tile_preserves_dsv4_and_environment_precedence() -> None:
+    gemv = _source("csrc/musa/gemv.mu")
+    moe = gemv[gemv.index("void musa_fused_gemv_moe(") :]
+    dispatch = moe[moe.index("BlockConfig forced_config") : moe.index("switch (")]
+
+    assert "int64_t requested_block_n" in gemv
+    assert "int64_t requested_block_k" in gemv
+    assert dispatch.index("ShouldUseDeepSeekV4Fp8MoeSplitTile(") < dispatch.index(
+        "ParseForcedBlockConfig(&forced_config)"
+    )
+    assert dispatch.index("ParseForcedBlockConfig(&forced_config)") < dispatch.index(
+        "requested_config.valid"
+    )
+    assert "requested GEMV block must provide both block_n and block_k" in gemv
+
+
+def test_contract_selector_does_not_forward_explicit_environment_override() -> None:
+    fused_moe = _source("vllm_musa/model_executor/layers/fused_moe/fused_moe.py")
+
+    helper = fused_moe[
+        fused_moe.index("def _requested_gemv_block(") : fused_moe.index(
+            "def _tensors_share_device("
+        )
+    ]
+    assert "os.environ.get(_GEMV_MOE_BLOCK_ENV) is not None" in helper
+    assert 'shape.gemv_block != "16x8"' in helper
+    assert "return 0, 0" in helper

--- a/tests/test_deepseek_v4_gemv_numeric.py
+++ b/tests/test_deepseek_v4_gemv_numeric.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_musa")
+
+
+requires_mp31 = pytest.mark.skipif(
+    not hasattr(torch, "musa")
+    or not torch.musa.is_available()
+    or tuple(torch.musa.get_device_capability()) != (3, 1),
+    reason="requires an mp31 MUSA device",
+)
+
+
+@requires_mp31
+@pytest.mark.parametrize("rows", [1, 2, 3, 4, 5])
+def test_requested_16x8_gemv_matches_reference(rows: int) -> None:
+    from vllm_musa import _custom_ops as musa_ops
+
+    vllm_musa = pytest.importorskip("vllm_musa")
+    vllm_musa.register_custom_ops()
+    torch.manual_seed(60083 + rows)
+
+    hidden_size = 128
+    output_size = 32
+    a = torch.randn((rows, hidden_size), device="musa", dtype=torch.bfloat16)
+    b = torch.randn(
+        (1, output_size, hidden_size), device="musa", dtype=torch.bfloat16
+    )
+    c = torch.empty((rows, output_size), device="musa", dtype=torch.bfloat16)
+    topk_weights = torch.ones((rows, 1), device="musa", dtype=torch.float32)
+    topk_ids = torch.zeros((rows, 1), device="musa", dtype=torch.int32)
+
+    musa_ops.musa_fused_gemv_moe(
+        a,
+        b,
+        c,
+        None,
+        None,
+        topk_weights,
+        topk_ids,
+        False,
+        1,
+        False,
+        False,
+        block_n=16,
+        block_k=8,
+    )
+    torch.musa.synchronize()
+
+    expected = torch.matmul(a.float(), b[0].float().transpose(0, 1)).to(
+        torch.bfloat16
+    )
+    torch.testing.assert_close(c.float(), expected.float(), rtol=2e-2, atol=2e-2)
+
+
+@requires_mp31
+def test_requested_gemv_block_is_graph_static() -> None:
+    from vllm_musa import _custom_ops as musa_ops
+
+    vllm_musa = pytest.importorskip("vllm_musa")
+    vllm_musa.register_custom_ops()
+
+    rows, hidden_size, output_size = 1, 128, 32
+    a = torch.empty((rows, hidden_size), device="musa", dtype=torch.bfloat16)
+    b = torch.randn(
+        (1, output_size, hidden_size), device="musa", dtype=torch.bfloat16
+    )
+    c = torch.empty((rows, output_size), device="musa", dtype=torch.bfloat16)
+    topk_weights = torch.ones((rows, 1), device="musa", dtype=torch.float32)
+    topk_ids = torch.zeros((rows, 1), device="musa", dtype=torch.int32)
+
+    warmup = torch.musa.Stream()
+    warmup.wait_stream(torch.musa.current_stream())
+    with torch.musa.stream(warmup):
+        for seed in (3, 5, 7):
+            torch.manual_seed(seed)
+            a.copy_(torch.randn_like(a))
+            musa_ops.musa_fused_gemv_moe(
+                a,
+                b,
+                c,
+                None,
+                None,
+                topk_weights,
+                topk_ids,
+                False,
+                1,
+                False,
+                False,
+                block_n=16,
+                block_k=8,
+            )
+    torch.musa.current_stream().wait_stream(warmup)
+
+    graph = torch.musa.MUSAGraph()
+    with torch.musa.graph(graph):
+        musa_ops.musa_fused_gemv_moe(
+            a,
+            b,
+            c,
+            None,
+            None,
+            topk_weights,
+            topk_ids,
+            False,
+            1,
+            False,
+            False,
+            block_n=16,
+            block_k=8,
+        )
+
+    for seed in (11, 13, 17):
+        torch.manual_seed(seed)
+        next_a = torch.randn_like(a)
+        expected = torch.matmul(next_a.float(), b[0].float().transpose(0, 1)).to(
+            torch.bfloat16
+        )
+        a.copy_(next_a)
+        graph.replay()
+        torch.musa.synchronize()
+        torch.testing.assert_close(c.float(), expected.float(), rtol=2e-2, atol=2e-2)

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -100,6 +100,15 @@ def test_flash_base_tp4_is_supported_but_not_tp8_preferred() -> None:
     assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
 
 
+def test_model_config_without_execution_topology_is_support_only() -> None:
+    config = _flash_base_config()
+
+    contract = resolve_optimization_contract(model_config=config.model_config)
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
+    assert not contract.preferred_features
+
+
 def test_incomplete_deepseek_identity_fails_closed() -> None:
     config = _flash_base_config()
     config.model_config.architectures = []

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -84,12 +84,18 @@ def test_flash_base_tp8_resolves_validated_profile() -> None:
     assert contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
     )
+    assert contract.supports(
+        OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD
+    )
 
 
 def test_flash_base_tp4_is_supported_but_not_tp8_preferred() -> None:
     contract = resolve_optimization_contract(_flash_base_config(tp=4))
 
     assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert contract.supports(
+        OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD
+    )
     assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from vllm_musa.optimization_contract import (
+    ModelFamily,
+    ModelRole,
+    OptimizationFeature,
+    bind_optimization_contract,
+    resolve_optimization_contract,
+)
+
+
+def _flash_base_config(*, tp: int = 8, speculative: bool = False):
+    text_config = SimpleNamespace(
+        architectures=["DeepseekV4ForCausalLM"],
+        model_type="deepseek_v4",
+        hidden_size=4096,
+        num_hidden_layers=43,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        head_dim=512,
+        vocab_size=129280,
+        n_routed_experts=256,
+        num_experts_per_tok=6,
+        n_shared_experts=1,
+        moe_intermediate_size=2048,
+        expert_dtype="fp8",
+        hidden_act="silu",
+        swiglu_limit=10.0,
+        index_topk=512,
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        },
+    )
+    model_config = SimpleNamespace(
+        architectures=["DeepseekV4ForCausalLM"],
+        hf_text_config=text_config,
+        hf_config=text_config,
+        dtype="bfloat16",
+        quantization="deepseek_v4_fp8",
+        use_mla=True,
+        is_hybrid=False,
+        is_moe=True,
+        enforce_eager=False,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=tp,
+            pipeline_parallel_size=1,
+            data_parallel_size=1,
+            decode_context_parallel_size=1,
+        ),
+        cache_config=SimpleNamespace(cache_dtype="fp8", block_size=64),
+        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        attention_config=SimpleNamespace(backend="FLASHMLA"),
+        compilation_config=SimpleNamespace(
+            mode="NONE",
+            cudagraph_mode="FULL_DECODE_ONLY",
+        ),
+        speculative_config=object() if speculative else None,
+        quant_config=SimpleNamespace(weight_block_size=[128, 128]),
+    )
+
+
+def test_flash_base_tp8_resolves_validated_profile() -> None:
+    contract = resolve_optimization_contract(_flash_base_config())
+
+    assert contract.model.family is ModelFamily.DEEPSEEK_V4
+    assert contract.model.role is ModelRole.TEXT
+    assert contract.model.uses_mla is True
+    assert contract.profile == "deepseek_v4.tp8_flash_base"
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER
+    )
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256)
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
+def test_flash_base_tp4_is_supported_but_not_tp8_preferred() -> None:
+    contract = resolve_optimization_contract(_flash_base_config(tp=4))
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
+
+
+def test_incomplete_deepseek_identity_fails_closed() -> None:
+    config = _flash_base_config()
+    config.model_config.architectures = []
+    config.model_config.hf_text_config.architectures = []
+    config.model_config.hf_config.architectures = []
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.model.family is ModelFamily.DEEPSEEK_V4
+    assert contract.profile == "deepseek_v4.unvalidated"
+    assert not contract.supported_features
+    assert not contract.preferred_features
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hidden_size", 7168),
+        ("num_hidden_layers", 44),
+        ("num_attention_heads", 32),
+        ("num_key_value_heads", 2),
+        ("head_dim", 256),
+        ("vocab_size", 129281),
+        ("n_routed_experts", 384),
+        ("num_experts_per_tok", 8),
+        ("n_shared_experts", 2),
+        ("moe_intermediate_size", 3072),
+        ("expert_dtype", "bf16"),
+        ("hidden_act", "gelu"),
+        ("swiglu_limit", 0.0),
+        ("index_topk", 1024),
+    ],
+)
+def test_one_field_model_mismatch_disables_flash_base_features(
+    field: str,
+    value: object,
+) -> None:
+    config = _flash_base_config()
+    setattr(config.model_config.hf_text_config, field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.model.family is ModelFamily.DEEPSEEK_V4
+    assert not contract.supported_features
+    assert not contract.preferred_features
+
+
+def test_model_config_use_mla_takes_precedence_over_missing_hf_fact() -> None:
+    config = _flash_base_config()
+    assert not hasattr(config.model_config.hf_text_config, "use_mla")
+    assert not hasattr(config.model_config.hf_text_config, "kv_lora_rank")
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.model.uses_mla is True
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
+
+
+def test_speculative_execution_keeps_support_but_disables_tp8_preferences() -> None:
+    contract = resolve_optimization_contract(_flash_base_config(speculative=True))
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+
+
+@pytest.mark.parametrize(
+    ("owner", "field", "value"),
+    [
+        ("cache_config", "cache_dtype", "auto"),
+        ("scheduler_config", "max_num_seqs", 4),
+        ("attention_config", "backend", "FLASH_ATTN"),
+        ("compilation_config", "mode", "VLLM_COMPILE"),
+        ("compilation_config", "cudagraph_mode", "PIECEWISE"),
+    ],
+)
+def test_one_field_execution_mismatch_disables_tp8_profile(
+    owner: str,
+    field: str,
+    value: object,
+) -> None:
+    config = _flash_base_config()
+    setattr(getattr(config, owner), field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
+def test_batch_invariant_is_snapshotted_as_an_execution_fact(monkeypatch) -> None:
+    fake_vllm = ModuleType("vllm")
+    fake_envs = ModuleType("vllm.envs")
+    fake_envs.VLLM_BATCH_INVARIANT = True
+    fake_vllm.envs = fake_envs
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+    monkeypatch.setitem(sys.modules, "vllm.envs", fake_envs)
+
+    contract = resolve_optimization_contract(_flash_base_config())
+
+    assert contract.execution.batch_invariant_enabled is True
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+
+
+def test_contract_binds_to_runtime_owner_once_resolved() -> None:
+    owner = SimpleNamespace()
+
+    contract = bind_optimization_contract(owner, _flash_base_config())
+
+    assert owner._musa_optimization_contract is contract
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -130,6 +130,90 @@ def test_incomplete_deepseek_identity_fails_closed() -> None:
 
 
 @pytest.mark.parametrize(
+    ("owner", "field", "value", "expected_supported"),
+    [
+        ("model_config", "architectures", ["Qwen3ForCausalLM"], frozenset()),
+        ("text_config", "model_type", "qwen3", frozenset()),
+        (
+            "model_config",
+            "dtype",
+            "float16",
+            frozenset(
+                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+            ),
+        ),
+        (
+            "model_config",
+            "quantization",
+            "compressed-tensors",
+            frozenset(
+                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+            ),
+        ),
+        (
+            "model_config",
+            "use_mla",
+            False,
+            frozenset(
+                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+            ),
+        ),
+    ],
+)
+def test_identity_and_model_traits_fail_closed(
+    owner: str,
+    field: str,
+    value: object,
+    expected_supported: frozenset[OptimizationFeature],
+) -> None:
+    config = _flash_base_config()
+    target = (
+        config.model_config.hf_text_config
+        if owner == "text_config"
+        else config.model_config
+    )
+    setattr(target, field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.supported_features == expected_supported
+    assert not contract.preferred_features
+
+
+def test_hybrid_deepseek_v4_does_not_enable_flash_base_features() -> None:
+    config = _flash_base_config()
+    config.model_config.is_hybrid = True
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.supported_features == frozenset(
+        {
+            OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD,
+            OptimizationFeature.HYBRID_SEPARATE_MAMBA_POOL,
+        }
+    )
+    assert contract.preferred_features == frozenset(
+        {OptimizationFeature.HYBRID_SEPARATE_MAMBA_POOL}
+    )
+
+
+def test_non_block128_quantization_fails_closed() -> None:
+    config = _flash_base_config()
+    config.quant_config.weight_block_size = [64, 128]
+    config.model_config.hf_text_config.quantization_config["weight_block_size"] = [
+        64,
+        128,
+    ]
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.supported_features == frozenset(
+        {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+    )
+    assert not contract.preferred_features
+
+
+@pytest.mark.parametrize(
     ("field", "value"),
     [
         ("hidden_size", 7168),
@@ -158,7 +242,9 @@ def test_one_field_model_mismatch_disables_flash_base_features(
     contract = resolve_optimization_contract(config)
 
     assert contract.model.family is ModelFamily.DEEPSEEK_V4
-    assert not contract.supported_features
+    assert contract.supported_features == frozenset(
+        {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
+    )
     assert not contract.preferred_features
 
 
@@ -205,6 +291,46 @@ def test_one_field_execution_mismatch_disables_tp8_profile(
 
     assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("pipeline_parallel_size", 2),
+        ("data_parallel_size", 2),
+        ("decode_context_parallel_size", 2),
+    ],
+)
+def test_non_reference_parallel_topology_disables_tp8_profile(
+    field: str,
+    value: int,
+) -> None:
+    config = _flash_base_config()
+    setattr(config.parallel_config, field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
+def test_pooling_and_missing_quant_runtime_disable_tp8_profile() -> None:
+    config = _flash_base_config()
+    config.quant_config = None
+
+    contract = resolve_optimization_contract(config, is_pooling_model=True)
+
+    assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
     )

--- a/tests/test_deepseek_v4_swiglu_fp8_fusion.py
+++ b/tests/test_deepseek_v4_swiglu_fp8_fusion.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""S5000 correctness coverage for the DeepSeek-V4 shared-MLP fusion."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+pytest.importorskip("torchada")
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_musa")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _musa_device() -> Iterator[None]:
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        pytest.skip("MUSA device is not available")
+    torch.musa.set_device(0)
+
+    from vllm.platforms import current_platform
+
+    import vllm_musa
+
+    if not current_platform.is_device_capability((3, 1)):
+        pytest.skip("the fused clamp-SwiGLU group-quant kernel requires mp31")
+    vllm_musa.register_custom_ops()
+    yield
+
+
+def _quant_outputs(rows: int, hidden: int = 256):
+    q = torch.empty((rows, hidden), device="musa", dtype=torch.float8_e4m3fn)
+    s = torch.empty((rows, hidden // 128), device="musa", dtype=torch.float32)
+    return q, s
+
+
+def _materialized_activation(gate_up, limit: float = 10.0):
+    hidden = gate_up.shape[-1] // 2
+    gate = torch.clamp(gate_up[..., :hidden], max=limit)
+    up = torch.clamp(gate_up[..., hidden:], min=-limit, max=limit)
+    return gate * torch.sigmoid(gate) * up
+
+
+@pytest.mark.parametrize("rows", [1, 4, 16, 64, 4096, 4100])
+def test_clamp_swiglu_group_quant_is_bit_exact(rows: int) -> None:
+    torch.manual_seed(60156 + rows)
+    gate_up = torch.randn((rows, 512), device="musa", dtype=torch.bfloat16)
+    boundary = torch.tensor(
+        [
+            float("-inf"),
+            -20.0,
+            -10.0,
+            -0.0,
+            0.0,
+            10.0,
+            20.0,
+            float("inf"),
+        ],
+        device="musa",
+        dtype=torch.bfloat16,
+    )
+    gate_up[0, :8] = boundary
+    gate_up[0, 256:264] = boundary.flip(0)
+
+    reference_q, reference_s = _quant_outputs(rows)
+    fused_q, fused_s = _quant_outputs(rows)
+    activated = _materialized_activation(gate_up)
+    torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+        activated,
+        reference_q,
+        reference_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+    )
+    torch.ops._C_musa_ops.silu_and_mul_clamp_per_token_group_fp8_quant(
+        gate_up,
+        fused_q,
+        fused_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+        10.0,
+    )
+    torch.musa.synchronize()
+
+    assert torch.equal(
+        reference_q.view(torch.uint8).cpu(), fused_q.view(torch.uint8).cpu()
+    )
+    assert torch.equal(
+        reference_s.view(torch.int32).cpu(), fused_s.view(torch.int32).cpu()
+    )
+
+
+@pytest.mark.parametrize("rows", [1, 4, 64])
+def test_bit_exact_quantization_preserves_bf16_down_projection(rows: int) -> None:
+    torch.manual_seed(60256 + rows)
+    gate_up = torch.randn((rows, 512), device="musa", dtype=torch.bfloat16)
+    reference_q, reference_s = _quant_outputs(rows)
+    fused_q, fused_s = _quant_outputs(rows)
+
+    torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+        _materialized_activation(gate_up),
+        reference_q,
+        reference_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+    )
+    torch.ops._C_musa_ops.silu_and_mul_clamp_per_token_group_fp8_quant(
+        gate_up,
+        fused_q,
+        fused_s,
+        128,
+        1e-10,
+        -448.0,
+        448.0,
+        10.0,
+    )
+
+    reference_dequant = reference_q.float() * reference_s.repeat_interleave(128, -1)
+    fused_dequant = fused_q.float() * fused_s.repeat_interleave(128, -1)
+    weight = torch.randn((4096, 256), device="musa", dtype=torch.bfloat16)
+    reference_out = (reference_dequant @ weight.float().T).to(torch.bfloat16)
+    fused_out = (fused_dequant @ weight.float().T).to(torch.bfloat16)
+    torch.musa.synchronize()
+
+    assert torch.equal(reference_out, fused_out)
+
+
+def test_clamp_swiglu_group_quant_replays_with_new_inputs() -> None:
+    gate_up = torch.empty((1, 512), device="musa", dtype=torch.bfloat16)
+    fused_q, fused_s = _quant_outputs(1)
+
+    warmup_stream = torch.musa.Stream()
+    warmup_stream.wait_stream(torch.musa.current_stream())
+    with torch.musa.stream(warmup_stream):
+        for seed in (23, 29, 31):
+            torch.manual_seed(seed)
+            gate_up.copy_(torch.randn_like(gate_up))
+            torch.ops._C_musa_ops.silu_and_mul_clamp_per_token_group_fp8_quant(
+                gate_up,
+                fused_q,
+                fused_s,
+                128,
+                1e-10,
+                -448.0,
+                448.0,
+                10.0,
+            )
+    torch.musa.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.musa.MUSAGraph()
+    with torch.musa.graph(graph):
+        torch.ops._C_musa_ops.silu_and_mul_clamp_per_token_group_fp8_quant(
+            gate_up,
+            fused_q,
+            fused_s,
+            128,
+            1e-10,
+            -448.0,
+            448.0,
+            10.0,
+        )
+
+    for seed in (37, 41, 43):
+        torch.manual_seed(seed)
+        next_gate_up = torch.randn_like(gate_up)
+        reference_q, reference_s = _quant_outputs(1)
+        torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+            _materialized_activation(next_gate_up),
+            reference_q,
+            reference_s,
+            128,
+            1e-10,
+            -448.0,
+            448.0,
+        )
+        gate_up.copy_(next_gate_up)
+
+        graph.replay()
+        torch.musa.synchronize()
+
+        assert torch.equal(
+            reference_q.view(torch.uint8).cpu(), fused_q.view(torch.uint8).cpu()
+        )
+        assert torch.equal(
+            reference_s.view(torch.int32).cpu(), fused_s.view(torch.int32).cpu()
+        )

--- a/tests/test_deepseek_v4_swiglu_fp8_fusion.py
+++ b/tests/test_deepseek_v4_swiglu_fp8_fusion.py
@@ -56,12 +56,13 @@ def test_clamp_swiglu_group_quant_is_bit_exact(rows: int) -> None:
             10.0,
             20.0,
             float("inf"),
+            float("nan"),
         ],
         device="musa",
         dtype=torch.bfloat16,
     )
-    gate_up[0, :8] = boundary
-    gate_up[0, 256:264] = boundary.flip(0)
+    gate_up[0, :9] = boundary
+    gate_up[0, 256:265] = boundary.flip(0)
 
     reference_q, reference_s = _quant_outputs(rows)
     fused_q, fused_s = _quant_outputs(rows)

--- a/tests/test_fused_moe_chunking.py
+++ b/tests/test_fused_moe_chunking.py
@@ -524,6 +524,7 @@ def test_musa_dispatcher_routes_forced_backends(monkeypatch):
     assert native_calls[0][1] == {
         "inplace": False,
         "_allow_deepgemm_prefill": False,
+        "_gemv_block": (16, 8),
     }
 
     grouped_calls = []

--- a/tests/test_musa_jit_custom_all_reduce_graph.py
+++ b/tests/test_musa_jit_custom_all_reduce_graph.py
@@ -11,36 +11,112 @@ custom_ar = pytest.importorskip(
 )
 
 
+def _deepseek_v4_config(capture_sizes: tuple[object, ...]) -> SimpleNamespace:
+    text_config = SimpleNamespace(
+        model_type="deepseek_v4",
+        architectures=("DeepseekV4ForCausalLM",),
+        hidden_size=4096,
+        num_hidden_layers=43,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        head_dim=512,
+        vocab_size=129280,
+        n_routed_experts=256,
+        num_experts_per_tok=6,
+        n_shared_experts=1,
+        moe_intermediate_size=2048,
+        expert_dtype="fp8",
+        hidden_act="silu",
+        swiglu_limit=10.0,
+        index_topk=512,
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        },
+    )
+    model_config = SimpleNamespace(
+        architectures=("DeepseekV4ForCausalLM",),
+        hf_config=text_config,
+        hf_text_config=text_config,
+        dtype="bfloat16",
+        quantization="deepseek_v4_fp8",
+        use_mla=True,
+        is_hybrid=False,
+        is_moe=True,
+        enforce_eager=False,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=8,
+            pipeline_parallel_size=1,
+            data_parallel_size=1,
+            decode_context_parallel_size=1,
+        ),
+        cache_config=SimpleNamespace(cache_dtype="fp8", block_size=64),
+        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        attention_config=SimpleNamespace(backend="FLASHMLA"),
+        compilation_config=SimpleNamespace(
+            mode="NONE",
+            cudagraph_mode="FULL_DECODE_ONLY",
+            cudagraph_capture_sizes=capture_sizes,
+        ),
+        speculative_config=None,
+        quant_config=SimpleNamespace(weight_block_size=[128, 128]),
+    )
+
+
 @pytest.mark.parametrize(
-    ("model_type", "architectures", "capture_sizes", "expected"),
+    ("capture_sizes", "expected"),
     [
-        ("deepseek_v4", ("DeepseekV4ForCausalLM",), (1,), True),
-        ("deepseek_v4", ("DeepseekV4ForCausalLM",), (1, 2, 4), False),
-        (None, ("DeepseekV4ForCausalLM",), (1, 2, 4), False),
-        ("qwen3", ("Qwen3ForCausalLM",), (1, 2, 4), True),
+        ((1,), True),
+        ((1, 2, 4), False),
+        ((), False),
+        ((1, "invalid"), False),
     ],
 )
-def test_graph_registered_inputs_model_gate(
-    monkeypatch, model_type, architectures, capture_sizes, expected
-):
-    model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(
-            model_type=model_type,
-            architectures=architectures,
-        ),
-        architectures=architectures,
-    )
+def test_graph_registered_inputs_preserve_deepseek_capture_guard(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_sizes: tuple[object, ...],
+    expected: bool,
+) -> None:
+    vllm_config = _deepseek_v4_config(capture_sizes)
     monkeypatch.setattr(
         "vllm.config.get_current_vllm_config_or_none",
-        lambda: SimpleNamespace(
-            model_config=model_config,
-            compilation_config=SimpleNamespace(
-                cudagraph_capture_sizes=capture_sizes,
-            ),
-        ),
+        lambda: vllm_config,
     )
 
     assert custom_ar._use_graph_registered_inputs_for_current_model() is expected
+
+
+@pytest.mark.parametrize(
+    ("model_type", "architectures", "model_field", "model_value"),
+    [
+        ("deepseek_v4", ("Qwen3ForCausalLM",), None, None),
+        ("qwen3", ("FakeDeepseekV4ForCausalLM",), None, None),
+        ("deepseek_v4", ("DeepseekV4ForCausalLM",), "hidden_size", 7168),
+    ],
+)
+def test_graph_registered_inputs_reject_incomplete_deepseek_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+    architectures: tuple[str, ...],
+    model_field: str | None,
+    model_value: object,
+) -> None:
+    vllm_config = _deepseek_v4_config((1, 2, 4))
+    text_config = vllm_config.model_config.hf_text_config
+    text_config.model_type = model_type
+    text_config.architectures = architectures
+    vllm_config.model_config.architectures = architectures
+    if model_field is not None:
+        setattr(text_config, model_field, model_value)
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config_or_none",
+        lambda: vllm_config,
+    )
+
+    assert custom_ar._use_graph_registered_inputs_for_current_model() is True
 
 
 def test_register_graph_buffers_populates_persistent_rank_data(monkeypatch):

--- a/tests/test_musa_jit_custom_all_reduce_graph.py
+++ b/tests/test_musa_jit_custom_all_reduce_graph.py
@@ -90,33 +90,43 @@ def test_graph_registered_inputs_preserve_deepseek_capture_guard(
 
 
 @pytest.mark.parametrize(
-    ("model_type", "architectures", "model_field", "model_value"),
+    ("model_type", "architectures", "expected"),
     [
-        ("deepseek_v4", ("Qwen3ForCausalLM",), None, None),
-        ("qwen3", ("FakeDeepseekV4ForCausalLM",), None, None),
-        ("deepseek_v4", ("DeepseekV4ForCausalLM",), "hidden_size", 7168),
+        ("deepseek_v4", ("Qwen3ForCausalLM",), False),
+        ("qwen3", ("DeepseekV4ForCausalLM",), False),
+        ("qwen3", ("FakeDeepseekV4ForCausalLM",), True),
     ],
 )
-def test_graph_registered_inputs_reject_incomplete_deepseek_identity(
+def test_graph_registered_inputs_fail_closed_for_partial_deepseek_identity(
     monkeypatch: pytest.MonkeyPatch,
     model_type: str,
     architectures: tuple[str, ...],
-    model_field: str | None,
-    model_value: object,
+    expected: bool,
 ) -> None:
     vllm_config = _deepseek_v4_config((1, 2, 4))
     text_config = vllm_config.model_config.hf_text_config
     text_config.model_type = model_type
     text_config.architectures = architectures
     vllm_config.model_config.architectures = architectures
-    if model_field is not None:
-        setattr(text_config, model_field, model_value)
     monkeypatch.setattr(
         "vllm.config.get_current_vllm_config_or_none",
         lambda: vllm_config,
     )
 
-    assert custom_ar._use_graph_registered_inputs_for_current_model() is True
+    assert custom_ar._use_graph_registered_inputs_for_current_model() is expected
+
+
+def test_graph_registered_inputs_guard_all_exact_deepseek_v4_configs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vllm_config = _deepseek_v4_config((1, 2, 4))
+    vllm_config.model_config.hf_text_config.hidden_size = 7168
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config_or_none",
+        lambda: vllm_config,
+    )
+
+    assert custom_ar._use_graph_registered_inputs_for_current_model() is False
 
 
 def test_register_graph_buffers_populates_persistent_rank_data(monkeypatch):

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -681,6 +681,8 @@ class TestMUSANativeKernelReviewHardening:
         # (avoid brittle cross-literal substring matching).
         assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X must be one of" in source
         assert "128, 256, 512, or 1024" in source
+        assert "int requested_block" in source
+        assert "env_forced_block > 0 ? env_forced_block : requested_block" in source
 
     def test_fused_rmsnorm_qwen2_small_hidden_uses_256_threads(self):
         source = (
@@ -733,9 +735,33 @@ class TestMUSAPlatformDefaults:
     ):
         from types import SimpleNamespace
 
+        is_deepseek_v4 = architectures == ["DeepseekV4ForCausalLM"]
+        if is_deepseek_v4 and attention_backend is None:
+            attention_backend = "FLASHMLA"
+        if is_deepseek_v4 and cudagraph_mode is None:
+            cudagraph_mode = "FULL_DECODE_ONLY"
+        if is_deepseek_v4 and quantization_config is None:
+            quantization_config = {
+                "quant_method": "fp8",
+                "weight_block_size": [128, 128],
+            }
         hf_config = SimpleNamespace(
             architectures=architectures,
+            model_type="deepseek_v4" if is_deepseek_v4 else None,
             quantization_config=quantization_config,
+            hidden_size=4096 if is_deepseek_v4 else None,
+            num_hidden_layers=43 if is_deepseek_v4 else None,
+            num_attention_heads=64 if is_deepseek_v4 else None,
+            num_key_value_heads=1 if is_deepseek_v4 else None,
+            head_dim=512 if is_deepseek_v4 else None,
+            vocab_size=129280 if is_deepseek_v4 else None,
+            n_routed_experts=256 if is_deepseek_v4 else None,
+            num_experts_per_tok=6 if is_deepseek_v4 else None,
+            n_shared_experts=1 if is_deepseek_v4 else None,
+            moe_intermediate_size=2048 if is_deepseek_v4 else None,
+            expert_dtype="fp8" if is_deepseek_v4 else None,
+            hidden_act="silu" if is_deepseek_v4 else None,
+            swiglu_limit=10.0 if is_deepseek_v4 else None,
         )
         if index_topk is not None:
             hf_config.index_topk = index_topk
@@ -743,22 +769,32 @@ class TestMUSAPlatformDefaults:
             model_config=SimpleNamespace(
                 architectures=architectures,
                 hf_config=hf_config,
+                hf_text_config=hf_config,
+                dtype="bfloat16",
                 quantization=quantization,
                 use_mla=use_mla,
+                is_hybrid=False,
+                is_moe=is_deepseek_v4,
+                enforce_eager=False,
                 is_mm_prefix_lm=False,
             ),
             parallel_config=SimpleNamespace(
                 tensor_parallel_size=tensor_parallel_size,
                 worker_cls="auto",
             ),
-            cache_config=SimpleNamespace(block_size=cache_block_size),
+            cache_config=SimpleNamespace(
+                block_size=cache_block_size,
+                cache_dtype="fp8" if is_deepseek_v4 else "auto",
+            ),
             scheduler_config=SimpleNamespace(
                 is_multimodal_model=False,
                 disable_chunked_mm_input=False,
+                max_num_seqs=1 if is_deepseek_v4 else 64,
             ),
             attention_config=SimpleNamespace(backend=attention_backend),
             compilation_config=SimpleNamespace(
                 custom_ops=[],
+                mode="NONE",
                 cudagraph_mode=cudagraph_mode,
                 max_cudagraph_capture_size=max_cudagraph_capture_size,
                 cudagraph_capture_sizes=cudagraph_capture_sizes,
@@ -852,7 +888,7 @@ class TestMUSAPlatformDefaults:
         assert vllm_config.compilation_config.max_cudagraph_capture_size == 512
         assert vllm_config.compilation_config.cudagraph_capture_sizes == [1, 2, 4, 8]
 
-    def test_deepseek_v4_defaults_moe_gemv_block32x8(self):
+    def test_deepseek_v4_does_not_default_generic_kernel_envs(self):
         from vllm_musa.platform import MUSAPlatformBase
 
         vllm_config = self._make_vllm_config(
@@ -860,13 +896,13 @@ class TestMUSAPlatformDefaults:
         )
 
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV", None)
             os.environ.pop("VLLM_MUSA_GEMV_MOE_BLOCK", None)
+            os.environ.pop("VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X", None)
 
             MUSAPlatformBase.check_and_update_config(vllm_config)
 
-            assert "VLLM_MUSA_DEEPSEEK_V4_FUSED_MOE_GEMV" not in os.environ
-            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "32x8"
+            assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in os.environ
+            assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in os.environ
 
     def test_deepseek_v4_preserves_user_moe_gemv_block(self):
         from vllm_musa.platform import MUSAPlatformBase
@@ -906,12 +942,18 @@ class TestMUSAPlatformDefaults:
 
             assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in os.environ
 
-    def test_deepseek_v4_tp8_uses_validated_defaults_without_profile_env(self):
+    def test_deepseek_v4_tp8_uses_contract_without_profile_env(self):
+        from vllm_musa.optimization_contract import (
+            OptimizationFeature,
+            resolve_optimization_contract,
+        )
         from vllm_musa.platform import MUSAPlatformBase
 
         vllm_config = self._make_vllm_config(
             architectures=["DeepseekV4ForCausalLM"],
             tensor_parallel_size=8,
+            use_mla=True,
+            index_topk=512,
         )
 
         with patch.dict(os.environ, {}, clear=False):
@@ -928,8 +970,15 @@ class TestMUSAPlatformDefaults:
 
             MUSAPlatformBase.check_and_update_config(vllm_config)
 
-            assert os.environ["VLLM_MUSA_GEMV_MOE_BLOCK"] == "16x8"
-            assert os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] == "256"
+            contract = resolve_optimization_contract(vllm_config)
+            assert contract.prefers(
+                OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+            )
+            assert contract.prefers(
+                OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+            )
+            assert "VLLM_MUSA_GEMV_MOE_BLOCK" not in os.environ
+            assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in os.environ
             assert "VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE" not in os.environ
             assert (
                 os.environ.get("VLLM_MUSA_DEEPSEEK_V4_FLASHMLA_SPARSE_BLOCK_SIZE")

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -735,11 +735,14 @@ class TestMUSAPlatformDefaults:
     ):
         from types import SimpleNamespace
 
+        from vllm.config import CUDAGraphMode
+        from vllm.config.compilation import CompilationMode
+
         is_deepseek_v4 = architectures == ["DeepseekV4ForCausalLM"]
         if is_deepseek_v4 and attention_backend is None:
             attention_backend = "FLASHMLA"
         if is_deepseek_v4 and cudagraph_mode is None:
-            cudagraph_mode = "FULL_DECODE_ONLY"
+            cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
         if is_deepseek_v4 and quantization_config is None:
             quantization_config = {
                 "quant_method": "fp8",
@@ -780,6 +783,9 @@ class TestMUSAPlatformDefaults:
             ),
             parallel_config=SimpleNamespace(
                 tensor_parallel_size=tensor_parallel_size,
+                pipeline_parallel_size=1,
+                data_parallel_size=1,
+                decode_context_parallel_size=1,
                 worker_cls="auto",
             ),
             cache_config=SimpleNamespace(
@@ -792,9 +798,12 @@ class TestMUSAPlatformDefaults:
                 max_num_seqs=1 if is_deepseek_v4 else 64,
             ),
             attention_config=SimpleNamespace(backend=attention_backend),
+            quant_config=SimpleNamespace(weight_block_size=[128, 128])
+            if is_deepseek_v4
+            else None,
             compilation_config=SimpleNamespace(
                 custom_ops=[],
-                mode="NONE",
+                mode=CompilationMode.NONE if is_deepseek_v4 else "NONE",
                 cudagraph_mode=cudagraph_mode,
                 max_cudagraph_capture_size=max_cudagraph_capture_size,
                 cudagraph_capture_sizes=cudagraph_capture_sizes,

--- a/tests/test_qwen_contract_source.py
+++ b/tests/test_qwen_contract_source.py
@@ -42,7 +42,8 @@ def test_qwen_patch_consumers_bind_contract_features() -> None:
     assert "+    return True" in mamba_pool
 
 
-def test_deepseek_provider_is_not_registered_yet() -> None:
+def test_deepseek_provider_is_registered_explicitly() -> None:
     providers = _source("vllm_musa/optimization_contract/providers.py")
     assert "resolve_qwen_contract" in providers
-    assert "resolve_deepseek" not in providers
+    assert "resolve_deepseek_v4_contract" in providers
+    assert "resolve_deepseek_v4_contract," in providers

--- a/tests/test_qwen_optimization_contract.py
+++ b/tests/test_qwen_optimization_contract.py
@@ -128,7 +128,6 @@ def test_resolves_qwen_family_without_model_name(
     [
         "Qwen3VLForConditionalGeneration",
         "Qwen3OmniMoeForConditionalGeneration",
-        "DeepseekV4ForCausalLM",
         "LlamaForCausalLM",
     ],
 )
@@ -149,7 +148,7 @@ def test_supported_and_preferred_feature_sets_are_independent() -> None:
     assert contract.supported_features is not contract.preferred_features
 
 
-def test_deepseek_v4_facts_are_normalized_without_enabling_a_provider() -> None:
+def test_deepseek_v4_incomplete_facts_are_normalized_but_fail_closed() -> None:
     text_config = SimpleNamespace(
         model_type="deepseek_v4",
         kv_lora_rank=512,
@@ -179,12 +178,13 @@ def test_deepseek_v4_facts_are_normalized_without_enabling_a_provider() -> None:
             quant_config=None,
         )
     )
-    assert contract.model.family is ModelFamily.UNKNOWN
+    assert contract.model.family is ModelFamily.DEEPSEEK_V4
     assert contract.model.uses_mla is True
     assert contract.model.index_topk == 2048
     assert contract.model.quant_block_shape == (128, 128)
     assert contract.execution.attention_backend == "flashmla"
     assert contract.execution.cudagraph_mode == "full_decode_only"
+    assert not contract.supported_features
     assert not contract.preferred_features
 
 

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -142,12 +142,14 @@ def musa_fused_add_rms_norm(
     residual: torch.Tensor,
     weight: torch.Tensor,
     eps: float,
+    block_x: int = 0,
 ) -> None:
     return torch.ops._C_musa_ops.musa_fused_add_rms_norm(
         input,
         residual,
         weight,
         eps,
+        block_x,
     )
 
 

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -31,6 +31,8 @@ def musa_fused_gemv_moe(
     topk: int,
     use_int4_w4a16: bool,
     use_swigelu: bool,
+    block_n: int = 0,
+    block_k: int = 0,
 ) -> None:
     return torch.ops._C_musa_ops.musa_fused_gemv_moe(
         A,
@@ -44,6 +46,8 @@ def musa_fused_gemv_moe(
         topk,
         use_int4_w4a16,
         use_swigelu,
+        block_n,
+        block_k,
     )
 
 

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -12,6 +12,11 @@ from vllm.logger import init_logger
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_musa.jit_kernel.csrc import allreduce as jit_ar
+from vllm_musa.optimization_contract import (
+    ModelFamily,
+    OptimizationFeature,
+    resolve_optimization_contract,
+)
 from vllm_musa.utils.environ import envs
 
 logger = init_logger(__name__)
@@ -35,18 +40,11 @@ def _use_graph_registered_inputs_for_current_model() -> bool:
     except (ImportError, RuntimeError):
         return True
 
-    model_config = getattr(vllm_config, "model_config", None)
-    if model_config is None:
-        return True
-
-    hf_config = getattr(model_config, "hf_config", None)
-    architectures = getattr(model_config, "architectures", None)
-    if architectures is None and hf_config is not None:
-        architectures = getattr(hf_config, "architectures", None)
-    is_deepseek_v4 = getattr(hf_config, "model_type", None) == "deepseek_v4" or any(
-        "DeepseekV4" in str(arch) for arch in architectures or ()
-    )
-    if not is_deepseek_v4:
+    contract = resolve_optimization_contract(vllm_config)
+    feature = OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD
+    if contract.model.family is not ModelFamily.DEEPSEEK_V4 or not contract.supports(
+        feature
+    ):
         return True
 
     compilation_config = getattr(vllm_config, "compilation_config", None)

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -42,10 +42,10 @@ def _use_graph_registered_inputs_for_current_model() -> bool:
 
     contract = resolve_optimization_contract(vllm_config)
     feature = OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD
-    if contract.model.family is not ModelFamily.DEEPSEEK_V4 or not contract.supports(
-        feature
-    ):
+    if contract.model.family is not ModelFamily.DEEPSEEK_V4:
         return True
+    if not contract.supports(feature):
+        return False
 
     compilation_config = getattr(vllm_config, "compilation_config", None)
     capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None)

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -1366,6 +1366,22 @@ def _musa_fused_moe_shape(
 ) -> MusaFusedMoeShape:
     block_n = block_shape[0] if block_shape else 0
     block_k = block_shape[1] if block_shape and len(block_shape) > 1 else 0
+    gemv_block = os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK")
+    if gemv_block is None:
+        # DeepSeek-V4 Flash TP8 has a unique per-rank routed-expert shape.
+        # Keep this launch choice op-local: the generic env remains an explicit
+        # diagnostic override, while the normal path no longer receives a
+        # process-global model-derived default from platform.py.
+        is_deepseek_v4_flash_tp8_shape = (
+            w1.shape[0] == 256
+            and w1.shape[1] == 512
+            and w2.shape[2] == 256
+            and hidden_states.shape[1] == 4096
+            and topk_ids.shape[1] == 6
+            and block_n == 128
+            and block_k == 128
+        )
+        gemv_block = "16x8" if is_deepseek_v4_flash_tp8_shape else "auto"
     return MusaFusedMoeShape(
         device_capability=device_capability,
         multiprocessor_count=multiprocessor_count,
@@ -1383,7 +1399,7 @@ def _musa_fused_moe_shape(
         scale_dtype=str(w1_scale.dtype) if w1_scale is not None else "none",
         w1_scale_shape=tuple(w1_scale.shape) if w1_scale is not None else (),
         w2_scale_shape=tuple(w2_scale.shape) if w2_scale is not None else (),
-        gemv_block=os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK", "auto"),
+        gemv_block=gemv_block,
         graph_mode="capture" if stream_is_capturing else "eager",
     )
 

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -66,6 +66,7 @@ _DEEPGEMM_BF16_PREFILL_MIN_TOKENS = 1024
 _DEEPGEMM_BF16_PREFILL_WARNED = False
 _MUSA_GROUPED_GEMM_AVAILABLE = True
 _MUSA_FUSED_MOE_REQUESTED_BACKEND = parse_dispatch_backend()
+_GEMV_MOE_BLOCK_ENV = "VLLM_MUSA_GEMV_MOE_BLOCK"
 
 
 def _env_flag_enabled(name: str) -> bool:
@@ -92,6 +93,25 @@ def _env_int(name: str, default: int) -> int:
         return int(os.environ.get(name, default))
     except ValueError:
         return default
+
+
+def _requested_gemv_block(shape: MusaFusedMoeShape | None) -> tuple[int, int]:
+    """Return a graph-static tile request for a contract-selected GEMV shape.
+
+    The legacy environment override remains owned by the C++ op.  Passing
+    zeroes here lets that override (and the one-token DeepSeek-V4 split-tile
+    rule) retain their existing precedence.  Only a selector produced by the
+    Python policy, with no explicit environment override, is forwarded.
+    """
+
+    if shape is None or os.environ.get(_GEMV_MOE_BLOCK_ENV) is not None:
+        return 0, 0
+    # The only contract-backed scalar today is the DeepSeek-V4 TP8 profile.
+    # Keep unknown policy labels on the C++ heuristic until they have their
+    # own kernel evidence.
+    if shape.gemv_block != "16x8":
+        return 0, 0
+    return 16, 8
 
 
 def _tensors_share_device(
@@ -1477,6 +1497,7 @@ def fused_experts_impl(
     *,
     inplace: bool = False,
     _allow_deepgemm_prefill: bool = True,
+    _gemv_block: tuple[int, int] = (0, 0),
 ) -> torch.Tensor:
     # Check constraints.
     if use_int4_w4a16:
@@ -1636,6 +1657,7 @@ def fused_experts_impl(
         "Triton MoE JSON config lookup.",
         scope="global",
     )
+    gemv_block_n, gemv_block_k = _gemv_block
     CHUNK_SIZE = 16384
     M = min(num_tokens, CHUNK_SIZE)
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
@@ -1670,6 +1692,8 @@ def fused_experts_impl(
             topk_ids.shape[1],
             use_int4_w4a16,
             use_swigelu=True,
+            block_n=gemv_block_n,
+            block_k=gemv_block_k,
         )
         musa_ops.musa_fused_gemv_moe(
             curr_intermediate_cache2,
@@ -1683,6 +1707,8 @@ def fused_experts_impl(
             1,
             use_int4_w4a16,
             use_swigelu=False,
+            block_n=gemv_block_n,
+            block_k=gemv_block_k,
         )
         # ========================== END ====================
         moe_sum_input = curr_intermediate_cache3.view(*curr_intermediate_cache3.size())
@@ -1730,6 +1756,7 @@ def _musa_fused_experts_impl_dispatch(
     backend = MusaFusedMoeBackend.UPSTREAM
     policy = None
     shape = None
+    requested_gemv_block = (0, 0)
 
     # Skip all shape construction and capture queries for non-FP8 callers and
     # for the explicit rollback path. This wrapper sits on every MoE layer.
@@ -1850,6 +1877,8 @@ def _musa_fused_experts_impl_dispatch(
                     requested=_MUSA_FUSED_MOE_REQUESTED_BACKEND,
                     thresholds=policy,
                 )
+                if backend == MusaFusedMoeBackend.GEMV:
+                    requested_gemv_block = _requested_gemv_block(shape)
 
     # Native GEMV records inside ``fused_experts_impl`` after expanding any
     # per-tensor scales.  Record every other dispatcher outcome here so the
@@ -1925,6 +1954,12 @@ def _musa_fused_experts_impl_dispatch(
         if grouped_output is not None:
             return grouped_output
     elif backend == MusaFusedMoeBackend.GEMV:
+        gemv_kwargs = {
+            "inplace": False,
+            "_allow_deepgemm_prefill": False,
+        }
+        if requested_gemv_block != (0, 0):
+            gemv_kwargs["_gemv_block"] = requested_gemv_block
         return fused_experts_impl(
             hidden_states,
             w1,
@@ -1950,8 +1985,7 @@ def _musa_fused_experts_impl_dispatch(
             block_shape,
             w1_bias,
             w2_bias,
-            inplace=False,
-            _allow_deepgemm_prefill=False,
+            **gemv_kwargs,
         )
 
     prefer_upstream_qwen_prefill = (

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -98,7 +98,7 @@ def _env_int(name: str, default: int) -> int:
 def _requested_gemv_block(shape: MusaFusedMoeShape | None) -> tuple[int, int]:
     """Return a graph-static tile request for a contract-selected GEMV shape.
 
-    The legacy environment override remains owned by the C++ op.  Passing
+    The explicit environment override remains owned by the C++ op. Passing
     zeroes here lets that override (and the one-token DeepSeek-V4 split-tile
     rule) retain their existing precedence.  Only a selector produced by the
     Python policy, with no explicit environment override, is forwarded.
@@ -106,9 +106,8 @@ def _requested_gemv_block(shape: MusaFusedMoeShape | None) -> tuple[int, int]:
 
     if shape is None or os.environ.get(_GEMV_MOE_BLOCK_ENV) is not None:
         return 0, 0
-    # The only contract-backed scalar today is the DeepSeek-V4 TP8 profile.
-    # Keep unknown policy labels on the C++ heuristic until they have their
-    # own kernel evidence.
+    # Only the DeepSeek-V4 TP8 profile has end-to-end evidence for this scalar.
+    # Unknown policy labels stay on the C++ heuristic.
     if shape.gemv_block != "16x8":
         return 0, 0
     return 16, 8
@@ -1388,10 +1387,9 @@ def _musa_fused_moe_shape(
     block_k = block_shape[1] if block_shape and len(block_shape) > 1 else 0
     gemv_block = os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK")
     if gemv_block is None:
-        # DeepSeek-V4 Flash TP8 has a unique per-rank routed-expert shape.
-        # Keep this launch choice op-local: the generic env remains an explicit
-        # diagnostic override, while the normal path no longer receives a
-        # process-global model-derived default from platform.py.
+        # DeepSeek-V4 Flash TP8 has a unique per-rank routed-expert shape. The
+        # explicit generic override wins in C++; otherwise this label forwards
+        # the validated 16x8 tile for multi-token GEMV dispatch.
         is_deepseek_v4_flash_tp8_shape = (
             w1.shape[0] == 256
             and w1.shape[1] == 512

--- a/vllm_musa/model_executor/layers/layernorm.py
+++ b/vllm_musa/model_executor/layers/layernorm.py
@@ -3,9 +3,14 @@
 
 import torch
 import torch.nn as nn
+from vllm.config import get_current_vllm_config_or_none
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm, RMSNormGated
 
 from vllm_musa.jit_kernel.csrc import norm as musa_jit_norm
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    bind_optimization_contract,
+)
 from vllm_musa.utils.environ import envs
 
 
@@ -31,6 +36,17 @@ def _can_use_musa_jit_rmsnorm(
 
 @RMSNorm.register_oot
 class MusaRMSNorm(RMSNorm):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        var_hidden_size: int | None = None,
+        has_weight: bool = True,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__(hidden_size, eps, var_hidden_size, has_weight, dtype)
+        bind_optimization_contract(self, get_current_vllm_config_or_none())
+
     def forward_oot(
         self,
         x: torch.Tensor,
@@ -43,6 +59,36 @@ class MusaRMSNorm(RMSNorm):
             return self.forward_native(x, residual)
 
         if residual is not None:
+            contract = self._musa_optimization_contract
+            weight = self.weight.data
+            if (
+                envs.VLLM_MUSA_FUSED_ADD_RMSNORM.get()
+                and contract.prefers(
+                    OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+                )
+                and x.device.type == "musa"
+                and x.dim() == 2
+                and residual.shape == x.shape
+                and x.shape[1] == 4096
+                and weight.shape == (4096,)
+                and x.dtype == torch.bfloat16
+                and residual.dtype == x.dtype
+                and weight.dtype == x.dtype
+                and x.is_contiguous()
+                and residual.is_contiguous()
+                and weight.is_contiguous()
+            ):
+                from vllm_musa import _custom_ops as musa_ops
+
+                musa_ops.musa_fused_add_rms_norm(
+                    x,
+                    residual,
+                    weight,
+                    self.variance_epsilon,
+                    block_x=256,
+                )
+                return x, residual
+
             # All residual calls use IR. It validates donation and selects the
             # measured JIT kernel, the broad C-extension kernel, or native.
             return self.forward_native(x, residual)

--- a/vllm_musa/model_executor/layers/linear.py
+++ b/vllm_musa/model_executor/layers/linear.py
@@ -6,6 +6,11 @@ from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.model_executor.layers.linear import RowParallelLinear
 from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
 
+from vllm_musa.optimization_contract import (
+    OptimizationFeature,
+    prefers_optimization,
+)
+
 
 def _deepgemm_block_fp8(quant_method) -> bool:
     # MUSA: the DeepGemm block-FP8 kernel writes the GEMM result into a caller
@@ -32,7 +37,10 @@ class MusaRowParallelLinear(RowParallelLinear):
         activation and linear path unchanged.
         """
         fast = (
-            not envs.VLLM_BATCH_INVARIANT
+            prefers_optimization(
+                self,
+                OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8,
+            )
             and self.input_is_parallel
             and _deepgemm_block_fp8(self.quant_method)
             and self.bias is None

--- a/vllm_musa/optimization_contract/__init__.py
+++ b/vllm_musa/optimization_contract/__init__.py
@@ -1,5 +1,9 @@
 from .qwen import matches_qwen35_moe_bf16_prefill_layer
-from .resolver import prefers_optimization, resolve_optimization_contract
+from .resolver import (
+    bind_optimization_contract,
+    prefers_optimization,
+    resolve_optimization_contract,
+)
 from .types import (
     ExecutionSignature,
     ModelFamily,
@@ -16,6 +20,7 @@ __all__ = [
     "ModelSignature",
     "MusaOptimizationContract",
     "OptimizationFeature",
+    "bind_optimization_contract",
     "matches_qwen35_moe_bf16_prefill_layer",
     "prefers_optimization",
     "resolve_optimization_contract",

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -57,6 +57,7 @@ def _matches_tp8_reference(execution: ExecutionSignature) -> bool:
         and execution.data_parallel_size == 1
         and execution.decode_context_parallel_size == 1
         and not execution.has_speculative_config
+        and execution.has_quant_config
         and not execution.is_pooling_model
         and execution.cache_dtype == "fp8"
         and execution.max_num_seqs == 1
@@ -81,6 +82,9 @@ def resolve_deepseek_v4_contract(
     supported: set[OptimizationFeature] = set()
     preferred: set[OptimizationFeature] = set()
 
+    if _has_complete_identity(model):
+        supported.add(OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD)
+
     if _matches_flash_base(model):
         supported.update(
             {
@@ -89,7 +93,6 @@ def resolve_deepseek_v4_contract(
                 OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
-                OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD,
             }
         )
         if execution.has_parallel_config:

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -91,12 +91,13 @@ def resolve_deepseek_v4_contract(
                 OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
             }
         )
-        preferred.update(
-            {
-                OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER,
-                OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
-            }
-        )
+        if execution.has_parallel_config:
+            preferred.update(
+                {
+                    OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER,
+                    OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
+                }
+            )
         if _matches_tp8_reference(execution):
             preferred.update(
                 {

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -89,6 +89,7 @@ def resolve_deepseek_v4_contract(
                 OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
+                OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD,
             }
         )
         if execution.has_parallel_config:

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from .types import (
+    ExecutionSignature,
+    ModelFamily,
+    ModelRole,
+    ModelSignature,
+    MusaOptimizationContract,
+    OptimizationFeature,
+)
+
+_DEEPSEEK_V4_ARCHITECTURES = ("DeepseekV4ForCausalLM",)
+_DEEPSEEK_V4_QUANTIZATION = frozenset({"fp8", "deepseek_v4_fp8"})
+
+
+def _has_complete_identity(model: ModelSignature) -> bool:
+    architectures = model.outer_architectures or model.architectures
+    return (
+        architectures == _DEEPSEEK_V4_ARCHITECTURES
+        and model.model_type == "deepseek_v4"
+    )
+
+
+def _matches_flash_base(model: ModelSignature) -> bool:
+    return (
+        _has_complete_identity(model)
+        and model.dtype == "bfloat16"
+        and model.quantization in _DEEPSEEK_V4_QUANTIZATION
+        and model.hidden_size == 4096
+        and model.num_hidden_layers == 43
+        and model.num_attention_heads == 64
+        and model.num_key_value_heads == 1
+        and model.head_dim == 512
+        and model.vocab_size == 129280
+        and model.num_experts == 256
+        and model.num_experts_per_tok == 6
+        and model.num_shared_experts == 1
+        and model.moe_intermediate_size == 2048
+        and model.expert_dtype == "fp8"
+        and model.hidden_act == "silu"
+        and model.swiglu_limit == 10.0
+        and model.quant_block_shape == (128, 128)
+        and model.has_routed_experts is True
+        and model.uses_mla is True
+        and model.index_topk == 512
+        and model.is_hybrid is False
+    )
+
+
+def _matches_tp8_reference(execution: ExecutionSignature) -> bool:
+    return (
+        execution.has_parallel_config
+        and execution.tensor_parallel_size == 8
+        and execution.pipeline_parallel_size == 1
+        and execution.data_parallel_size == 1
+        and execution.decode_context_parallel_size == 1
+        and not execution.has_speculative_config
+        and not execution.is_pooling_model
+        and execution.cache_dtype == "fp8"
+        and execution.max_num_seqs == 1
+        and execution.attention_backend == "flashmla"
+        and execution.compilation_mode == "none"
+        and execution.cudagraph_mode == "full_decode_only"
+    )
+
+
+def resolve_deepseek_v4_contract(
+    model: ModelSignature,
+    execution: ExecutionSignature,
+) -> MusaOptimizationContract | None:
+    architectures = model.outer_architectures or model.architectures
+    if (
+        "DeepseekV4ForCausalLM" not in architectures
+        and model.model_type != "deepseek_v4"
+    ):
+        return None
+
+    model = replace(model, family=ModelFamily.DEEPSEEK_V4, role=ModelRole.TEXT)
+    supported: set[OptimizationFeature] = set()
+    preferred: set[OptimizationFeature] = set()
+
+    if _matches_flash_base(model):
+        supported.update(
+            {
+                OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8,
+                OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER,
+                OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
+                OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
+                OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
+            }
+        )
+        preferred.update(
+            {
+                OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER,
+                OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
+            }
+        )
+        if _matches_tp8_reference(execution):
+            preferred.update(
+                {
+                    OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
+                    OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
+                }
+            )
+            if not execution.batch_invariant_enabled:
+                preferred.add(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+
+    profile = (
+        "deepseek_v4.tp8_flash_base"
+        if _matches_flash_base(model) and _matches_tp8_reference(execution)
+        else "deepseek_v4.unvalidated"
+    )
+    return MusaOptimizationContract(
+        model=model,
+        execution=execution,
+        profile=profile,
+        supported_features=frozenset(supported),
+        preferred_features=frozenset(preferred),
+    )

--- a/vllm_musa/optimization_contract/providers.py
+++ b/vllm_musa/optimization_contract/providers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from .deepseek_v4 import resolve_deepseek_v4_contract
 from .qwen import resolve_qwen_contract
 from .types import ExecutionSignature, ModelSignature, MusaOptimizationContract
 
@@ -10,6 +11,10 @@ ContractProvider = Callable[
     MusaOptimizationContract | None,
 ]
 
-# Keep provider registration explicit. DeepSeek-V4 will be added here only
-# after its merged policy has an isolated evidence and migration pass.
-CONTRACT_PROVIDERS: tuple[ContractProvider, ...] = (resolve_qwen_contract,)
+# Keep provider registration explicit. Providers must fail closed when their
+# exact family metadata is incomplete so one family cannot enable another's
+# fast paths.
+CONTRACT_PROVIDERS: tuple[ContractProvider, ...] = (
+    resolve_deepseek_v4_contract,
+    resolve_qwen_contract,
+)

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -349,18 +349,10 @@ def bind_optimization_contract(
 ) -> MusaOptimizationContract:
     """Resolve once and bind an immutable contract to a runtime owner."""
 
-    contract = (
-        getattr(vllm_config, "_musa_optimization_contract", None)
-        if vllm_config is not None
-        else None
+    contract = resolve_optimization_contract(
+        vllm_config,
+        model_config=model_config,
+        is_pooling_model=is_pooling_model,
     )
-    if not isinstance(contract, MusaOptimizationContract):
-        contract = resolve_optimization_contract(
-            vllm_config,
-            model_config=model_config,
-            is_pooling_model=is_pooling_model,
-        )
-        if vllm_config is not None:
-            vllm_config._musa_optimization_contract = contract
     owner._musa_optimization_contract = contract
     return contract

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -42,6 +42,22 @@ def _int_attr(config: Any, *names: str) -> int | None:
     return None
 
 
+def _float_attr(config: Any, *names: str) -> float | None:
+    for name in names:
+        value = getattr(config, name, None)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return None
+
+
+def _str_attr(config: Any, *names: str) -> str | None:
+    for name in names:
+        value = getattr(config, name, None)
+        if value is not None:
+            return str(value).lower()
+    return None
+
+
 def _text_config(model_config: Any) -> Any:
     text_config = getattr(model_config, "hf_text_config", None)
     if text_config is not None:
@@ -132,7 +148,9 @@ def _model_signature(model_config: Any, vllm_config: Any | None) -> ModelSignatu
             quantization_config.get("weight_block_size")
             or quantization_config.get("weight_block_shape")
         )
-    uses_mla = getattr(text_config, "use_mla", None)
+    uses_mla = getattr(model_config, "use_mla", None)
+    if not isinstance(uses_mla, bool):
+        uses_mla = getattr(text_config, "use_mla", None)
     if not isinstance(uses_mla, bool):
         uses_mla = getattr(text_config, "kv_lora_rank", None) is not None
     is_hybrid = getattr(model_config, "is_hybrid", None)
@@ -170,7 +188,15 @@ def _model_signature(model_config: Any, vllm_config: Any | None) -> ModelSignatu
             "num_experts_per_token",
             "top_k",
         ),
+        num_shared_experts=_int_attr(
+            text_config,
+            "num_shared_experts",
+            "n_shared_experts",
+        ),
         moe_intermediate_size=_int_attr(text_config, "moe_intermediate_size"),
+        expert_dtype=_str_attr(text_config, "expert_dtype"),
+        hidden_act=_str_attr(text_config, "hidden_act"),
+        swiglu_limit=_float_attr(text_config, "swiglu_limit"),
         gdn_conv_width=gdn_width,
         gdn_conv_dim=gdn_dim,
         has_routed_experts=_has_routed_experts(model_config, text_config),
@@ -201,6 +227,13 @@ def _execution_signature(
         return value if isinstance(value, int) and value > 0 else 1
 
     block_size = getattr(cache_config, "block_size", None)
+    try:
+        import vllm.envs as vllm_envs
+
+        batch_invariant_enabled = bool(vllm_envs.VLLM_BATCH_INVARIANT)
+    except (AttributeError, ImportError):
+        batch_invariant_enabled = False
+
     return ExecutionSignature(
         tensor_parallel_size=size("tensor_parallel_size"),
         pipeline_parallel_size=size("pipeline_parallel_size"),
@@ -224,6 +257,7 @@ def _execution_signature(
         cudagraph_mode=_normalize_name(
             getattr(compilation_config, "cudagraph_mode", None)
         ),
+        batch_invariant_enabled=batch_invariant_enabled,
     )
 
 
@@ -256,7 +290,11 @@ def resolve_optimization_contract(
             vocab_size=None,
             num_experts=None,
             num_experts_per_tok=None,
+            num_shared_experts=None,
             moe_intermediate_size=None,
+            expert_dtype=None,
+            hidden_act=None,
+            swiglu_limit=None,
             gdn_conv_width=None,
             gdn_conv_dim=None,
             has_routed_experts=False,
@@ -300,3 +338,29 @@ def prefers_optimization(owner: Any, feature: OptimizationFeature) -> bool:
     return contract is not None and feature in getattr(
         contract, "preferred_features", ()
     )
+
+
+def bind_optimization_contract(
+    owner: Any,
+    vllm_config: Any | None = None,
+    *,
+    model_config: Any | None = None,
+    is_pooling_model: bool = False,
+) -> MusaOptimizationContract:
+    """Resolve once and bind an immutable contract to a runtime owner."""
+
+    contract = (
+        getattr(vllm_config, "_musa_optimization_contract", None)
+        if vllm_config is not None
+        else None
+    )
+    if not isinstance(contract, MusaOptimizationContract):
+        contract = resolve_optimization_contract(
+            vllm_config,
+            model_config=model_config,
+            is_pooling_model=is_pooling_model,
+        )
+        if vllm_config is not None:
+            vllm_config._musa_optimization_contract = contract
+    owner._musa_optimization_contract = contract
+    return contract

--- a/vllm_musa/optimization_contract/types.py
+++ b/vllm_musa/optimization_contract/types.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 class ModelFamily(str, Enum):
     UNKNOWN = "unknown"
+    DEEPSEEK_V4 = "deepseek_v4"
     QWEN2 = "qwen2"
     QWEN3 = "qwen3"
     QWEN35_36 = "qwen3.5_3.6"
@@ -18,6 +19,15 @@ class ModelRole(str, Enum):
 
 
 class OptimizationFeature(str, Enum):
+    DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8 = "deepseek_v4.shared_mlp_clamp_fp8"
+    DEEPSEEK_V4_NATIVE_SPARSE_INDEXER = "deepseek_v4.native_sparse_indexer"
+    DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER = (
+        "deepseek_v4.materialized_prefill_indexer"
+    )
+    DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256 = "deepseek_v4.tp8_flashmla_sparse_page256"
+    DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256 = (
+        "deepseek_v4.tp8_fused_add_rmsnorm_block256"
+    )
     QWEN_V2_SAMPLING = "qwen.v2_sampling"
     QWEN_LEGACY_SAMPLING = "qwen.legacy_sampling"
     QWEN_FA3_SCHEDULER = "qwen.fa3_scheduler"
@@ -56,7 +66,11 @@ class ModelSignature:
     vocab_size: int | None
     num_experts: int | None
     num_experts_per_tok: int | None
+    num_shared_experts: int | None
     moe_intermediate_size: int | None
+    expert_dtype: str | None
+    hidden_act: str | None
+    swiglu_limit: float | None
     gdn_conv_width: int | None
     gdn_conv_dim: int | None
     has_routed_experts: bool | None
@@ -86,6 +100,7 @@ class ExecutionSignature:
     attention_backend: str | None = None
     compilation_mode: str | None = None
     cudagraph_mode: str | None = None
+    batch_invariant_enabled: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_musa/optimization_contract/types.py
+++ b/vllm_musa/optimization_contract/types.py
@@ -28,6 +28,9 @@ class OptimizationFeature(str, Enum):
     DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256 = (
         "deepseek_v4.tp8_fused_add_rmsnorm_block256"
     )
+    DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD = (
+        "deepseek_v4.car_graph_input_capture_guard"
+    )
     QWEN_V2_SAMPLING = "qwen.v2_sampling"
     QWEN_LEGACY_SAMPLING = "qwen.legacy_sampling"
     QWEN_FA3_SCHEDULER = "qwen.fa3_scheduler"

--- a/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
+++ b/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
@@ -1,0 +1,173 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Mon, 3 Aug 2026 19:17:49 +0800
+Subject: [PATCH 101/101] MUSA: bind DeepSeek-V4 optimization contract
+
+---
+ .../layers/sparse_attn_indexer.py             | 26 +++++++++++++++----
+ vllm/models/deepseek_v4/attention.py          | 19 +++++++++++++-
+ vllm/models/deepseek_v4/nvidia/model.py       |  6 +++++
+ 3 files changed, 45 insertions(+), 6 deletions(-)
+
+diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
+index e21e566f7f..77b78e6e25 100644
+--- a/vllm/model_executor/layers/sparse_attn_indexer.py
++++ b/vllm/model_executor/layers/sparse_attn_indexer.py
+@@ -535,6 +535,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+     topk_indices: torch.Tensor,
+     topk_tokens: int,
+     head_dim: int,
++    allow_deepseek_v4: bool = False,
+ ) -> bool:
+     is_glm52 = (
+         q_quant.ndim == 3
+@@ -549,7 +550,9 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+     implementation_enabled = (
+         is_glm52 and _musa_sparse_indexer_glm52_materialized_enabled()
+     ) or (
+-        is_deepseek_v4 and _musa_sparse_indexer_materialized_prefill_enabled()
++        is_deepseek_v4
++        and allow_deepseek_v4
++        and _musa_sparse_indexer_materialized_prefill_enabled()
+     )
+     if (
+         not implementation_enabled
+@@ -776,6 +779,7 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
+     topk_indices: torch.Tensor,
+     topk_tokens: int,
+     head_dim: int,
++    allow_deepseek_v4_materialized: bool = False,
+ ) -> bool:
+     if (
+         q_quant.ndim == 3
+@@ -851,6 +855,7 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
+         topk_indices[:rows, :topk],
+         topk,
+         head_dim,
++        allow_deepseek_v4_materialized,
+     ):
+         return True
+ 
+@@ -1204,6 +1209,7 @@ def _musa_fill_exact_sparse_indexer_indices(
+     max_model_len: int,
+     topk_indices_buffer: torch.Tensor,
+     use_fp4_cache: bool,
++    use_musa_materialized_prefill: bool = False,
+ ) -> torch.Tensor:
+     if _musa_try_fill_all_sparse_indexer_indices(
+         hidden_states,
+@@ -1270,6 +1276,7 @@ def _musa_fill_exact_sparse_indexer_indices(
+                 topk_indices_buffer[token_start:token_end, :topk_tokens],
+                 topk_tokens,
+                 head_dim,
++                use_musa_materialized_prefill,
+             ):
+                 continue
+             if q_deq is None:
+@@ -1742,6 +1749,7 @@ class SparseAttnIndexer(CustomOp):
+         skip_k_cache_insert: bool = False,
+         use_fp4_cache: bool = False,
+         use_musa_native_indexer: bool = False,
++        use_musa_materialized_prefill: bool = False,
+     ):
+         super().__init__()
+         self.k_cache = k_cache
+@@ -1755,6 +1763,7 @@ class SparseAttnIndexer(CustomOp):
+         self.skip_k_cache_insert = skip_k_cache_insert
+         self.use_fp4_cache = use_fp4_cache
+         self.use_musa_native_indexer = use_musa_native_indexer
++        self.use_musa_materialized_prefill = use_musa_materialized_prefill
+         if current_platform.is_cuda() and not has_deep_gemm():
+             raise RuntimeError(
+                 "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
+@@ -1776,11 +1785,16 @@ class SparseAttnIndexer(CustomOp):
+             current_platform.is_musa()
+             and (
+                 self.use_musa_native_indexer
+-                or os.getenv(
+-                    "VLLM_MUSA_ENABLE_GLM52_SPARSE_INDEXER_MUSA_IMPL",
+-                    "1",
++                or (
++                    not isinstance(q_quant, tuple)
++                    and q_quant.ndim == 3
++                    and q_quant.shape[1] == 32
++                    and os.getenv(
++                        "VLLM_MUSA_ENABLE_GLM52_SPARSE_INDEXER_MUSA_IMPL",
++                        "1",
++                    )
++                    == "1"
+                 )
+-                == "1"
+                 or os.getenv(
+                     "VLLM_MUSA_ENABLE_TORCH_SPARSE_ATTN_INDEXER_FALLBACK",
+                     "0",
+@@ -1800,6 +1814,7 @@ class SparseAttnIndexer(CustomOp):
+                     self.max_model_len,
+                     self.topk_indices_buffer,
+                     self.use_fp4_cache,
++                    self.use_musa_materialized_prefill,
+                 )
+             except NotImplementedError:
+                 return _musa_fill_recent_sparse_indexer_indices(
+@@ -1824,6 +1839,7 @@ class SparseAttnIndexer(CustomOp):
+         """
+         return (
+             current_platform.is_musa()
++            and self.use_musa_native_indexer
+             and _musa_sparse_indexer_is_current_stream_capturing()
+             and not _musa_sparse_indexer_graph_exact_decode_enabled()
+         )
+diff --git a/vllm/models/deepseek_v4/attention.py b/vllm/models/deepseek_v4/attention.py
+index 34842fc34e..b2d29e1973 100644
+--- a/vllm/models/deepseek_v4/attention.py
++++ b/vllm/models/deepseek_v4/attention.py
+@@ -874,6 +874,22 @@ class DeepseekV4Indexer(nn.Module):
+             use_fp4_cache=self.use_fp4_kv,
+         )
+ 
++        use_musa_native_indexer = False
++        use_musa_materialized_prefill = False
++        if current_platform.is_musa():
++            from vllm_musa.optimization_contract import (
++                OptimizationFeature,
++                resolve_optimization_contract,
++            )
++
++            optimization_contract = resolve_optimization_contract(vllm_config)
++            use_musa_native_indexer = optimization_contract.prefers(
++                OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER
++            )
++            use_musa_materialized_prefill = optimization_contract.prefers(
++                OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER
++            )
++
+         self.indexer_op = SparseAttnIndexer(
+             self.k_cache,
+             self.quant_block_size,
+@@ -885,7 +901,8 @@ class DeepseekV4Indexer(nn.Module):
+             self.topk_indices_buffer,
+             skip_k_cache_insert=True,
+             use_fp4_cache=self.use_fp4_kv,
+-            use_musa_native_indexer=True,
++            use_musa_native_indexer=use_musa_native_indexer,
++            use_musa_materialized_prefill=use_musa_materialized_prefill,
+         )
+ 
+         # None on ROCm — maybe_execute_in_parallel falls back to sequential.
+diff --git a/vllm/models/deepseek_v4/nvidia/model.py b/vllm/models/deepseek_v4/nvidia/model.py
+index d334a1d7bf..a58cf0f2b0 100644
+--- a/vllm/models/deepseek_v4/nvidia/model.py
++++ b/vllm/models/deepseek_v4/nvidia/model.py
+@@ -114,6 +114,12 @@ class DeepseekV4MLP(nn.Module):
+             disable_tp=is_sequence_parallel,
+             prefix=f"{prefix}.down_proj",
+         )
++        if current_platform.is_musa():
++            from vllm.config import get_current_vllm_config
++
++            from vllm_musa.optimization_contract import bind_optimization_contract
++
++            bind_optimization_contract(self.down_proj, get_current_vllm_config())
+         if hidden_act != "silu":
+             raise ValueError(
+                 f"Unsupported activation: {hidden_act}. Only silu is supported for now."

--- a/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
+++ b/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
@@ -163,11 +163,11 @@ index d334a1d7bf..a58cf0f2b0 100644
              prefix=f"{prefix}.down_proj",
          )
 +        if current_platform.is_musa():
-+            from vllm.config import get_current_vllm_config
++            from vllm.config import get_current_vllm_config_or_none
 +
 +            from vllm_musa.optimization_contract import bind_optimization_contract
 +
-+            bind_optimization_contract(self.down_proj, get_current_vllm_config())
++            bind_optimization_contract(self.down_proj, get_current_vllm_config_or_none())
          if hidden_act != "silu":
              raise ValueError(
                  f"Unsupported activation: {hidden_act}. Only silu is supported for now."

--- a/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
+++ b/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
@@ -1,88 +1,49 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: musa <musa@local>
 Date: Mon, 3 Aug 2026 19:17:49 +0800
-Subject: [PATCH 101/101] MUSA: bind DeepSeek-V4 optimization contract
+Subject: [PATCH] MUSA: bind DeepSeek-V4 optimization contract
 
----
- .../layers/sparse_attn_indexer.py             | 26 +++++++++++++++----
- vllm/models/deepseek_v4/attention.py          | 19 +++++++++++++-
- vllm/models/deepseek_v4/nvidia/model.py       |  6 +++++
- 3 files changed, 45 insertions(+), 6 deletions(-)
 
 diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
-index e21e566f7f..77b78e6e25 100644
+index e21e566f7..77b78e6e2 100644
 --- a/vllm/model_executor/layers/sparse_attn_indexer.py
 +++ b/vllm/model_executor/layers/sparse_attn_indexer.py
-@@ -535,6 +535,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
-     topk_indices: torch.Tensor,
-     topk_tokens: int,
+@@ -537,2 +537,3 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
      head_dim: int,
 +    allow_deepseek_v4: bool = False,
  ) -> bool:
-     is_glm52 = (
-         q_quant.ndim == 3
-@@ -549,7 +550,9 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
-     implementation_enabled = (
-         is_glm52 and _musa_sparse_indexer_glm52_materialized_enabled()
+@@ -551,3 +552,5 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
      ) or (
 -        is_deepseek_v4 and _musa_sparse_indexer_materialized_prefill_enabled()
 +        is_deepseek_v4
 +        and allow_deepseek_v4
 +        and _musa_sparse_indexer_materialized_prefill_enabled()
      )
-     if (
-         not implementation_enabled
-@@ -776,6 +779,7 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
-     topk_indices: torch.Tensor,
-     topk_tokens: int,
+@@ -778,2 +781,3 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
      head_dim: int,
 +    allow_deepseek_v4_materialized: bool = False,
  ) -> bool:
-     if (
-         q_quant.ndim == 3
-@@ -851,6 +855,7 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
-         topk_indices[:rows, :topk],
-         topk,
+@@ -853,2 +857,3 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
          head_dim,
 +        allow_deepseek_v4_materialized,
      ):
-         return True
- 
-@@ -1204,6 +1209,7 @@ def _musa_fill_exact_sparse_indexer_indices(
-     max_model_len: int,
-     topk_indices_buffer: torch.Tensor,
+@@ -1206,2 +1211,3 @@ def _musa_fill_exact_sparse_indexer_indices(
      use_fp4_cache: bool,
 +    use_musa_materialized_prefill: bool = False,
  ) -> torch.Tensor:
-     if _musa_try_fill_all_sparse_indexer_indices(
-         hidden_states,
-@@ -1270,6 +1276,7 @@ def _musa_fill_exact_sparse_indexer_indices(
-                 topk_indices_buffer[token_start:token_end, :topk_tokens],
-                 topk_tokens,
+@@ -1272,2 +1278,3 @@ def _musa_fill_exact_sparse_indexer_indices(
                  head_dim,
 +                use_musa_materialized_prefill,
              ):
-                 continue
-             if q_deq is None:
-@@ -1742,6 +1749,7 @@ class SparseAttnIndexer(CustomOp):
-         skip_k_cache_insert: bool = False,
-         use_fp4_cache: bool = False,
+@@ -1744,2 +1751,3 @@ class SparseAttnIndexer(CustomOp):
          use_musa_native_indexer: bool = False,
 +        use_musa_materialized_prefill: bool = False,
      ):
-         super().__init__()
-         self.k_cache = k_cache
-@@ -1755,6 +1763,7 @@ class SparseAttnIndexer(CustomOp):
-         self.skip_k_cache_insert = skip_k_cache_insert
-         self.use_fp4_cache = use_fp4_cache
+@@ -1757,2 +1765,3 @@ class SparseAttnIndexer(CustomOp):
          self.use_musa_native_indexer = use_musa_native_indexer
 +        self.use_musa_materialized_prefill = use_musa_materialized_prefill
          if current_platform.is_cuda() and not has_deep_gemm():
-             raise RuntimeError(
-                 "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
-@@ -1776,11 +1785,16 @@ class SparseAttnIndexer(CustomOp):
-             current_platform.is_musa()
-             and (
+@@ -1778,7 +1787,12 @@ class SparseAttnIndexer(CustomOp):
                  self.use_musa_native_indexer
 -                or os.getenv(
 -                    "VLLM_MUSA_ENABLE_GLM52_SPARSE_INDEXER_MUSA_IMPL",
@@ -99,32 +60,19 @@ index e21e566f7f..77b78e6e25 100644
                  )
 -                == "1"
                  or os.getenv(
-                     "VLLM_MUSA_ENABLE_TORCH_SPARSE_ATTN_INDEXER_FALLBACK",
-                     "0",
-@@ -1800,6 +1814,7 @@ class SparseAttnIndexer(CustomOp):
-                     self.max_model_len,
-                     self.topk_indices_buffer,
+@@ -1802,2 +1816,3 @@ class SparseAttnIndexer(CustomOp):
                      self.use_fp4_cache,
 +                    self.use_musa_materialized_prefill,
                  )
-             except NotImplementedError:
-                 return _musa_fill_recent_sparse_indexer_indices(
-@@ -1824,6 +1839,7 @@ class SparseAttnIndexer(CustomOp):
-         """
-         return (
+@@ -1826,2 +1841,3 @@ class SparseAttnIndexer(CustomOp):
              current_platform.is_musa()
 +            and self.use_musa_native_indexer
              and _musa_sparse_indexer_is_current_stream_capturing()
-             and not _musa_sparse_indexer_graph_exact_decode_enabled()
-         )
 diff --git a/vllm/models/deepseek_v4/attention.py b/vllm/models/deepseek_v4/attention.py
-index 34842fc34e..b2d29e1973 100644
+index 34842fc34..b2d29e197 100644
 --- a/vllm/models/deepseek_v4/attention.py
 +++ b/vllm/models/deepseek_v4/attention.py
-@@ -874,6 +874,22 @@ class DeepseekV4Indexer(nn.Module):
-             use_fp4_cache=self.use_fp4_kv,
-         )
- 
+@@ -877 +877,17 @@ class DeepseekV4Indexer(nn.Module):
 +        use_musa_native_indexer = False
 +        use_musa_materialized_prefill = False
 +        if current_platform.is_musa():
@@ -142,25 +90,17 @@ index 34842fc34e..b2d29e1973 100644
 +            )
 +
          self.indexer_op = SparseAttnIndexer(
-             self.k_cache,
-             self.quant_block_size,
-@@ -885,7 +901,8 @@ class DeepseekV4Indexer(nn.Module):
-             self.topk_indices_buffer,
-             skip_k_cache_insert=True,
+@@ -887,3 +903,4 @@ class DeepseekV4Indexer(nn.Module):
              use_fp4_cache=self.use_fp4_kv,
 -            use_musa_native_indexer=True,
 +            use_musa_native_indexer=use_musa_native_indexer,
 +            use_musa_materialized_prefill=use_musa_materialized_prefill,
          )
- 
-         # None on ROCm — maybe_execute_in_parallel falls back to sequential.
 diff --git a/vllm/models/deepseek_v4/nvidia/model.py b/vllm/models/deepseek_v4/nvidia/model.py
-index d334a1d7bf..a58cf0f2b0 100644
+index d334a1d7b..9bed7d80f 100644
 --- a/vllm/models/deepseek_v4/nvidia/model.py
 +++ b/vllm/models/deepseek_v4/nvidia/model.py
-@@ -114,6 +114,12 @@ class DeepseekV4MLP(nn.Module):
-             disable_tp=is_sequence_parallel,
-             prefix=f"{prefix}.down_proj",
+@@ -116,2 +116,8 @@ class DeepseekV4MLP(nn.Module):
          )
 +        if current_platform.is_musa():
 +            from vllm.config import get_current_vllm_config_or_none
@@ -169,5 +109,3 @@ index d334a1d7bf..a58cf0f2b0 100644
 +
 +            bind_optimization_contract(self.down_proj, get_current_vllm_config_or_none())
          if hidden_act != "silu":
-             raise ValueError(
-                 f"Unsupported activation: {hidden_act}. Only silu is supported for now."

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,9 +17,10 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **103 patches**: this branch adds the DeepSeek-V4 shared-expert SwiGLU
-FP8 patch and removes the obsolete auxiliary-overlap patch after making that
-path the model default, so the upstream total remains unchanged. These are MUSA
+Currently **104 patches**: this stack adds one follow-up patch that binds the
+DeepSeek-V4 shared-MLP and sparse-indexer decisions to the MUSA optimization
+contract. The base branch adds the shared-expert SwiGLU FP8 patch and removes
+the obsolete auxiliary-overlap patch, leaving its total unchanged. These are MUSA
 source edits against the immutable vLLM commit recorded as `VLLM_COMMIT` in
 `third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
 object/registration patches (which patch live objects at import) are kept

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,12 +17,10 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **104 patches**: this stack adds one follow-up patch that binds the
-DeepSeek-V4 shared-MLP and sparse-indexer decisions to the MUSA optimization
-contract. The base branch adds the shared-expert SwiGLU FP8 patch and removes
-the obsolete auxiliary-overlap patch, leaving its total unchanged. These are MUSA
-source edits against the immutable vLLM commit recorded as `VLLM_COMMIT` in
-`third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
+Currently **104 patches**. The final patch binds DeepSeek-V4 shared-MLP and
+sparse-indexer policy to the MUSA optimization contract. The series contains
+MUSA source edits against the immutable vLLM commit recorded as `VLLM_COMMIT`
+in `third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
 object/registration patches (which patch live objects at import) are kept
 separately in `vllm_musa/patches/`, not in this build-time series. Run
 `python3 tools/musa_sync.py verify` to replay and verify the complete manifest

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -30,6 +30,7 @@ else:
 import pymtml as pynvml
 
 from vllm_musa.optimization_contract import (
+    ModelFamily,
     OptimizationFeature,
     resolve_optimization_contract,
 )
@@ -39,23 +40,6 @@ logger = init_logger(__name__)
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
-_DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV = "VLLM_MUSA_GEMV_MOE_BLOCK"
-_DEEPSEEK_V4_DEFAULT_GEMV_MOE_BLOCK = "32x8"
-
-
-def _is_deepseek_v4_model(model_config: Any | None) -> bool:
-    if model_config is None:
-        return False
-
-    hf_config = getattr(model_config, "hf_config", None)
-    model_type = getattr(hf_config, "model_type", None)
-    if model_type == "deepseek_v4":
-        return True
-
-    architectures = getattr(model_config, "architectures", None)
-    if architectures is None and hf_config is not None:
-        architectures = getattr(hf_config, "architectures", None)
-    return any("DeepseekV4" in str(arch) for arch in architectures or ())
 
 
 def _has_routed_experts(model_config: Any | None) -> bool:
@@ -115,8 +99,7 @@ def _is_qwen3_qk_rope_kv_fusion_config(vllm_config: Any) -> bool:
 
 
 def _deepseek_v4_flashmla_sparse_block_size(
-    model_config: Any | None,
-    tensor_parallel_size: int | None,
+    vllm_config: Any,
 ) -> int:
     """Return the validated FlashMLA sparse page size for DeepSeek-V4.
 
@@ -124,7 +107,9 @@ def _deepseek_v4_flashmla_sparse_block_size(
     the generic 64-token page for other models and parallel layouts; this is a
     model/shape decision rather than a process-wide environment switch.
     """
-    if _is_deepseek_v4_model(model_config) and tensor_parallel_size == 8:
+    if resolve_optimization_contract(vllm_config).prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    ):
         return 256
     return 64
 
@@ -583,32 +568,6 @@ class MUSAPlatformBase(Platform):
                 FUSED_ADD_RMSNORM_MIN_ROWS - 1,
             )
 
-        if _is_deepseek_v4_model(model_config):
-            # Keep the generic GEMV selector available for other models, but
-            # make the validated DeepSeek-V4 TP8 choice independent of a
-            # DeepSeek-specific profile environment variable. Explicit
-            # generic overrides still win for A/B diagnostics.
-            tensor_parallel_size = getattr(
-                parallel_config, "tensor_parallel_size", None
-            )
-            if (
-                tensor_parallel_size == 8
-                and "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in os.environ
-            ):
-                os.environ["VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X"] = "256"
-            if _DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV not in os.environ:
-                os.environ[_DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV] = (
-                    "16x8"
-                    if tensor_parallel_size == 8
-                    else _DEEPSEEK_V4_DEFAULT_GEMV_MOE_BLOCK
-                )
-                logger.info(
-                    "Defaulting DeepSeek-V4 MUSA GEMV/MoE block selector to "
-                    "%s=%s (set it explicitly to override).",
-                    _DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV,
-                    os.environ[_DEEPSEEK_V4_GEMV_MOE_BLOCK_ENV],
-                )
-
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm_musa.worker.MTGPUWorker"
 
@@ -658,8 +617,7 @@ class MUSAPlatformBase(Platform):
                     use_flashmla_sparse = True
 
                 sparse_block_size = _deepseek_v4_flashmla_sparse_block_size(
-                    model_config,
-                    getattr(parallel_config, "tensor_parallel_size", None),
+                    vllm_config,
                 )
                 if use_flashmla_sparse and cache_config.block_size != sparse_block_size:
                     cache_config.block_size = sparse_block_size
@@ -736,7 +694,10 @@ class MUSAPlatformBase(Platform):
             or model_config.is_hybrid
         ):
             return
-        if _is_deepseek_v4_model(model_config):
+        if (
+            resolve_optimization_contract(vllm_config).model.family
+            is ModelFamily.DEEPSEEK_V4
+        ):
             return
         backend_cls = cls._find_non_ssm_backend(vllm_config)
         if backend_cls is None:


### PR DESCRIPTION
## Summary

This PR extends the optimization-contract infrastructure from #166 to
DeepSeek-V4. It is intentionally stacked on
`feat/musa-60083-qwen-contract`; reviewers should review only the eight commits
after `e2c012dde`.

The contract combines immutable model facts from `config.json` with runtime
execution facts (parallel topology, KV dtype, attention backend, compilation
mode, CUDA-graph mode, and max sequences). Consumers bind the resolved
contract to their owning module and fail closed when identity or execution
metadata is incomplete.

The DeepSeek-V4 contract now owns selection for:

- the clamp-aware shared-MLP SwiGLU + group-128 FP8 path from #156;
- the native sparse indexer and materialized prefill indexer;
- the TP8 FLASHMLA sparse page-size and fused-add RMSNorm block-size choices;
- the custom-all-reduce graph registered-input guard; and
- the TP8 fused-MoE GEMV tile request, forwarded as graph-static op arguments.

Unsupported model identities, shapes, quantization layouts, parallel
topologies, or execution modes retain the existing path. Explicit generic
kernel overrides remain available and keep precedence over contract-selected
defaults.

## Why

DeepSeek-V4 optimizations previously mixed model-name checks, shape checks,
process-wide environment mutation, and consumer-local assumptions. That made
selection difficult to audit and could leak one model's tuning into another
model loaded by the same process.

This change centralizes the static and runtime contract while leaving the
optimized kernels and vLLM-Omni integration boundary unchanged.

## Performance alignment with #156

This stack is based on #156, so it does **not** claim the original +4.46%
shared-MLP fusion gain again. The performance gate here is preservation of the
#156 result while replacing its runtime selection plumbing.

The exact #156 TP8 workload was repeated on one isolated 8 x S5000 node with
the 5.2.0-server driver and image
`registry.mthreads.com/mcconline/inference/vllm:v0.24.0-ph1-5.2.0-torch2.9.1.post1-20260725`:

- `/home/dist/models/DeepSeek-V4-Flash-Base`, BF16 model, block-FP8 weights;
- TP8, FLASHMLA, FP8 KV, max model length 6144, max batched tokens 8195;
- max sequences/concurrency 1, prefix cache off, async scheduling on;
- compilation `NONE`, `FULL_DECODE_ONLY`, capture sizes `[1]`, copy inputs off;
- random 4096 input / 1024 output tokens, ignore EOS, temperature 0;
- five warmups before each measured phase, A1 -> B1 -> B2 -> A2.

| Variant | Output TPS runs | Mean output TPS | Mean TTFT | Mean TPOT | Mean E2E |
|---|---:|---:|---:|---:|---:|
| Current control (`e2c012dde`, includes #156) | 50.7941 / 50.9307 | 50.8624 tok/s | 792.99 ms | 18.8067 ms | 20032.20 ms |
| Contract candidate (`4d0572f12`) | 50.8215 / 50.8993 | 50.8604 tok/s | 789.75 ms | 18.8105 ms | 20032.94 ms |
| Candidate vs current control | - | **-0.004%** | **-0.409%** | **+0.021%** | **+0.004%** |

All four measurements completed 1/1 requests, generated 1024 tokens, and had
zero failures.

For direct comparison, #156 reported a controlled candidate mean of
51.0648 tok/s, 779.92 ms TTFT, and 18.7415 ms TPOT. This candidate differs by
-0.40% TPS, +1.26% TTFT, and +0.37% TPOT, within a 3% repeatability envelope.
The controlled current-stack A/B is effectively neutral, so the contract
migration does not remove the #156 optimization.

## Validation

Candidate source: `4d0572f12c450c24a9bbfc3c7e2b4fae306a9cb9`.
Pinned upstream vLLM: `ee0da84ab9e04ac7610e28580af62c365e898389`.

- contract, patch, and regression slice: `171 passed, 2 skipped`;
- all DeepSeek-V4 tests: `112 passed`;
- JIT C++ regression: `64 passed`;
- fused-add RMSNorm and clamp-SwiGLU numeric/graph tests: `17 passed`;
- GEMV M=1..5 numeric and graph replay tests: `6 passed`;
- real `EngineArgs` for `DeepSeek-V4-Flash-Base` resolved the
  `deepseek_v4.tp8_flash_base` profile;
- model config SHA256:
  `90c592a2dc666e9352a9bc28387414486f074351c7f57a1028bd528e0d0243bc`;
- all 104 ordered patches replayed on the pinned upstream checkout, including
  the new `0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch`;
- `ruff` passes for the new contract modules and focused DSV4 tests, and
  `git diff --check` passes for the complete stack. The existing import-order
  findings in `tests/test_patches.py` and the lazy DeepGEMM import block are
  unchanged from the stack base.

### Model regression on the final candidate SHA

| Path | Mode / backend | Result |
|---|---|---|
| Qwen3-8B BF16 | `VLLM_COMPILE`, `FULL_DECODE_ONLY`, FLASH_ATTN | HTTP 200, graph capture complete, `Beijing`, health 200 |
| Qwen3-8B FP8 | eager, FLASH_ATTN | HTTP 200, `quantization=fp8`, `Beijing`, health 200 |
| Qwen3-30B-A3B FP8 | eager, FLASH_ATTN, DeepGEMM MoE | HTTP 200, `Qwen3MoeForCausalLM`, `Beijing`, health 200 |
| DeepSeek-V2-Lite-Chat FP8 | eager, FLASHMLA, native GEMV MoE | six sequential multi-turn requests, all HTTP 200, `Beijing`, final health 200 |
| DeepSeek-V4-Flash-Base | TP8, #156 graph configuration, FLASHMLA | sparse page 256, GEMV 16x8 eager/capture, HTTP 200, `Beijing`, health 200 |

The BF16 MoE/MLA fallback smoke currently stops before serving on
`UnquantizedFusedMoEMethod.is_monolithic`. The same exception reproduces with
the `e2c012dde` control image, so it is recorded as a pre-existing stack
baseline failure rather than attributed to this PR. The FP8 MoE/MLA add-ons,
normal compiled dense path, and target DeepSeek-V4 path all pass on the final
candidate.

`musa_sync verify` still reports the pre-existing FlashAttention cat-4a
modified-copy tripwire drift; the complete ordered patch series itself replays
cleanly, and this PR does not change that copied module.

## Review order

1. Review #166 first for the generic contract types, resolver, and Qwen
   migration.
2. Review this PR for the DeepSeek-V4 provider and consumer bindings.
3. Merge #166 before this stacked PR, then retarget this PR to
   `v0.24.0-dev` if GitHub does not do so automatically.
