### PR TITLE
perf(musa): accelerate small-batch Qwen BF16 MoE decode

### DIFF
--- a/tests/test_fused_moe_chunking.py
+++ b/tests/test_fused_moe_chunking.py
@@ -545,6 +545,68 @@ def test_musa_dispatcher_routes_forced_backends(monkeypatch):
     assert grouped_calls[0]["inplace"] is False
 
 
+@pytest.mark.parametrize(("tokens", "expect_gemv"), [(5, True), (6, False)])
+def test_musa_dispatcher_auto_preserves_dsv4_fp8_gemv_threshold(
+    monkeypatch, tokens, expect_gemv
+):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    monkeypatch.delenv("VLLM_MUSA_GEMV_MOE_BLOCK", raising=False)
+    kwargs = _deepgemm_gate_kwargs(torch)
+    kwargs.update(
+        hidden_states=torch.empty(
+            (tokens, 4096), device="meta", dtype=torch.bfloat16
+        ),
+        topk_ids=torch.empty((tokens, 6), device="meta", dtype=torch.int32),
+        topk_weights=torch.empty(
+            (tokens, 6), device="meta", dtype=torch.float32
+        ),
+    )
+    native_output = torch.empty((1,), device="meta")
+    upstream_output = torch.empty((2,), device="meta")
+    native_calls = []
+    upstream_calls = []
+    monkeypatch.setattr(
+        fused_moe,
+        "_MUSA_FUSED_MOE_REQUESTED_BACKEND",
+        fused_moe.MusaFusedMoeBackend.AUTO,
+    )
+    monkeypatch.setattr(
+        fused_moe,
+        "_musa_device_fingerprint",
+        lambda *_args, **_kwargs: ((3, 1), 60),
+    )
+    monkeypatch.setattr(fused_moe, "_musa_stream_is_capturing", lambda: True)
+    monkeypatch.setattr(
+        fused_moe,
+        "fused_experts_impl",
+        lambda *args, **call_kwargs: native_calls.append((args, call_kwargs))
+        or native_output,
+    )
+    monkeypatch.setattr(
+        fused_moe._upstream_fused_moe,
+        "_musa_original_fused_experts_impl",
+        lambda *args, **call_kwargs: upstream_calls.append((args, call_kwargs))
+        or upstream_output,
+    )
+
+    result = fused_moe._musa_fused_experts_impl_dispatch(**kwargs)
+
+    if expect_gemv:
+        assert result is native_output
+        assert len(native_calls) == 1
+        assert native_calls[0][1] == {
+            "inplace": False,
+            "_allow_deepgemm_prefill": False,
+            "_gemv_block": (16, 8),
+        }
+        assert not upstream_calls
+    else:
+        assert result is upstream_output
+        assert not native_calls
+        assert len(upstream_calls) == 1
+
+
 def test_musa_dispatcher_rejects_gemv_input_router_weighting(monkeypatch):
     from vllm_musa.model_executor.layers.fused_moe import fused_moe
 

--- a/tests/test_fused_moe_dispatch_policy.py
+++ b/tests/test_fused_moe_dispatch_policy.py
@@ -255,6 +255,64 @@ def test_pr113_folded_qwen_shape_requires_fresh_calibration():
     assert thresholds_for_shape(folded_qwen).source == "uncalibrated-shape"
 
 
+def test_qwen35_bf16_decode_gemv_uses_tp4_local_crossover():
+    shape = _shape(
+        multiprocessor_count=60,
+        local_experts=257,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=9,
+        block_n=0,
+        block_k=0,
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+    )
+
+    assert thresholds_for_shape(shape).gemv_max_tokens == 12
+    for token_count in (1, 4, 8, 12):
+        assert (
+            select_fused_moe_backend(
+                shape=shape,
+                num_tokens=token_count,
+                can_use_gemv=True,
+                can_use_grouped_gemm=False,
+                stream_is_capturing=False,
+            )
+            == MusaFusedMoeBackend.GEMV
+        )
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=16,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=False,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+    capture_shape = _shape(**{**shape.__dict__, "graph_mode": "capture"})
+    assert thresholds_for_shape(capture_shape).gemv_max_tokens == 12
+
+    unfolded = _shape(
+        multiprocessor_count=60,
+        local_experts=256,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=8,
+        block_n=0,
+        block_k=0,
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+    )
+    assert thresholds_for_shape(unfolded).gemv_max_tokens == 12
+
+
 def test_force_modes_preserve_eligibility_checks():
     shape = _shape()
 

--- a/tests/test_qwen_moe_bf16_prefill_policy.py
+++ b/tests/test_qwen_moe_bf16_prefill_policy.py
@@ -29,6 +29,22 @@ def _inputs(
     return hidden_states, w1, w2, topk_weights, topk_ids
 
 
+def _decode_inputs(
+    *,
+    tokens: int = 1,
+    hidden_size: int = 2048,
+    experts: int = 257,
+    topk: int = 9,
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[torch.Tensor, ...]:
+    hidden_states = torch.empty((tokens, hidden_size), dtype=dtype, device="meta")
+    w1 = torch.empty((experts, 256, hidden_size), dtype=dtype, device="meta")
+    w2 = torch.empty((experts, hidden_size, 128), dtype=dtype, device="meta")
+    topk_weights = torch.empty((tokens, topk), dtype=torch.float32, device="meta")
+    topk_ids = torch.empty((tokens, topk), dtype=torch.int32, device="meta")
+    return hidden_states, w1, w2, topk_weights, topk_ids
+
+
 def test_qwen_moe_bf16_prefill_shape_is_enabled_by_default() -> None:
     assert fused_moe._is_calibrated_qwen_moe_bf16_prefill_shape(
         *_inputs(), global_num_experts=256
@@ -61,3 +77,37 @@ def test_qwen_moe_bf16_prefill_policy_wires_upstream_fallback() -> None:
     assert "prefer_upstream_qwen_prefill" in source
     assert "and not prefer_upstream_qwen_prefill" in source
     assert "VLLM_MUSA_QWEN_MOE_UPSTREAM_PREFILL" not in source
+
+
+@pytest.mark.parametrize(
+    ("tokens", "experts", "topk", "global_num_experts"),
+    [(1, 257, 9, 257), (4, 257, 9, 257), (8, 256, 8, 256), (12, 256, 8, 256)],
+)
+def test_qwen_moe_bf16_decode_gemv_matches_calibrated_tokens(
+    tokens: int, experts: int, topk: int, global_num_experts: int
+) -> None:
+    assert fused_moe.matches_qwen35_moe_bf16_decode_gemv_layer(
+        *_decode_inputs(tokens=tokens, experts=experts, topk=topk),
+        global_num_experts=global_num_experts,
+        max_tokens=12,
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "global_num_experts"),
+    [
+        ({"tokens": 16}, 257),
+        ({"hidden_size": 4096}, 257),
+        ({"experts": 255, "topk": 8}, 255),
+        ({"topk": 8}, 257),
+        ({"dtype": torch.float16}, 257),
+    ],
+)
+def test_qwen_moe_bf16_decode_gemv_rejects_other_contracts(
+    kwargs: dict[str, object], global_num_experts: int
+) -> None:
+    assert not fused_moe.matches_qwen35_moe_bf16_decode_gemv_layer(
+        *_decode_inputs(**kwargs),
+        global_num_experts=global_num_experts,
+        max_tokens=12,
+    )

--- a/vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py
+++ b/vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py
@@ -97,6 +97,36 @@ def _s5000_fp8_shape(
     )
 
 
+def _s5000_qwen35_bf16_decode_shape(
+    *, graph_mode: str, folded_shared_expert: bool
+) -> MusaFusedMoeShape:
+    """TP4-local Qwen3.5/3.6 BF16 decode shape."""
+
+    experts = 257 if folded_shared_expert else 256
+    top_k = 9 if folded_shared_expert else 8
+
+    return MusaFusedMoeShape(
+        device_capability=(3, 1),
+        multiprocessor_count=60,
+        local_experts=experts,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=top_k,
+        block_n=0,
+        block_k=0,
+        activation="silu",
+        expert_parallel=False,
+        hidden_dtype="torch.bfloat16",
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+        gemv_block="auto",
+        graph_mode=graph_mode,
+    )
+
+
 def _thresholds(
     gemv_max_tokens: int | None,
     grouped_gemm_min_tokens: int | None,
@@ -198,6 +228,26 @@ _CALIBRATED_THRESHOLDS.update(
             ),
         )
         for graph_mode in ("eager", "capture")
+    }
+)
+_CALIBRATED_THRESHOLDS.update(
+    {
+        _s5000_qwen35_bf16_decode_shape(
+            graph_mode=graph_mode,
+            folded_shared_expert=folded_shared_expert,
+        ): _thresholds(
+            # Exact TP4-local Qwen crossover: M=1/2/4/8/12 are faster on
+            # native GEMV, while M>=16 is not a stable production win.
+            gemv_max_tokens=12,
+            grouped_gemm_min_tokens=None,
+            source=(
+                f"s5000-mp60-20260806-qwen35-36-bf16-e"
+                f"{257 if folded_shared_expert else 256}-"
+                f"n256-k2048-v128-{graph_mode}-crossover-v1"
+            ),
+        )
+        for graph_mode in ("eager", "capture")
+        for folded_shared_expert in (False, True)
     }
 )
 

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -36,7 +36,10 @@ from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (
     select_fused_moe_backend,
     thresholds_for_shape,
 )
-from vllm_musa.optimization_contract import matches_qwen35_moe_bf16_prefill_layer
+from vllm_musa.optimization_contract import (
+    matches_qwen35_moe_bf16_decode_gemv_layer,
+    matches_qwen35_moe_bf16_prefill_layer,
+)
 
 logger = init_logger(__name__)
 
@@ -1368,6 +1371,69 @@ def _can_use_musa_native_fp8_moe_gemv(
     ) and _musa_fp8_moe_scale_layout_is_supported(w2_scale, w2)
 
 
+def _can_use_qwen35_bf16_moe_decode_gemv(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: str,
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+    ocp_mx_scheme: str | None,
+    per_channel_quant: bool,
+    global_num_experts: int,
+    expert_map: torch.Tensor | None,
+    w1_scale: torch.Tensor | None,
+    w2_scale: torch.Tensor | None,
+    w1_zp: torch.Tensor | None,
+    w2_zp: torch.Tensor | None,
+    a1_scale: torch.Tensor | None,
+    a2_scale: torch.Tensor | None,
+    w1_bias: torch.Tensor | None,
+    w2_bias: torch.Tensor | None,
+) -> bool:
+    if (
+        use_fp8_w8a8
+        or use_int8_w8a8
+        or use_int8_w8a16
+        or use_int4_w4a16
+        or ocp_mx_scheme is not None
+        or per_channel_quant
+        or expert_map is not None
+        or w1_scale is not None
+        or w2_scale is not None
+        or w1_zp is not None
+        or w2_zp is not None
+        or a1_scale is not None
+        or a2_scale is not None
+        or w1_bias is not None
+        or w2_bias is not None
+        or activation != "silu"
+    ):
+        return False
+    if not (
+        hidden_states.is_contiguous()
+        and w1.is_contiguous()
+        and w2.is_contiguous()
+        and topk_weights.is_contiguous()
+        and topk_ids.is_contiguous()
+    ):
+        return False
+    return matches_qwen35_moe_bf16_decode_gemv_layer(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        global_num_experts,
+        max_tokens=12,
+    )
+
+
 def _musa_fused_moe_shape(
     *,
     hidden_states: torch.Tensor,
@@ -1756,11 +1822,49 @@ def _musa_fused_experts_impl_dispatch(
     shape = None
     requested_gemv_block = (0, 0)
 
-    # Skip all shape construction and capture queries for non-FP8 callers and
-    # for the explicit rollback path. This wrapper sits on every MoE layer.
+    # Keep the expensive contract matcher off unrelated MoE calls.  The
+    # tensor geometry is the runtime half of the Qwen3.5/3.6 model contract;
+    # all non-matching models take the old upstream path.
+    qwen35_bf16_decode_gemv = False
+    if (
+        hidden_states.ndim == 2
+        and 0 < hidden_states.shape[0] <= 12
+        and w1.ndim == 3
+        and w1.shape[0] in (256, 257)
+        and hidden_states.dtype == torch.bfloat16
+        and w1.dtype == torch.bfloat16
+        and w2.dtype == torch.bfloat16
+    ):
+        qwen35_bf16_decode_gemv = _can_use_qwen35_bf16_moe_decode_gemv(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=activation,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a8=use_int8_w8a8,
+            use_int8_w8a16=use_int8_w8a16,
+            use_int4_w4a16=use_int4_w4a16,
+            ocp_mx_scheme=ocp_mx_scheme,
+            per_channel_quant=per_channel_quant,
+            global_num_experts=global_num_experts,
+            expert_map=expert_map,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            w1_zp=w1_zp,
+            w2_zp=w2_zp,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+        )
+
+    # Skip all shape construction and capture queries for unsupported callers
+    # and for the explicit rollback path. This wrapper sits on every MoE layer.
     if (
         _MUSA_FUSED_MOE_REQUESTED_BACKEND != MusaFusedMoeBackend.UPSTREAM
-        and use_fp8_w8a8
+        and (use_fp8_w8a8 or qwen35_bf16_decode_gemv)
         and not use_int8_w8a8
         and not use_int8_w8a16
         and not use_int4_w4a16
@@ -1822,6 +1926,7 @@ def _musa_fused_experts_impl_dispatch(
                     w1_bias=w1_bias,
                     w2_bias=w2_bias,
                 )
+                or (not apply_router_weight_on_input and qwen35_bf16_decode_gemv)
             )
             can_use_grouped_gemm = _can_use_musa_fp8_moe_grouped_gemm(
                 hidden_states=hidden_states,

--- a/vllm_musa/optimization_contract/__init__.py
+++ b/vllm_musa/optimization_contract/__init__.py
@@ -1,4 +1,7 @@
-from .qwen import matches_qwen35_moe_bf16_prefill_layer
+from .qwen import (
+    matches_qwen35_moe_bf16_decode_gemv_layer,
+    matches_qwen35_moe_bf16_prefill_layer,
+)
 from .resolver import (
     bind_optimization_contract,
     prefers_optimization,
@@ -21,6 +24,7 @@ __all__ = [
     "MusaOptimizationContract",
     "OptimizationFeature",
     "bind_optimization_contract",
+    "matches_qwen35_moe_bf16_decode_gemv_layer",
     "matches_qwen35_moe_bf16_prefill_layer",
     "prefers_optimization",
     "resolve_optimization_contract",

--- a/vllm_musa/optimization_contract/qwen.py
+++ b/vllm_musa/optimization_contract/qwen.py
@@ -94,6 +94,53 @@ def matches_qwen35_moe_bf16_prefill_layer(
         return False
 
 
+def matches_qwen35_moe_bf16_decode_gemv_layer(
+    hidden_states,
+    w1,
+    w2,
+    topk_weights,
+    topk_ids,
+    global_num_experts: int | None,
+    *,
+    max_tokens: int,
+) -> bool:
+    """Match the TP4-local Qwen3.5/3.6 BF16 decode GEMV shape.
+
+    The local TP4 weights have two supported runtime forms.  With shared
+    expert folding they are ``E=257`` and ``top_k=9``; without folding they
+    are ``E=256`` and ``top_k=8``.  Both use the same local ``N/K/V`` sizes.
+    Keeping this shape contract at the dispatch boundary makes the small-M
+    native GEMV opt-in fail closed for other MoE families and for prefill.
+    """
+
+    def dtype_name(value) -> str:
+        return str(value).lower().removeprefix("torch.")
+
+    try:
+        folded = global_num_experts == 257
+        unfolded = global_num_experts == 256
+        expected_experts = 257 if folded else 256
+        expected_top_k = 9 if folded else 8
+        return (
+            (folded or unfolded)
+            and hidden_states.ndim == 2
+            and dtype_name(hidden_states.dtype) == "bfloat16"
+            and dtype_name(w1.dtype) == "bfloat16"
+            and dtype_name(w2.dtype) == "bfloat16"
+            and 0 < hidden_states.shape[0] <= max_tokens
+            and hidden_states.shape[1] == 2048
+            and tuple(w1.shape) == (expected_experts, 256, 2048)
+            and tuple(w2.shape) == (expected_experts, 2048, 128)
+            and topk_weights.ndim == 2
+            and topk_ids.ndim == 2
+            and topk_weights.shape == topk_ids.shape
+            and topk_ids.shape[0] == hidden_states.shape[0]
+            and topk_ids.shape[1] == expected_top_k
+        )
+    except (AttributeError, IndexError, TypeError, ValueError):
+        return False
+
+
 def _has_architecture(model: ModelSignature, allowed: frozenset[str]) -> bool:
     architectures = model.outer_architectures or model.architectures
     return any(architecture in allowed for architecture in architectures)


### PR DESCRIPTION
## Summary

Use the existing MUSA native BF16 MoE GEMV for the small-token Qwen3.5/Qwen3.6
decode shapes where it is faster than the upstream Triton implementation.
This is a narrow runtime/tensor contract; it adds no process environment gate
and preserves the upstream fallback for every mismatch.

Supported TP4-local BF16 forms:

- unfolded shared expert: `E=256`, `w1=[256,256,2048]`,
  `w2=[256,2048,128]`, `top_k=8`;
- folded shared expert: `E=257`, same local `N/K/V`, `top_k=9`.

Native GEMV is selected only for `M <= 12`.  `M >= 16`, quantized weights,
biases, expert maps, non-contiguous tensors, other dimensions, explicit
upstream selection, and unsupported models retain the existing path.

## Why

Qwen3.5-35B-A3B BF16 TP4 profiles show `fused_moe_kernel` at 31--34% of
steady-state device time.  The existing default dispatcher skipped BF16
native GEMV entirely because its earlier calibration was intended to protect
large prefill.  A cold-cache S5000 crossover at the exact TP4-local shape
shows a strong small-M win and a safe large-M fallback.

## Evidence

All serving runs used the pinned `v0.24.0-ph1-5.2.0-torch2.9.1.post1-20260731`
image, BF16 Qwen3.5-35B-A3B, TP4, FLASH_ATTN, normal FULL graph, frozen
4096-token input vectors, 1024 generated tokens, and three measured
repetitions.

| Workload | Control TPOT (A/B) | Candidate TPOT | Delta |
|---|---:|---:|---:|
| BS1 | 16.323 / 16.332 ms | 11.236 ms | -31.2% vs control mean |
| BS4 | 15.239 / 15.224 ms | 13.109 ms | -13.9% vs control mean |

The candidate selected native GEMV at BS1/BS4.  Candidate BS64 passed a
semantic fallback smoke with the complete graph ladder `1,4,16,64`; the exact
M16/M64 operator dispatch stays on upstream.  Qwen3.6-35B-A3B passed a TP4
BS1 sibling semantic smoke.

Standalone exact-shape operator dispatch on S5000 (candidate vs direct
upstream) measured approximately 3.84x at M1, 1.30x at M4, 1.01x at M16,
and 1.00x at M64.  All outputs passed the upstream comparison
(`relative_l2` around 0.004--0.006).

## Validation

- Local policy/contract tests: `33 passed, 1 skipped`.
- `ruff`/`py_compile` passed for changed Python files (the existing unrelated
  import-order warning in `fused_moe.py` is unchanged).
- MUSA operator and serving semantic receipts passed on S5000 driver
  `3.3.5-server`.

The hardware lease was non-isolated, so the serving numbers are diagnostic
A-B-A evidence rather than an isolated release benchmark.  No FP8 or DeepSeek
claim is made by this PR.  This branch is intended to stack on PR #170.

Original performance-evidence source: `7ef2888a89b6395f27304b46191d2f464af89ca3`.
The reproducible local evidence bundle is
`generated/MUSA-60086/evidence/stageb-bf16-moe-serving-evidence.tar.gz`
(SHA256 `654b9ec3799bb522cd40273ec587ab7da30aba63fca8ea0dc104ad9641850bed`).


## Post-review rebase

Rebased on PR #170 at `f54bffee2dae5ae4dbc25ff4d00d527bbfad5fec`
(current `v0.24.0-dev`, including #171). The current remote head is
`4ff0b72fc575dd6d6d858da9c392c170ae98de64`; its tree is identical to local
`43e8822b4ad848ed1289f410ff233ca64b1b0f4a`. An exact DeepSeek-V4 Flash FP8
dispatch regression now proves that `M<=5` keeps native GEMV with the `16x8`
tile and `M=6` falls back upstream. Pure policy/source tests report `19 passed`;
the Torch-dependent dispatcher test is not runnable in the host Python
environment. The performance table above is the original pre-rebase evidence
and needs a fresh confirmation before final merge readiness.


Remote focused validation on 10.20.34.82 (image digest `sha256:6a344d5f9ffe3b9b0f2ebd064f5c0ec53f9196b29decf260fd1e49fdc6ecc1a5`) completed `61 passed`, including the DSV4 dispatcher regression. The task-local log was removed with the drifted container; this is not a retained CI artifact. Serving/performance A/B after the #171 rebase is still pending.