### PR TITLE
[stacked on #174] fix DSV4 MTP multi-batch OOM

### DIFF
--- a/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
+++ b/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
@@ -159,6 +159,61 @@ __global__ void deepseek_v4_inv_rope_fp8_quant_kernel(
   }
 }
 
+// The FP32-scale path has no cross-chunk packing dependency. Give each
+// 128-element quantization chunk its own block so the four chunks in a
+// DeepSeek-V4 head can execute concurrently. Only real tokens are launched;
+// token 0 also clears the at-most-three scale-padding slots required by the
+// downstream aligned layout.
+__global__ void deepseek_v4_inv_rope_fp8_quant_chunk_kernel(
+    const __mt_bfloat16* __restrict__ o, int64_t o_stride_token,
+    int64_t o_stride_head, const void* __restrict__ positions,
+    int position_kind, const float* __restrict__ cos_sin_cache,
+    int64_t cache_stride_pos, uint8_t* __restrict__ fp8_out,
+    int64_t fp8_stride_group, int64_t fp8_stride_token,
+    float* __restrict__ scale, int64_t scale_stride_group,
+    int64_t scale_stride_k, int64_t num_tokens, int64_t aligned_tokens,
+    int64_t heads_per_group) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x);
+  const int64_t global_head = static_cast<int64_t>(blockIdx.y);
+  const int64_t chunk = static_cast<int64_t>(blockIdx.z);
+  const int tid = threadIdx.x;
+
+  const int64_t group = global_head / heads_per_group;
+  const int64_t head_in_group = global_head - group * heads_per_group;
+  const int64_t out_chunk = head_in_group * kChunksPerHead + chunk;
+  const int64_t dim = chunk * kQuantGroupSize + tid;
+
+  const int64_t pos = load_index(positions, position_kind, token);
+  const float* cos_ptr = cos_sin_cache + pos * cache_stride_pos;
+  const float* sin_ptr = cos_ptr + kRopeDim / 2;
+  const __mt_bfloat16* input =
+      o + token * o_stride_token + global_head * o_stride_head;
+  uint8_t* output = fp8_out + group * fp8_stride_group +
+                    token * fp8_stride_token + head_in_group * kHeadDim;
+
+  const float value = load_rotated_or_raw(input, dim, cos_ptr, sin_ptr);
+  __shared__ float reduce[kThreads];
+  const float absmax = reduce_max_128(reduce, tid, fabsf(value));
+  const float scale_raw = fmaxf(absmax / kFp8Max, kScaleEps);
+  const float scale_pow2 = exp2f(ceilf(log2f(scale_raw)));
+
+  if (tid == 0) {
+    scale[group * scale_stride_group + token + out_chunk * scale_stride_k] =
+        scale_pow2;
+  }
+
+  float q = value / scale_pow2;
+  q = fminf(fmaxf(q, kFp8Min), kFp8Max);
+  const __mt_fp8_e4m3 packed(q);
+  output[dim] = packed.__x;
+
+  const int64_t padding = aligned_tokens - num_tokens;
+  if (token == 0 && tid < padding) {
+    scale[group * scale_stride_group + num_tokens + tid +
+          out_chunk * scale_stride_k] = 0.0f;
+  }
+}
+
 int index_kind(const torch::Tensor& tensor, const char* name) {
   if (tensor.scalar_type() == torch::kInt32) {
     return kIndexInt32;
@@ -263,15 +318,17 @@ std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_inv_rope_fp8_quant(
             scale_buf.stride(0), scale_buf.stride(2), num_tokens,
             heads_per_group);
   } else {
-    deepseek_v4_inv_rope_fp8_quant_kernel<false>
-        <<<grid, block, 0, stream>>>(
-            static_cast<const __mt_bfloat16*>(o.data_ptr()), o.stride(0),
-            o.stride(1), positions.data_ptr(), index_kind(positions, "positions"),
-            static_cast<const float*>(cos_sin_cache.data_ptr()),
-            cos_sin_cache.stride(0), static_cast<uint8_t*>(fp8_buf.data_ptr()),
-            fp8_buf.stride(0), fp8_buf.stride(1), scale_buf.data_ptr(),
-            scale_buf.stride(0), scale_buf.stride(2), num_tokens,
-            heads_per_group);
+    const dim3 chunk_grid(static_cast<unsigned int>(num_tokens),
+                          static_cast<unsigned int>(num_heads),
+                          static_cast<unsigned int>(kChunksPerHead));
+    deepseek_v4_inv_rope_fp8_quant_chunk_kernel<<<chunk_grid, block, 0, stream>>>(
+        static_cast<const __mt_bfloat16*>(o.data_ptr()), o.stride(0),
+        o.stride(1), positions.data_ptr(), index_kind(positions, "positions"),
+        static_cast<const float*>(cos_sin_cache.data_ptr()),
+        cos_sin_cache.stride(0), static_cast<uint8_t*>(fp8_buf.data_ptr()),
+        fp8_buf.stride(0), fp8_buf.stride(1),
+        static_cast<float*>(scale_buf.data_ptr()), scale_buf.stride(0),
+        scale_buf.stride(2), num_tokens, aligned_tokens, heads_per_group);
   }
 
   const auto err = musaGetLastError();

--- a/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
+++ b/csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu
@@ -171,8 +171,8 @@ __global__ void deepseek_v4_inv_rope_fp8_quant_chunk_kernel(
     int64_t cache_stride_pos, uint8_t* __restrict__ fp8_out,
     int64_t fp8_stride_group, int64_t fp8_stride_token,
     float* __restrict__ scale, int64_t scale_stride_group,
-    int64_t scale_stride_k, int64_t num_tokens, int64_t aligned_tokens,
-    int64_t heads_per_group) {
+    int64_t scale_stride_token, int64_t scale_stride_k, int64_t num_tokens,
+    int64_t aligned_tokens, int64_t heads_per_group) {
   const int64_t token = static_cast<int64_t>(blockIdx.x);
   const int64_t global_head = static_cast<int64_t>(blockIdx.y);
   const int64_t chunk = static_cast<int64_t>(blockIdx.z);
@@ -198,8 +198,8 @@ __global__ void deepseek_v4_inv_rope_fp8_quant_chunk_kernel(
   const float scale_pow2 = exp2f(ceilf(log2f(scale_raw)));
 
   if (tid == 0) {
-    scale[group * scale_stride_group + token + out_chunk * scale_stride_k] =
-        scale_pow2;
+    scale[group * scale_stride_group + token * scale_stride_token +
+          out_chunk * scale_stride_k] = scale_pow2;
   }
 
   float q = value / scale_pow2;
@@ -209,7 +209,8 @@ __global__ void deepseek_v4_inv_rope_fp8_quant_chunk_kernel(
 
   const int64_t padding = aligned_tokens - num_tokens;
   if (token == 0 && tid < padding) {
-    scale[group * scale_stride_group + num_tokens + tid +
+    scale[group * scale_stride_group +
+          (num_tokens + tid) * scale_stride_token +
           out_chunk * scale_stride_k] = 0.0f;
   }
 }
@@ -291,10 +292,14 @@ std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_inv_rope_fp8_quant(
   } else {
     scale_storage = torch::empty({n_groups * num_scale_blocks * aligned_tokens},
                                  o.options().dtype(torch::kFloat32));
+    // Keep each group-local [token, block] scale matrix contiguous.  The
+    // downstream DeepSeek-V4 o-proj consumes one group at a time, so this
+    // layout preserves the public [token, group, block] view while avoiding a
+    // device copy for every layer and decode step.
     scale_buf =
         scale_storage.as_strided({n_groups, num_tokens, num_scale_blocks},
-                                 {num_scale_blocks * aligned_tokens, 1,
-                                  aligned_tokens});
+                                 {num_scale_blocks * aligned_tokens,
+                                  num_scale_blocks, 1});
   }
 
   if (num_tokens == 0 || num_heads == 0) {
@@ -328,7 +333,8 @@ std::tuple<torch::Tensor, torch::Tensor> deepseek_v4_fused_inv_rope_fp8_quant(
         cos_sin_cache.stride(0), static_cast<uint8_t*>(fp8_buf.data_ptr()),
         fp8_buf.stride(0), fp8_buf.stride(1),
         static_cast<float*>(scale_buf.data_ptr()), scale_buf.stride(0),
-        scale_buf.stride(2), num_tokens, aligned_tokens, heads_per_group);
+        scale_buf.stride(1), scale_buf.stride(2), num_tokens, aligned_tokens,
+        heads_per_group);
   }
 
   const auto err = musaGetLastError();

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -616,6 +616,51 @@ bool ShouldUseDeepSeekV4Fp8MoeSplitTile(
            IsForcedBlockConfigValid(config, nr_n, hidden_size, vlen);
 }
 
+bool SelectDeepSeekV4Fp8OProjTile(
+    int current_arch,
+    bool is_fp8,
+    bool use_swigelu,
+    bool use_rms_norm,
+    bool use_int4_w4a16,
+    int reduce_size,
+    int hidden_size,
+    int nr_n,
+    int scale_k_group_tile,
+    int vlen,
+    int bseqlen,
+    BlockConfig* config) {
+    if (current_arch < 300 || !is_fp8 || use_swigelu || use_rms_norm ||
+        use_int4_w4a16 || reduce_size != 1024 || hidden_size != 4096 ||
+        nr_n != 1024 || scale_k_group_tile != 128) {
+        return false;
+    }
+
+    // DeepSeek-V4 TP8 O-proj is [M,4096] x [1024,4096]^T.  The platform's
+    // VLLM_MUSA_GEMV_MOE_BLOCK=16x8 default belongs to routed MoE, but the
+    // non-MoE GEMV historically consumed it too.  Cold-L2 calibration on an
+    // S5000 mp60 shows that the production graph-capture ladder needs more N
+    // tiles at small M and different K reductions as M grows.  Match only the
+    // exact O-proj contract; unsupported/eager sizes retain the generic path.
+    switch (bseqlen) {
+        case 1:
+        case 2:
+        case 8:
+            *config = BlockConfig{4, 32, 0.f, true};
+            break;
+        case 4:
+        case 32:
+        case 64:
+            *config = BlockConfig{8, 16, 0.f, true};
+            break;
+        case 16:
+            *config = BlockConfig{32, 4, 0.f, true};
+            break;
+        default:
+            return false;
+    }
+    return IsForcedBlockConfigValid(*config, nr_n, hidden_size, vlen);
+}
+
 void musa_fused_gemv(
     torch::Tensor &A,
     torch::Tensor &B,
@@ -730,18 +775,35 @@ void musa_fused_gemv(
         fallback_config = BlockConfig{128, 1, -1.0f, false};
     }
     BlockConfig forced_config{0, 0, 0.f, false};
+    BlockConfig deepseek_v4_o_proj_config{0, 0, 0.f, false};
     BlockConfig* best_config = &fallback_config;
-    if (ParseForcedBlockConfig(&forced_config)) {
-        TORCH_CHECK(
-            IsForcedBlockConfigValid(forced_config, nr_n, hidden_size, vlen),
-            kGemvMoeBlockEnv, "=", forced_config.block_n, "x",
-            forced_config.block_k, " is invalid for nr_n=", nr_n,
-            ", hidden_size=", hidden_size, ", vlen=", vlen);
-        best_config = &forced_config;
+    if (SelectDeepSeekV4Fp8OProjTile(
+            current_arch,
+            is_fp8,
+            use_swigelu,
+            use_rms_norm,
+            use_int4_w4a16,
+            reduce_size,
+            hidden_size,
+            nr_n,
+            scale_k_group_tile,
+            vlen,
+            bseqlen,
+            &deepseek_v4_o_proj_config)) {
+        best_config = &deepseek_v4_o_proj_config;
     } else {
-        for (auto& config : configs) {
-            if (config.valid && config.score > best_config->score) {
-                best_config = &config;
+        if (ParseForcedBlockConfig(&forced_config)) {
+            TORCH_CHECK(
+                IsForcedBlockConfigValid(forced_config, nr_n, hidden_size, vlen),
+                kGemvMoeBlockEnv, "=", forced_config.block_n, "x",
+                forced_config.block_k, " is invalid for nr_n=", nr_n,
+                ", hidden_size=", hidden_size, ", vlen=", vlen);
+            best_config = &forced_config;
+        } else {
+            for (auto& config : configs) {
+                if (config.valid && config.score > best_config->score) {
+                    best_config = &config;
+                }
             }
         }
     }

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -661,6 +661,32 @@ bool SelectDeepSeekV4Fp8OProjTile(
     return IsForcedBlockConfigValid(*config, nr_n, hidden_size, vlen);
 }
 
+bool SelectDeepSeekV4Fp8SharedGateUpTile(
+    int current_arch,
+    bool is_fp8,
+    bool use_swigelu,
+    bool use_rms_norm,
+    bool use_int4_w4a16,
+    int reduce_size,
+    int hidden_size,
+    int nr_n,
+    int scale_k_group_tile,
+    int vlen,
+    int bseqlen,
+    BlockConfig* config) {
+    if (current_arch < 300 || !is_fp8 || use_swigelu || use_rms_norm ||
+        use_int4_w4a16 || reduce_size != 512 || hidden_size != 4096 ||
+        nr_n != 512 || scale_k_group_tile != 128 || bseqlen != 1) {
+        return false;
+    }
+
+    // Python dispatch already limits this exact contract to the DeepSeek-V4
+    // TP8 shared-expert gate-up layer.  Select the cold-L2 winner here before
+    // the routed-MoE 16x8 environment default can leak into the dense GEMV.
+    *config = BlockConfig{4, 32, 0.f, true};
+    return IsForcedBlockConfigValid(*config, nr_n, hidden_size, vlen);
+}
+
 void musa_fused_gemv(
     torch::Tensor &A,
     torch::Tensor &B,
@@ -775,7 +801,7 @@ void musa_fused_gemv(
         fallback_config = BlockConfig{128, 1, -1.0f, false};
     }
     BlockConfig forced_config{0, 0, 0.f, false};
-    BlockConfig deepseek_v4_o_proj_config{0, 0, 0.f, false};
+    BlockConfig deepseek_v4_linear_config{0, 0, 0.f, false};
     BlockConfig* best_config = &fallback_config;
     if (SelectDeepSeekV4Fp8OProjTile(
             current_arch,
@@ -789,8 +815,21 @@ void musa_fused_gemv(
             scale_k_group_tile,
             vlen,
             bseqlen,
-            &deepseek_v4_o_proj_config)) {
-        best_config = &deepseek_v4_o_proj_config;
+            &deepseek_v4_linear_config) ||
+        SelectDeepSeekV4Fp8SharedGateUpTile(
+            current_arch,
+            is_fp8,
+            use_swigelu,
+            use_rms_norm,
+            use_int4_w4a16,
+            reduce_size,
+            hidden_size,
+            nr_n,
+            scale_k_group_tile,
+            vlen,
+            bseqlen,
+            &deepseek_v4_linear_config)) {
+        best_config = &deepseek_v4_linear_config;
     } else {
         if (ParseForcedBlockConfig(&forced_config)) {
             TORCH_CHECK(

--- a/tests/test_deepseek_v4_contract_source.py
+++ b/tests/test_deepseek_v4_contract_source.py
@@ -18,7 +18,7 @@ def test_platform_uses_contract_without_model_derived_kernel_envs() -> None:
     assert "VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X" not in source
 
 
-def test_shared_mlp_and_rmsnorm_bind_instance_contracts() -> None:
+def test_shared_mlp_owner_guards_and_rmsnorm_instance_contract() -> None:
     linear = _source("vllm_musa/model_executor/layers/linear.py")
     layernorm = _source("vllm_musa/model_executor/layers/layernorm.py")
     model_patch = _source(
@@ -26,8 +26,14 @@ def test_shared_mlp_and_rmsnorm_bind_instance_contracts() -> None:
         "0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch"
     )
 
-    assert "DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8" in linear
-    assert "prefers_optimization(" in linear
+    assert "def forward_swiglu_clamp(" in linear
+    assert "This hook is only called by DeepSeek-V4's MLP" in linear
+    assert "not envs.VLLM_BATCH_INVARIANT" in linear
+    assert "_deepgemm_block_fp8(self.quant_method)" in linear
+    assert (
+        'tuple(getattr(self, "weight_block_size", None) or ()) == (128, 128)' in linear
+    )
+    assert "swiglu_limit == 10.0" in linear
     assert "bind_optimization_contract(self.down_proj" in model_patch
     assert "bind_optimization_contract(self" in layernorm
     assert "DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256" in layernorm
@@ -45,6 +51,33 @@ def test_sparse_indexer_contract_keeps_glm_entry_shape_local() -> None:
     assert "use_musa_materialized_prefill" in patch
     assert "q_quant.shape[1] == 32" in patch
     assert "and self.use_musa_native_indexer" in patch
+
+
+def test_mtp_sparse_prefill_fixes_are_bound_at_the_dsv4_owner() -> None:
+    patch = _source(
+        "vllm_musa/patches/series/"
+        "0102-MUSA-preserve-DeepSeek-V4-MTP-sparse-prefill-headroom.patch"
+    )
+
+    assert "DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT" in patch
+    assert "allow_dsv4_tp8_mtp_direct_out=" in patch
+    assert 'attention_backend_hint="flashmla"' in patch
+    assert "deepseek_v4_mtp_sparse_prefill_headroom_bytes" in patch
+    assert "musa_workspace_headroom_bytes" in patch
+    assert "if current_platform.is_musa():" in patch
+
+    queue_fence = _source(
+        "vllm_musa/patches/series/"
+        "0103-MUSA-fence-DeepSeek-V4-MTP-prefill-queues.patch"
+    )
+    assert "deepseek_v4_mtp_prefill_step_requires_sync" in queue_fence
+    assert "scheduled_spec_decode_tokens" not in queue_fence
+    assert "torch.musa.synchronize()" in queue_fence
+    policy = _source("vllm_musa/optimization_contract/policy.py")
+    assert "scheduled_spec_decode_tokens" not in policy
+    assert "scheduled_new_reqs" in policy
+    assert '0 in getattr(cached_reqs, "num_output_tokens", ())' in policy
+    assert "_musa_dsv4_mtp_prefill_queue_fence" in queue_fence
 
 
 def test_fused_add_rmsnorm_argument_is_graph_static_and_env_override_wins() -> None:
@@ -70,6 +103,11 @@ def test_custom_all_reduce_uses_contract_identity_and_dynamic_capture_guard() ->
     )
 
     assert "DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD" in source
+    assert "deepseek_v4_mtp_car_graph_staging_plan" in source
+    assert "plan.allows_descriptor(descriptor)" in source
+    assert "_DSV4_MTP_MAX_CAPTURE_SIZE" not in source
+    assert "self._pending_graph_inputs: list[torch.Tensor] = []" in source
+    assert "self._graph_input_refs: list[torch.Tensor] = []" in source
     assert "contract.model.family is not ModelFamily.DEEPSEEK_V4" in source
     assert "contract.supports(" in source
     assert "cudagraph_capture_sizes" in source

--- a/tests/test_deepseek_v4_o_proj_dispatch.py
+++ b/tests/test_deepseek_v4_o_proj_dispatch.py
@@ -10,6 +10,7 @@ MODULE_PATH = (
     / "deepseek_v4_jit"
     / "fp8_einsum.py"
 )
+GEMV_PATH = Path(__file__).resolve().parents[1] / "csrc" / "musa" / "gemv.mu"
 
 
 def _module_tree() -> ast.Module:
@@ -61,3 +62,34 @@ def test_o_proj_dispatch_keeps_small_m_gemv_fallback() -> None:
     assert source.index("fp8_gemm_nt(") < source.index("musa_ops.musa_fused_gemv(")
     assert "tokens >= _DEEPGEMM_MIN_TOKENS" in source
     assert "is_deep_gemm_e8m0_used=False" in source
+
+
+def test_o_proj_gemv_uses_calibrated_capture_ladder_tiles() -> None:
+    source = GEMV_PATH.read_text(encoding="utf-8")
+    helper = source[
+        source.index("bool SelectDeepSeekV4Fp8OProjTile(") : source.index(
+            "void musa_fused_gemv("
+        )
+    ]
+    generic = source[
+        source.index("void musa_fused_gemv(") : source.index(
+            "void musa_fused_gemv_moe("
+        )
+    ]
+
+    assert "reduce_size != 1024" in helper
+    assert "hidden_size != 4096" in helper
+    assert "nr_n != 1024" in helper
+    assert "scale_k_group_tile != 128" in helper
+    assert "case 1:" in helper and "case 2:" in helper and "case 8:" in helper
+    assert "BlockConfig{4, 32" in helper
+    assert "case 4:" in helper and "case 32:" in helper and "case 64:" in helper
+    assert "BlockConfig{8, 16" in helper
+    assert "case 16:" in helper and "BlockConfig{32, 4" in helper
+
+    dispatch = generic[
+        generic.index("BlockConfig forced_config") : generic.index("switch (")
+    ]
+    assert dispatch.index("SelectDeepSeekV4Fp8OProjTile(") < dispatch.index(
+        "ParseForcedBlockConfig(&forced_config)"
+    )

--- a/tests/test_deepseek_v4_o_proj_dispatch.py
+++ b/tests/test_deepseek_v4_o_proj_dispatch.py
@@ -11,6 +11,9 @@ MODULE_PATH = (
     / "fp8_einsum.py"
 )
 GEMV_PATH = Path(__file__).resolve().parents[1] / "csrc" / "musa" / "gemv.mu"
+CUSTOM_OPS_PATH = (
+    Path(__file__).resolve().parents[1] / "vllm_musa" / "_custom_ops.py"
+)
 
 
 def _module_tree() -> ast.Module:
@@ -93,3 +96,51 @@ def test_o_proj_gemv_uses_calibrated_capture_ladder_tiles() -> None:
     assert dispatch.index("SelectDeepSeekV4Fp8OProjTile(") < dispatch.index(
         "ParseForcedBlockConfig(&forced_config)"
     )
+
+
+def test_o_proj_gemv_writes_one_group_result_directly() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = _module_tree()
+    dispatcher = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "try_musa_deepseek_v4_fp8_einsum_gemv"
+    )
+    gemv_call = next(
+        node
+        for node in ast.walk(dispatcher)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "musa_fused_gemv"
+    )
+    output_keyword = next(
+        keyword for keyword in gemv_call.keywords if keyword.arg == "output"
+    )
+
+    assert isinstance(output_keyword.value, ast.Name)
+    assert output_keyword.value.id == "direct_group_out"
+    assert "group_out_view if group_out_view.is_contiguous() else None" in source
+    assert "if direct_group_out is None:" in source
+    assert "group_out_view.copy_(group_out)" in source
+
+
+def test_musa_fused_gemv_accepts_caller_owned_fp8_output() -> None:
+    tree = ast.parse(CUSTOM_OPS_PATH.read_text(encoding="utf-8"))
+    wrapper = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "musa_fused_gemv"
+    )
+    output_arg = next(arg for arg in wrapper.args.args if arg.arg == "output")
+    assert output_arg.arg == "output"
+
+    native_call = next(
+        node
+        for node in ast.walk(wrapper)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "musa_fused_gemv"
+    )
+    assert isinstance(native_call.args[2], ast.Name)
+    assert native_call.args[2].id == "output"

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -106,6 +106,22 @@ def test_flash_base_tp4_is_supported_but_not_tp8_preferred() -> None:
     assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
 
 
+def test_flash_base_multibatch_keeps_shared_mlp_path() -> None:
+    config = _flash_base_config()
+    config.scheduler_config.max_num_seqs = 64
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.profile == "deepseek_v4.unvalidated"
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
+    )
+
+
 def test_model_config_without_execution_topology_is_support_only() -> None:
     config = _flash_base_config()
 
@@ -279,7 +295,7 @@ def test_speculative_execution_keeps_support_but_disables_tp8_preferences() -> N
         ("compilation_config", "cudagraph_mode", "PIECEWISE"),
     ],
 )
-def test_one_field_execution_mismatch_disables_tp8_profile(
+def test_one_field_execution_mismatch_keeps_only_shared_mlp(
     owner: str,
     field: str,
     value: object,
@@ -290,7 +306,10 @@ def test_one_field_execution_mismatch_disables_tp8_profile(
     contract = resolve_optimization_contract(config)
 
     assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
-    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    if owner == "scheduler_config":
+        assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    else:
+        assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
     )
@@ -331,6 +350,7 @@ def test_pooling_and_missing_quant_runtime_disable_tp8_profile() -> None:
     contract = resolve_optimization_contract(config, is_pooling_model=True)
 
     assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+    assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
     )

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -12,12 +12,32 @@ from vllm_musa.optimization_contract import (
     bind_optimization_contract,
     resolve_optimization_contract,
 )
+from vllm_musa.optimization_contract.policy import (
+    deepseek_v4_mtp_async_prefill_queue_fence_enabled,
+    deepseek_v4_mtp_car_graph_guard_enabled,
+    deepseek_v4_mtp_car_graph_staging_plan,
+    deepseek_v4_mtp_graph_registered_inputs_enabled,
+    deepseek_v4_mtp_prefill_step_requires_sync,
+    deepseek_v4_mtp_sparse_prefill_headroom_bytes,
+)
 
 
-def _flash_base_config(*, tp: int = 8, speculative: bool = False):
+def _flash_base_config(
+    *,
+    tp: int = 8,
+    speculative: bool = False,
+    speculative_method: str = "mtp",
+    max_num_seqs: int = 1,
+    max_num_batched_tokens: int = 8195,
+    mtp_draft: bool = False,
+    cache_dtype: str = "fp8",
+    async_scheduling: bool = True,
+):
+    architectures = ["DeepSeekV4MTPModel" if mtp_draft else "DeepseekV4ForCausalLM"]
+    model_type = "deepseek_mtp" if mtp_draft else "deepseek_v4"
     text_config = SimpleNamespace(
-        architectures=["DeepseekV4ForCausalLM"],
-        model_type="deepseek_v4",
+        architectures=architectures,
+        model_type=model_type,
         hidden_size=4096,
         num_hidden_layers=43,
         num_attention_heads=64,
@@ -38,7 +58,8 @@ def _flash_base_config(*, tp: int = 8, speculative: bool = False):
         },
     )
     model_config = SimpleNamespace(
-        architectures=["DeepseekV4ForCausalLM"],
+        architectures=architectures,
+        model_type=model_type,
         hf_text_config=text_config,
         hf_config=text_config,
         dtype="bfloat16",
@@ -56,14 +77,25 @@ def _flash_base_config(*, tp: int = 8, speculative: bool = False):
             data_parallel_size=1,
             decode_context_parallel_size=1,
         ),
-        cache_config=SimpleNamespace(cache_dtype="fp8", block_size=64),
-        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        cache_config=SimpleNamespace(cache_dtype=cache_dtype, block_size=64),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=max_num_seqs,
+            max_num_batched_tokens=max_num_batched_tokens,
+            async_scheduling=async_scheduling,
+        ),
         attention_config=SimpleNamespace(backend="FLASHMLA"),
         compilation_config=SimpleNamespace(
             mode="NONE",
             cudagraph_mode="FULL_DECODE_ONLY",
         ),
-        speculative_config=object() if speculative else None,
+        speculative_config=(
+            SimpleNamespace(
+                method=speculative_method,
+                num_speculative_tokens=4,
+            )
+            if speculative
+            else None
+        ),
         quant_config=SimpleNamespace(weight_block_size=[128, 128]),
     )
 
@@ -154,25 +186,19 @@ def test_incomplete_deepseek_identity_fails_closed() -> None:
             "model_config",
             "dtype",
             "float16",
-            frozenset(
-                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
-            ),
+            frozenset({OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}),
         ),
         (
             "model_config",
             "quantization",
             "compressed-tensors",
-            frozenset(
-                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
-            ),
+            frozenset({OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}),
         ),
         (
             "model_config",
             "use_mla",
             False,
-            frozenset(
-                {OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}
-            ),
+            frozenset({OptimizationFeature.DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD}),
         ),
     ],
 )
@@ -276,12 +302,213 @@ def test_model_config_use_mla_takes_precedence_over_missing_hf_fact() -> None:
 
 
 def test_speculative_execution_keeps_support_but_disables_tp8_preferences() -> None:
-    contract = resolve_optimization_contract(_flash_base_config(speculative=True))
+    config = _flash_base_config(speculative=True)
+    contract = resolve_optimization_contract(config)
 
     assert contract.supports(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
+    )
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_MTP_CAR_GRAPH_STAGING_ARENA)
+    assert deepseek_v4_mtp_graph_registered_inputs_enabled(config)
+    plan = deepseek_v4_mtp_car_graph_staging_plan(config)
+    assert plan is not None
+    assert plan.eager_reserve_bytes == 68 * 1024 * 1024
+    assert plan.car_ops_per_descriptor == 87
+    assert plan.bytes_per_token == 8192
+    assert plan.graph_data_capacity_bytes == 110_469_120
+    assert plan.graph_meta_capacity_bytes == 117_596_160
+    assert plan.max_meta_bytes_per_slot == 16 * 1024
+    assert plan.communicator_buffer_bytes == 184 * 1024 * 1024
+    assert plan.capture_descriptors == frozenset(
+        ((5, 1), (10, 2), (20, 4), (40, 8), (80, 16))
+    )
+    assert plan.allows_descriptor(
+        SimpleNamespace(
+            num_tokens=80,
+            num_reqs=16,
+            uniform=True,
+            has_lora=False,
+            num_active_loras=0,
+        )
+    )
+    assert not plan.allows_descriptor(
+        SimpleNamespace(
+            num_tokens=160,
+            num_reqs=32,
+            uniform=True,
+            has_lora=False,
+            num_active_loras=0,
+        )
+    )
+    assert not plan.allows_descriptor(
+        SimpleNamespace(
+            num_tokens=80,
+            num_reqs=None,
+            uniform=True,
+            has_lora=False,
+            num_active_loras=0,
+        )
+    )
+    assert not deepseek_v4_mtp_prefill_step_requires_sync(
+        SimpleNamespace(scheduled_new_reqs=[]),
+    )
+
+
+def test_mtp_car_graph_staging_plan_requires_mtp4() -> None:
+    config = _flash_base_config(speculative=True, max_num_seqs=64)
+    config.speculative_config.num_speculative_tokens = 3
+
+    assert deepseek_v4_mtp_car_graph_guard_enabled(config)
+    assert deepseek_v4_mtp_car_graph_staging_plan(config) is None
+
+
+def test_mtp4_bs1_preserves_registered_graph_path() -> None:
+    config = _flash_base_config(speculative=True, max_num_seqs=1)
+
+    assert deepseek_v4_mtp_graph_registered_inputs_enabled(config)
+    assert deepseek_v4_mtp_car_graph_staging_plan(config) is not None
+
+
+def test_tp8_mtp_target_prefers_sparse_prefill_fixes() -> None:
+    config = _flash_base_config(
+        speculative=True,
+        max_num_seqs=64,
+        cache_dtype="fp8_ds_mla",
+    )
+    contract = resolve_optimization_contract(config)
+
+    assert contract.profile == "deepseek_v4.tp8_flash_base_mtp"
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT)
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM
+    )
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_MTP_CAR_GRAPH_STAGING_ARENA)
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_ASYNC_PREFILL_QUEUE_FENCE
+    )
+    assert deepseek_v4_mtp_sparse_prefill_headroom_bytes(config) == 1_073_938_432
+
+    config.parallel_config.disable_custom_all_reduce = True
+    assert deepseek_v4_mtp_sparse_prefill_headroom_bytes(config) == 537_067_520
+
+
+def test_tp8_mtp_multibatch_syncs_only_prefill_or_mixed_steps() -> None:
+    config = _flash_base_config(
+        speculative=True,
+        max_num_seqs=64,
+        cache_dtype="fp8_ds_mla",
+    )
+    def step(*, new=(), cached_context=(), scheduled=("a", "b")):
+        context_req_ids = set(cached_context)
+        return SimpleNamespace(
+            scheduled_new_reqs=list(new),
+            scheduled_cached_reqs=SimpleNamespace(
+                num_output_tokens=[
+                    0 if req_id in context_req_ids else 1 for req_id in scheduled
+                ]
+            ),
+            num_scheduled_tokens=dict.fromkeys(scheduled, 1),
+            # A structured-output decode may legitimately have no drafts.
+            scheduled_spec_decode_tokens={},
+        )
+
+    assert deepseek_v4_mtp_async_prefill_queue_fence_enabled(config)
+    assert not deepseek_v4_mtp_prefill_step_requires_sync(step())
+    assert deepseek_v4_mtp_prefill_step_requires_sync(
+        step(new=("new",), scheduled=("new", "a"))
+    )
+    assert deepseek_v4_mtp_prefill_step_requires_sync(step(cached_context=("a",)))
+
+    sync_config = _flash_base_config(
+        speculative=True,
+        max_num_seqs=64,
+        cache_dtype="fp8_ds_mla",
+        async_scheduling=False,
+    )
+    assert not resolve_optimization_contract(sync_config).prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_ASYNC_PREFILL_QUEUE_FENCE
+    )
+    assert not deepseek_v4_mtp_async_prefill_queue_fence_enabled(sync_config)
+
+
+def test_flashmla_owner_hint_only_fills_a_missing_backend() -> None:
+    config = _flash_base_config(
+        speculative=True,
+        max_num_seqs=64,
+        cache_dtype="fp8_ds_mla",
+    )
+    config.attention_config.backend = None
+
+    unhinted = resolve_optimization_contract(config)
+    hinted = resolve_optimization_contract(
+        config,
+        attention_backend_hint="flashmla",
+    )
+
+    assert not unhinted.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT
+    )
+    assert hinted.prefers(OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT)
+
+    config.attention_config.backend = "FLASH_ATTN"
+    conflicting = resolve_optimization_contract(
+        config,
+        attention_backend_hint="flashmla",
+    )
+    assert conflicting.execution.attention_backend == "flash_attn"
+    assert not conflicting.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT
+    )
+
+
+def test_tp8_mtp_draft_prefers_sparse_prefill_fixes() -> None:
+    config = _flash_base_config(
+        max_num_seqs=64,
+        mtp_draft=True,
+        cache_dtype="fp8_ds_mla",
+    )
+    contract = resolve_optimization_contract(config)
+
+    assert contract.model.role is ModelRole.MTP_DRAFT
+    assert contract.profile == "deepseek_v4.tp8_flash_mtp_draft"
+    assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT)
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM
+    )
+
+
+@pytest.mark.parametrize(
+    ("owner", "field", "value"),
+    [
+        ("parallel_config", "tensor_parallel_size", 4),
+        ("scheduler_config", "max_num_seqs", 1),
+        ("scheduler_config", "max_num_seqs", None),
+        ("cache_config", "cache_dtype", "auto"),
+        ("attention_config", "backend", "FLASH_ATTN"),
+        ("compilation_config", "mode", "VLLM_COMPILE"),
+        ("compilation_config", "cudagraph_mode", "PIECEWISE"),
+    ],
+)
+def test_tp8_mtp_sparse_prefill_fixes_fail_closed(
+    owner: str,
+    field: str,
+    value: object,
+) -> None:
+    config = _flash_base_config(
+        max_num_seqs=64,
+        mtp_draft=True,
+    )
+    setattr(getattr(config, owner), field, value)
+
+    contract = resolve_optimization_contract(config)
+
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM
     )
 
 
@@ -309,7 +536,9 @@ def test_one_field_execution_mismatch_keeps_only_shared_mlp(
     if owner == "scheduler_config":
         assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     else:
-        assert not contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+        assert not contract.prefers(
+            OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8
+        )
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256
     )

--- a/tests/test_deepseek_v4_shared_gate_gemv_source.py
+++ b/tests/test_deepseek_v4_shared_gate_gemv_source.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_shared_gate_gemv_is_layer_scoped() -> None:
+    source = (
+        ROOT
+        / "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+    ).read_text()
+    assert '".shared_experts.gate_up_proj"' in source
+    assert 'getattr(layer, "tp_size", None) == 8' in source
+    assert "tuple(params.weight.shape) == (512, 4096)" in source
+    assert "use_deepseek_v4_shared_gate_up_gemv" in source
+
+
+def test_shared_gate_native_tile_precedes_generic_override() -> None:
+    source = (ROOT / "csrc/musa/gemv.mu").read_text()
+    selector = source.index("SelectDeepSeekV4Fp8SharedGateUpTile(")
+    dispatch = source.index("SelectDeepSeekV4Fp8SharedGateUpTile(", selector + 1)
+    forced = source.index("ParseForcedBlockConfig(&forced_config)", dispatch)
+    assert dispatch < forced
+    assert "BlockConfig{4, 32, 0.f, true}" in source[selector:dispatch]

--- a/tests/test_flashmla_sparse_direct_out.py
+++ b/tests/test_flashmla_sparse_direct_out.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm_musa.v1.attention.ops import flashmla
+
+_HAS_MUSA = hasattr(torch.version, "musa") and torch.version.musa is not None
+
+
+class _FakeFlashMLA:
+    def __init__(self) -> None:
+        self.public_calls = 0
+
+    def flash_mla_sparse_fwd(self, **kwargs):
+        self.public_calls += 1
+        q = kwargs["q"]
+        result = torch.full_like(q, 3)
+        aux_shape = (q.shape[0], q.shape[1])
+        max_logits = torch.full(aux_shape, 4, dtype=torch.float32)
+        lse = torch.full(aux_shape, 5, dtype=torch.float32)
+        return result, max_logits, lse
+
+
+class _FakeAdapter:
+    def __init__(
+        self,
+        *,
+        result_idx: tuple[int, ...] = (8, 9, 10),
+        launch_error: Exception | None = None,
+    ) -> None:
+        self.result_idx = list(result_idx)
+        self.launch_error = launch_error
+        self.calls = 0
+
+    def executable(self, *args):
+        self.calls += 1
+        if self.launch_error is not None:
+            raise self.launch_error
+        out, max_logits, lse = args[-3:]
+        out.fill_(6)
+        max_logits.fill_(7)
+        lse.fill_(8)
+
+
+def _fake_kernel(
+    adapter: _FakeAdapter,
+    *,
+    backend: str = "tvm_ffi",
+    param_names: tuple[str, ...] = flashmla._MATE_SPARSE_DIRECT_OUT_PARAM_NAMES,
+):
+    return SimpleNamespace(
+        execution_backend=backend,
+        adapter=adapter,
+        prim_func=SimpleNamespace(
+            params=[SimpleNamespace(name=name) for name in param_names]
+        ),
+    )
+
+
+def _inputs(heads: int = 64):
+    q = torch.zeros((8, heads, 512), dtype=torch.bfloat16)
+    kv = torch.zeros((8, 1, 512), dtype=torch.bfloat16)
+    indices = torch.zeros((8, 1, 64), dtype=torch.int32)
+    topk_length = torch.full((8,), 64, dtype=torch.int32)
+    attn_sink = torch.zeros((heads,), dtype=torch.float32)
+    out = torch.empty_like(q)
+    return q, kv, indices, topk_length, attn_sink, out
+
+
+def _direct_out_patches(
+    adapter: _FakeAdapter,
+    *,
+    kernel_backend: str = "tvm_ffi",
+    param_names: tuple[str, ...] = flashmla._MATE_SPARSE_DIRECT_OUT_PARAM_NAMES,
+    raise_complete_if_dry_run=lambda: None,
+    is_musa_tensor=lambda tensor: True,
+    is_capturing=lambda: False,
+):
+    kernel = _fake_kernel(
+        adapter,
+        backend=kernel_backend,
+        param_names=param_names,
+    )
+    return patch.multiple(
+        flashmla,
+        _MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR=None,
+        _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED=True,
+        _mate_raise_complete_if_dry_run=raise_complete_if_dry_run,
+        _mate_resolve_num_mps=lambda device, requested: 1,
+        _mate_sparse_model1_kernel=lambda *args, **kwargs: kernel,
+        _mate_optional_prefill_attn_sink=lambda sink, heads, device: (
+            torch.empty((0,), dtype=torch.float32),
+            sink is not None,
+        ),
+        _mate_require_token_lengths=(
+            lambda lengths, seq_len, topk, device, name: lengths
+        ),
+        _is_musa_tensor=is_musa_tensor,
+        _is_current_stream_capturing=is_capturing,
+    )
+
+
+def _call(
+    fake: _FakeFlashMLA,
+    *,
+    allow_direct_out: bool,
+    heads: int = 64,
+    out_alias_q: bool = False,
+):
+    q, kv, indices, topk_length, attn_sink, out = _inputs(heads)
+    if out_alias_q:
+        out = q
+    with patch.object(flashmla, "_flash_mla", fake):
+        result = flashmla.flash_mla_sparse_fwd(
+            q,
+            kv,
+            indices,
+            1.0,
+            attn_sink=attn_sink,
+            topk_length=topk_length,
+            out=out,
+            allow_dsv4_tp8_mtp_direct_out=allow_direct_out,
+        )
+    return result, out
+
+
+def test_dsv4_tp8_sparse_prefill_writes_directly_to_out() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(adapter):
+        (result, max_logits, lse), out = _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 0
+    assert adapter.calls == 1
+    assert result is out
+    assert torch.all(out == 6)
+    assert torch.all(max_logits == 7)
+    assert torch.all(lse == 8)
+
+
+@pytest.mark.parametrize(
+    ("allow_direct_out", "heads"),
+    [(False, 64), (True, 8)],
+)
+def test_sparse_prefill_preserves_public_fallback_without_exact_owner_and_shape(
+    allow_direct_out: bool,
+    heads: int,
+) -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(adapter):
+        (result, max_logits, lse), out = _call(
+            fake,
+            allow_direct_out=allow_direct_out,
+            heads=heads,
+        )
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+    assert result is out
+    assert torch.all(out == 3)
+    assert torch.all(max_logits == 4)
+    assert torch.all(lse == 5)
+
+
+def test_sparse_prefill_preserves_public_fallback_on_non_musa_device() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(
+        adapter,
+        is_musa_tensor=flashmla._is_musa_tensor,
+    ):
+        _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+
+
+def test_sparse_prefill_preserves_public_fallback_on_optional_import_failure() -> None:
+    fake = _FakeFlashMLA()
+
+    with patch.multiple(
+        flashmla,
+        _MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR=OSError("missing TileLang runtime"),
+        _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED=False,
+    ):
+        _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 1
+
+
+def test_sparse_prefill_preserves_public_fallback_during_graph_capture() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(adapter, is_capturing=lambda: True):
+        _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+
+
+def test_sparse_prefill_preserves_public_fallback_when_out_aliases_input() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    with _direct_out_patches(adapter):
+        _call(fake, allow_direct_out=True, out_alias_q=True)
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("kernel_backend", "param_names", "result_idx"),
+    [
+        ("python", flashmla._MATE_SPARSE_DIRECT_OUT_PARAM_NAMES, (8, 9, 10)),
+        ("tvm_ffi", ("wrong",), (8, 9, 10)),
+        ("tvm_ffi", flashmla._MATE_SPARSE_DIRECT_OUT_PARAM_NAMES, (3, 4, 5)),
+    ],
+)
+def test_sparse_prefill_preserves_public_fallback_on_private_abi_mismatch(
+    kernel_backend: str,
+    param_names: tuple[str, ...],
+    result_idx: tuple[int, ...],
+) -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter(result_idx=result_idx)
+
+    with _direct_out_patches(
+        adapter,
+        kernel_backend=kernel_backend,
+        param_names=param_names,
+    ):
+        _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 1
+    assert adapter.calls == 0
+
+
+def test_sparse_prefill_dry_run_completes_before_private_launch() -> None:
+    class _DryRunComplete(RuntimeError):
+        pass
+
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter()
+
+    def _raise_dry_run() -> None:
+        raise _DryRunComplete
+
+    with _direct_out_patches(
+        adapter,
+        raise_complete_if_dry_run=_raise_dry_run,
+    ):
+        with pytest.raises(_DryRunComplete):
+            _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 0
+    assert adapter.calls == 0
+
+
+def test_sparse_prefill_does_not_retry_after_private_launch_failure() -> None:
+    fake = _FakeFlashMLA()
+    adapter = _FakeAdapter(launch_error=RuntimeError("launch failed"))
+
+    with _direct_out_patches(adapter):
+        with pytest.raises(RuntimeError, match="launch failed"):
+            _call(fake, allow_direct_out=True)
+
+    assert fake.public_calls == 0
+    assert adapter.calls == 1
+
+
+@pytest.mark.skipif(not _HAS_MUSA, reason="requires MUSA hardware")
+def test_dsv4_tp8_sparse_direct_out_matches_public_path_on_musa() -> None:
+    from flash_mla import flash_mla_sparse_fwd as public_flash_mla_sparse_fwd
+
+    device = torch.device("musa")
+    seq_len = 128
+    q = torch.randn((seq_len, 64, 512), dtype=torch.bfloat16, device=device)
+    kv = torch.randn((seq_len, 1, 512), dtype=torch.bfloat16, device=device)
+    indices = torch.arange(64, dtype=torch.int32, device=device)
+    indices = indices.view(1, 1, 64).expand(seq_len, 1, 64).contiguous()
+    topk_length = torch.full((seq_len,), 64, dtype=torch.int32, device=device)
+    attn_sink = torch.zeros((64,), dtype=torch.float32, device=device)
+
+    public_out, public_max, public_lse = public_flash_mla_sparse_fwd(
+        q=q,
+        kv=kv,
+        indices=indices,
+        sm_scale=1.0,
+        attn_sink=attn_sink,
+        topk_length=topk_length,
+    )
+    direct_buffer = torch.empty_like(q)
+    direct_results = []
+    original_direct_out = flashmla._flash_mla_sparse_fwd_direct_out
+
+    def _record_direct_out(*args, **kwargs):
+        result = original_direct_out(*args, **kwargs)
+        direct_results.append(result)
+        return result
+
+    with patch.object(
+        flashmla,
+        "_flash_mla_sparse_fwd_direct_out",
+        _record_direct_out,
+    ):
+        direct_out, direct_max, direct_lse = flashmla.flash_mla_sparse_fwd(
+            q,
+            kv,
+            indices,
+            1.0,
+            d_v=512,
+            attn_sink=attn_sink,
+            topk_length=topk_length,
+            out=direct_buffer,
+            allow_dsv4_tp8_mtp_direct_out=True,
+        )
+
+    assert len(direct_results) == 1
+    assert direct_results[0] is not None
+    assert direct_out is direct_buffer
+    assert torch.equal(direct_out, public_out)
+    assert torch.equal(direct_max, public_max)
+    assert torch.equal(direct_lse, public_lse)

--- a/tests/test_musa_jit_custom_all_reduce_graph.py
+++ b/tests/test_musa_jit_custom_all_reduce_graph.py
@@ -11,7 +11,9 @@ custom_ar = pytest.importorskip(
 )
 
 
-def _deepseek_v4_config(capture_sizes: tuple[object, ...]) -> SimpleNamespace:
+def _deepseek_v4_config(
+    capture_sizes: tuple[object, ...], *, mtp: bool = False
+) -> SimpleNamespace:
     text_config = SimpleNamespace(
         model_type="deepseek_v4",
         architectures=("DeepseekV4ForCausalLM",),
@@ -54,14 +56,19 @@ def _deepseek_v4_config(capture_sizes: tuple[object, ...]) -> SimpleNamespace:
             decode_context_parallel_size=1,
         ),
         cache_config=SimpleNamespace(cache_dtype="fp8", block_size=64),
-        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=1,
+            max_num_batched_tokens=8195,
+        ),
         attention_config=SimpleNamespace(backend="FLASHMLA"),
         compilation_config=SimpleNamespace(
             mode="NONE",
             cudagraph_mode="FULL_DECODE_ONLY",
             cudagraph_capture_sizes=capture_sizes,
         ),
-        speculative_config=None,
+        speculative_config=(
+            SimpleNamespace(method="mtp", num_speculative_tokens=4) if mtp else None
+        ),
         quant_config=SimpleNamespace(weight_block_size=[128, 128]),
     )
 
@@ -127,6 +134,41 @@ def test_graph_registered_inputs_guard_all_exact_deepseek_v4_configs(
     )
 
     assert custom_ar._use_graph_registered_inputs_for_current_model() is False
+
+
+@pytest.mark.parametrize(
+    "capture_sizes",
+    [
+        (5,),
+        (5, 10, 20, 40, 80, 160, 320),
+        (5, 6),
+        (),
+    ],
+)
+def test_mtp_graph_registered_inputs_are_replaced_by_staging_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_sizes: tuple[object, ...],
+) -> None:
+    vllm_config = _deepseek_v4_config(capture_sizes, mtp=True)
+    vllm_config.scheduler_config.max_num_seqs = 64
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config_or_none",
+        lambda: vllm_config,
+    )
+
+    assert custom_ar._use_graph_registered_inputs_for_current_model() is False
+
+
+def test_mtp4_bs1_keeps_registered_inputs_for_capture_size_five(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vllm_config = _deepseek_v4_config((5,), mtp=True)
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config_or_none",
+        lambda: vllm_config,
+    )
+
+    assert custom_ar._use_graph_registered_inputs_for_current_model() is True
 
 
 def test_register_graph_buffers_populates_persistent_rank_data(monkeypatch):
@@ -250,10 +292,325 @@ def test_graph_launch_uses_next_persistent_slot(monkeypatch):
     assert impl._pending_graph_inputs == [input_tensor]
 
 
-def test_deepseek_graph_capture_uses_fixed_staging(monkeypatch):
+def test_mtp_graph_registration_accepts_bounded_multi_capture_inputs():
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl._graph_registered_input_enabled = True
+
+    assert impl._graph_registered_input_eligible(
+        SimpleNamespace(
+            numel=lambda: 64 * 1024,
+            element_size=lambda: 8,
+        )
+    )
+    assert not impl._graph_registered_input_eligible(
+        SimpleNamespace(
+            numel=lambda: 64 * 1024 + 1,
+            element_size=lambda: 8,
+        )
+    )
+
+
+def test_graph_staging_uses_disjoint_preallocated_slots_per_ordinal(monkeypatch):
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl._use_graph_staging_arena = True
+    impl._IS_CAPTURING = True
+    impl._graph_staging_eager_reserve_bytes = 1024
+    impl._graph_staging_data_offset = 1024
+    impl._graph_staging_meta_offset = 1024
+    impl._graph_staging_data_limit = 8192
+    impl._graph_staging_meta_limit = 8192
+    impl._graph_staging_ledger = []
+    impl._graph_staging_cpu_refs = []
+    impl.buffer_rank_data = torch.tensor([10_000, 20_000], dtype=torch.int64)
+    impl.signal_ptrs_cpu = torch.tensor([30_000, 40_000], dtype=torch.int64)
+    impl.meta_ptrs = [50_000, 60_000]
+    impl.buffer_ptrs = [70_000, 80_000]
+    impl.meta_size = 256
+    impl.max_size = 8192
+    impl.rank = 0
+    monkeypatch.setattr(impl, "_graph_staging_capture_active", lambda: True)
+    monkeypatch.setattr(
+        impl,
+        "_current_graph_staging_descriptor",
+        lambda: SimpleNamespace(num_tokens=5, num_reqs=1),
+    )
+
+    input_tensor = torch.empty((5, 8), dtype=torch.bfloat16)
+    first = impl._graph_staging_launch_args(input_tensor, "first")
+    second = impl._graph_staging_launch_args(input_tensor, "second")
+
+    assert first[3] == 70_000 + 1024
+    assert second[3] == 70_000 + 1280
+    assert first[2] == 50_000 + 1024
+    assert second[2] == 50_000 + 1536
+    assert first[4] == 256
+    assert second[4] == 256
+    assert len(impl._graph_staging_ledger) == 2
+
+
+def test_graph_staging_meta_partition_starts_after_eager_signal_region() -> None:
+    plan = SimpleNamespace(
+        eager_reserve_bytes=1024,
+        graph_data_capacity_bytes=2048,
+        graph_meta_capacity_bytes=4096,
+        max_meta_bytes_per_slot=512,
+    )
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl._graph_staging_plan = plan
+    impl._use_graph_staging_arena = True
+    impl._use_graph_collective_fallback = False
+    impl._dsv4_mtp_graph_guard = True
+    impl._graph_staging_eager_reserve_bytes = plan.eager_reserve_bytes
+    impl.meta_size = 320
+    impl.max_size = 8192
+
+    impl._configure_graph_staging_arena()
+
+    assert impl._graph_staging_data_start == 1024
+    assert impl._graph_staging_meta_start == 1536
+    assert impl._graph_staging_meta_start >= impl.meta_size + 1024
+    assert impl._graph_staging_data_limit == 3072
+    assert impl._graph_staging_meta_limit == 5632
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "num_reqs", "expected"),
+    [
+        (5, 1, True),
+        (80, 16, True),
+        (80, None, False),
+        (160, 32, False),
+        (320, 64, False),
+    ],
+)
+def test_graph_staging_gate_uses_forward_context_descriptor(
+    monkeypatch: pytest.MonkeyPatch,
+    num_tokens: int,
+    num_reqs: int | None,
+    expected: bool,
+) -> None:
+    from vllm import forward_context
+
+    plan = custom_ar._graph_staging_plan_for_current_model()
+    if plan is None:
+        # Build the exact contract without depending on process-global config.
+        from vllm_musa.optimization_contract.policy import (
+            deepseek_v4_mtp_car_graph_staging_plan,
+        )
+
+        plan = deepseek_v4_mtp_car_graph_staging_plan(
+            _deepseek_v4_config((5, 10, 20, 40, 80, 160, 320), mtp=True)
+        )
+    assert plan is not None
+    descriptor = forward_context.BatchDescriptor(
+        num_tokens=num_tokens,
+        num_reqs=num_reqs,
+        uniform=True,
+    )
+    monkeypatch.setattr(forward_context, "is_forward_context_available", lambda: True)
+    monkeypatch.setattr(
+        forward_context,
+        "get_forward_context",
+        lambda: SimpleNamespace(batch_descriptor=descriptor),
+    )
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl._use_graph_staging_arena = True
+    impl._IS_CAPTURING = True
+    impl._graph_staging_plan = plan
+
+    assert impl._graph_staging_descriptor_enabled() is expected
+
+
+def test_mtp3_graph_fails_closed_to_standard_collective(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _deepseek_v4_config((4, 8, 16, 32, 64, 128, 256), mtp=True)
+    config.speculative_config.num_speculative_tokens = 3
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config_or_none",
+        lambda: config,
+    )
+    assert custom_ar._dsv4_mtp_graph_guard_for_current_model()
+    assert custom_ar._graph_staging_plan_for_current_model() is None
+
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl.disabled = False
+    impl._IS_CAPTURING = True
+    impl._use_graph_collective_fallback = True
+    impl._use_graph_staging_arena = False
+    impl.max_size = 1024
+    inp = torch.empty(8, dtype=torch.bfloat16)
+
+    assert not impl.should_custom_ar(inp)
+    impl._IS_CAPTURING = False
+    assert impl.should_custom_ar(inp)
+
+
+@pytest.mark.parametrize(
+    "impl_name",
+    [
+        "_custom_all_reduce_impl",
+        "_graph_custom_all_reduce_impl",
+        "_fused_allreduce_rmsnorm_impl",
+        "_fused_allreduce_residual_rmsnorm_impl",
+        "_fused_allreduce_residual_rmsnorm_no_raw_impl",
+    ],
+)
+def test_low_level_custom_ops_cannot_bypass_graph_collective_fallback(
+    impl_name: str,
+) -> None:
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl._IS_CAPTURING = True
+    impl._use_graph_collective_fallback = True
+    impl._use_graph_staging_arena = False
+    impl.buffer_rank_data = torch.zeros(8, dtype=torch.int64)
+    impl.signal_ptrs_cpu = torch.zeros(8, dtype=torch.int64)
+    inp = torch.empty((1, 8), dtype=torch.bfloat16)
+    weight = torch.empty(8, dtype=torch.bfloat16)
+    residual = torch.empty_like(inp)
+    if impl_name in {"_custom_all_reduce_impl", "_graph_custom_all_reduce_impl"}:
+        args = (inp,)
+    elif impl_name == "_fused_allreduce_rmsnorm_impl":
+        args = (inp, weight, 1e-5)
+    else:
+        args = (inp, residual, weight, 1e-5)
+
+    with pytest.raises(RuntimeError, match="requires the standard collective"):
+        getattr(impl, impl_name)(*args)
+
+
+def test_graph_staging_recapture_fails_closed_while_old_graphs_may_live() -> None:
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl._IS_CAPTURING = False
+    impl._use_graph_staging_arena = True
+    impl._graph_staging_capture_sealed = True
+
+    with pytest.raises(RuntimeError, match="previously captured graphs"):
+        with impl.capture():
+            pass
+
+
+def _capture_consensus_impl() -> object:
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl.rank = 0
+    impl.world_size = 2
+    impl.group = object()
+    impl._graph_staging_plan = SimpleNamespace(capture_descriptors=frozenset())
+    impl._graph_staging_ledger = []
+    impl._graph_staging_data_offset = 1024
+    impl._graph_staging_data_start = 1024
+    impl._graph_staging_meta_offset = 2048
+    impl._graph_staging_meta_start = 2048
+    return impl
+
+
+def test_graph_staging_plan_mismatch_fails_before_buffer_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl.rank = 0
+    impl.world_size = 2
+    impl.group = object()
+    monkeypatch.setattr(impl, "_graph_staging_plan_fingerprint", lambda: ("local",))
+    monkeypatch.setattr(custom_ar.dist, "get_process_group_ranks", lambda group: [4, 9])
+
+    def broadcast(payload, src, group, device):
+        if src == 9:
+            payload[0] = ("peer",)
+
+    monkeypatch.setattr(custom_ar.dist, "broadcast_object_list", broadcast)
+
+    with pytest.raises(RuntimeError, match="contract differs across ranks"):
+        impl._validate_graph_staging_plan_consensus()
+
+
+def test_empty_graph_staging_ledger_still_reaches_rank_consensus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    impl = _capture_consensus_impl()
+    sources: list[int] = []
+
+    def broadcast(payload, src, group, device):
+        assert group is impl.group
+        assert device == "cpu"
+        sources.append(src)
+        if src == 9:
+            payload[0] = {"success": True, "error": None, "ledger": []}
+
+    monkeypatch.setattr(custom_ar.dist, "get_process_group_ranks", lambda group: [4, 9])
+    monkeypatch.setattr(custom_ar.dist, "broadcast_object_list", broadcast)
+
+    impl._validate_graph_staging_capture(True, None)
+
+    assert sources == [4, 9]
+
+
+def test_graph_staging_capture_failure_is_shared_with_every_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    impl = _capture_consensus_impl()
+    sources: list[int] = []
+
+    def broadcast(payload, src, group, device):
+        sources.append(src)
+        if src == 9:
+            payload[0] = {"success": True, "error": None, "ledger": []}
+
+    monkeypatch.setattr(custom_ar.dist, "get_process_group_ranks", lambda group: [4, 9])
+    monkeypatch.setattr(custom_ar.dist, "broadcast_object_list", broadcast)
+
+    with pytest.raises(RuntimeError, match="capture failed across ranks"):
+        impl._validate_graph_staging_capture(False, RuntimeError("rank 0 failed"))
+
+    assert sources == [4, 9]
+
+
+def test_graph_staging_rank_ledger_mismatch_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    impl = _capture_consensus_impl()
+
+    def broadcast(payload, src, group, device):
+        if src == 9:
+            payload[0] = {
+                "success": True,
+                "error": None,
+                "ledger": [(5, 1, "allreduce", 1, 2, 3, 4, 5)],
+            }
+
+    monkeypatch.setattr(custom_ar.dist, "get_process_group_ranks", lambda group: [4, 9])
+    monkeypatch.setattr(custom_ar.dist, "broadcast_object_list", broadcast)
+
+    with pytest.raises(RuntimeError, match="ledger differs across ranks"):
+        impl._validate_graph_staging_capture(True, None)
+
+
+def test_graph_staging_eager_allgather_respects_partition(monkeypatch) -> None:
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl.disabled = False
+    impl._use_graph_staging_arena = True
+    impl._graph_staging_eager_reserve_bytes = 64
+    impl._IS_CAPTURING = False
+    impl.max_size = 1024
+    impl.world_size = 2
+    impl.group_size = 2
+    monkeypatch.setattr(impl, "_is_communicator_tensor", lambda tensor: True)
+
+    assert impl.should_custom_all_gather(
+        torch.empty((1, 8), dtype=torch.bfloat16),
+        dim=1,
+    )
+    assert not impl.should_custom_all_gather(
+        torch.empty((4, 8), dtype=torch.bfloat16),
+        dim=1,
+    )
+
+
+def test_deepseek_eager_custom_ar_retains_fixed_staging(monkeypatch):
     impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
     impl._use_graph_registered_inputs = False
-    impl._IS_CAPTURING = True
+    impl._use_graph_staging_arena = False
+    impl._IS_CAPTURING = False
     impl.buffer_rank_data = torch.zeros(8, dtype=torch.int64)
     impl.signal_ptrs_cpu = torch.zeros(2, dtype=torch.int64)
     impl.meta_ptrs = [10, 20]
@@ -267,6 +624,11 @@ def test_deepseek_graph_capture_uses_fixed_staging(monkeypatch):
         impl,
         "_graph_custom_all_reduce_impl",
         lambda _input: pytest.fail("DeepSeek must not register graph input pointers"),
+    )
+    monkeypatch.setattr(
+        impl,
+        "_graph_staging_launch_args",
+        lambda *_args: pytest.fail("non-target eager CAR must keep the direct path"),
     )
     monkeypatch.setattr(custom_ar.jit_ar, "preferred_shot", lambda _world, _size: 1)
     captured = {}

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -60,6 +60,7 @@ def musa_fused_gemv(
     use_rms_norm: bool = False,
     gamma: torch.Tensor = None,
     eps: float = 1e-6,
+    output: torch.Tensor | None = None,
 ):
     use_int4_w4a16 = False
     out_shape = x.shape[:-1] + (
@@ -84,7 +85,13 @@ def musa_fused_gemv(
             qweight.dtype == torch.float8_e4m3fn
         ), "FP8 grouped matmul weight only support float8_e4m3fn!"
         assert qweight_scales is not None, "FP8 grouped matmul weight scales is None!"
-        output = torch.empty(out_shape, device=x.device, dtype=torch.bfloat16)
+        if output is None:
+            output = torch.empty(out_shape, device=x.device, dtype=torch.bfloat16)
+        else:
+            assert output.shape == out_shape
+            assert output.device == x.device
+            assert output.dtype == torch.bfloat16
+            assert output.is_contiguous()
         torch.ops._C_musa_ops.musa_fused_gemv(
             x,
             qweight,
@@ -109,6 +116,7 @@ def musa_fused_gemv(
         out_shape = x.shape[:-1] + (
             qweight.shape[0] if not use_swigelu else qweight.shape[0] // 2,
         )
+        assert output is None, "caller-owned output is only supported for FP8 GEMV"
         output = torch.empty(out_shape, device=x.device, dtype=x.dtype)
         torch.ops._C_musa_ops.musa_fused_gemv(
             x,
@@ -125,6 +133,7 @@ def musa_fused_gemv(
         return output
     # general gemv
     else:
+        assert output is None, "caller-owned output is only supported for FP8 GEMV"
         output = torch.empty(out_shape, device=x.device, dtype=x.dtype)
         torch.ops._C_musa_ops.musa_fused_gemv(
             x,

--- a/vllm_musa/deepseek_v4_jit/fp8_einsum.py
+++ b/vllm_musa/deepseek_v4_jit/fp8_einsum.py
@@ -161,13 +161,19 @@ def try_musa_deepseek_v4_fp8_einsum_gemv(
         from vllm_musa import _custom_ops as musa_ops
 
         for group_idx in range(groups):
+            group_out_view = out[:, group_idx, :]
+            direct_group_out = (
+                group_out_view if group_out_view.is_contiguous() else None
+            )
             group_out = musa_ops.musa_fused_gemv(
                 activation[:, group_idx, :].contiguous(),
                 weight[group_idx].contiguous(),
                 activation_scale[:, group_idx, :].contiguous(),
                 scales[group_idx].contiguous(),
+                output=direct_group_out,
             )
-            out[:, group_idx, :].copy_(group_out)
+            if direct_group_out is None:
+                group_out_view.copy_(group_out)
     except Exception as exc:
         return False, f"{type(exc).__name__}: {exc}"
 

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -17,6 +17,12 @@ from vllm_musa.optimization_contract import (
     OptimizationFeature,
     resolve_optimization_contract,
 )
+from vllm_musa.optimization_contract.policy import (
+    DeepSeekV4MtpCarGraphStagingPlan,
+    deepseek_v4_mtp_car_graph_guard_enabled,
+    deepseek_v4_mtp_car_graph_staging_plan,
+    deepseek_v4_mtp_graph_registered_inputs_enabled,
+)
 
 logger = init_logger(__name__)
 _INT32_MAX = (1 << 31) - 1
@@ -25,9 +31,21 @@ _INT32_MAX = (1 << 31) - 1
 _MAX_GRAPH_RANK_DATA_BYTES = 8 * 1024 * 1024
 _MAX_RANKS = 8
 _MU_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11
+_GRAPH_STAGING_ALIGNMENT = 256
 
 
 cudaError_t = ctypes.c_int
+
+
+def _max_cudagraph_capture_size(vllm_config: Any) -> int | None:
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None)
+    if not capture_sizes:
+        return None
+    try:
+        return max(int(size) for size in capture_sizes)
+    except (TypeError, ValueError):
+        return None
 
 
 def _use_graph_registered_inputs_for_current_model() -> bool:
@@ -50,10 +68,32 @@ def _use_graph_registered_inputs_for_current_model() -> bool:
     capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None)
     if not capture_sizes:
         return False
-    try:
-        return max(int(size) for size in capture_sizes) <= 1
-    except (TypeError, ValueError):
+    max_capture_size = _max_cudagraph_capture_size(vllm_config)
+    if max_capture_size is None:
         return False
+    if deepseek_v4_mtp_graph_registered_inputs_enabled(vllm_config):
+        return 0 < max_capture_size <= 5
+    return max_capture_size <= 1
+
+
+def _graph_staging_plan_for_current_model() -> DeepSeekV4MtpCarGraphStagingPlan | None:
+    try:
+        from vllm.config import get_current_vllm_config_or_none
+
+        vllm_config = get_current_vllm_config_or_none()
+    except (ImportError, RuntimeError):
+        return None
+    return deepseek_v4_mtp_car_graph_staging_plan(vllm_config)
+
+
+def _dsv4_mtp_graph_guard_for_current_model() -> bool:
+    try:
+        from vllm.config import get_current_vllm_config_or_none
+
+        vllm_config = get_current_vllm_config_or_none()
+    except (ImportError, RuntimeError):
+        return False
+    return deepseek_v4_mtp_car_graph_guard_enabled(vllm_config)
 
 
 class cudaIpcMemHandle_t(ctypes.Structure):
@@ -419,6 +459,33 @@ class _MusaJitCustomAllreduceImpl:
         self._use_graph_registered_inputs = (
             _use_graph_registered_inputs_for_current_model()
         )
+        self._dsv4_mtp_graph_guard = _dsv4_mtp_graph_guard_for_current_model()
+        self._graph_staging_plan = _graph_staging_plan_for_current_model()
+        if self._graph_staging_plan is not None:
+            # Every eligible DSV4 MTP4 eager/graph CAR tensor is bounded by the
+            # contract below. Larger tensors already fail should_custom_* and
+            # use the standard collective, so allocating the global 512-MiB
+            # staging pair only wastes this memory-constrained model's budget.
+            self.max_size = min(
+                self.max_size,
+                self._graph_staging_plan.communicator_buffer_bytes,
+            )
+        self._use_graph_staging_arena = (
+            self._graph_staging_plan is not None
+            and not self._use_graph_registered_inputs
+        )
+        self._use_graph_collective_fallback = (
+            self._dsv4_mtp_graph_guard and self._graph_staging_plan is None
+        )
+        self._graph_staging_eager_reserve_bytes = (
+            self._graph_staging_plan.eager_reserve_bytes
+            if self._graph_staging_plan is not None
+            else self.max_size
+        )
+        self._graph_staging_data_start = self._graph_staging_eager_reserve_bytes
+        self._graph_staging_meta_start = self._graph_staging_eager_reserve_bytes
+        self._graph_staging_data_limit = self.max_size
+        self._graph_staging_meta_limit = self.max_size
         self._comm_id: int | None = None
         self.meta_ptrs: list[int] = []
         self.meta_opened_ipc_ptrs: list[int] = []
@@ -426,6 +493,7 @@ class _MusaJitCustomAllreduceImpl:
         self.buffer_opened_ipc_ptrs: list[int] = []
         self.buffer_rank_data: torch.Tensor | None = None
         self.graph_rank_data: torch.Tensor | None = None
+        self.meta_size = 0
         self._pending_graph_inputs: list[torch.Tensor] = []
         self._graph_input_refs: list[torch.Tensor] = []
         self._graph_local_handles: dict[int, bytes] = {}
@@ -433,6 +501,13 @@ class _MusaJitCustomAllreduceImpl:
         self._graph_opened_ptrs: list[int] = []
         self._next_graph_slot = 0
         self._graph_registered_input_enabled = self._use_graph_registered_inputs
+        self._graph_staging_data_offset = self._graph_staging_data_start
+        self._graph_staging_meta_offset = self._graph_staging_meta_start
+        self._graph_staging_ledger: list[
+            tuple[int, int, str, int, int, int, int, int]
+        ] = []
+        self._graph_staging_cpu_refs: list[torch.Tensor] = []
+        self._graph_staging_capture_sealed = False
 
         if isinstance(device, int):
             device = torch.device(f"musa:{device}")
@@ -451,9 +526,12 @@ class _MusaJitCustomAllreduceImpl:
                 self._SUPPORTED_WORLD_SIZES,
             )
             return
+        self._validate_graph_staging_plan_consensus()
 
         try:
             meta_bytes = jit_ar.meta_size(self.world_size)
+            self.meta_size = meta_bytes
+            self._configure_graph_staging_arena()
             meta_buffer = _make_shared_buffer(meta_bytes + self.max_size, group=group)
             self.meta_ptrs = meta_buffer.pointers
             self.meta_opened_ipc_ptrs = meta_buffer.opened_ipc_ptrs
@@ -503,14 +581,31 @@ class _MusaJitCustomAllreduceImpl:
                 dtype=torch.int64,
                 device=self.device,
             )
-            if self._graph_registered_input_enabled:
-                logger.info_once(
-                    "MUSA fused CAR-RMSNorm graph registered-input path is enabled "
-                    "(capacity=%d, max_input_bytes=%d). Eager execution and larger "
-                    "graph inputs use the staging path.",
-                    graph_slots,
-                    self._GRAPH_REGISTERED_INPUT_MAX_BYTES,
-                )
+            logger.info_once(
+                "MUSA fused CAR-RMSNorm graph registered-input path is enabled "
+                "(capacity=%d, max_input_bytes=%d). Eager execution and larger "
+                "graph inputs use the staging path.",
+                graph_slots,
+                self._GRAPH_REGISTERED_INPUT_MAX_BYTES,
+            )
+        elif self._use_graph_staging_arena:
+            logger.info_once(
+                "Using ordinal-partitioned MUSA JIT custom all-reduce staging arena "
+                "for DeepSeek-V4 MTP graphs (eager_reserve_bytes=%d, "
+                "data_capacity_bytes=%d, meta_capacity_bytes=%d, "
+                "communicator_buffer_bytes=%d, descriptors=%s).",
+                self._graph_staging_eager_reserve_bytes,
+                self._graph_staging_plan.graph_data_capacity_bytes,
+                self._graph_staging_plan.graph_meta_capacity_bytes,
+                self._graph_staging_plan.communicator_buffer_bytes,
+                tuple(sorted(self._graph_staging_plan.capture_descriptors)),
+            )
+        elif self._use_graph_collective_fallback:
+            logger.info_once(
+                "Using the standard collective fallback instead of MUSA JIT "
+                "custom all-reduce for DeepSeek-V4 MTP graph capture. Eager "
+                "execution retains the fixed-staging custom path."
+            )
         else:
             logger.info_once(
                 "Using fixed-staging MUSA JIT custom all-reduce for "
@@ -524,23 +619,385 @@ class _MusaJitCustomAllreduceImpl:
             self.max_size,
         )
 
+    def _configure_graph_staging_arena(self) -> None:
+        plan = self._graph_staging_plan
+        if plan is None:
+            return
+        data_start = plan.eager_reserve_bytes
+        meta_start = self._align_graph_staging_size(
+            self.meta_size + plan.eager_reserve_bytes
+        )
+        data_limit = data_start + plan.graph_data_capacity_bytes
+        meta_limit = meta_start + plan.graph_meta_capacity_bytes
+        invalid_reason = None
+        if self.meta_size > plan.max_meta_bytes_per_slot:
+            invalid_reason = (
+                f"meta_size={self.meta_size} exceeds "
+                f"max_meta_bytes_per_slot={plan.max_meta_bytes_per_slot}"
+            )
+        elif data_limit > self.max_size or meta_limit > self.max_size:
+            invalid_reason = (
+                f"data_limit={data_limit}, meta_limit={meta_limit}, "
+                f"capacity={self.max_size}"
+            )
+        if invalid_reason is not None:
+            logger.warning_once(
+                "Disabling the DSV4 MTP graph CAR staging arena: %s. Graph "
+                "capture will use the standard collective fallback.",
+                invalid_reason,
+            )
+            self._graph_staging_plan = None
+            self._use_graph_staging_arena = False
+            self._use_graph_collective_fallback = self._dsv4_mtp_graph_guard
+            self._graph_staging_eager_reserve_bytes = self.max_size
+            self._graph_staging_data_start = self.max_size
+            self._graph_staging_meta_start = self.max_size
+            self._graph_staging_data_limit = self.max_size
+            self._graph_staging_meta_limit = self.max_size
+            return
+        self._graph_staging_data_start = data_start
+        self._graph_staging_meta_start = meta_start
+        self._graph_staging_data_limit = data_limit
+        self._graph_staging_meta_limit = meta_limit
+
     @contextmanager
     def capture(self):
         if self._IS_CAPTURING:
             raise RuntimeError("Nested MUSA custom-allreduce capture is unsupported")
+        if getattr(self, "_use_graph_staging_arena", False) and getattr(
+            self, "_graph_staging_capture_sealed", False
+        ):
+            raise RuntimeError(
+                "MUSA custom AR graph staging arena cannot be reused while "
+                "previously captured graphs may still reference its slots"
+            )
         self._pending_graph_inputs = []
+        self._graph_staging_data_offset = getattr(self, "_graph_staging_data_start", 0)
+        self._graph_staging_meta_offset = getattr(self, "_graph_staging_meta_start", 0)
+        self._graph_staging_ledger = []
+        self._graph_staging_cpu_refs = []
         capture_succeeded = False
+        capture_error: BaseException | None = None
+        consensus_error: BaseException | None = None
         try:
             self._IS_CAPTURING = True
             yield
             capture_succeeded = True
+        except BaseException as exc:
+            capture_error = exc
         finally:
             try:
                 if capture_succeeded and self._pending_graph_inputs:
                     self._register_graph_buffers()
+                if getattr(self, "_use_graph_staging_arena", False):
+                    try:
+                        self._validate_graph_staging_capture(
+                            capture_succeeded,
+                            capture_error,
+                        )
+                        if capture_succeeded:
+                            self._graph_staging_capture_sealed = True
+                    except BaseException as exc:
+                        consensus_error = exc
             finally:
                 self._pending_graph_inputs = []
                 self._IS_CAPTURING = False
+        if consensus_error is not None:
+            if capture_error is not None:
+                raise consensus_error from capture_error
+            raise consensus_error
+        if capture_error is not None:
+            raise capture_error
+
+    @staticmethod
+    def _align_graph_staging_size(size: int) -> int:
+        alignment = _GRAPH_STAGING_ALIGNMENT
+        return (size + alignment - 1) // alignment * alignment
+
+    def _graph_staging_plan_fingerprint(self) -> tuple[object, ...]:
+        plan = self._graph_staging_plan
+        plan_fingerprint: tuple[object, ...] | None = None
+        if plan is not None:
+            plan_fingerprint = (
+                plan.eager_reserve_bytes,
+                tuple(sorted(plan.capture_descriptors)),
+                plan.car_ops_per_descriptor,
+                plan.bytes_per_token,
+                plan.graph_data_capacity_bytes,
+                plan.graph_meta_capacity_bytes,
+                plan.max_meta_bytes_per_slot,
+                plan.communicator_buffer_bytes,
+            )
+        return (
+            self._dsv4_mtp_graph_guard,
+            self._use_graph_registered_inputs,
+            self._use_graph_staging_arena,
+            self._use_graph_collective_fallback,
+            plan_fingerprint,
+        )
+
+    def _validate_graph_staging_plan_consensus(self) -> None:
+        if self.world_size <= 1:
+            return
+        local_fingerprint = self._graph_staging_plan_fingerprint()
+        ranks = dist.get_process_group_ranks(self.group)
+        fingerprints: list[tuple[object, ...] | None] = [None] * self.world_size
+        fingerprints[self.rank] = local_fingerprint
+        for group_rank, src in enumerate(ranks):
+            payload = [fingerprints[group_rank]]
+            dist.broadcast_object_list(payload, src=src, group=self.group, device="cpu")
+            fingerprints[group_rank] = payload[0]
+        if any(fingerprint != local_fingerprint for fingerprint in fingerprints):
+            raise RuntimeError(
+                "MUSA custom AR graph contract differs across ranks: "
+                f"rank={self.rank}, fingerprints={fingerprints}"
+            )
+
+    def _graph_staging_capture_active(self) -> bool:
+        return (
+            getattr(self, "_use_graph_staging_arena", False)
+            and getattr(self, "_IS_CAPTURING", False)
+            and self._graph_staging_descriptor_enabled()
+            and self._is_current_stream_capturing()
+        )
+
+    def _graph_staging_descriptor_enabled(self) -> bool:
+        if not (
+            getattr(self, "_use_graph_staging_arena", False)
+            and getattr(self, "_IS_CAPTURING", False)
+        ):
+            return True
+        descriptor = self._current_graph_staging_descriptor()
+        plan = getattr(self, "_graph_staging_plan", None)
+        return plan is not None and plan.allows_descriptor(descriptor)
+
+    def _graph_capture_requires_standard_collective(self) -> bool:
+        if not getattr(self, "_IS_CAPTURING", False):
+            return False
+        if getattr(self, "_use_graph_collective_fallback", False):
+            return True
+        return (
+            getattr(self, "_use_graph_staging_arena", False)
+            and not self._graph_staging_descriptor_enabled()
+        )
+
+    def _require_custom_ar_graph_path(self) -> None:
+        if self._graph_capture_requires_standard_collective():
+            raise RuntimeError(
+                "MUSA JIT custom all-reduce was invoked for a graph descriptor "
+                "whose contract requires the standard collective"
+            )
+
+    @staticmethod
+    def _current_graph_staging_descriptor() -> Any | None:
+        try:
+            from vllm.forward_context import (
+                get_forward_context,
+                is_forward_context_available,
+            )
+
+            if not is_forward_context_available():
+                return None
+            descriptor = get_forward_context().batch_descriptor
+        except (ImportError, LookupError, RuntimeError):
+            return None
+        return descriptor
+
+    def _graph_staging_launch_args(
+        self,
+        tensor: torch.Tensor,
+        op_kind: str,
+    ) -> tuple[torch.Tensor, torch.Tensor, int, int, int]:
+        assert self.buffer_rank_data is not None
+        assert self.signal_ptrs_cpu is not None
+        if not self._graph_staging_capture_active():
+            return (
+                self.buffer_rank_data,
+                self.signal_ptrs_cpu,
+                self.meta_ptrs[self.rank],
+                self.buffer_ptrs[self.rank],
+                self._graph_staging_eager_reserve_bytes
+                if getattr(self, "_use_graph_staging_arena", False)
+                else self.max_size,
+            )
+
+        descriptor = self._current_graph_staging_descriptor()
+        if descriptor is None:
+            raise RuntimeError(
+                "MUSA custom AR graph staging capture is missing BatchDescriptor"
+            )
+        descriptor_key = (int(descriptor.num_tokens), int(descriptor.num_reqs))
+        input_bytes = tensor.numel() * tensor.element_size()
+        data_size = self._align_graph_staging_size(input_bytes)
+        meta_size = self._align_graph_staging_size(self.meta_size + input_bytes)
+        data_offset = self._graph_staging_data_offset
+        meta_offset = self._graph_staging_meta_offset
+        data_end = data_offset + data_size
+        meta_end = meta_offset + meta_size
+        if (
+            data_end > self._graph_staging_data_limit
+            or meta_end > self._graph_staging_meta_limit
+        ):
+            raise RuntimeError(
+                "MUSA custom AR graph staging arena is exhausted: "
+                f"op={op_kind}, descriptor={descriptor_key}, "
+                f"input_bytes={input_bytes}, data_end={data_end}, "
+                f"meta_end={meta_end}, "
+                f"data_limit={self._graph_staging_data_limit}, "
+                f"meta_limit={self._graph_staging_meta_limit}, "
+                f"captured_ops={len(self._graph_staging_ledger)}"
+            )
+        rank_data = self.buffer_rank_data + data_offset
+        signal_ptrs = self.signal_ptrs_cpu + meta_offset
+        self._graph_staging_cpu_refs.extend((rank_data, signal_ptrs))
+        self._graph_staging_data_offset = data_end
+        self._graph_staging_meta_offset = meta_end
+        self._graph_staging_ledger.append(
+            (
+                descriptor_key[0],
+                descriptor_key[1],
+                op_kind,
+                input_bytes,
+                data_offset,
+                data_size,
+                meta_offset,
+                meta_size,
+            )
+        )
+        return (
+            rank_data,
+            signal_ptrs,
+            self.meta_ptrs[self.rank] + meta_offset,
+            self.buffer_ptrs[self.rank] + data_offset,
+            data_size,
+        )
+
+    def _graph_staging_manifest_error(self) -> str | None:
+        plan = self._graph_staging_plan
+        if plan is None:
+            return "graph staging plan is unavailable"
+        grouped: dict[tuple[int, int], list[tuple[Any, ...]]] = {}
+        for entry in self._graph_staging_ledger:
+            grouped.setdefault((entry[0], entry[1]), []).append(entry)
+        for descriptor, entries in grouped.items():
+            if descriptor not in plan.capture_descriptors:
+                return f"unsupported captured descriptor={descriptor}"
+            num_tokens, _ = descriptor
+            expected_input_bytes = num_tokens * plan.bytes_per_token
+            if len(entries) != plan.car_ops_per_descriptor:
+                return (
+                    f"descriptor={descriptor} captured_ops={len(entries)} "
+                    f"expected_ops={plan.car_ops_per_descriptor}"
+                )
+            if any(entry[3] != expected_input_bytes for entry in entries):
+                return (
+                    f"descriptor={descriptor} has unexpected input byte sizes: "
+                    f"{sorted({entry[3] for entry in entries})}, "
+                    f"expected={expected_input_bytes}"
+                )
+            expected_data_bytes = self._align_graph_staging_size(
+                plan.expected_descriptor_data_bytes(num_tokens)
+            )
+            actual_data_bytes = sum(entry[5] for entry in entries)
+            if actual_data_bytes != expected_data_bytes:
+                return (
+                    f"descriptor={descriptor} data_bytes={actual_data_bytes} "
+                    f"expected={expected_data_bytes}"
+                )
+            expected_meta_bytes = plan.car_ops_per_descriptor * (
+                self._align_graph_staging_size(self.meta_size + expected_input_bytes)
+            )
+            actual_meta_bytes = sum(entry[7] for entry in entries)
+            if actual_meta_bytes != expected_meta_bytes:
+                return (
+                    f"descriptor={descriptor} meta_bytes={actual_meta_bytes} "
+                    f"expected={expected_meta_bytes}"
+                )
+        expected_data_total = sum(
+            self._align_graph_staging_size(
+                plan.expected_descriptor_data_bytes(num_tokens)
+            )
+            for num_tokens, _ in grouped
+        )
+        expected_meta_total = sum(
+            self._align_graph_staging_size(
+                self.meta_size + num_tokens * plan.bytes_per_token
+            )
+            * plan.car_ops_per_descriptor
+            for num_tokens, _ in grouped
+        )
+        if (
+            self._graph_staging_data_offset - self._graph_staging_data_start
+            != expected_data_total
+            or self._graph_staging_meta_offset - self._graph_staging_meta_start
+            != expected_meta_total
+        ):
+            return (
+                "graph staging arena totals differ from descriptor manifest: "
+                f"data={self._graph_staging_data_offset - self._graph_staging_data_start}"
+                f"/{expected_data_total}, "
+                f"meta={self._graph_staging_meta_offset - self._graph_staging_meta_start}"
+                f"/{expected_meta_total}"
+            )
+        return None
+
+    def _validate_graph_staging_capture(
+        self,
+        capture_succeeded: bool,
+        capture_error: BaseException | None,
+    ) -> None:
+        manifest_error = (
+            self._graph_staging_manifest_error() if capture_succeeded else None
+        )
+        local_payload: dict[str, Any] = {
+            "success": capture_succeeded and manifest_error is None,
+            "error": (
+                manifest_error
+                if manifest_error is not None
+                else (
+                    None
+                    if capture_error is None
+                    else f"{type(capture_error).__name__}: {capture_error}"
+                )
+            ),
+            "ledger": self._graph_staging_ledger,
+        }
+        gathered: list[dict[str, Any] | None] = [None] * self.world_size
+        gathered[self.rank] = local_payload
+        ranks = sorted(dist.get_process_group_ranks(group=self.group))
+        for group_rank, global_rank in enumerate(ranks):
+            payload = [gathered[group_rank]]
+            dist.broadcast_object_list(
+                payload,
+                src=global_rank,
+                group=self.group,
+                device="cpu",
+            )
+            gathered[group_rank] = payload[0]
+        failures = [
+            (rank, None if payload is None else payload["error"])
+            for rank, payload in enumerate(gathered)
+            if payload is None or not payload["success"]
+        ]
+        if failures:
+            raise RuntimeError(
+                "MUSA custom AR graph staging capture failed across ranks: "
+                f"{failures}"
+            )
+        ledgers = [payload["ledger"] for payload in gathered if payload is not None]
+        if any(ledger != self._graph_staging_ledger for ledger in ledgers):
+            raise RuntimeError(
+                "MUSA custom AR graph staging ledger differs across ranks: "
+                f"local_ops={len(self._graph_staging_ledger)}, "
+                f"gathered_ops={[len(ledger) for ledger in ledgers]}"
+            )
+        logger.info_once(
+            "Captured %d disjoint MUSA custom AR graph staging slots "
+            "(data_bytes=%d, meta_bytes=%d).",
+            len(self._graph_staging_ledger),
+            self._graph_staging_data_offset - self._graph_staging_data_start,
+            self._graph_staging_meta_offset - self._graph_staging_meta_start,
+        )
 
     def _graph_pointer_meta(self, tensor: torch.Tensor) -> tuple[bytes, int]:
         pointer = tensor.data_ptr()
@@ -641,7 +1098,8 @@ class _MusaJitCustomAllreduceImpl:
 
     def _use_registered_graph_input(self, tensor: torch.Tensor) -> bool:
         return (
-            self._graph_registered_input_eligible(tensor)
+            self._use_graph_registered_inputs
+            and self._graph_registered_input_eligible(tensor)
             and self._IS_CAPTURING
             and self._is_current_stream_capturing()
         )
@@ -649,10 +1107,28 @@ class _MusaJitCustomAllreduceImpl:
     def should_custom_ar(self, inp: torch.Tensor) -> bool:
         if self.disabled:
             return False
+        if (
+            self._IS_CAPTURING
+            and (self._use_graph_collective_fallback or self._use_graph_staging_arena)
+            and self._graph_capture_requires_standard_collective()
+        ):
+            return False
+        if (
+            self._IS_CAPTURING
+            and self._use_graph_registered_inputs
+            and not self._graph_registered_input_eligible(inp)
+        ):
+            return False
         if inp.dtype not in (torch.float16, torch.bfloat16, torch.float32):
             return False
         inp_size = inp.numel() * inp.element_size()
         if inp_size % 16 != 0 or inp_size > self.max_size:
+            return False
+        if (
+            getattr(self, "_use_graph_staging_arena", False)
+            and not getattr(self, "_IS_CAPTURING", False)
+            and inp_size > self._graph_staging_eager_reserve_bytes
+        ):
             return False
         return inp.is_contiguous()
 
@@ -663,6 +1139,12 @@ class _MusaJitCustomAllreduceImpl:
         output_dtype: torch.dtype | None = None,
     ) -> bool:
         if self.disabled or self.world_size not in (2, 4, 8) or inp.ndim != 2:
+            return False
+        if (
+            self._IS_CAPTURING
+            and (self._use_graph_collective_fallback or self._use_graph_staging_arena)
+            and self._graph_capture_requires_standard_collective()
+        ):
             return False
         if not self._is_communicator_tensor(inp):
             return False
@@ -686,6 +1168,11 @@ class _MusaJitCustomAllreduceImpl:
         output_numel = inp.numel() * self.world_size
         output_element_size = 4 if output_dtype == torch.float32 else inp.element_size()
         output_size = output_numel * output_element_size
+        if (
+            getattr(self, "_use_graph_staging_arena", False)
+            and output_size > self._graph_staging_eager_reserve_bytes
+        ):
+            return False
         return (
             inp_size <= self.max_size
             and inp_size % 16 == 0
@@ -709,6 +1196,12 @@ class _MusaJitCustomAllreduceImpl:
     ) -> str | None:
         if self.disabled:
             return "communicator is disabled"
+        if (
+            self._IS_CAPTURING
+            and (self._use_graph_collective_fallback or self._use_graph_staging_arena)
+            and self._graph_capture_requires_standard_collective()
+        ):
+            return "active graph capture requires the standard collective"
         if inp.device.type != "musa" or weight.device.type != "musa":
             return f"device mismatch: input={inp.device} weight={weight.device}"
         if inp.dim() != 2 or weight.dim() != 1:
@@ -733,6 +1226,15 @@ class _MusaJitCustomAllreduceImpl:
         inp_size = inp.numel() * inp.element_size()
         if inp_size % 16 != 0 or inp_size > self.max_size:
             return f"unsupported byte size: bytes={inp_size} max_size={self.max_size}"
+        if (
+            getattr(self, "_use_graph_staging_arena", False)
+            and not getattr(self, "_IS_CAPTURING", False)
+            and inp_size > self._graph_staging_eager_reserve_bytes
+        ):
+            return (
+                "input exceeds the eager partition of the graph staging arena: "
+                f"bytes={inp_size} reserve={self._graph_staging_eager_reserve_bytes}"
+            )
         return None
 
     def should_fused_allreduce_rmsnorm(
@@ -812,24 +1314,35 @@ class _MusaJitCustomAllreduceImpl:
     def _custom_all_reduce_impl(self, input: torch.Tensor) -> torch.Tensor:
         assert self.buffer_rank_data is not None
         assert self.signal_ptrs_cpu is not None
-        if (
-            self._use_graph_registered_inputs
-            and self._IS_CAPTURING
-            and self._is_current_stream_capturing()
-        ):
+        self._require_custom_ar_graph_path()
+        if self._IS_CAPTURING and self._use_registered_graph_input(input):
             return self._graph_custom_all_reduce_impl(input)
         out = torch.empty_like(input)
         shot = jit_ar.preferred_shot(
             self.world_size, input.numel() * input.element_size()
         )
+        if self._use_graph_staging_arena:
+            (
+                rank_data,
+                signal_ptrs,
+                self_meta_ptr,
+                self_buffer_ptr,
+                max_size,
+            ) = self._graph_staging_launch_args(input, "allreduce")
+        else:
+            rank_data = self.buffer_rank_data
+            signal_ptrs = self.signal_ptrs_cpu
+            self_meta_ptr = self.meta_ptrs[self.rank]
+            self_buffer_ptr = self.buffer_ptrs[self.rank]
+            max_size = self.max_size
         jit_ar.launch_unregistered(
-            self.buffer_rank_data,
-            self.signal_ptrs_cpu,
+            rank_data,
+            signal_ptrs,
             input,
             out,
-            self.meta_ptrs[self.rank],
-            self.buffer_ptrs[self.rank],
-            self.max_size,
+            self_meta_ptr,
+            self_buffer_ptr,
+            max_size,
             self.rank,
             self.world_size,
             shot,
@@ -838,6 +1351,7 @@ class _MusaJitCustomAllreduceImpl:
 
     def _graph_custom_all_reduce_impl(self, input: torch.Tensor) -> torch.Tensor:
         assert self.signal_ptrs_cpu is not None
+        self._require_custom_ar_graph_path()
         rank_data = self._graph_rank_data_for_input(input)
         out = torch.empty_like(input)
         jit_ar.launch_graph_registered(
@@ -921,17 +1435,33 @@ class _MusaJitCustomAllreduceImpl:
         self, input: torch.Tensor, weight: torch.Tensor, eps: float
     ) -> tuple[torch.Tensor, torch.Tensor]:
         assert self.buffer_rank_data is not None
+        self._require_custom_ar_graph_path()
         norm_out = torch.empty_like(input)
         reduced = torch.empty_like(input)
         shot = jit_ar.preferred_shot(
             self.world_size, input.numel() * input.element_size()
         )
         use_registered = self._use_registered_graph_input(input)
-        rank_data = (
-            self._graph_rank_data_for_input(input)
-            if use_registered
-            else self.buffer_rank_data
-        )
+        if use_registered:
+            rank_data = self._graph_rank_data_for_input(input)
+            signal_ptrs = self.signal_ptrs_cpu
+            self_meta_ptr = self.meta_ptrs[self.rank]
+            self_buffer_ptr = self.buffer_ptrs[self.rank]
+            max_size = self.max_size
+        elif self._use_graph_staging_arena:
+            (
+                rank_data,
+                signal_ptrs,
+                self_meta_ptr,
+                self_buffer_ptr,
+                max_size,
+            ) = self._graph_staging_launch_args(input, "fused_rmsnorm")
+        else:
+            rank_data = self.buffer_rank_data
+            signal_ptrs = self.signal_ptrs_cpu
+            self_meta_ptr = self.meta_ptrs[self.rank]
+            self_buffer_ptr = self.buffer_ptrs[self.rank]
+            max_size = self.max_size
         launcher = (
             jit_ar.launch_fused_allreduce_rmsnorm_registered
             if use_registered
@@ -939,14 +1469,14 @@ class _MusaJitCustomAllreduceImpl:
         )
         launcher(
             rank_data,
-            self.signal_ptrs_cpu,
+            signal_ptrs,
             input,
             weight,
             norm_out,
             reduced,
-            self.meta_ptrs[self.rank],
-            self.buffer_ptrs[self.rank],
-            self.max_size,
+            self_meta_ptr,
+            self_buffer_ptr,
+            max_size,
             self.rank,
             self.world_size,
             shot,
@@ -1010,6 +1540,7 @@ class _MusaJitCustomAllreduceImpl:
         self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert self.buffer_rank_data is not None
+        self._require_custom_ar_graph_path()
         norm_out = torch.empty_like(input)
         residual_out = torch.empty_like(input)
         reduced = torch.empty_like(input)
@@ -1017,11 +1548,26 @@ class _MusaJitCustomAllreduceImpl:
             self.world_size, input.numel() * input.element_size()
         )
         use_registered = self._use_registered_graph_input(input)
-        rank_data = (
-            self._graph_rank_data_for_input(input)
-            if use_registered
-            else self.buffer_rank_data
-        )
+        if use_registered:
+            rank_data = self._graph_rank_data_for_input(input)
+            signal_ptrs = self.signal_ptrs_cpu
+            self_meta_ptr = self.meta_ptrs[self.rank]
+            self_buffer_ptr = self.buffer_ptrs[self.rank]
+            max_size = self.max_size
+        elif self._use_graph_staging_arena:
+            (
+                rank_data,
+                signal_ptrs,
+                self_meta_ptr,
+                self_buffer_ptr,
+                max_size,
+            ) = self._graph_staging_launch_args(input, "fused_residual_rmsnorm")
+        else:
+            rank_data = self.buffer_rank_data
+            signal_ptrs = self.signal_ptrs_cpu
+            self_meta_ptr = self.meta_ptrs[self.rank]
+            self_buffer_ptr = self.buffer_ptrs[self.rank]
+            max_size = self.max_size
         launcher = (
             jit_ar.launch_fused_allreduce_residual_rmsnorm_registered
             if use_registered
@@ -1029,16 +1575,16 @@ class _MusaJitCustomAllreduceImpl:
         )
         launcher(
             rank_data,
-            self.signal_ptrs_cpu,
+            signal_ptrs,
             input,
             residual,
             weight,
             norm_out,
             residual_out,
             reduced,
-            self.meta_ptrs[self.rank],
-            self.buffer_ptrs[self.rank],
-            self.max_size,
+            self_meta_ptr,
+            self_buffer_ptr,
+            max_size,
             self.rank,
             self.world_size,
             shot,
@@ -1050,17 +1596,33 @@ class _MusaJitCustomAllreduceImpl:
         self, input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
     ) -> tuple[torch.Tensor, torch.Tensor]:
         assert self.buffer_rank_data is not None
+        self._require_custom_ar_graph_path()
         norm_out = torch.empty_like(input)
         residual_out = torch.empty_like(input)
         shot = jit_ar.preferred_shot(
             self.world_size, input.numel() * input.element_size()
         )
         use_registered = self._use_registered_graph_input(input)
-        rank_data = (
-            self._graph_rank_data_for_input(input)
-            if use_registered
-            else self.buffer_rank_data
-        )
+        if use_registered:
+            rank_data = self._graph_rank_data_for_input(input)
+            signal_ptrs = self.signal_ptrs_cpu
+            self_meta_ptr = self.meta_ptrs[self.rank]
+            self_buffer_ptr = self.buffer_ptrs[self.rank]
+            max_size = self.max_size
+        elif self._use_graph_staging_arena:
+            (
+                rank_data,
+                signal_ptrs,
+                self_meta_ptr,
+                self_buffer_ptr,
+                max_size,
+            ) = self._graph_staging_launch_args(input, "fused_residual_rmsnorm_no_raw")
+        else:
+            rank_data = self.buffer_rank_data
+            signal_ptrs = self.signal_ptrs_cpu
+            self_meta_ptr = self.meta_ptrs[self.rank]
+            self_buffer_ptr = self.buffer_ptrs[self.rank]
+            max_size = self.max_size
         launcher = (
             jit_ar.launch_fused_allreduce_residual_rmsnorm_no_raw_registered
             if use_registered
@@ -1068,15 +1630,15 @@ class _MusaJitCustomAllreduceImpl:
         )
         launcher(
             rank_data,
-            self.signal_ptrs_cpu,
+            signal_ptrs,
             input,
             residual,
             weight,
             norm_out,
             residual_out,
-            self.meta_ptrs[self.rank],
-            self.buffer_ptrs[self.rank],
-            self.max_size,
+            self_meta_ptr,
+            self_buffer_ptr,
+            max_size,
             self.rank,
             self.world_size,
             shot,
@@ -1119,6 +1681,9 @@ class _MusaJitCustomAllreduceImpl:
         self._graph_local_handles = {}
         self._graph_input_refs = []
         self._pending_graph_inputs = []
+        self._graph_staging_ledger = []
+        self._graph_staging_cpu_refs = []
+        self._graph_staging_capture_sealed = False
         self._next_graph_slot = 0
         self.disabled = True
 
@@ -1171,7 +1736,8 @@ class MusaJitCustomAllreduce:
 
         if self._jit_available:
             logger.info_once(
-                "Using MUSA JIT custom all-reduce for eager and CUDA graph paths."
+                "Using MUSA JIT custom all-reduce for eager and eligible CUDA "
+                "graph paths."
             )
 
     @property

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -53,9 +53,15 @@ def _should_use_musa_fp8_small_m_gemv(
     weight_scale: torch.Tensor,
     group_size: int,
     use_deep_gemm_e8m0: bool,
+    use_deepseek_v4_shared_gate_up_gemv: bool = False,
 ) -> bool:
+    use_calibrated_deepseek_v4_shape = (
+        use_deepseek_v4_shared_gate_up_gemv
+        and input.shape == (1, 4096)
+        and weight.shape == (512, 4096)
+    )
     if (
-        not _MUSA_FP8_SMALL_M_GEMV_ENABLED
+        not (_MUSA_FP8_SMALL_M_GEMV_ENABLED or use_calibrated_deepseek_v4_shape)
         or not current_platform.is_musa()
         or use_deep_gemm_e8m0
         or group_size != 128
@@ -87,6 +93,7 @@ class MUSADeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
 
     def __init__(self, config: FP8ScaledMMLinearLayerConfig):
         super().__init__(config)
+        self.use_deepseek_v4_shared_gate_up_gemv = False
         self.use_deep_gemm_e8m0 = False
         act_scale_descriptor = config.activation_quant_key.scale
         self.is_deep_gemm_supported = is_deep_gemm_supported()
@@ -104,6 +111,16 @@ class MUSADeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         super().process_weights_after_loading(layer)
         params = self._get_layer_params(layer)
         assert layer.weight_block_size is not None
+
+        # Shape alone cannot distinguish the DeepSeek-V4 shared-expert gate-up
+        # from unrelated dense projections.  Cache the layer identity while
+        # the module prefix is still available and route only the TP8 shared
+        # expert instance through the calibrated BF16-input/FP8-weight GEMV.
+        self.use_deepseek_v4_shared_gate_up_gemv = (
+            getattr(layer, "tp_size", None) == 8
+            and ".shared_experts.gate_up_proj" in getattr(layer, "prefix", "")
+            and tuple(params.weight.shape) == (512, 4096)
+        )
 
         if self.is_deep_gemm_supported:
             weight_scale_invs = params.weight_scale_inv
@@ -161,7 +178,15 @@ class MUSADeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         group_size = self.weight_group_shape.col
 
         return run_deepgemm(
-            A, B, Bs, group_size, self.use_deep_gemm_e8m0, output=kwargs.get("output")
+            A,
+            B,
+            Bs,
+            group_size,
+            self.use_deep_gemm_e8m0,
+            output=kwargs.get("output"),
+            use_deepseek_v4_shared_gate_up_gemv=(
+                self.use_deepseek_v4_shared_gate_up_gemv
+            ),
         )
 
 
@@ -172,9 +197,15 @@ def run_deepgemm(
     group_size: int,
     use_deep_gemm_e8m0: bool,
     output: torch.Tensor | None = None,
+    use_deepseek_v4_shared_gate_up_gemv: bool = False,
 ) -> torch.Tensor:
     if _should_use_musa_fp8_small_m_gemv(
-        input, weight, weight_scale, group_size, use_deep_gemm_e8m0
+        input,
+        weight,
+        weight_scale,
+        group_size,
+        use_deep_gemm_e8m0,
+        use_deepseek_v4_shared_gate_up_gemv,
     ):
         return torch.ops.vllm.musa_fp8_small_m_gemv_op(
             input,

--- a/vllm_musa/model_executor/layers/linear.py
+++ b/vllm_musa/model_executor/layers/linear.py
@@ -6,12 +6,6 @@ from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.model_executor.layers.linear import RowParallelLinear
 from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
 
-from vllm_musa.optimization_contract import (
-    OptimizationFeature,
-    prefers_optimization,
-)
-
-
 def _deepgemm_block_fp8(quant_method) -> bool:
     # MUSA: the DeepGemm block-FP8 kernel writes the GEMM result into a caller
     # buffer, so out_proj/o_proj can skip the output-buffer copy at tp=1.
@@ -37,10 +31,11 @@ class MusaRowParallelLinear(RowParallelLinear):
         activation and linear path unchanged.
         """
         fast = (
-            prefers_optimization(
-                self,
-                OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8,
-            )
+            # This hook is only called by DeepSeek-V4's MLP.  Keep the
+            # confirmed kernel path independent of the contract snapshot
+            # taken before vLLM's runtime config exists; the tensor guards
+            # below remain the authoritative safety checks.
+            not envs.VLLM_BATCH_INVARIANT
             and self.input_is_parallel
             and _deepgemm_block_fp8(self.quant_method)
             and self.bias is None

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -49,7 +49,16 @@ def _matches_flash_base(model: ModelSignature) -> bool:
     )
 
 
-def _matches_tp8_reference(execution: ExecutionSignature) -> bool:
+def _matches_tp8_reference(
+    execution: ExecutionSignature,
+    *,
+    allow_multi_batch: bool = False,
+) -> bool:
+    max_num_seqs_matches = execution.max_num_seqs == 1
+    if allow_multi_batch:
+        max_num_seqs_matches = (
+            execution.max_num_seqs is not None and execution.max_num_seqs > 0
+        )
     return (
         execution.has_parallel_config
         and execution.tensor_parallel_size == 8
@@ -60,7 +69,7 @@ def _matches_tp8_reference(execution: ExecutionSignature) -> bool:
         and execution.has_quant_config
         and not execution.is_pooling_model
         and execution.cache_dtype == "fp8"
-        and execution.max_num_seqs == 1
+        and max_num_seqs_matches
         and execution.attention_backend == "flashmla"
         and execution.compilation_mode == "none"
         and execution.cudagraph_mode == "full_decode_only"
@@ -102,6 +111,16 @@ def resolve_deepseek_v4_contract(
                     OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
                 }
             )
+        # The shared-expert clamp + FP8 down-projection is shape-safe for every
+        # positive max-num-seqs in the same no-MTP TP8 decode contract.  The
+        # original migration accidentally restricted this already-validated
+        # path to the single-sequence capture experiment, disabling it for the
+        # production capture ladder (e.g. max-num-seqs=64).
+        if _matches_tp8_reference(execution, allow_multi_batch=True) and not (
+            execution.batch_invariant_enabled
+        ):
+            preferred.add(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
+
         if _matches_tp8_reference(execution):
             preferred.update(
                 {
@@ -109,8 +128,6 @@ def resolve_deepseek_v4_contract(
                     OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
                 }
             )
-            if not execution.batch_invariant_enabled:
-                preferred.add(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
 
     profile = (
         "deepseek_v4.tp8_flash_base"

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -12,6 +12,7 @@ from .types import (
 )
 
 _DEEPSEEK_V4_ARCHITECTURES = ("DeepseekV4ForCausalLM",)
+_DEEPSEEK_V4_MTP_ARCHITECTURES = ("DeepSeekV4MTPModel",)
 _DEEPSEEK_V4_QUANTIZATION = frozenset({"fp8", "deepseek_v4_fp8"})
 
 
@@ -23,10 +24,18 @@ def _has_complete_identity(model: ModelSignature) -> bool:
     )
 
 
-def _matches_flash_base(model: ModelSignature) -> bool:
+def _has_complete_mtp_draft_identity(model: ModelSignature) -> bool:
+    architectures = model.outer_architectures or model.architectures
     return (
-        _has_complete_identity(model)
-        and model.dtype == "bfloat16"
+        architectures == _DEEPSEEK_V4_MTP_ARCHITECTURES
+        and model.model_type == "deepseek_mtp"
+        and model.outer_model_type == "deepseek_mtp"
+    )
+
+
+def _matches_flash_shape(model: ModelSignature) -> bool:
+    return (
+        model.dtype == "bfloat16"
         and model.quantization in _DEEPSEEK_V4_QUANTIZATION
         and model.hidden_size == 4096
         and model.num_hidden_layers == 43
@@ -49,6 +58,14 @@ def _matches_flash_base(model: ModelSignature) -> bool:
     )
 
 
+def _matches_flash_base(model: ModelSignature) -> bool:
+    return _has_complete_identity(model) and _matches_flash_shape(model)
+
+
+def _matches_mtp_draft_flash_base(model: ModelSignature) -> bool:
+    return _has_complete_mtp_draft_identity(model) and _matches_flash_shape(model)
+
+
 def _matches_tp8_reference(
     execution: ExecutionSignature,
     *,
@@ -68,11 +85,54 @@ def _matches_tp8_reference(
         and not execution.has_speculative_config
         and execution.has_quant_config
         and not execution.is_pooling_model
-        and execution.cache_dtype == "fp8"
+        and execution.cache_dtype in {"fp8", "fp8_ds_mla"}
         and max_num_seqs_matches
         and execution.attention_backend == "flashmla"
         and execution.compilation_mode == "none"
         and execution.cudagraph_mode == "full_decode_only"
+    )
+
+
+def _matches_tp8_mtp(execution: ExecutionSignature) -> bool:
+    if not execution.has_speculative_config:
+        return False
+    if execution.speculative_method not in ("mtp", "deepseek_mtp"):
+        return False
+    if execution.max_num_seqs is None or execution.max_num_seqs <= 1:
+        return False
+    return _matches_tp8_reference(
+        replace(execution, has_speculative_config=False),
+        allow_multi_batch=True,
+    )
+
+
+def _matches_tp8_mtp_car(execution: ExecutionSignature) -> bool:
+    """Match target DSV4 MTP CAR, including the BS1 reference profile."""
+    if not execution.has_speculative_config:
+        return False
+    if execution.speculative_method not in ("mtp", "deepseek_mtp"):
+        return False
+    return _matches_tp8_reference(
+        replace(execution, has_speculative_config=False),
+        allow_multi_batch=True,
+    )
+
+
+def _matches_tp8_mtp_draft(execution: ExecutionSignature) -> bool:
+    # The draft-local VllmConfig no longer contains the outer
+    # speculative_config. Its exact DeepSeek-V4 MTP model role is the MTP
+    # proof; retain every other execution guard.
+    return (
+        execution.max_num_seqs is not None
+        and execution.max_num_seqs > 1
+        and _matches_tp8_reference(
+            replace(
+                execution,
+                has_speculative_config=False,
+                speculative_method="",
+            ),
+            allow_multi_batch=True,
+        )
     )
 
 
@@ -84,10 +144,17 @@ def resolve_deepseek_v4_contract(
     if (
         "DeepseekV4ForCausalLM" not in architectures
         and model.model_type != "deepseek_v4"
+        and "DeepSeekV4MTPModel" not in architectures
+        and model.model_type != "deepseek_mtp"
     ):
         return None
 
-    model = replace(model, family=ModelFamily.DEEPSEEK_V4, role=ModelRole.TEXT)
+    is_mtp_draft = _has_complete_mtp_draft_identity(model)
+    model = replace(
+        model,
+        family=ModelFamily.DEEPSEEK_V4,
+        role=ModelRole.MTP_DRAFT if is_mtp_draft else ModelRole.TEXT,
+    )
     supported: set[OptimizationFeature] = set()
     preferred: set[OptimizationFeature] = set()
 
@@ -102,6 +169,9 @@ def resolve_deepseek_v4_contract(
                 OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
                 OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256,
+                OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT,
+                OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM,
+                OptimizationFeature.DEEPSEEK_V4_TP8_MTP_ASYNC_PREFILL_QUEUE_FENCE,
             }
         )
         if execution.has_parallel_config:
@@ -121,7 +191,30 @@ def resolve_deepseek_v4_contract(
         ):
             preferred.add(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
 
-        if _matches_tp8_reference(execution):
+        if _matches_tp8_mtp(execution):
+            preferred.update(
+                {
+                    OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT,
+                    OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM,
+                }
+            )
+            if execution.async_scheduling:
+                preferred.add(
+                    OptimizationFeature.DEEPSEEK_V4_TP8_MTP_ASYNC_PREFILL_QUEUE_FENCE
+                )
+        if _matches_tp8_mtp_car(execution):
+            supported.add(OptimizationFeature.DEEPSEEK_V4_MTP_CAR_GRAPH_STAGING_ARENA)
+            preferred.add(OptimizationFeature.DEEPSEEK_V4_MTP_CAR_GRAPH_STAGING_ARENA)
+            # A dedicated BS1 deployment keeps registered graph inputs for its
+            # single capture descriptor. Multi-batch deployments use staging.
+            if execution.max_num_seqs == 1:
+                supported.add(
+                    OptimizationFeature.DEEPSEEK_V4_MTP_CAR_GRAPH_REGISTERED_INPUTS
+                )
+                preferred.add(
+                    OptimizationFeature.DEEPSEEK_V4_MTP_CAR_GRAPH_REGISTERED_INPUTS
+                )
+        elif _matches_tp8_reference(execution):
             preferred.update(
                 {
                     OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256,
@@ -129,11 +222,23 @@ def resolve_deepseek_v4_contract(
                 }
             )
 
-    profile = (
-        "deepseek_v4.tp8_flash_base"
-        if _matches_flash_base(model) and _matches_tp8_reference(execution)
-        else "deepseek_v4.unvalidated"
-    )
+    if _matches_mtp_draft_flash_base(model):
+        mtp_draft_features = {
+            OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT,
+            OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM,
+        }
+        supported.update(mtp_draft_features)
+        if _matches_tp8_mtp_draft(execution):
+            preferred.update(mtp_draft_features)
+
+    if _matches_mtp_draft_flash_base(model) and _matches_tp8_mtp_draft(execution):
+        profile = "deepseek_v4.tp8_flash_mtp_draft"
+    elif _matches_flash_base(model) and _matches_tp8_mtp(execution):
+        profile = "deepseek_v4.tp8_flash_base_mtp"
+    elif _matches_flash_base(model) and _matches_tp8_reference(execution):
+        profile = "deepseek_v4.tp8_flash_base"
+    else:
+        profile = "deepseek_v4.unvalidated"
     return MusaOptimizationContract(
         model=model,
         execution=execution,

--- a/vllm_musa/optimization_contract/policy.py
+++ b/vllm_musa/optimization_contract/policy.py
@@ -9,15 +9,188 @@ consumer.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from .resolver import resolve_optimization_contract
 from .types import OptimizationFeature
 
+_DEEPSEEK_V4_SPARSE_PADDED_HEADS = 64
+_DEEPSEEK_V4_SPARSE_HEAD_DIM = 512
+_DEEPSEEK_V4_SPARSE_DTYPE_BYTES = 2
+_DEEPSEEK_V4_CUSTOM_AR_ALLOCATOR_MARGIN_BYTES = 512 * 1024 * 1024
+_DEEPSEEK_V4_MTP4_TOKENS_PER_REQUEST = 5
+# The exact MTP4 graph ladder is 5 * batch_size. The graph-local CAR contract
+# covers descriptors whose launch grid stays below the long-descriptor path;
+# the 32/64-request descriptors retain the standard collective. Keeping the
+# set explicit prevents a future capture ladder from entering an unproved path
+# merely because its token count happens to fit the arena.
+_DEEPSEEK_V4_MTP_CAR_GRAPH_REQUEST_SIZES = (1, 2, 4, 8, 16)
+_DEEPSEEK_V4_MTP_CAR_GRAPH_BUFFER_BYTES = 512 * 1024 * 1024
+_DEEPSEEK_V4_MTP_CAR_EAGER_ALIGNMENT_BYTES = 4 * 1024 * 1024
+_DEEPSEEK_V4_MTP_CAR_MAX_META_BYTES_PER_SLOT = 16 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class DeepSeekV4MtpCarGraphStagingPlan:
+    """Capture-time resource contract for DSV4 MTP4 JIT CAR graphs."""
+
+    eager_reserve_bytes: int
+    capture_descriptors: frozenset[tuple[int, int]]
+    car_ops_per_descriptor: int
+    bytes_per_token: int
+    graph_data_capacity_bytes: int
+    graph_meta_capacity_bytes: int
+    max_meta_bytes_per_slot: int
+    communicator_buffer_bytes: int
+
+    def allows_descriptor(self, descriptor: Any) -> bool:
+        if descriptor is None or not bool(getattr(descriptor, "uniform", False)):
+            return False
+        if bool(getattr(descriptor, "has_lora", False)) or int(
+            getattr(descriptor, "num_active_loras", 0) or 0
+        ):
+            return False
+        num_tokens = getattr(descriptor, "num_tokens", None)
+        num_reqs = getattr(descriptor, "num_reqs", None)
+        if (
+            not isinstance(num_tokens, int)
+            or isinstance(num_tokens, bool)
+            or not isinstance(num_reqs, int)
+            or isinstance(num_reqs, bool)
+        ):
+            return False
+        key = (num_tokens, num_reqs)
+        return key in self.capture_descriptors
+
+    def expected_descriptor_data_bytes(self, num_tokens: int) -> int:
+        return self.car_ops_per_descriptor * num_tokens * self.bytes_per_token
+
 
 def prefers_feature(vllm_config: Any, feature: OptimizationFeature) -> bool:
     """Return whether a config's frozen contract prefers ``feature``."""
     return resolve_optimization_contract(vllm_config).prefers(feature)
+
+
+def deepseek_v4_mtp_car_graph_guard_enabled(vllm_config: Any) -> bool:
+    """Guard eligible DSV4 MTP graph CAR even when no arena plan exists."""
+    return resolve_optimization_contract(vllm_config).supports(
+        OptimizationFeature.DEEPSEEK_V4_MTP_CAR_GRAPH_STAGING_ARENA
+    )
+
+
+def deepseek_v4_mtp_graph_registered_inputs_enabled(vllm_config: Any) -> bool:
+    """Return the contract decision for the DSV4 MTP graph CAR path."""
+    return prefers_feature(
+        vllm_config,
+        OptimizationFeature.DEEPSEEK_V4_MTP_CAR_GRAPH_REGISTERED_INPUTS,
+    )
+
+
+def deepseek_v4_mtp_car_graph_staging_plan(
+    vllm_config: Any,
+) -> DeepSeekV4MtpCarGraphStagingPlan | None:
+    """Return the bounded DSV4 MTP4 graph staging plan, or fail closed."""
+    if not prefers_feature(
+        vllm_config,
+        OptimizationFeature.DEEPSEEK_V4_MTP_CAR_GRAPH_STAGING_ARENA,
+    ):
+        return None
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    if (
+        getattr(speculative_config, "num_speculative_tokens", None)
+        != _DEEPSEEK_V4_MTP4_TOKENS_PER_REQUEST - 1
+    ):
+        return None
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    model_config = getattr(vllm_config, "model_config", None)
+    text_config = getattr(model_config, "hf_text_config", None)
+    max_num_batched_tokens = int(
+        getattr(scheduler_config, "max_num_batched_tokens", 0) or 0
+    )
+    hidden_size = int(getattr(text_config, "hidden_size", 0) or 0)
+    num_hidden_layers = int(getattr(text_config, "num_hidden_layers", 0) or 0)
+    if max_num_batched_tokens <= 0 or hidden_size <= 0 or num_hidden_layers <= 0:
+        return None
+    required_eager_bytes = max_num_batched_tokens * hidden_size * 2
+    alignment = _DEEPSEEK_V4_MTP_CAR_EAGER_ALIGNMENT_BYTES
+    eager_reserve_bytes = (
+        (required_eager_bytes + alignment - 1) // alignment * alignment
+    )
+    capture_descriptors = frozenset(
+        (
+            _DEEPSEEK_V4_MTP4_TOKENS_PER_REQUEST * num_reqs,
+            num_reqs,
+        )
+        for num_reqs in _DEEPSEEK_V4_MTP_CAR_GRAPH_REQUEST_SIZES
+    )
+    # The exact DeepSeek-V4 graph contains two CAR sites per transformer layer
+    # plus the final model-parallel reduction. Every captured CAR ordinal gets
+    # a disjoint slice so graph replay never depends on host-side stream/queue
+    # ordering to protect shared signal or staging storage. The capture-time
+    # manifest checks the operation count and tensor bytes on every rank.
+    car_ops_per_descriptor = 2 * num_hidden_layers + 1
+    bytes_per_token = hidden_size * 2
+    graph_slot_count = car_ops_per_descriptor * len(capture_descriptors)
+    graph_data_capacity_bytes = (
+        car_ops_per_descriptor
+        * sum(num_tokens for num_tokens, _ in capture_descriptors)
+        * bytes_per_token
+    )
+    # DSV4 H=4096 BF16 inputs and the conservative meta bound are both
+    # 256-byte aligned, so runtime align(meta_size + input_bytes, 256) is
+    # bounded exactly by input_bytes + max_meta_bytes_per_slot.
+    graph_meta_capacity_bytes = (
+        graph_data_capacity_bytes
+        + graph_slot_count * _DEEPSEEK_V4_MTP_CAR_MAX_META_BYTES_PER_SLOT
+    )
+    required_communicator_buffer_bytes = max(
+        eager_reserve_bytes + graph_data_capacity_bytes,
+        eager_reserve_bytes
+        + _DEEPSEEK_V4_MTP_CAR_MAX_META_BYTES_PER_SLOT
+        + graph_meta_capacity_bytes,
+    )
+    communicator_buffer_bytes = (
+        (
+            required_communicator_buffer_bytes
+            + _DEEPSEEK_V4_MTP_CAR_EAGER_ALIGNMENT_BYTES
+            - 1
+        )
+        // _DEEPSEEK_V4_MTP_CAR_EAGER_ALIGNMENT_BYTES
+        * _DEEPSEEK_V4_MTP_CAR_EAGER_ALIGNMENT_BYTES
+    )
+    if communicator_buffer_bytes > _DEEPSEEK_V4_MTP_CAR_GRAPH_BUFFER_BYTES:
+        return None
+    return DeepSeekV4MtpCarGraphStagingPlan(
+        eager_reserve_bytes=eager_reserve_bytes,
+        capture_descriptors=capture_descriptors,
+        car_ops_per_descriptor=car_ops_per_descriptor,
+        bytes_per_token=bytes_per_token,
+        graph_data_capacity_bytes=graph_data_capacity_bytes,
+        graph_meta_capacity_bytes=graph_meta_capacity_bytes,
+        max_meta_bytes_per_slot=_DEEPSEEK_V4_MTP_CAR_MAX_META_BYTES_PER_SLOT,
+        communicator_buffer_bytes=communicator_buffer_bytes,
+    )
+
+
+def deepseek_v4_mtp_async_prefill_queue_fence_enabled(vllm_config: Any) -> bool:
+    """Return whether this execution contract needs the async queue fence."""
+    return prefers_feature(
+        vllm_config,
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_ASYNC_PREFILL_QUEUE_FENCE
+    )
+
+
+def deepseek_v4_mtp_prefill_step_requires_sync(scheduler_output: Any) -> bool:
+    """Return whether a scheduler step contains DSV4 prefill/context work."""
+
+    # New requests always contain context work. Cached requests expose the
+    # scheduler's explicit context-phase fact, which remains correct when
+    # structured output drops every speculative token from a pure decode step.
+    if getattr(scheduler_output, "scheduled_new_reqs", ()):
+        return True
+    cached_reqs = getattr(scheduler_output, "scheduled_cached_reqs", None)
+    return 0 in getattr(cached_reqs, "num_output_tokens", ())
 
 
 def model_has_routed_experts(model_config: Any | None) -> bool:
@@ -69,3 +242,38 @@ def deepseek_v4_flashmla_sparse_page_size(vllm_config: Any) -> int:
     ):
         return 256
     return 64
+
+
+def deepseek_v4_mtp_sparse_prefill_headroom_bytes(vllm_config: Any) -> int:
+    """Return transient H64 query workspace omitted by MTP profiling.
+
+    When JIT custom all-reduce is enabled, its persistent 512-MiB-class
+    staging allocation increases fragmentation around the equally large
+    padded query. Keep one additional staging-sized margin so the production
+    query allocation remains satisfiable at high memory utilization. The
+    explicit ``--disable-custom-all-reduce`` path does not need that margin.
+    """
+    if not prefers_feature(
+        vllm_config,
+        OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM,
+    ):
+        return 0
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    max_num_batched_tokens = int(
+        getattr(scheduler_config, "max_num_batched_tokens", 0) or 0
+    )
+    if max_num_batched_tokens <= 0:
+        return 0
+    workspace_bytes = (
+        max_num_batched_tokens
+        * _DEEPSEEK_V4_SPARSE_PADDED_HEADS
+        * _DEEPSEEK_V4_SPARSE_HEAD_DIM
+        * _DEEPSEEK_V4_SPARSE_DTYPE_BYTES
+    )
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    custom_all_reduce_enabled = not bool(
+        getattr(parallel_config, "disable_custom_all_reduce", False)
+    )
+    if custom_all_reduce_enabled:
+        workspace_bytes += _DEEPSEEK_V4_CUSTOM_AR_ALLOCATOR_MARGIN_BYTES
+    return workspace_bytes

--- a/vllm_musa/optimization_contract/resolver.py
+++ b/vllm_musa/optimization_contract/resolver.py
@@ -221,6 +221,7 @@ def _execution_signature(
     scheduler_config = getattr(vllm_config, "scheduler_config", None)
     attention_config = getattr(vllm_config, "attention_config", None)
     compilation_config = getattr(vllm_config, "compilation_config", None)
+    speculative_config = getattr(vllm_config, "speculative_config", None)
 
     def size(name: str) -> int:
         value = getattr(parallel_config, name, 1)
@@ -258,6 +259,10 @@ def _execution_signature(
             getattr(compilation_config, "cudagraph_mode", None)
         ),
         batch_invariant_enabled=batch_invariant_enabled,
+        speculative_method=_normalize_name(getattr(speculative_config, "method", None)),
+        async_scheduling=bool(
+            getattr(scheduler_config, "async_scheduling", False)
+        ),
     )
 
 
@@ -266,6 +271,7 @@ def resolve_optimization_contract(
     *,
     model_config: Any | None = None,
     is_pooling_model: bool = False,
+    attention_backend_hint: str | None = None,
 ) -> MusaOptimizationContract:
     if model_config is None:
         model_config = getattr(vllm_config, "model_config", None)
@@ -273,6 +279,11 @@ def resolve_optimization_contract(
         vllm_config,
         is_pooling_model=is_pooling_model,
     )
+    if execution.attention_backend is None and attention_backend_hint is not None:
+        execution = replace(
+            execution,
+            attention_backend=_normalize_name(attention_backend_hint),
+        )
     if model_config is None:
         model = ModelSignature(
             family=ModelFamily.UNKNOWN,

--- a/vllm_musa/optimization_contract/types.py
+++ b/vllm_musa/optimization_contract/types.py
@@ -15,6 +15,7 @@ class ModelFamily(str, Enum):
 class ModelRole(str, Enum):
     UNKNOWN = "unknown"
     TEXT = "text_generation"
+    MTP_DRAFT = "mtp_draft"
     COSYVOICE_TALKER = "cosyvoice_talker"
 
 
@@ -25,12 +26,23 @@ class OptimizationFeature(str, Enum):
         "deepseek_v4.materialized_prefill_indexer"
     )
     DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256 = "deepseek_v4.tp8_flashmla_sparse_page256"
+    DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT = "deepseek_v4.tp8_mtp_sparse_direct_out"
+    DEEPSEEK_V4_TP8_MTP_SPARSE_PREFILL_HEADROOM = (
+        "deepseek_v4.tp8_mtp_sparse_prefill_headroom"
+    )
+    DEEPSEEK_V4_TP8_MTP_ASYNC_PREFILL_QUEUE_FENCE = (
+        "deepseek_v4.tp8_mtp_async_prefill_queue_fence"
+    )
     DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256 = (
         "deepseek_v4.tp8_fused_add_rmsnorm_block256"
     )
     DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD = (
         "deepseek_v4.car_graph_input_capture_guard"
     )
+    DEEPSEEK_V4_MTP_CAR_GRAPH_REGISTERED_INPUTS = (
+        "deepseek_v4.mtp_car_graph_registered_inputs"
+    )
+    DEEPSEEK_V4_MTP_CAR_GRAPH_STAGING_ARENA = "deepseek_v4.mtp_car_graph_staging_arena"
     QWEN_V2_SAMPLING = "qwen.v2_sampling"
     QWEN_LEGACY_SAMPLING = "qwen.legacy_sampling"
     QWEN_FA3_SCHEDULER = "qwen.fa3_scheduler"
@@ -104,6 +116,8 @@ class ExecutionSignature:
     compilation_mode: str | None = None
     cudagraph_mode: str | None = None
     batch_invariant_enabled: bool = False
+    speculative_method: str | None = None
+    async_scheduling: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_musa/patches/series/0102-MUSA-preserve-DeepSeek-V4-MTP-sparse-prefill-headroom.patch
+++ b/vllm_musa/patches/series/0102-MUSA-preserve-DeepSeek-V4-MTP-sparse-prefill-headroom.patch
@@ -1,0 +1,174 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sat, 8 Aug 2026 06:56:54 +0800
+Subject: [PATCH] MUSA: preserve DeepSeek-V4 MTP sparse-prefill headroom
+
+---
+ vllm/models/deepseek_v4/nvidia/flashmla.py | 56 +++++++++++++++++-----
+ vllm/v1/worker/gpu_worker.py               | 38 +++++++++++++--
+ 2 files changed, 79 insertions(+), 15 deletions(-)
+
+diff --git a/vllm/models/deepseek_v4/nvidia/flashmla.py b/vllm/models/deepseek_v4/nvidia/flashmla.py
+index 8839e3cbd5..3ebe58040e 100644
+--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
++++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
+@@ -4,8 +4,14 @@
+ from typing import TYPE_CHECKING, cast
+
+ import torch
++from vllm_musa.v1.attention.ops.flashmla import (
++    flash_mla_sparse_fwd,
++    flash_mla_with_kvcache,
++)
+
++from vllm.config import get_current_vllm_config_or_none
+ from vllm.forward_context import get_forward_context
++from vllm.logger import init_logger
+ from vllm.models.deepseek_v4.attention import DeepseekV4Attention
+ from vllm.models.deepseek_v4.common.ops import (
+     combine_topk_swa_indices,
+@@ -20,13 +26,13 @@ from vllm.models.deepseek_v4.sparse_mla import (
+     DeepseekV4FlashMLABackend,
+     DeepseekV4FlashMLAMetadata,
+ )
+-from vllm_musa.v1.attention.ops.flashmla import (
+-    flash_mla_sparse_fwd,
+-    flash_mla_with_kvcache,
+-)
++from vllm.platforms import current_platform
+ from vllm.v1.worker.workspace import current_workspace_manager
+
++logger = init_logger(__name__)
++
+ if TYPE_CHECKING:
++    from vllm.config import VllmConfig
+     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
+
+
+@@ -35,9 +41,34 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
+
+     backend_cls = DeepseekV4FlashMLABackend
+
+-    def __init__(self, *args, **kwargs) -> None:
+-        super().__init__(*args, **kwargs)
++    def __init__(
++        self,
++        vllm_config: "VllmConfig",
++        *args,
++        **kwargs,
++    ) -> None:
++        super().__init__(vllm_config, *args, **kwargs)
+         self._einsum_recipe, self._tma_aligned_scales = compute_fp8_einsum_recipe()
++        self._musa_tp8_mtp_sparse_direct_out = False
++        if current_platform.is_musa():
++            from vllm_musa.optimization_contract import (
++                OptimizationFeature,
++                resolve_optimization_contract,
++            )
++
++            contract_vllm_config = get_current_vllm_config_or_none() or vllm_config
++            optimization_contract = resolve_optimization_contract(
++                contract_vllm_config,
++                attention_backend_hint="flashmla",
++            )
++            self._musa_tp8_mtp_sparse_direct_out = optimization_contract.prefers(
++                OptimizationFeature.DEEPSEEK_V4_TP8_MTP_SPARSE_DIRECT_OUT
++            )
++            logger.debug_once(
++                "MUSA DeepSeek-V4 FlashMLA contract: profile=%s, direct_out=%s.",
++                optimization_contract.profile,
++                self._musa_tp8_mtp_sparse_direct_out,
++            )
+
+     def _o_proj(self, o: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+         return deep_gemm_fp8_o_proj(
+@@ -72,12 +103,12 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
+         positions: torch.Tensor,
+         output: torch.Tensor,
+     ) -> None:
+-        assert output.shape == q.shape, (
+-            f"output buffer shape {output.shape} must match q shape {q.shape}"
+-        )
+-        assert output.dtype == q.dtype, (
+-            f"output buffer dtype {output.dtype} must match q dtype {q.dtype}"
+-        )
++        assert (
++            output.shape == q.shape
++        ), f"output buffer shape {output.shape} must match q shape {q.shape}"
++        assert (
++            output.dtype == q.dtype
++        ), f"output buffer dtype {output.dtype} must match q dtype {q.dtype}"
+
+         # Get SWA and indexer metadata from forward context
+         forward_context = get_forward_context()
+@@ -354,4 +385,5 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
+                 attn_sink=self.attn_sink,
+                 topk_length=combined_lens,
+                 out=output[query_start:query_end],
++                allow_dsv4_tp8_mtp_direct_out=(self._musa_tp8_mtp_sparse_direct_out),
+             )
+diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
+index 4c4594a478..b64ea2addc 100644
+--- a/vllm/v1/worker/gpu_worker.py
++++ b/vllm/v1/worker/gpu_worker.py
+@@ -217,9 +217,9 @@ class Worker(WorkerBase):
+
+         allocator = get_mem_allocator_instance()
+         if tag == "weights":
+-            assert allocator.get_current_usage() == 0, (
+-                "CuMem allocator can only be used for one instance per process."
+-            )
++            assert (
++                allocator.get_current_usage() == 0
++            ), "CuMem allocator can only be used for one instance per process."
+         return allocator.use_memory_pool(tag=tag)
+
+     @contextmanager
+@@ -409,7 +409,25 @@ class Worker(WorkerBase):
+             You may limit the usage of GPU memory
+             by adjusting the `gpu_memory_utilization` parameter.
+         """
++        musa_workspace_headroom_bytes = 0
++        if current_platform.is_musa():
++            from vllm_musa.optimization_contract.policy import (
++                deepseek_v4_mtp_sparse_prefill_headroom_bytes,
++            )
++
++            musa_workspace_headroom_bytes = (
++                deepseek_v4_mtp_sparse_prefill_headroom_bytes(self.vllm_config)
++            )
++
+         if kv_cache_memory_bytes := self.cache_config.kv_cache_memory_bytes:
++            if musa_workspace_headroom_bytes > 0:
++                logger.warning_once(
++                    "Explicit kv_cache_memory_bytes bypasses the automatic "
++                    "%.2f GiB DeepSeek-V4 MTP sparse-prefill headroom; "
++                    "configure the KV-cache byte budget to leave at least "
++                    "this much device memory outside the KV allocation.",
++                    musa_workspace_headroom_bytes / GiB_bytes,
++                )
+             # still need a profile run which compiles the model for
+             # max_num_batched_tokens
+             self.model_runner.profile_run()
+@@ -490,7 +508,21 @@ class Worker(WorkerBase):
+             self.requested_memory
+             - profile_result.non_kv_cache_memory
+             - cudagraph_memory_estimate_applied
++            - musa_workspace_headroom_bytes
+         )
++        if musa_workspace_headroom_bytes > 0:
++            if self.available_kv_cache_memory_bytes <= 0:
++                raise ValueError(
++                    "DeepSeek-V4 MTP sparse-prefill headroom leaves no memory "
++                    "for the KV cache. Lower max_num_batched_tokens, or "
++                    "increase gpu_memory_utilization only when sufficient "
++                    "unused physical device memory remains."
++                )
++            logger.info_once(
++                "Reserved %.2f GiB of DeepSeek-V4 MTP sparse-prefill "
++                "workspace before KV-cache sizing.",
++                musa_workspace_headroom_bytes / GiB_bytes,
++            )
+
+         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
+         logger.debug(

--- a/vllm_musa/patches/series/0103-MUSA-fence-DeepSeek-V4-MTP-prefill-queues.patch
+++ b/vllm_musa/patches/series/0103-MUSA-fence-DeepSeek-V4-MTP-prefill-queues.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Sat, 8 Aug 2026 08:20:00 +0800
+Subject: [PATCH] MUSA: fence DeepSeek-V4 MTP mixed prefill queues
+
+---
+ vllm/v1/worker/gpu_model_runner.py | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index c1f1b43606..8a82734604 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -4458,22 +4458,48 @@ class GPUModelRunner:
+         self.execute_model_state = ExecuteModelState(
+             scheduler_output,
+             logits,
+             spec_decode_metadata,
+             spec_decode_common_attn_metadata,
+             hidden_states,
+             sample_hidden_states,
+             aux_hidden_states,
+             ec_connector_output,
+             cudagraph_stats,
+             slot_mappings,
+         )
+         self.kv_connector_output = kv_connector_output
+
++        # A DSV4 MTP prefill step can enqueue work on several MUSA task queues.
++        # Fence those queues before async scheduling reuses the next step's
++        # graph inputs and metadata.
+         # Now the batch has been launched we can wait for corrections from the
+         # previous model forward without breaking async scheduling.
+         if deferred_state_corrections_fn:
+             deferred_state_corrections_fn()
+
++        queue_fence = getattr(
++            self, "_musa_dsv4_mtp_prefill_queue_fence", None
++        )
++        if queue_fence is None:
++            from vllm_musa.optimization_contract.policy import (
++                deepseek_v4_mtp_async_prefill_queue_fence_enabled,
++                deepseek_v4_mtp_prefill_step_requires_sync,
++            )
++
++            queue_fence = (
++                deepseek_v4_mtp_prefill_step_requires_sync
++                if deepseek_v4_mtp_async_prefill_queue_fence_enabled(
++                    self.vllm_config
++                )
++                else False
++            )
++            self._musa_dsv4_mtp_prefill_queue_fence = queue_fence
++        if (
++            queue_fence
++            and queue_fence(scheduler_output)
++            and not torch.musa.is_current_stream_capturing()
++        ):
++            torch.musa.synchronize()
+         return None
+
+     def _input_fits_in_drafter(

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,9 +17,11 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **107 patches**. This branch adds Qwen3.6 patches for common GDN
+Currently **109 patches**. This branch adds Qwen3.6 patches for common GDN
 decode metadata reuse, uniform-decode SSM slot-mapping removal, and the BF16 W1
-tile specialization on top of the upstream 104-patch series. The series contains
+tile specialization, plus the contract-bound DeepSeek-V4 MTP sparse-prefill
+headroom and mixed-prefill queue-fence patches, on top of the upstream
+104-patch series. The series contains
 MUSA source edits against the immutable vLLM commit recorded as `VLLM_COMMIT`
 in `third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
 object/registration patches (which patch live objects at import) are kept

--- a/vllm_musa/v1/attention/ops/flashmla.py
+++ b/vllm_musa/v1/attention/ops/flashmla.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from importlib.metadata import version
+from typing import Any, Callable, TypeVar
+
 import torch
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -27,6 +30,60 @@ else:
             )
             _flash_mla = None
             break
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def _identity_decorator(func: _F) -> _F:
+    return func
+
+
+_MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR: Exception | None = None
+try:
+    from mate.api_logging import mate_api as _mate_api
+    from mate.execution_context import (
+        raise_complete_if_dry_run as _mate_raise_complete_if_dry_run,
+    )
+    from mate.mate_runtime import resolve_num_mps as _mate_resolve_num_mps
+    from mate.sparse_mla.tilelang.sparse_mla_model1_fwd_pipelined import (
+        sparse_attention_fwd_kernel_model1 as _mate_sparse_model1_kernel,
+    )
+    from mate.sparse_mla.tilelang.sparse_mla_prefill_common import (
+        optional_prefill_attn_sink as _mate_optional_prefill_attn_sink,
+    )
+    from mate.sparse_mla.tilelang.sparse_mla_prefill_common import (
+        require_token_lengths as _mate_require_token_lengths,
+    )
+except Exception as exc:
+    # This is an optional private fast path. Missing symbols, shared libraries,
+    # or incompatible TileLang/MATE imports must leave the public path usable.
+    _MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR = exc
+    _mate_api = _identity_decorator
+    _mate_raise_complete_if_dry_run = None
+    _mate_resolve_num_mps = None
+    _mate_sparse_model1_kernel = None
+    _mate_optional_prefill_attn_sink = None
+    _mate_require_token_lengths = None
+
+try:
+    _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED = version("mate").split("+", 1)[0] == "0.2.4"
+except Exception:
+    _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED = False
+
+_MATE_SPARSE_DIRECT_OUT_PARAM_NAMES = (
+    "q_handle",
+    "kv_handle",
+    "indices_handle",
+    "topk_length_handle",
+    "extra_kv_handle",
+    "extra_indices_handle",
+    "extra_topk_length_handle",
+    "attn_sink_handle",
+    "output_handle",
+    "max_logits_out_handle",
+    "lse_handle",
+)
+_MATE_SPARSE_DIRECT_OUT_RESULT_INDICES = (8, 9, 10)
 
 
 class _UnavailableFlashMLASchedMeta:
@@ -110,6 +167,194 @@ def get_mla_metadata(*args, **kwargs):
     return flash_mla.get_mla_metadata(*args, **kwargs)
 
 
+def _is_musa_tensor(tensor: torch.Tensor) -> bool:
+    return current_platform.is_musa() and tensor.device.type == "musa"
+
+
+def _is_current_stream_capturing() -> bool:
+    try:
+        is_capturing = getattr(
+            torch.get_device_module(),
+            "is_current_stream_capturing",
+            None,
+        )
+        return True if is_capturing is None else bool(is_capturing())
+    except Exception:
+        # The private direct-output shim is not capture-safe. Fail closed when
+        # the accelerator cannot report capture state.
+        return True
+
+
+def _tensors_overlap(left: torch.Tensor, right: torch.Tensor) -> bool:
+    if left.device != right.device or left.numel() == 0 or right.numel() == 0:
+        return False
+    left_start = left.data_ptr()
+    left_end = left_start + left.numel() * left.element_size()
+    right_start = right.data_ptr()
+    right_end = right_start + right.numel() * right.element_size()
+    return left_start < right_end and right_start < left_end
+
+
+def _out_overlaps_inputs(
+    out: torch.Tensor,
+    *inputs: torch.Tensor | None,
+) -> bool:
+    return any(
+        input_tensor is not None and _tensors_overlap(out, input_tensor)
+        for input_tensor in inputs
+    )
+
+
+def _can_use_dsv4_tp8_sparse_direct_out(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    attn_sink: torch.Tensor | None,
+    topk_length: torch.Tensor | None,
+    out: torch.Tensor | None,
+    d_v: int,
+    allow_dsv4_tp8_mtp_direct_out: bool,
+) -> bool:
+    return (
+        allow_dsv4_tp8_mtp_direct_out
+        and _MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR is None
+        and _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED
+        and _mate_raise_complete_if_dry_run is not None
+        and _mate_resolve_num_mps is not None
+        and _mate_sparse_model1_kernel is not None
+        and _mate_optional_prefill_attn_sink is not None
+        and _mate_require_token_lengths is not None
+        and out is not None
+        and topk_length is not None
+        and _is_musa_tensor(q)
+        and not _is_current_stream_capturing()
+        and d_v == 512
+        and q.ndim == 3
+        and q.shape[0] > 0
+        and q.shape[1:] == (64, 512)
+        and q.dtype == torch.bfloat16
+        and q.is_contiguous()
+        and out.shape == q.shape
+        and out.dtype == q.dtype
+        and out.device == q.device
+        and out.is_contiguous()
+        and kv.ndim == 3
+        and kv.shape[1:] == (1, 512)
+        and kv.dtype == torch.bfloat16
+        and kv.device == q.device
+        and kv.is_contiguous()
+        and indices.ndim == 3
+        and indices.shape[0] == q.shape[0]
+        and indices.shape[1] == 1
+        and indices.shape[2] % 64 == 0
+        and indices.dtype == torch.int32
+        and indices.device == q.device
+        and indices.is_contiguous()
+        and topk_length.shape == (q.shape[0],)
+        and topk_length.dtype == torch.int32
+        and topk_length.device == q.device
+        and (
+            attn_sink is None
+            or (
+                attn_sink.shape == (64,)
+                and attn_sink.dtype == torch.float32
+                and attn_sink.device == q.device
+                and attn_sink.is_contiguous()
+            )
+        )
+        and not _out_overlaps_inputs(
+            out,
+            q,
+            kv,
+            indices,
+            topk_length,
+            attn_sink,
+        )
+    )
+
+
+def _has_expected_mate_sparse_direct_out_abi(kernel: Any) -> bool:
+    adapter = getattr(kernel, "adapter", None)
+    prim_func = getattr(kernel, "prim_func", None)
+    params = getattr(prim_func, "params", ())
+    param_names = tuple(getattr(param, "name", None) for param in params)
+    result_indices = tuple(getattr(adapter, "result_idx", ()))
+    return (
+        getattr(kernel, "execution_backend", None) == "tvm_ffi"
+        and callable(getattr(adapter, "executable", None))
+        and param_names == _MATE_SPARSE_DIRECT_OUT_PARAM_NAMES
+        and result_indices == _MATE_SPARSE_DIRECT_OUT_RESULT_INDICES
+    )
+
+
+@_mate_api
+def _flash_mla_sparse_fwd_direct_out(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    attn_sink: torch.Tensor | None,
+    topk_length: torch.Tensor,
+    out: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+    assert _mate_raise_complete_if_dry_run is not None
+    assert _mate_resolve_num_mps is not None
+    assert _mate_sparse_model1_kernel is not None
+    assert _mate_optional_prefill_attn_sink is not None
+    assert _mate_require_token_lengths is not None
+
+    seq_len, heads, dim = q.shape
+    normalized_topk_length = _mate_require_token_lengths(
+        topk_length,
+        seq_len,
+        indices.shape[-1],
+        q.device,
+        "topk_length",
+    )
+    kernel = _mate_sparse_model1_kernel(
+        heads,
+        dim,
+        has_extra=False,
+        kv_group=kv.shape[1],
+        sm_scale=sm_scale,
+        has_attn_sink=attn_sink is not None,
+        is_persistence=True,
+        persistent_blocks=_mate_resolve_num_mps(q.device, None),
+    )
+    if not _has_expected_mate_sparse_direct_out_abi(kernel):
+        logger.warning_once(
+            "MATE sparse-prefill private ABI does not match the validated "
+            "0.2.4 layout; using the public FlashMLA path."
+        )
+        return None
+
+    _mate_raise_complete_if_dry_run()
+    attn_sink_arg, _ = _mate_optional_prefill_attn_sink(
+        attn_sink,
+        heads,
+        q.device,
+    )
+    max_logits = torch.empty((seq_len, heads), dtype=torch.float32, device=q.device)
+    lse = torch.empty((seq_len, heads), dtype=torch.float32, device=q.device)
+    kernel.adapter.executable(
+        q,
+        kv,
+        indices,
+        normalized_topk_length,
+        kv,
+        indices[:, :, :0],
+        normalized_topk_length,
+        attn_sink_arg,
+        out,
+        max_logits,
+        lse,
+    )
+    logger.info_once(
+        "Using caller-owned output for DeepSeek-V4 TP8 MATE sparse prefill."
+    )
+    return out, max_logits, lse
+
+
 def flash_mla_sparse_fwd(
     q: torch.Tensor,
     kv: torch.Tensor,
@@ -119,8 +364,47 @@ def flash_mla_sparse_fwd(
     attn_sink: torch.Tensor | None = None,
     topk_length: torch.Tensor | None = None,
     out: torch.Tensor | None = None,
+    allow_dsv4_tp8_mtp_direct_out: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     flash_mla = _require_flashmla()
+
+    if allow_dsv4_tp8_mtp_direct_out:
+        if _MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR is not None:
+            logger.warning_once(
+                "MATE sparse direct-out is unavailable (%s); using the "
+                "public FlashMLA path.",
+                _MATE_SPARSE_DIRECT_OUT_IMPORT_ERROR,
+            )
+        elif not _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED:
+            logger.warning_once(
+                "MATE sparse direct-out requires the validated 0.2.4 ABI; "
+                "using the public FlashMLA path."
+            )
+
+    can_use_direct_out = _can_use_dsv4_tp8_sparse_direct_out(
+        q,
+        kv,
+        indices,
+        attn_sink,
+        topk_length,
+        out,
+        d_v,
+        allow_dsv4_tp8_mtp_direct_out,
+    )
+    if can_use_direct_out:
+        assert topk_length is not None
+        assert out is not None
+        direct_result = _flash_mla_sparse_fwd_direct_out(
+            q,
+            kv,
+            indices,
+            sm_scale,
+            attn_sink,
+            topk_length,
+            out,
+        )
+        if direct_result is not None:
+            return direct_result
 
     result, max_logits, lse = flash_mla.flash_mla_sparse_fwd(
         q=q,


### PR DESCRIPTION
This draft is stacked directly on PR #174 head `7b0fe680`. Commit `caf77a1e` is the OOM fix; once reviewed it can be cherry-picked onto #174 or this branch can replace the current #174 head.

## What changed

- preserve the MTP4 ladder `[5,10,20,40,80,160,320]`
- use disjoint CAR staging/signal storage per captured op for descriptors through `(80,16)`
- keep `(160,32)` and `(320,64)` on the standard graph collective
- contract-bound each DSV4 MTP4 CAR communicator buffer to 184 MiB instead of the global 512 MiB default
- keep eager and graph staging regions disjoint, including the signal/meta prefix
- validate the plan and capture ledger across TP ranks; fail closed on unsafe recapture
- retain the dedicated BS1 registered-input path; mixed registered/staging capture was tested and dropped after a native worker exit

## Driver 5.2 validation

Exact #174 MTP4 parameters, TP8 S5000, 4K input / 1K output, five warmups:

| BS | success | TTFT ms | TPOT ms | output tok/s |
|---:|---:|---:|---:|---:|
| 4 | 4/4 | 3270.60 | 21.43 | 143.86 |
| 16 | 16/16 | 11284.48 | 31.99 | 322.47 |
| 64 | 64/64 | 42307.21 | 80.18 | 489.15 |

BS64 produced 65,536/65,536 tokens with no OOM or communication failure. KV capacity stayed at 66,943 tokens; ready-state free memory increased from about 1.07 GiB to 4.99 GiB per GPU.

2K/64 report parity, three repeats each:

- BS1 mean TTFT/TPOT: 426.04/11.21 ms (report: 440.21/11.81)
- BS4 mean TTFT/TPOT: 1211.05/27.34 ms (report: 1260.43/30.22)

Dedicated `max_num_seqs=1`, capture-size-5 registered-input 4K/1K also passed.

## Tests

- `167 passed, 2 skipped` for patch + contract + CAR graph regression
- local source/contract slice: `59 passed, 1 skipped`
- `ruff check` and `git diff --check` pass

This remains draft pending #174 review and integration.