### PR TITLE
perf(musa): optimize Qwen3.5 decode and multimodal encoder paths

### DIFF
--- a/tests/jit_kernel/test_qwen3_qk_cache_out_wrapper.py
+++ b/tests/jit_kernel/test_qwen3_qk_cache_out_wrapper.py
@@ -127,11 +127,17 @@ def test_qwen35_cache_out_matches_no_cache_across_page_boundaries(
         torch.bfloat16
     )
     sentinel = -9.0
-    key_cache = torch.full(
-        (160, kv_heads * head_dim), sentinel, device=device, dtype=torch.bfloat16
+    block_size = 64
+    interleaved_storage = torch.full(
+        (3, 3, 2, block_size, kv_heads, head_dim),
+        sentinel,
+        device=device,
+        dtype=torch.bfloat16,
     )
-    value_cache = torch.full_like(key_cache, sentinel)
-    touched: set[int] = set()
+    key_cache = interleaved_storage[:, 1, 0]
+    value_cache = interleaved_storage[:, 1, 1]
+    expected_key = key_cache.clone()
+    expected_value = value_cache.clone()
 
     first_slots = [63 + index for index in range(tokens)]
     if tokens > 1:
@@ -196,17 +202,12 @@ def test_qwen35_cache_out_matches_no_cache_across_page_boundaries(
         torch.testing.assert_close(k_out, k_ref)
         for token, slot in enumerate(slot_values):
             if slot >= 0:
-                touched.add(slot)
-                torch.testing.assert_close(key_cache[slot], k_out[token].reshape(-1))
-                torch.testing.assert_close(value_cache[slot], v[token].reshape(-1))
+                block, offset = divmod(slot, block_size)
+                expected_key[block, offset].copy_(k_out[token])
+                expected_value[block, offset].copy_(v[token])
 
-    untouched = sorted(set(range(key_cache.shape[0])) - touched)
-    torch.testing.assert_close(
-        key_cache[untouched], torch.full_like(key_cache[untouched], sentinel)
-    )
-    torch.testing.assert_close(
-        value_cache[untouched], torch.full_like(value_cache[untouched], sentinel)
-    )
+    torch.testing.assert_close(key_cache, expected_key)
+    torch.testing.assert_close(value_cache, expected_value)
 
 
 def test_qwen3_hnd_runtime_falls_back_before_cache_view(monkeypatch) -> None:

--- a/tests/jit_kernel/test_qwen3_qk_cache_out_wrapper.py
+++ b/tests/jit_kernel/test_qwen3_qk_cache_out_wrapper.py
@@ -109,6 +109,106 @@ def test_qwen3_cache_out_wrapper_registers_and_preserves_padding(q_heads: int) -
     assert torch.equal(value_cache[1:], torch.full_like(value_cache[1:], sentinel))
 
 
+@pytest.mark.parametrize("tokens", [1, 2, 8, 16])
+def test_qwen35_cache_out_matches_no_cache_across_page_boundaries(
+    tokens: int,
+) -> None:
+    from vllm_musa.jit_kernel.csrc.norm import (
+        fused_qk_rmsnorm_mrope,
+        fused_qk_rmsnorm_mrope_cache_out,
+    )
+
+    device = torch.device("musa")
+    q_heads, kv_heads, head_dim, rot_dim = 32, 2, 256, 64
+    q_weight = torch.randn((head_dim,), device=device, dtype=torch.bfloat16)
+    k_weight = torch.randn((head_dim,), device=device, dtype=torch.bfloat16)
+    angles = torch.randn((128, rot_dim // 2), device=device, dtype=torch.float32)
+    cos_sin_cache = torch.cat((angles.cos(), angles.sin()), dim=-1).to(
+        torch.bfloat16
+    )
+    sentinel = -9.0
+    key_cache = torch.full(
+        (160, kv_heads * head_dim), sentinel, device=device, dtype=torch.bfloat16
+    )
+    value_cache = torch.full_like(key_cache, sentinel)
+    touched: set[int] = set()
+
+    first_slots = [63 + index for index in range(tokens)]
+    if tokens > 1:
+        first_slots[-1] = -1
+    second_slots = [127 - index for index in range(tokens)]
+    second_slots[0] = first_slots[0]
+    for step, slot_values in enumerate((first_slots, second_slots)):
+        q = torch.randn(
+            (tokens, q_heads, head_dim), device=device, dtype=torch.bfloat16
+        )
+        k = torch.randn(
+            (tokens, kv_heads, head_dim), device=device, dtype=torch.bfloat16
+        )
+        v = torch.randn_like(k)
+        positions = (
+            torch.arange(step * tokens, (step + 1) * tokens, device=device)
+            .to(torch.int64)
+            .repeat(3, 1)
+        )
+        slots = torch.tensor(slot_values, device=device, dtype=torch.int32)
+        q_ref, k_ref = fused_qk_rmsnorm_mrope(
+            q,
+            k,
+            q_weight,
+            k_weight,
+            positions,
+            cos_sin_cache,
+            True,
+            11,
+            11,
+            10,
+            True,
+            1e-6,
+            True,
+        )
+        q_out = torch.empty_like(q)
+        k_out = torch.empty_like(k)
+        fused_qk_rmsnorm_mrope_cache_out(
+            q,
+            k,
+            v,
+            q_weight,
+            k_weight,
+            positions,
+            cos_sin_cache,
+            q_out,
+            k_out,
+            key_cache,
+            value_cache,
+            slots,
+            True,
+            11,
+            11,
+            10,
+            True,
+            1e-6,
+            True,
+        )
+        torch.musa.synchronize()
+
+        torch.testing.assert_close(q_out, q_ref)
+        torch.testing.assert_close(k_out, k_ref)
+        for token, slot in enumerate(slot_values):
+            if slot >= 0:
+                touched.add(slot)
+                torch.testing.assert_close(key_cache[slot], k_out[token].reshape(-1))
+                torch.testing.assert_close(value_cache[slot], v[token].reshape(-1))
+
+    untouched = sorted(set(range(key_cache.shape[0])) - touched)
+    torch.testing.assert_close(
+        key_cache[untouched], torch.full_like(key_cache[untouched], sentinel)
+    )
+    torch.testing.assert_close(
+        value_cache[untouched], torch.full_like(value_cache[untouched], sentinel)
+    )
+
+
 def test_qwen3_hnd_runtime_falls_back_before_cache_view(monkeypatch) -> None:
     from vllm_musa.jit_kernel.csrc import norm
     from vllm_musa.v1.attention.backends import flash_attn

--- a/tests/test_moe_fused_shared_topk_router.py
+++ b/tests/test_moe_fused_shared_topk_router.py
@@ -75,7 +75,7 @@ def _run_contract_checks() -> None:
             hidden_states=hidden_states,
             gating_output=router_logits,
             topk=8,
-            renormalize=False,
+            renormalize=True,
             indices_type=None,
             scoring_func="softmax",
             shared_expert_gate_output=shared_logits,
@@ -89,7 +89,7 @@ def _run_contract_checks() -> None:
     assert fake_topk.calls == [
         {
             "shape": (2, 9),
-            "renormalize": False,
+            "renormalize": True,
             "correction_bias": None,
             "shared": shared_logits,
             "num_shared": 1,
@@ -109,7 +109,7 @@ def _run_contract_checks() -> None:
             side_effect=unexpected_import,
         ),
     ):
-        for experts, renormalize in ((255, False), (256, True)):
+        for experts, renormalize in ((255, False), (257, True)):
             result = grouped_router._musa_jit_fused_topk(
                 hidden_states=hidden_states,
                 gating_output=torch.empty(2, experts),

--- a/tests/test_moe_fused_shared_topk_router.py
+++ b/tests/test_moe_fused_shared_topk_router.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_contract_checks() -> None:
+    import importlib.util
+    from types import SimpleNamespace
+    from unittest import mock
+
+    package_root = REPO_ROOT / "vllm_musa"
+    spec = importlib.util.spec_from_file_location(
+        "vllm_musa",
+        package_root / "__init__.py",
+        submodule_search_locations=[str(package_root)],
+    )
+    assert spec is not None and spec.loader is not None
+    candidate = importlib.util.module_from_spec(spec)
+    sys.modules["vllm_musa"] = candidate
+    spec.loader.exec_module(candidate)
+
+    import torch
+
+    from vllm_musa.model_executor.layers.fused_moe.router import (
+        fused_topk_router as plain_router,
+    )
+    from vllm_musa.model_executor.layers.fused_moe.router import (
+        grouped_topk_router as grouped_router,
+    )
+
+    class FakeTopKModule:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def topk_softmax(
+            self,
+            topk_weights: torch.Tensor,
+            topk_ids: torch.Tensor,
+            gating_output: torch.Tensor,
+            renormalize: bool,
+            *,
+            correction_bias: torch.Tensor | None,
+            shared_expert_gate_output: torch.Tensor | None,
+            num_fused_shared_experts: int,
+        ) -> None:
+            self.calls.append(
+                {
+                    "shape": tuple(topk_weights.shape),
+                    "renormalize": renormalize,
+                    "correction_bias": correction_bias,
+                    "shared": shared_expert_gate_output,
+                    "num_shared": num_fused_shared_experts,
+                }
+            )
+
+    fake_topk = FakeTopKModule()
+    hidden_states = torch.empty(2, 3072)
+    router_logits = torch.empty(2, 256)
+    shared_logits = torch.empty(2, 1)
+    with (
+        mock.patch.object(
+            grouped_router, "_can_use_musa_jit_topk", return_value=True
+        ),
+        mock.patch.object(
+            grouped_router, "_maybe_import_musa_jit_topk", return_value=fake_topk
+        ),
+    ):
+        result = grouped_router._musa_jit_fused_topk(
+            hidden_states=hidden_states,
+            gating_output=router_logits,
+            topk=8,
+            renormalize=False,
+            indices_type=None,
+            scoring_func="softmax",
+            shared_expert_gate_output=shared_logits,
+            num_fused_shared_experts=1,
+        )
+
+    assert result is not None
+    topk_weights, topk_ids = result
+    assert topk_weights.shape == (2, 9)
+    assert topk_ids.shape == (2, 9)
+    assert fake_topk.calls == [
+        {
+            "shape": (2, 9),
+            "renormalize": False,
+            "correction_bias": None,
+            "shared": shared_logits,
+            "num_shared": 1,
+        }
+    ]
+
+    def unexpected_import() -> None:
+        raise AssertionError("unsupported shared shape must fall back")
+
+    with (
+        mock.patch.object(
+            grouped_router, "_can_use_musa_jit_topk", return_value=True
+        ),
+        mock.patch.object(
+            grouped_router,
+            "_maybe_import_musa_jit_topk",
+            side_effect=unexpected_import,
+        ),
+    ):
+        for experts, renormalize in ((255, False), (256, True)):
+            result = grouped_router._musa_jit_fused_topk(
+                hidden_states=hidden_states,
+                gating_output=torch.empty(2, experts),
+                topk=8,
+                renormalize=renormalize,
+                indices_type=None,
+                scoring_func="softmax",
+                shared_expert_gate_output=shared_logits,
+                num_fused_shared_experts=1,
+            )
+            assert result is None
+
+    gate_inputs: list[torch.Tensor] = []
+    jit_calls: list[dict[str, object]] = []
+
+    def shared_gate(states: torch.Tensor):
+        gate_inputs.append(states)
+        return shared_logits, None
+
+    expected = (torch.empty(2, 9), torch.empty(2, 9, dtype=torch.int32))
+
+    def fake_jit(**kwargs):
+        jit_calls.append(kwargs)
+        return expected
+
+    router = SimpleNamespace(
+        top_k=8,
+        renormalize=False,
+        scoring_func="softmax",
+        _musa_shared_gate=shared_gate,
+        _musa_shared_expert_id=256,
+    )
+    with mock.patch.object(plain_router, "_musa_jit_fused_topk", fake_jit):
+        result = plain_router._compute_routing(
+            router,
+            hidden_states,
+            router_logits,
+            None,
+        )
+
+    assert result is expected
+    assert gate_inputs == [hidden_states]
+    assert len(jit_calls) == 1
+    assert jit_calls[0]["shared_expert_gate_output"] is shared_logits
+    assert jit_calls[0]["num_fused_shared_experts"] == 1
+
+    routed_weights = torch.empty(2, 8)
+    routed_ids = torch.empty(2, 8, dtype=torch.int32)
+    extended = (torch.empty(2, 9), torch.empty(2, 9, dtype=torch.int32))
+    extension_calls: list[tuple[object, ...]] = []
+
+    def fake_extend(*args):
+        extension_calls.append(args)
+        return extended
+
+    router = SimpleNamespace(
+        top_k=8,
+        renormalize=False,
+        scoring_func="softmax",
+        _musa_shared_gate=lambda states: (shared_logits, None),
+        _musa_shared_expert_id=256,
+    )
+    with (
+        mock.patch.object(plain_router, "_musa_jit_fused_topk", return_value=None),
+        mock.patch.object(
+            plain_router,
+            "fused_topk",
+            return_value=(routed_weights, routed_ids, None),
+        ),
+        mock.patch.object(plain_router, "extend_topk_with_shared", fake_extend),
+    ):
+        result = plain_router._compute_routing(
+            router,
+            hidden_states,
+            router_logits,
+            None,
+        )
+
+    assert result[0] is extended[0]
+    assert result[1] is extended[1]
+    assert extension_calls == [(routed_weights, routed_ids, shared_logits, 256)]
+
+
+def test_router_contract_in_isolated_process() -> None:
+    env = os.environ.copy()
+    env["VLLM_PLUGINS"] = ""
+    subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), "--child"],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] != ["--child"]:
+        raise SystemExit("expected --child")
+    _run_contract_checks()

--- a/tests/test_moe_fused_shared_topk_source.py
+++ b/tests/test_moe_fused_shared_topk_source.py
@@ -41,6 +41,8 @@ def test_jit_topk_writes_shared_column_with_input_dtype_rounding() -> None:
     assert "const SharedT shared_weight" in source
     assert "from_float<SharedT>(stable_sigmoid" in source
     assert "topk_ids[shared_out_idx] = NumExperts" in source
+    assert "if (renormalize)" in source
+    assert "TVM_FFI_ICHECK(!renormalize)" not in source
 
 
 def test_fused_shared_topk_preserves_bf16_sigmoid_rounding() -> None:

--- a/tests/test_moe_fused_shared_topk_source.py
+++ b/tests/test_moe_fused_shared_topk_source.py
@@ -6,7 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_unquantized_moe_uses_fused_shared_topk_extension() -> None:
+def test_unquantized_moe_keeps_shared_topk_extension_fallback() -> None:
     source = (
         REPO_ROOT
         / "vllm_musa/model_executor/layers/fused_moe/"
@@ -17,6 +17,30 @@ def test_unquantized_moe_uses_fused_shared_topk_extension() -> None:
     assert "topk_weights, topk_ids = extend_topk_with_shared(" in source
     assert "VLLM_MUSA_MOE_FUSED_SHARED_TOPK" not in source
     assert "torch.cat([topk_weights, shared_weight]" not in source
+
+
+def test_plain_router_moves_shared_gate_before_jit_topk() -> None:
+    source = (
+        REPO_ROOT
+        / "vllm_musa/model_executor/layers/fused_moe/router/"
+        "fused_topk_router.py"
+    ).read_text()
+
+    assert 'shared_gate = getattr(self, "_musa_shared_gate", None)' in source
+    assert "shared_logits, _ = shared_gate(hidden_states)" in source
+    assert "shared_expert_gate_output=shared_logits" in source
+    assert "num_fused_shared_experts=1 if shared_logits is not None else 0" in source
+
+
+def test_jit_topk_writes_shared_column_with_input_dtype_rounding() -> None:
+    source = (
+        REPO_ROOT / "vllm_musa/jit_kernel/csrc/topk/topk_gating.mu"
+    ).read_text()
+
+    assert "topk_softmax_no_bias_warp_shared1_kernel_fixed_k" in source
+    assert "const SharedT shared_weight" in source
+    assert "from_float<SharedT>(stable_sigmoid" in source
+    assert "topk_ids[shared_out_idx] = NumExperts" in source
 
 
 def test_fused_shared_topk_preserves_bf16_sigmoid_rounding() -> None:
@@ -42,3 +66,13 @@ def test_qwen35_tp_only_fold_uses_explicit_ep_setting() -> None:
 
     assert "+            and not parallel_config.enable_expert_parallel" in patch
     assert "-            and self.ep_size <= 1" in patch
+
+
+def test_qwen35_fold_stashes_owning_router() -> None:
+    patch = (
+        REPO_ROOT
+        / "vllm_musa/patches/series/"
+        "0105-MUSA-bind-qwen35-shared-gate-to-router.patch"
+    ).read_text()
+
+    assert "+            routed._musa_shared_router = self.experts.router" in patch

--- a/tests/test_moe_fused_shared_topk_source.py
+++ b/tests/test_moe_fused_shared_topk_source.py
@@ -31,3 +31,14 @@ def test_fused_shared_topk_has_no_runtime_gate() -> None:
     source = (REPO_ROOT / "vllm_musa/utils/environ.py").read_text()
 
     assert "VLLM_MUSA_MOE_FUSED_SHARED_TOPK" not in source
+
+
+def test_qwen35_tp_only_fold_uses_explicit_ep_setting() -> None:
+    patch = (
+        REPO_ROOT
+        / "vllm_musa/patches/series/"
+        "0104-MUSA-enable-qwen35-shared-fold-tp-only.patch"
+    ).read_text()
+
+    assert "+            and not parallel_config.enable_expert_parallel" in patch
+    assert "-            and self.ep_size <= 1" in patch

--- a/tests/test_musa.py
+++ b/tests/test_musa.py
@@ -432,19 +432,31 @@ class TestMUSAPlatformBase:
             )
         )
 
-    @pytest.mark.parametrize(("layout", "expected"), [("NHD", True), ("HND", False)])
+    @pytest.mark.parametrize(
+        ("layout", "shape", "expected"),
+        [
+            ("NHD", (16, 8, 128), True),
+            ("NHD", (32, 8, 128), True),
+            ("NHD", (4, 1, 256), True),
+            ("NHD", (32, 2, 256), True),
+            ("HND", (32, 2, 256), False),
+            ("NHD", (32, 4, 256), False),
+        ],
+    )
     def test_qwen3_qk_rope_kv_provider_layout_gate(
         self,
         monkeypatch,
         layout: str,
+        shape: tuple[int, int, int],
         expected: bool,
     ) -> None:
         from vllm_musa.v1.attention.backends import flash_attn
 
+        num_heads, num_kv_heads, head_size = shape
         impl = SimpleNamespace(
-            num_heads=16,
-            num_kv_heads=8,
-            head_size=128,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
             attn_type=flash_attn.AttentionType.DECODER,
             kv_cache_dtype="auto",
             alibi_slopes=None,

--- a/vllm_musa/jit_kernel/csrc/norm/qk_mrope.mu
+++ b/vllm_musa/jit_kernel/csrc/norm/qk_mrope.mu
@@ -92,8 +92,8 @@ void check_fused_qk_mrope_cache_inputs(
   TVM_FFI_ICHECK_EQ(k.ndim(), 3);
   TVM_FFI_ICHECK_EQ(v.ndim(), 3);
   TVM_FFI_ICHECK_EQ(q_out.ndim(), 3);
-  TVM_FFI_ICHECK_EQ(k_cache.ndim(), 2);
-  TVM_FFI_ICHECK_EQ(v_cache.ndim(), 2);
+  TVM_FFI_ICHECK(k_cache.ndim() == 2 || k_cache.ndim() == 4);
+  TVM_FFI_ICHECK_EQ(v_cache.ndim(), k_cache.ndim());
   TVM_FFI_ICHECK_EQ(positions.ndim(), 2);
   TVM_FFI_ICHECK_EQ(indices.ndim(), 1);
   TVM_FFI_ICHECK_EQ(positions.size(0), 3);
@@ -109,8 +109,17 @@ void check_fused_qk_mrope_cache_inputs(
   TVM_FFI_ICHECK_GT(cos_sin_cache.size(1), 0);
   TVM_FFI_ICHECK_LE(cos_sin_cache.size(1), q.size(2));
   TVM_FFI_ICHECK_EQ(cos_sin_cache.size(1) % 2, 0);
-  TVM_FFI_ICHECK_EQ(k_cache.size(1), k.size(1) * k.size(2));
-  TVM_FFI_ICHECK_EQ(v_cache.size(1), v.size(1) * v.size(2));
+  if (k_cache.ndim() == 2) {
+    TVM_FFI_ICHECK_EQ(k_cache.size(1), k.size(1) * k.size(2));
+    TVM_FFI_ICHECK_EQ(v_cache.size(1), v.size(1) * v.size(2));
+  } else {
+    TVM_FFI_ICHECK_EQ(k_cache.size(0), v_cache.size(0));
+    TVM_FFI_ICHECK_EQ(k_cache.size(1), v_cache.size(1));
+    TVM_FFI_ICHECK_EQ(k_cache.size(2), k.size(1));
+    TVM_FFI_ICHECK_EQ(v_cache.size(2), v.size(1));
+    TVM_FFI_ICHECK_EQ(k_cache.size(3), k.size(2));
+    TVM_FFI_ICHECK_EQ(v_cache.size(3), v.size(2));
+  }
   TVM_FFI_ICHECK_EQ(q_out.size(0), q.size(0));
   TVM_FFI_ICHECK_EQ(q_out.size(1), q.size(1));
   TVM_FFI_ICHECK_EQ(q_out.size(2), q.size(2));
@@ -118,8 +127,17 @@ void check_fused_qk_mrope_cache_inputs(
   TVM_FFI_ICHECK_EQ(k.stride(2), 1);
   TVM_FFI_ICHECK_EQ(v.stride(2), 1);
   TVM_FFI_ICHECK_EQ(q_out.stride(2), 1);
-  TVM_FFI_ICHECK_EQ(k_cache.stride(1), 1);
-  TVM_FFI_ICHECK_EQ(v_cache.stride(1), 1);
+  if (k_cache.ndim() == 2) {
+    TVM_FFI_ICHECK_EQ(k_cache.stride(1), 1);
+    TVM_FFI_ICHECK_EQ(v_cache.stride(1), 1);
+  } else {
+    TVM_FFI_ICHECK_EQ(k_cache.stride(3), 1);
+    TVM_FFI_ICHECK_EQ(v_cache.stride(3), 1);
+    TVM_FFI_ICHECK_EQ(k_cache.stride(2), k_cache.size(3));
+    TVM_FFI_ICHECK_EQ(v_cache.stride(2), v_cache.size(3));
+    TVM_FFI_ICHECK_EQ(k_cache.stride(1), k_cache.size(2) * k_cache.size(3));
+    TVM_FFI_ICHECK_EQ(v_cache.stride(1), v_cache.size(2) * v_cache.size(3));
+  }
   TVM_FFI_ICHECK_EQ(cos_sin_cache.stride(1), 1);
   TVM_FFI_ICHECK_EQ(q.device().device_id, k.device().device_id);
   TVM_FFI_ICHECK_EQ(q.device().device_id, v.device().device_id);
@@ -871,7 +889,9 @@ __global__ void fused_qk_rmsnorm_mrope_cache_h256r64_bf16_kernel(
     int64_t k_head_stride, int64_t v_batch_stride, int64_t v_head_stride,
     int64_t q_out_batch_stride, int64_t q_out_head_stride,
     int64_t k_out_batch_stride, int64_t k_out_head_stride,
-    int64_t k_cache_row_stride, int64_t v_cache_row_stride,
+    int cache_block_size, int64_t k_cache_block_stride,
+    int64_t k_cache_token_stride, int64_t v_cache_block_stride,
+    int64_t v_cache_token_stride,
     int64_t indices_stride, float eps) {
   constexpr int hidden = 256;
   constexpr int embed_dim = 32;
@@ -892,13 +912,21 @@ __global__ void fused_qk_rmsnorm_mrope_cache_h256r64_bf16_kernel(
   const int64_t cache_idx =
       static_cast<int64_t>(indices[(int64_t)token * indices_stride]);
   const bool write_cache = cache_idx >= 0;
+  const int64_t cache_block =
+      cache_block_size > 0 ? cache_idx / cache_block_size : 0;
+  const int64_t cache_token =
+      cache_block_size > 0 ? cache_idx % cache_block_size : cache_idx;
+  const int64_t k_cache_base =
+      cache_block * k_cache_block_stride + cache_token * k_cache_token_stride;
+  const int64_t v_cache_base =
+      cache_block * v_cache_block_stride + cache_token * v_cache_token_stride;
 
   if (group == 0 && write_cache) {
     constexpr int kVec = 8;
     constexpr int row_dim = K_HEADS * hidden;
     constexpr int vec_count = row_dim / kVec;
     const int64_t v_token_base = (int64_t)token * v_batch_stride;
-    const int64_t v_out_base = cache_idx * v_cache_row_stride;
+    const int64_t v_out_base = v_cache_base;
     for (int vec_idx = tid; vec_idx < vec_count; vec_idx += (int)blockDim.x) {
       const int head = vec_idx >> 5;
       const int col = (vec_idx & 31) * kVec;
@@ -978,16 +1006,15 @@ __global__ void fused_qk_rmsnorm_mrope_cache_h256r64_bf16_kernel(
     q_out[q_out_base + lane + 224] = out_7;
   } else {
     if (write_cache) {
-      const int64_t k_cache_base =
-          cache_idx * k_cache_row_stride + (int64_t)head * hidden;
-      k_cache[k_cache_base + lane] = x_rot;
-      k_cache[k_cache_base + lane + 32] = y_rot;
-      k_cache[k_cache_base + lane + 64] = out_2;
-      k_cache[k_cache_base + lane + 96] = out_3;
-      k_cache[k_cache_base + lane + 128] = out_4;
-      k_cache[k_cache_base + lane + 160] = out_5;
-      k_cache[k_cache_base + lane + 192] = out_6;
-      k_cache[k_cache_base + lane + 224] = out_7;
+      const int64_t head_cache_base = k_cache_base + (int64_t)head * hidden;
+      k_cache[head_cache_base + lane] = x_rot;
+      k_cache[head_cache_base + lane + 32] = y_rot;
+      k_cache[head_cache_base + lane + 64] = out_2;
+      k_cache[head_cache_base + lane + 96] = out_3;
+      k_cache[head_cache_base + lane + 128] = out_4;
+      k_cache[head_cache_base + lane + 160] = out_5;
+      k_cache[head_cache_base + lane + 192] = out_6;
+      k_cache[head_cache_base + lane + 224] = out_7;
     }
     if constexpr (STORE_K_OUT) {
       const int64_t k_out_base = (int64_t)token * k_out_batch_stride +
@@ -2235,7 +2262,7 @@ void launch_h256r64_mrope_cache_kernel(
           static_cast<int64_t>(v.stride(0)), static_cast<int64_t>(v.stride(1)),
           static_cast<int64_t>(q_out.stride(0)),
           static_cast<int64_t>(q_out.stride(1)), 0, 0,
-          static_cast<int64_t>(k_cache.stride(0)),
+          0, 0, static_cast<int64_t>(k_cache.stride(0)), 0,
           static_cast<int64_t>(v_cache.stride(0)),
           static_cast<int64_t>(indices.stride(0)), eps);
 }
@@ -2252,6 +2279,14 @@ void launch_h256r64_mrope_cache_out_kernel(
   constexpr int threads = 32 * heads_per_block;
   constexpr int groups_per_token =
       (Q_HEADS + K_HEADS + heads_per_block - 1) / heads_per_block;
+  const int cache_block_size =
+      k_cache.ndim() == 4 ? static_cast<int>(k_cache.size(1)) : 0;
+  const int64_t k_cache_token_stride =
+      k_cache.ndim() == 4 ? static_cast<int64_t>(k_cache.stride(1))
+                          : static_cast<int64_t>(k_cache.stride(0));
+  const int64_t v_cache_token_stride =
+      v_cache.ndim() == 4 ? static_cast<int64_t>(v_cache.stride(1))
+                          : static_cast<int64_t>(v_cache.stride(0));
   fused_qk_rmsnorm_mrope_cache_h256r64_bf16_kernel<
       index_t, Q_HEADS, K_HEADS, HEADS_PER_BLOCK>
       <<<batch * groups_per_token, threads, 0, stream>>>(
@@ -2275,8 +2310,9 @@ void launch_h256r64_mrope_cache_out_kernel(
           static_cast<int64_t>(q_out.stride(1)),
           static_cast<int64_t>(k_out.stride(0)),
           static_cast<int64_t>(k_out.stride(1)),
-          static_cast<int64_t>(k_cache.stride(0)),
-          static_cast<int64_t>(v_cache.stride(0)),
+          cache_block_size, static_cast<int64_t>(k_cache.stride(0)),
+          k_cache_token_stride, static_cast<int64_t>(v_cache.stride(0)),
+          v_cache_token_stride,
           static_cast<int64_t>(indices.stride(0)), eps);
 }
 
@@ -2681,6 +2717,8 @@ void launch_fused_qk_rmsnorm_mrope_cache_out_bf16(
       gemma && is_interleaved && hidden == 256 && rot_dim == 64 &&
       mrope_section_t == 11 && mrope_section_h == 11 &&
       mrope_section_w == 10;
+  TVM_FFI_ICHECK(k_cache.ndim() == 2 || use_h256r64_mrope_specialization)
+      << "paged cache-out requires the h256r64 specialization";
   if (use_h256r64_mrope_specialization) {
     if (q_heads == 4 && k_heads == 1) {
       launch_h256r64_mrope_cache_out_kernel<index_t, 4, 1>(

--- a/vllm_musa/jit_kernel/csrc/topk.py
+++ b/vllm_musa/jit_kernel/csrc/topk.py
@@ -24,9 +24,19 @@ def _topk_softmax_impl(
     renormalize: bool = False,
     moe_softcapping: float = 0.0,
     correction_bias: Optional[torch.Tensor] = None,
+    shared_expert_gate_output: Optional[torch.Tensor] = None,
+    num_fused_shared_experts: int = 0,
 ) -> None:
     has_correction_bias = correction_bias is not None
     bias_arg = correction_bias if has_correction_bias else topk_weights.reshape(-1)
+    has_shared_experts = (
+        shared_expert_gate_output is not None and num_fused_shared_experts > 0
+    )
+    shared_arg = (
+        shared_expert_gate_output
+        if has_shared_experts
+        else topk_weights.reshape(-1)
+    )
     _topk_module().sgl_musa_topk_softmax(
         topk_weights,
         topk_ids,
@@ -35,6 +45,9 @@ def _topk_softmax_impl(
         float(moe_softcapping),
         bias_arg,
         bool(has_correction_bias),
+        shared_arg,
+        int(num_fused_shared_experts),
+        bool(has_shared_experts),
     )
 
 
@@ -44,9 +57,19 @@ def _topk_sigmoid_impl(
     gating_output: torch.Tensor,
     renormalize: bool = False,
     correction_bias: Optional[torch.Tensor] = None,
+    shared_expert_gate_output: Optional[torch.Tensor] = None,
+    num_fused_shared_experts: int = 0,
 ) -> None:
     has_correction_bias = correction_bias is not None
     bias_arg = correction_bias if has_correction_bias else topk_weights.reshape(-1)
+    has_shared_experts = (
+        shared_expert_gate_output is not None and num_fused_shared_experts > 0
+    )
+    shared_arg = (
+        shared_expert_gate_output
+        if has_shared_experts
+        else topk_weights.reshape(-1)
+    )
     _topk_module().sgl_musa_topk_sigmoid(
         topk_weights,
         topk_ids,
@@ -54,6 +77,9 @@ def _topk_sigmoid_impl(
         bool(renormalize),
         bias_arg,
         bool(has_correction_bias),
+        shared_arg,
+        int(num_fused_shared_experts),
+        bool(has_shared_experts),
     )
 
 
@@ -62,11 +88,19 @@ def _topk_softmax_custom(
     topk_ids: torch.Tensor,
     gating_output: torch.Tensor,
     correction_bias: torch.Tensor,
+    shared_expert_gate_output: torch.Tensor,
     renormalize: bool = False,
     moe_softcapping: float = 0.0,
     has_correction_bias: bool = False,
+    num_fused_shared_experts: int = 0,
+    has_shared_experts: bool = False,
 ) -> None:
     bias_arg = correction_bias if has_correction_bias else topk_weights.reshape(-1)
+    shared_arg = (
+        shared_expert_gate_output
+        if has_shared_experts
+        else topk_weights.reshape(-1)
+    )
     _topk_module().sgl_musa_topk_softmax(
         topk_weights,
         topk_ids,
@@ -75,6 +109,9 @@ def _topk_softmax_custom(
         float(moe_softcapping),
         bias_arg,
         bool(has_correction_bias),
+        shared_arg,
+        int(num_fused_shared_experts),
+        bool(has_shared_experts),
     )
 
 
@@ -83,9 +120,12 @@ def _topk_softmax_custom_fake(
     topk_ids: torch.Tensor,
     gating_output: torch.Tensor,
     correction_bias: torch.Tensor,
+    shared_expert_gate_output: torch.Tensor,
     renormalize: bool = False,
     moe_softcapping: float = 0.0,
     has_correction_bias: bool = False,
+    num_fused_shared_experts: int = 0,
+    has_shared_experts: bool = False,
 ) -> None:
     return
 
@@ -95,10 +135,18 @@ def _topk_sigmoid_custom(
     topk_ids: torch.Tensor,
     gating_output: torch.Tensor,
     correction_bias: torch.Tensor,
+    shared_expert_gate_output: torch.Tensor,
     renormalize: bool = False,
     has_correction_bias: bool = False,
+    num_fused_shared_experts: int = 0,
+    has_shared_experts: bool = False,
 ) -> None:
     bias_arg = correction_bias if has_correction_bias else topk_weights.reshape(-1)
+    shared_arg = (
+        shared_expert_gate_output
+        if has_shared_experts
+        else topk_weights.reshape(-1)
+    )
     _topk_module().sgl_musa_topk_sigmoid(
         topk_weights,
         topk_ids,
@@ -106,6 +154,9 @@ def _topk_sigmoid_custom(
         bool(renormalize),
         bias_arg,
         bool(has_correction_bias),
+        shared_arg,
+        int(num_fused_shared_experts),
+        bool(has_shared_experts),
     )
 
 
@@ -114,8 +165,11 @@ def _topk_sigmoid_custom_fake(
     topk_ids: torch.Tensor,
     gating_output: torch.Tensor,
     correction_bias: torch.Tensor,
+    shared_expert_gate_output: torch.Tensor,
     renormalize: bool = False,
     has_correction_bias: bool = False,
+    num_fused_shared_experts: int = 0,
+    has_shared_experts: bool = False,
 ) -> None:
     return
 
@@ -142,18 +196,31 @@ def topk_softmax(
     renormalize: bool = False,
     moe_softcapping: float = 0.0,
     correction_bias: Optional[torch.Tensor] = None,
+    shared_expert_gate_output: Optional[torch.Tensor] = None,
+    num_fused_shared_experts: int = 0,
 ) -> None:
     """sgl_kernel-compatible top-k softmax entry point."""
     has_correction_bias = correction_bias is not None
     bias_arg = correction_bias if has_correction_bias else topk_weights.reshape(-1)
+    has_shared_experts = (
+        shared_expert_gate_output is not None and num_fused_shared_experts > 0
+    )
+    shared_arg = (
+        shared_expert_gate_output
+        if has_shared_experts
+        else topk_weights.reshape(-1)
+    )
     torch.ops.vllm.musa_topk_softmax(
         topk_weights,
         topk_ids,
         gating_output,
         bias_arg,
+        shared_arg,
         renormalize,
         moe_softcapping,
         has_correction_bias,
+        num_fused_shared_experts,
+        has_shared_experts,
     )
 
 
@@ -163,14 +230,27 @@ def topk_sigmoid(
     gating_output: torch.Tensor,
     renormalize: bool = False,
     correction_bias: Optional[torch.Tensor] = None,
+    shared_expert_gate_output: Optional[torch.Tensor] = None,
+    num_fused_shared_experts: int = 0,
 ) -> None:
     has_correction_bias = correction_bias is not None
     bias_arg = correction_bias if has_correction_bias else topk_weights.reshape(-1)
+    has_shared_experts = (
+        shared_expert_gate_output is not None and num_fused_shared_experts > 0
+    )
+    shared_arg = (
+        shared_expert_gate_output
+        if has_shared_experts
+        else topk_weights.reshape(-1)
+    )
     torch.ops.vllm.musa_topk_sigmoid(
         topk_weights,
         topk_ids,
         gating_output,
         bias_arg,
+        shared_arg,
         renormalize,
         has_correction_bias,
+        num_fused_shared_experts,
+        has_shared_experts,
     )

--- a/vllm_musa/jit_kernel/csrc/topk/topk_gating.mu
+++ b/vllm_musa/jit_kernel/csrc/topk/topk_gating.mu
@@ -366,6 +366,95 @@ __global__ __launch_bounds__(
   }
 }
 
+template <typename T, typename SharedT, int NumExperts, int ValuesPerThread,
+          int TopK>
+__global__
+__launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_softmax_no_bias_warp_shared1_kernel_fixed_k(
+    const T *__restrict__ gating_output,
+    const SharedT *__restrict__ shared_gate_output,
+    float *__restrict__ topk_weights, int32_t *__restrict__ topk_ids,
+    int num_tokens, bool renormalize) {
+  constexpr int OutTopK = TopK + 1;
+  const int tid = threadIdx.x;
+  const int warp_id = tid / kWarpSize;
+  const int lane = lane_id();
+  const int row = blockIdx.x * kWarpsPerCta + warp_id;
+  if (row >= num_tokens) {
+    return;
+  }
+
+  float probs[ValuesPerThread];
+  float thread_max = kFloatMinimum;
+
+#pragma unroll
+  for (int i = 0; i < ValuesPerThread; ++i) {
+    const int expert = lane + i * kWarpSize;
+    const float val = to_float(gating_output[row * NumExperts + expert]);
+    probs[i] = val;
+    thread_max = fmaxf(thread_max, val);
+  }
+
+  const float row_max = warp_max(thread_max);
+  float thread_sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < ValuesPerThread; ++i) {
+    probs[i] = __expf(probs[i] - row_max);
+    thread_sum += probs[i];
+  }
+  const float inv_row_sum = 1.0f / warp_sum(thread_sum);
+#pragma unroll
+  for (int i = 0; i < ValuesPerThread; ++i) {
+    probs[i] *= inv_row_sum;
+  }
+
+  float selected_sum = 0.0f;
+#pragma unroll
+  for (int k_idx = 0; k_idx < TopK; ++k_idx) {
+    float max_val = probs[0];
+    int max_idx = lane;
+#pragma unroll
+    for (int i = 1; i < ValuesPerThread; ++i) {
+      const int expert = lane + i * kWarpSize;
+      const float val = probs[i];
+      if (val > max_val) {
+        max_val = val;
+        max_idx = expert;
+      }
+    }
+    warp_argmax(max_val, max_idx);
+
+    if (lane == 0) {
+      const int out_idx = row * OutTopK + k_idx;
+      topk_weights[out_idx] = max_val;
+      topk_ids[out_idx] = max_idx;
+      selected_sum += max_val;
+    }
+
+#pragma unroll
+    for (int i = 0; i < ValuesPerThread; ++i) {
+      const int expert = lane + i * kWarpSize;
+      if (expert == max_idx) {
+        probs[i] = kFloatMinimum;
+      }
+    }
+  }
+
+  if (lane == 0) {
+    if (renormalize) {
+      const float inv_selected_sum = 1.0f / selected_sum;
+#pragma unroll
+      for (int k_idx = 0; k_idx < TopK; ++k_idx) {
+        topk_weights[row * OutTopK + k_idx] *= inv_selected_sum;
+      }
+    }
+    const int shared_out_idx = row * OutTopK + TopK;
+    const SharedT shared_weight =
+        from_float<SharedT>(stable_sigmoid(to_float(shared_gate_output[row])));
+    topk_weights[shared_out_idx] = to_float(shared_weight);
+    topk_ids[shared_out_idx] = NumExperts;
+  }
+}
+
 template <typename T, int NumExperts, int ValuesPerThread, int TopK>
 __global__
 __launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_softmax_no_bias_renorm_warp_kernel_fixed_k(
@@ -807,6 +896,33 @@ int next_power_of_2(int value) {
   return out;
 }
 
+template <typename T, typename SharedT>
+void launch_topk_shared1(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
+                         ffi::TensorView gating_output, bool renormalize,
+                         ffi::TensorView shared_gate_output) {
+  const int num_tokens = static_cast<int>(gating_output.size(0));
+  if (num_tokens == 0) {
+    return;
+  }
+
+  const T *input_ptr = static_cast<const T *>(gating_output.data_ptr());
+  const SharedT *shared_ptr =
+      static_cast<const SharedT *>(shared_gate_output.data_ptr());
+  float *weights_ptr = static_cast<float *>(topk_weights.data_ptr());
+  int32_t *ids_ptr = static_cast<int32_t *>(topk_ids.data_ptr());
+  ffi::MUSADeviceGuard device_guard(gating_output.device().device_id);
+  musaStream_t stream = get_stream(gating_output.device());
+  const int blocks = (num_tokens + kWarpsPerCta - 1) / kWarpsPerCta;
+  topk_softmax_no_bias_warp_shared1_kernel_fixed_k<T, SharedT, 256, 8, 8>
+      <<<blocks, kWarpsPerCta * kWarpSize, 0, stream>>>(
+          input_ptr, shared_ptr, weights_ptr, ids_ptr, num_tokens, renormalize);
+
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA topk fused shared-expert kernel failed: "
+      << musaGetErrorString(err);
+}
+
 template <typename T, bool IsSoftmax>
 void launch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
                  ffi::TensorView gating_output, bool renormalize,
@@ -869,7 +985,8 @@ void launch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
       if (topk == 8 && !has_correction_bias && moe_softcapping <= 0.0f) {
         if (renormalize) {
           // MUSA: e256 renorm goes one-warp-per-row, matching the e1024 path.
-          topk_softmax_no_bias_renorm_warp_kernel_fixed_k<T, 256, values_per_thread, 8>
+          topk_softmax_no_bias_renorm_warp_kernel_fixed_k<T, 256,
+                                                          values_per_thread, 8>
               <<<blocks, kWarpsPerCta * kWarpSize, 0, stream>>>(
                   input_ptr, weights_ptr, ids_ptr, num_tokens);
         } else {
@@ -989,7 +1106,9 @@ void launch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
 void check_topk_inputs(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
                        ffi::TensorView gating_output,
                        ffi::TensorView correction_bias,
-                       bool has_correction_bias) {
+                       bool has_correction_bias,
+                       ffi::TensorView shared_gate_output,
+                       int num_fused_shared_experts, bool has_shared_experts) {
   CHECK_MUSA_CONTIGUOUS(topk_weights);
   CHECK_MUSA_CONTIGUOUS(topk_ids);
   CHECK_MUSA_CONTIGUOUS(gating_output);
@@ -1003,7 +1122,12 @@ void check_topk_inputs(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
   TVM_FFI_ICHECK_EQ(topk_weights.size(0), gating_output.size(0));
   TVM_FFI_ICHECK_EQ(topk_ids.size(0), gating_output.size(0));
   TVM_FFI_ICHECK_EQ(topk_ids.size(1), topk_weights.size(1));
-  TVM_FFI_ICHECK_LE(topk_weights.size(1), gating_output.size(1));
+  const int routed_topk =
+      has_shared_experts
+          ? static_cast<int>(topk_weights.size(1)) - num_fused_shared_experts
+          : static_cast<int>(topk_weights.size(1));
+  TVM_FFI_ICHECK_GE(routed_topk, 0);
+  TVM_FFI_ICHECK_LE(routed_topk, gating_output.size(1));
   TVM_FFI_ICHECK_LE(gating_output.size(1), 1024);
   TVM_FFI_ICHECK(dtype_equal(topk_weights.dtype(), dl_float32));
   TVM_FFI_ICHECK(dtype_equal(topk_ids.dtype(), dl_int32));
@@ -1015,13 +1139,66 @@ void check_topk_inputs(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
     TVM_FFI_ICHECK_EQ(correction_bias.size(0), gating_output.size(1));
     TVM_FFI_ICHECK(dtype_equal(correction_bias.dtype(), dl_float32));
   }
+  if (has_shared_experts) {
+    CHECK_MUSA_CONTIGUOUS(shared_gate_output);
+    TVM_FFI_ICHECK_EQ(shared_gate_output.device().device_id,
+                      gating_output.device().device_id);
+    TVM_FFI_ICHECK_EQ(shared_gate_output.ndim(), 2);
+    TVM_FFI_ICHECK_EQ(shared_gate_output.size(0), gating_output.size(0));
+    TVM_FFI_ICHECK_EQ(shared_gate_output.size(1), 1);
+    TVM_FFI_ICHECK_EQ(num_fused_shared_experts, 1);
+    TVM_FFI_ICHECK_EQ(gating_output.size(1), 256);
+    TVM_FFI_ICHECK_EQ(routed_topk, 8);
+    TVM_FFI_ICHECK_EQ(topk_weights.size(1), 9);
+    TVM_FFI_ICHECK(dtype_equal(shared_gate_output.dtype(), dl_float32) ||
+                   dtype_equal(shared_gate_output.dtype(), dl_float16) ||
+                   dtype_equal(shared_gate_output.dtype(), dl_bfloat16));
+  }
 }
 
 template <bool IsSoftmax>
 void dispatch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
                    ffi::TensorView gating_output, bool renormalize,
                    float moe_softcapping, ffi::TensorView correction_bias,
-                   bool has_correction_bias) {
+                   bool has_correction_bias, ffi::TensorView shared_gate_output,
+                   int num_fused_shared_experts, bool has_shared_experts) {
+  if (has_shared_experts) {
+    if constexpr (!IsSoftmax) {
+      TVM_FFI_THROW(ValueError)
+          << "Fused shared-expert topk only supports softmax routing";
+    }
+    TVM_FFI_ICHECK(!has_correction_bias);
+    TVM_FFI_ICHECK(!renormalize);
+    TVM_FFI_ICHECK(moe_softcapping <= 0.0f);
+
+#define DISPATCH_SHARED(GateT)                                                 \
+  if (dtype_equal(shared_gate_output.dtype(), dl_float32)) {                   \
+    launch_topk_shared1<GateT, float>(topk_weights, topk_ids, gating_output,   \
+                                      renormalize, shared_gate_output);        \
+  } else if (dtype_equal(shared_gate_output.dtype(), dl_float16)) {            \
+    launch_topk_shared1<GateT, half>(topk_weights, topk_ids, gating_output,    \
+                                     renormalize, shared_gate_output);         \
+  } else if (dtype_equal(shared_gate_output.dtype(), dl_bfloat16)) {           \
+    launch_topk_shared1<GateT, __mt_bfloat16>(topk_weights, topk_ids,          \
+                                              gating_output, renormalize,      \
+                                              shared_gate_output);             \
+  } else {                                                                     \
+    TVM_FFI_THROW(ValueError) << "Unsupported shared_gate_output dtype";       \
+  }
+
+    if (dtype_equal(gating_output.dtype(), dl_float32)) {
+      DISPATCH_SHARED(float)
+    } else if (dtype_equal(gating_output.dtype(), dl_float16)) {
+      DISPATCH_SHARED(half)
+    } else if (dtype_equal(gating_output.dtype(), dl_bfloat16)) {
+      DISPATCH_SHARED(__mt_bfloat16)
+    } else {
+      TVM_FFI_THROW(ValueError) << "Unsupported gating_output dtype";
+    }
+#undef DISPATCH_SHARED
+    return;
+  }
+
   if (dtype_equal(gating_output.dtype(), dl_float32)) {
     launch_topk<float, IsSoftmax>(topk_weights, topk_ids, gating_output,
                                   renormalize, moe_softcapping, correction_bias,
@@ -1039,28 +1216,35 @@ void dispatch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
   }
 }
 
-void sgl_musa_topk_softmax(ffi::TensorView topk_weights,
-                           ffi::TensorView topk_ids,
-                           ffi::TensorView gating_output, bool renormalize,
-                           double moe_softcapping,
-                           ffi::TensorView correction_bias,
-                           bool has_correction_bias) {
+void sgl_musa_topk_softmax(
+    ffi::TensorView topk_weights, ffi::TensorView topk_ids,
+    ffi::TensorView gating_output, bool renormalize, double moe_softcapping,
+    ffi::TensorView correction_bias, bool has_correction_bias,
+    ffi::TensorView shared_gate_output, int num_fused_shared_experts,
+    bool has_shared_experts) {
   check_topk_inputs(topk_weights, topk_ids, gating_output, correction_bias,
-                    has_correction_bias);
+                    has_correction_bias, shared_gate_output,
+                    num_fused_shared_experts, has_shared_experts);
   dispatch_topk<true>(topk_weights, topk_ids, gating_output, renormalize,
                       static_cast<float>(moe_softcapping), correction_bias,
-                      has_correction_bias);
+                      has_correction_bias, shared_gate_output,
+                      num_fused_shared_experts, has_shared_experts);
 }
 
 void sgl_musa_topk_sigmoid(ffi::TensorView topk_weights,
                            ffi::TensorView topk_ids,
                            ffi::TensorView gating_output, bool renormalize,
                            ffi::TensorView correction_bias,
-                           bool has_correction_bias) {
+                           bool has_correction_bias,
+                           ffi::TensorView shared_gate_output,
+                           int num_fused_shared_experts,
+                           bool has_shared_experts) {
   check_topk_inputs(topk_weights, topk_ids, gating_output, correction_bias,
-                    has_correction_bias);
+                    has_correction_bias, shared_gate_output,
+                    num_fused_shared_experts, has_shared_experts);
   dispatch_topk<false>(topk_weights, topk_ids, gating_output, renormalize, 0.0f,
-                       correction_bias, has_correction_bias);
+                       correction_bias, has_correction_bias, shared_gate_output,
+                       num_fused_shared_experts, has_shared_experts);
 }
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_topk_softmax, sgl_musa_topk_softmax);

--- a/vllm_musa/jit_kernel/csrc/topk/topk_gating.mu
+++ b/vllm_musa/jit_kernel/csrc/topk/topk_gating.mu
@@ -1168,7 +1168,6 @@ void dispatch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
           << "Fused shared-expert topk only supports softmax routing";
     }
     TVM_FFI_ICHECK(!has_correction_bias);
-    TVM_FFI_ICHECK(!renormalize);
     TVM_FFI_ICHECK(moe_softcapping <= 0.0f);
 
 #define DISPATCH_SHARED(GateT)                                                 \

--- a/vllm_musa/kernels/qwen3_qk_rope_kv.py
+++ b/vllm_musa/kernels/qwen3_qk_rope_kv.py
@@ -22,6 +22,13 @@ def qwen3_qk_rope_and_unified_kv_cache_update_impl(
     cos_sin_cache: torch.Tensor,
     q_out: torch.Tensor,
     k_out: torch.Tensor,
+    is_neox: bool,
+    mrope_section_t: int,
+    mrope_section_h: int,
+    mrope_section_w: int,
+    is_interleaved: bool,
+    eps: float,
+    gemma: bool,
     layer_name: LayerNameType,
 ) -> torch.Tensor:
     """Populate Q/K outputs and the current layer's paged KV cache."""
@@ -40,6 +47,13 @@ def qwen3_qk_rope_and_unified_kv_cache_update_impl(
         k_out,
         kv_cache,
         layer_slot_mapping,
+        is_neox,
+        mrope_section_t,
+        mrope_section_h,
+        mrope_section_w,
+        is_interleaved,
+        eps,
+        gemma,
     )
     return torch.empty(0, device=kv_cache.device, dtype=kv_cache.dtype)
 
@@ -54,8 +68,33 @@ def qwen3_qk_rope_and_unified_kv_cache_update_fake(
     cos_sin_cache: torch.Tensor,
     q_out: torch.Tensor,
     k_out: torch.Tensor,
+    is_neox: bool,
+    mrope_section_t: int,
+    mrope_section_h: int,
+    mrope_section_w: int,
+    is_interleaved: bool,
+    eps: float,
+    gemma: bool,
     layer_name: LayerNameType,
 ) -> torch.Tensor:
+    del (
+        k,
+        v,
+        q_weight,
+        k_weight,
+        positions,
+        cos_sin_cache,
+        q_out,
+        k_out,
+        is_neox,
+        mrope_section_t,
+        mrope_section_h,
+        mrope_section_w,
+        is_interleaved,
+        eps,
+        gemma,
+        layer_name,
+    )
     return torch.empty(0, device=q.device, dtype=q.dtype)
 
 

--- a/vllm_musa/model_executor/__init__.py
+++ b/vllm_musa/model_executor/__init__.py
@@ -1,4 +1,5 @@
 import vllm_musa.model_executor.layers.activation
+import vllm_musa.model_executor.layers.attention.mm_encoder_attention
 import vllm_musa.model_executor.layers.fused_moe.fused_moe
 import vllm_musa.model_executor.layers.fused_moe.router.fused_topk_router
 import vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router

--- a/vllm_musa/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm_musa/model_executor/layers/attention/mm_encoder_attention.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import einops
+import numpy as np
+import torch
+from vllm.model_executor.layers.attention.mm_encoder_attention import (
+    MMEncoderAttention,
+)
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+
+def _musa_flash_attn_maxseqlen_wrapper(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    batch_size: int,
+    fa_version: int | None,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: torch.Tensor | None = None,
+) -> torch.Tensor:
+    from vllm_musa.v1.attention.backends.fa_utils import flash_attn_varlen_func
+
+    q_len = q.size(1)
+    if cu_seqlens is None:
+        cu_seqlens = torch.arange(
+            0,
+            (batch_size + 1) * q_len,
+            step=q_len,
+            dtype=torch.int32,
+            device=q.device,
+        )
+    max_seqlen_value = q_len if max_seqlen is None else max_seqlen.item()
+
+    q, k, v = (einops.rearrange(x, "b s ... -> (b s) ...") for x in (q, k, v))
+    output = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max_seqlen_value,
+        max_seqlen_k=max_seqlen_value,
+        dropout_p=0.0,
+        causal=False,
+        softmax_scale=scale,
+        fa_version=fa_version,
+    )
+    return einops.rearrange(output, "(b s) h d -> b s h d", b=batch_size)
+
+
+def _musa_flash_attn_maxseqlen_wrapper_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    batch_size: int,
+    fa_version: int | None,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: torch.Tensor | None = None,
+) -> torch.Tensor:
+    del k, v, batch_size, fa_version, scale, cu_seqlens, max_seqlen
+    return torch.empty_like(q)
+
+
+direct_register_custom_op(
+    op_name="musa_flash_attn_maxseqlen_wrapper",
+    op_func=_musa_flash_attn_maxseqlen_wrapper,
+    fake_impl=_musa_flash_attn_maxseqlen_wrapper_fake,
+)
+
+
+@MMEncoderAttention.register_oot
+class MusaMMEncoderAttention(MMEncoderAttention):
+    @classmethod
+    def maybe_recompute_cu_seqlens(
+        cls,
+        attn_backend: AttentionBackendEnum,
+        cu_seqlens: np.ndarray,
+        hidden_size: int,
+        tp_size: int,
+        device: torch.device,
+        fp8_padded_hidden_size: int | None = None,
+    ) -> torch.Tensor:
+        if attn_backend == AttentionBackendEnum.TORCH_SDPA:
+            return torch.from_numpy(cu_seqlens)
+
+        return super().maybe_recompute_cu_seqlens(
+            attn_backend,
+            cu_seqlens,
+            hidden_size,
+            tp_size,
+            device,
+            fp8_padded_hidden_size=fp8_padded_hidden_size,
+        )
+
+    def _forward_fa(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert (cu_seqlens is not None and max_seqlen is not None) or (
+            cu_seqlens is None and max_seqlen is None
+        ), "cu_seqlens and max_seqlen should be both set or both None."
+
+        batch_size, query_len = query.size()[:2]
+        key_value_len = key.size(1)
+        is_reshaped = query.dim() != 4
+        query, key, value = self.view_qkv_to_4d(
+            query,
+            key,
+            value,
+            batch_size,
+            query_len,
+            key_value_len,
+        )
+
+        output = torch.ops.vllm.musa_flash_attn_maxseqlen_wrapper(
+            query,
+            key,
+            value,
+            batch_size,
+            self._fa_version,
+            self.scale,
+            cu_seqlens,
+            max_seqlen,
+        )
+        if is_reshaped:
+            output = output.reshape(batch_size, query_len, -1)
+        return output
+
+    def forward_native(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
+        sequence_lengths: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if self.is_flash_attn_backend:
+            return self._forward_fa(query, key, value, cu_seqlens, max_seqlen)
+        if self.attn_backend == AttentionBackendEnum.TRITON_ATTN:
+            return self._forward_triton(
+                query,
+                key,
+                value,
+                cu_seqlens,
+                max_seqlen,
+            )
+        if self.attn_backend == AttentionBackendEnum.FLASHINFER:
+            return self._forward_flashinfer(
+                query,
+                key,
+                value,
+                cu_seqlens,
+                max_seqlen,
+                sequence_lengths,
+            )
+        if self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
+            return self._forward_sdpa(query, key, value, cu_seqlens)
+        raise ValueError(
+            "Unsupported multi-modal encoder attention backend for MUSA: "
+            f"{self.attn_backend}."
+        )

--- a/vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py
+++ b/vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py
@@ -97,6 +97,37 @@ def _s5000_fp8_shape(
     )
 
 
+def _s5000_bf16_shape(
+    *,
+    local_experts: int,
+    w1_output_size: int,
+    w2_input_size: int,
+    hidden_size: int,
+    top_k: int,
+    graph_mode: str,
+) -> MusaFusedMoeShape:
+    return MusaFusedMoeShape(
+        device_capability=(3, 1),
+        multiprocessor_count=60,
+        local_experts=local_experts,
+        w1_output_size=w1_output_size,
+        w2_input_size=w2_input_size,
+        hidden_size=hidden_size,
+        top_k=top_k,
+        block_n=0,
+        block_k=0,
+        activation="silu",
+        expert_parallel=False,
+        hidden_dtype="torch.bfloat16",
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+        gemv_block="auto",
+        graph_mode=graph_mode,
+    )
+
+
 def _thresholds(
     gemv_max_tokens: int | None,
     grouped_gemm_min_tokens: int | None,
@@ -132,6 +163,26 @@ _CALIBRATED_THRESHOLDS: Final[dict[MusaFusedMoeShape, MusaFusedMoeThresholds]] =
     )
     for graph_mode in ("eager", "capture")
 }
+_CALIBRATED_THRESHOLDS.update(
+    {
+        _s5000_bf16_shape(
+            local_experts=257,
+            w1_output_size=256,
+            w2_input_size=128,
+            hidden_size=3072,
+            top_k=9,
+            graph_mode=graph_mode,
+        ): _thresholds(
+            gemv_max_tokens=10,
+            grouped_gemm_min_tokens=None,
+            source=(
+                f"s5000-mp60-20260806-qwen35-bf16-folded-"
+                f"e257-n256-k3072-{graph_mode}"
+            ),
+        )
+        for graph_mode in ("eager", "capture")
+    }
+)
 _CALIBRATED_THRESHOLDS.update(
     {
         _s5000_fp8_shape(

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -1368,6 +1368,61 @@ def _can_use_musa_native_fp8_moe_gemv(
     ) and _musa_fp8_moe_scale_layout_is_supported(w2_scale, w2)
 
 
+def _can_use_musa_native_bf16_moe_gemv(
+    *,
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+    ocp_mx_scheme: str | None,
+    per_channel_quant: bool,
+    global_num_experts: int,
+    expert_map: torch.Tensor | None,
+    w1_scale: torch.Tensor | None,
+    w2_scale: torch.Tensor | None,
+    w1_zp: torch.Tensor | None,
+    w2_zp: torch.Tensor | None,
+    a1_scale: torch.Tensor | None,
+    a2_scale: torch.Tensor | None,
+    w1_bias: torch.Tensor | None,
+    w2_bias: torch.Tensor | None,
+) -> bool:
+    if (
+        use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16
+        or ocp_mx_scheme is not None or per_channel_quant
+        or expert_map is not None or apply_router_weight_on_input
+        or activation != "silu"
+        or any(v is not None for v in (w1_scale, w2_scale, w1_zp, w2_zp,
+                                       a1_scale, a2_scale, w1_bias, w2_bias))
+    ):
+        return False
+    if (hidden_states.dtype != torch.bfloat16 or w1.dtype != torch.bfloat16
+            or w2.dtype != torch.bfloat16 or topk_ids.dtype != torch.int32
+            or topk_weights.dtype != torch.float32 or hidden_states.dim() != 2
+            or w1.dim() != 3 or w2.dim() != 3):
+        return False
+    E, N, K = w1.shape
+    if global_num_experts not in (-1, E) or w2.shape != (E, K, N // 2):
+        return False
+    if hidden_states.shape[1] != K or N % 2 or K % 64 or (N // 2) % 64:
+        return False
+    if not _musa_moe_routes_are_supported(hidden_states=hidden_states,
+                                           topk_weights=topk_weights,
+                                           topk_ids=topk_ids,
+                                           num_experts=E):
+        return False
+    return _tensors_share_device(hidden_states, w1, w2, topk_weights, topk_ids) and all(
+        t.is_contiguous() for t in (hidden_states, w1, w2, topk_weights, topk_ids)
+    )
+
+
 def _musa_fused_moe_shape(
     *,
     hidden_states: torch.Tensor,
@@ -1760,7 +1815,14 @@ def _musa_fused_experts_impl_dispatch(
     # for the explicit rollback path. This wrapper sits on every MoE layer.
     if (
         _MUSA_FUSED_MOE_REQUESTED_BACKEND != MusaFusedMoeBackend.UPSTREAM
-        and use_fp8_w8a8
+        and (
+            use_fp8_w8a8
+            or (
+                hidden_states.dtype == torch.bfloat16
+                and w1.dtype == torch.bfloat16
+                and w2.dtype == torch.bfloat16
+            )
+        )
         and not use_int8_w8a8
         and not use_int8_w8a16
         and not use_int4_w4a16
@@ -1798,29 +1860,57 @@ def _musa_fused_experts_impl_dispatch(
             # contract until it has its own exact policy key and evidence.
             can_use_gemv = (
                 not apply_router_weight_on_input
-                and _can_use_musa_native_fp8_moe_gemv(
-                    hidden_states=hidden_states,
-                    w1=w1,
-                    w2=w2,
-                    topk_weights=topk_weights,
-                    topk_ids=topk_ids,
-                    activation=activation,
-                    use_fp8_w8a8=use_fp8_w8a8,
-                    use_int8_w8a8=use_int8_w8a8,
-                    use_int8_w8a16=use_int8_w8a16,
-                    use_int4_w4a16=use_int4_w4a16,
-                    ocp_mx_scheme=ocp_mx_scheme,
-                    per_channel_quant=per_channel_quant,
-                    global_num_experts=global_num_experts,
-                    expert_map=expert_map,
-                    w1_scale=w1_scale,
-                    w2_scale=w2_scale,
-                    w1_zp=w1_zp,
-                    w2_zp=w2_zp,
-                    a1_scale=a1_scale,
-                    a2_scale=a2_scale,
-                    w1_bias=w1_bias,
-                    w2_bias=w2_bias,
+                and (
+                    _can_use_musa_native_fp8_moe_gemv(
+                        hidden_states=hidden_states,
+                        w1=w1,
+                        w2=w2,
+                        topk_weights=topk_weights,
+                        topk_ids=topk_ids,
+                        activation=activation,
+                        use_fp8_w8a8=use_fp8_w8a8,
+                        use_int8_w8a8=use_int8_w8a8,
+                        use_int8_w8a16=use_int8_w8a16,
+                        use_int4_w4a16=use_int4_w4a16,
+                        ocp_mx_scheme=ocp_mx_scheme,
+                        per_channel_quant=per_channel_quant,
+                        global_num_experts=global_num_experts,
+                        expert_map=expert_map,
+                        w1_scale=w1_scale,
+                        w2_scale=w2_scale,
+                        w1_zp=w1_zp,
+                        w2_zp=w2_zp,
+                        a1_scale=a1_scale,
+                        a2_scale=a2_scale,
+                        w1_bias=w1_bias,
+                        w2_bias=w2_bias,
+                    )
+                    if use_fp8_w8a8
+                    else _can_use_musa_native_bf16_moe_gemv(
+                        hidden_states=hidden_states,
+                        w1=w1,
+                        w2=w2,
+                        topk_weights=topk_weights,
+                        topk_ids=topk_ids,
+                        activation=activation,
+                        apply_router_weight_on_input=apply_router_weight_on_input,
+                        use_fp8_w8a8=use_fp8_w8a8,
+                        use_int8_w8a8=use_int8_w8a8,
+                        use_int8_w8a16=use_int8_w8a16,
+                        use_int4_w4a16=use_int4_w4a16,
+                        ocp_mx_scheme=ocp_mx_scheme,
+                        per_channel_quant=per_channel_quant,
+                        global_num_experts=global_num_experts,
+                        expert_map=expert_map,
+                        w1_scale=w1_scale,
+                        w2_scale=w2_scale,
+                        w1_zp=w1_zp,
+                        w2_zp=w2_zp,
+                        a1_scale=a1_scale,
+                        a2_scale=a2_scale,
+                        w1_bias=w1_bias,
+                        w2_bias=w2_bias,
+                    )
                 )
             )
             can_use_grouped_gemm = _can_use_musa_fp8_moe_grouped_gemm(

--- a/vllm_musa/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm_musa/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
 from vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router import (
     _musa_jit_fused_topk,
 )
+from vllm_musa.jit_kernel.extend_topk_shared import extend_topk_with_shared
 
 
 def _compute_routing(
@@ -25,6 +26,11 @@ def _compute_routing(
     input_ids: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     scoring_func = getattr(self, "scoring_func", "softmax")
+    shared_gate = getattr(self, "_musa_shared_gate", None)
+    shared_logits = None
+    if shared_gate is not None:
+        shared_logits, _ = shared_gate(hidden_states)
+
     jit_result = _musa_jit_fused_topk(
         hidden_states=hidden_states,
         gating_output=router_logits,
@@ -33,6 +39,8 @@ def _compute_routing(
         indices_type=indices_type,
         correction_bias=None,
         scoring_func=scoring_func,
+        shared_expert_gate_output=shared_logits,
+        num_fused_shared_experts=1 if shared_logits is not None else 0,
     )
     if jit_result is not None:
         return jit_result
@@ -45,6 +53,15 @@ def _compute_routing(
         indices_type=indices_type,
         scoring_func=scoring_func,
     )
+    if shared_logits is not None:
+        shared_expert_id = getattr(self, "_musa_shared_expert_id", None)
+        assert shared_expert_id is not None
+        topk_weights, topk_ids = extend_topk_with_shared(
+            topk_weights,
+            topk_ids,
+            shared_logits,
+            shared_expert_id,
+        )
     return topk_weights, topk_ids
 
 

--- a/vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -67,23 +67,45 @@ def _musa_jit_fused_topk(
     indices_type: torch.dtype | None,
     correction_bias: torch.Tensor | None = None,
     scoring_func: str = "softmax",
+    shared_expert_gate_output: torch.Tensor | None = None,
+    num_fused_shared_experts: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor] | None:
     if not _can_use_musa_jit_topk(hidden_states, gating_output, topk, correction_bias):
+        return None
+
+    has_shared_experts = (
+        shared_expert_gate_output is not None and num_fused_shared_experts > 0
+    )
+    if has_shared_experts and not (
+        scoring_func == "softmax"
+        and not renormalize
+        and correction_bias is None
+        and gating_output.shape[1] == 256
+        and topk == 8
+        and num_fused_shared_experts == 1
+        and shared_expert_gate_output.device == gating_output.device
+        and shared_expert_gate_output.dim() == 2
+        and shared_expert_gate_output.shape == (gating_output.shape[0], 1)
+        and shared_expert_gate_output.dtype
+        in (torch.float32, torch.float16, torch.bfloat16)
+        and shared_expert_gate_output.is_contiguous()
+    ):
         return None
 
     musa_jit_topk = _maybe_import_musa_jit_topk()
     if musa_jit_topk is None:
         return None
 
+    output_topk = topk + (num_fused_shared_experts if has_shared_experts else 0)
     topk_weights = torch.empty(
         gating_output.shape[0],
-        topk,
+        output_topk,
         dtype=torch.float32,
         device=gating_output.device,
     )
     topk_ids = torch.empty(
         gating_output.shape[0],
-        topk,
+        output_topk,
         dtype=torch.int32,
         device=gating_output.device,
     )
@@ -95,6 +117,8 @@ def _musa_jit_fused_topk(
             gating_output,
             renormalize,
             correction_bias=correction_bias,
+            shared_expert_gate_output=shared_expert_gate_output,
+            num_fused_shared_experts=num_fused_shared_experts,
         )
     elif scoring_func == "sigmoid":
         musa_jit_topk.topk_sigmoid(
@@ -103,6 +127,8 @@ def _musa_jit_fused_topk(
             gating_output,
             renormalize,
             correction_bias=correction_bias,
+            shared_expert_gate_output=shared_expert_gate_output,
+            num_fused_shared_experts=num_fused_shared_experts,
         )
     else:
         return None

--- a/vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -78,7 +78,6 @@ def _musa_jit_fused_topk(
     )
     if has_shared_experts and not (
         scoring_func == "softmax"
-        and not renormalize
         and correction_bias is None
         and gating_output.shape[1] == 256
         and topk == 8

--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -103,13 +103,18 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             assert (
                 shared_experts_input is None
             ), "folded shared expert expects shared_experts=None"
-            shared_logits, _ = layer._musa_shared_gate(x)
-            topk_weights, topk_ids = extend_topk_with_shared(
-                topk_weights,
-                topk_ids,
-                shared_logits,
-                layer._musa_shared_expert_id,
-            )
+            routed_topk = layer.moe_config.top_k
+            if topk_ids.shape[-1] == routed_topk:
+                shared_logits, _ = layer._musa_shared_gate(x)
+                topk_weights, topk_ids = extend_topk_with_shared(
+                    topk_weights,
+                    topk_ids,
+                    shared_logits,
+                    layer._musa_shared_expert_id,
+                )
+            else:
+                assert topk_ids.shape[-1] == routed_topk + 1
+                assert topk_weights.shape == topk_ids.shape
             global_num_experts = layer._musa_shared_expert_id + 1
         else:
             global_num_experts = layer.global_num_experts
@@ -155,6 +160,10 @@ def _fold_shared_expert_weights(layer: torch.nn.Module) -> None:
     layer.w2_weight = torch.nn.Parameter(w2, requires_grad=False)
     layer._musa_shared_expert_id = int(num_routed)
     layer._musa_shared_folded = True
+    router = getattr(layer, "_musa_shared_router", None)
+    if router is not None:
+        router._musa_shared_gate = layer._musa_shared_gate
+        router._musa_shared_expert_id = int(num_routed)
     logger.info_once(
         "MUSA shared-expert fold active: shared expert folded into the routed "
         "grouped GEMM as slot %d (%d routed + 1 shared).",

--- a/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm_musa/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -103,7 +103,7 @@ class MusaUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             assert (
                 shared_experts_input is None
             ), "folded shared expert expects shared_experts=None"
-            routed_topk = layer.moe_config.top_k
+            routed_topk = layer.top_k
             if topk_ids.shape[-1] == routed_topk:
                 shared_logits, _ = layer._musa_shared_gate(x)
                 topk_weights, topk_ids = extend_topk_with_shared(

--- a/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -121,7 +121,9 @@ class MusaQwenGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
                 self.head_v_dim,
             )
 
-        core_attn_out = torch.zeros(
+        # Every decode/prefill core path writes the complete output buffer;
+        # avoid a redundant zero-fill launch before the recurrent kernel.
+        core_attn_out = torch.empty(
             (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,

--- a/vllm_musa/patches/manifest.py
+++ b/vllm_musa/patches/manifest.py
@@ -261,6 +261,12 @@ _SHADOW_MODULES = [
     ),
     (
         "5",
+        "vllm_musa/model_executor/layers/attention/mm_encoder_attention.py",
+        "vllm/model_executor/layers/attention/mm_encoder_attention.py",
+        "OOT MM encoder attention routing with MUSA FlashAttention",
+    ),
+    (
+        "5",
         "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
         "vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
         "OOT subclass/register seam",

--- a/vllm_musa/patches/series/0102-MUSA-capture-Qwen3-VL-vision-blocks.patch
+++ b/vllm_musa/patches/series/0102-MUSA-capture-Qwen3-VL-vision-blocks.patch
@@ -1,0 +1,271 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Wed, 5 Aug 2026 16:00:00 +0800
+Subject: [PATCH] perf: capture Qwen3-VL vision blocks on MUSA
+
+Add an opt-in MUSA CUDA graph runner for the stable Qwen3 VL vision
+block stack.
+diff --git a/vllm/model_executor/models/qwen3_vl.py b/vllm/model_executor/models/qwen3_vl.py
+index 0e6ddef7f3..9c9e7f5795 100644
+--- a/vllm/model_executor/models/qwen3_vl.py
++++ b/vllm/model_executor/models/qwen3_vl.py
+@@ -24,6 +24,7 @@
+ # limitations under the License.
+ """Inference-only Qwen3VL model compatible with HuggingFace weights."""
+
++import os
+ from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+ from functools import lru_cache, partial
+ from itertools import islice
+@@ -48,6 +49,7 @@ from transformers.models.qwen3_vl.video_processing_qwen3_vl import (
+ )
+ from transformers.video_utils import VideoMetadata
+
++from vllm.compilation import monitor as compilation_monitor
+ from vllm.compilation.decorators import support_torch_compile
+ from vllm.config import VllmConfig
+ from vllm.config.multimodal import BaseDummyOptions, VideoDummyOptions
+@@ -465,6 +467,218 @@ class Qwen3_VisionBlock(nn.Module):
+         return x
+
+
++class _Qwen3VisionBlockGraphRunner:
++    """Capture stable Qwen3 ViT blocks and mergers for MUSA replay."""
++
++    _GRAPH_ENV = "VLLM_MUSA_QWEN3_VL_VISION_CUDAGRAPH"
++    _MAX_GRAPHS_ENV = "VLLM_MUSA_QWEN3_VL_VISION_CUDAGRAPH_MAX_GRAPHS"
++    _META_KEYS = (
++        "cu_seqlens",
++        "rotary_pos_emb_cos",
++        "rotary_pos_emb_sin",
++        "sequence_lengths",
++    )
++
++    def __init__(self, visual: "Qwen3_VisionTransformer") -> None:
++        self.visual = visual
++        self.graphs: dict[Any, dict[str, Any]] = {}
++        self.disabled = False
++        try:
++            self.max_graphs = int(os.environ.get(self._MAX_GRAPHS_ENV, "16"))
++        except ValueError:
++            self.max_graphs = 16
++
++    @classmethod
++    def enabled(cls) -> bool:
++        return os.environ.get(cls._GRAPH_ENV, "0") == "1"
++
++    @staticmethod
++    def _is_musa_runtime() -> bool:
++        return getattr(torch.version, "musa", None) is not None
++
++    @staticmethod
++    def _is_current_stream_capturing() -> bool:
++        try:
++            return bool(torch.cuda.is_current_stream_capturing())
++        except Exception:
++            return False
++
++    @staticmethod
++    def _is_outer_cudagraph_capture_active() -> bool:
++        try:
++            return bool(compilation_monitor.cudagraph_capturing_enabled)
++        except Exception:
++            return False
++
++    @staticmethod
++    def _tensor_signature(tensor: torch.Tensor | None) -> tuple[Any, ...] | None:
++        if tensor is None:
++            return None
++        signature = (
++            tuple(tensor.shape),
++            str(tensor.dtype),
++            str(tensor.device),
++            tuple(tensor.stride()),
++        )
++        if tensor.device.type == "cpu":
++            return (*signature, tuple(tensor.reshape(-1).tolist()))
++        return signature
++
++    @staticmethod
++    def _max_seqlen_key(max_seqlen: torch.Tensor | None) -> int | None:
++        if max_seqlen is None:
++            return None
++        return int(max_seqlen.item())
++
++    def _graph_key(
++        self,
++        hidden_states: torch.Tensor,
++        metadata: dict[str, torch.Tensor | None],
++    ) -> tuple[Any, ...]:
++        return (
++            tuple(hidden_states.shape),
++            str(hidden_states.dtype),
++            str(hidden_states.device),
++            self._max_seqlen_key(metadata.get("max_seqlen")),
++            tuple(
++                (key, self._tensor_signature(metadata.get(key)))
++                for key in self._META_KEYS
++            ),
++        )
++
++    def _make_metadata_buffers(
++        self,
++        metadata: dict[str, torch.Tensor | None],
++    ) -> dict[str, torch.Tensor | None]:
++        buffers: dict[str, torch.Tensor | None] = {
++            "max_seqlen": metadata.get("max_seqlen"),
++        }
++        for key in self._META_KEYS:
++            src = metadata.get(key)
++            if src is None:
++                buffers[key] = None
++            elif src.device.type == "cpu":
++                buffers[key] = src
++            else:
++                buf = torch.empty_like(src)
++                buf.copy_(src)
++                buffers[key] = buf
++        return buffers
++
++    def _copy_metadata_buffers(
++        self,
++        dst: dict[str, torch.Tensor | None],
++        src: dict[str, torch.Tensor | None],
++    ) -> None:
++        for key in self._META_KEYS:
++            dst_tensor = dst.get(key)
++            src_tensor = src.get(key)
++            if dst_tensor is None or src_tensor is None:
++                continue
++            if dst_tensor.device.type == "cpu":
++                continue
++            dst_tensor.copy_(src_tensor)
++
++    def _run_blocks(
++        self,
++        hidden_states: torch.Tensor,
++        metadata: dict[str, torch.Tensor | None],
++    ) -> torch.Tensor:
++        visual = self.visual
++        hidden_states = hidden_states.unsqueeze(1)
++
++        deepstack_feature_lists = []
++        for layer_num, blk in enumerate(visual.blocks):
++            hidden_states = blk(
++                hidden_states,
++                cu_seqlens=metadata["cu_seqlens"],
++                rotary_pos_emb_cos=metadata["rotary_pos_emb_cos"],
++                rotary_pos_emb_sin=metadata["rotary_pos_emb_sin"],
++                max_seqlen=metadata["max_seqlen"],
++                sequence_lengths=metadata.get("sequence_lengths"),
++            )
++            if layer_num in visual.deepstack_visual_indexes:
++                deepstack_merger_idx = visual.deepstack_visual_indexes.index(layer_num)
++                deepstack_feature = visual.deepstack_merger_list[deepstack_merger_idx](
++                    hidden_states
++                )
++                deepstack_feature_lists.append(deepstack_feature)
++
++        hidden_states = visual.merger(hidden_states)
++        return torch.cat([hidden_states] + deepstack_feature_lists, dim=1)
++
++    def _capture(
++        self,
++        key: tuple[Any, ...],
++        hidden_states: torch.Tensor,
++        metadata: dict[str, torch.Tensor | None],
++    ) -> dict[str, Any] | None:
++        if self.max_graphs <= 0 or len(self.graphs) >= self.max_graphs:
++            return None
++
++        input_buffer = torch.empty_like(hidden_states)
++        input_buffer.copy_(hidden_states)
++        metadata_buffers = self._make_metadata_buffers(metadata)
++
++        with torch.inference_mode():
++            self._run_blocks(input_buffer, metadata_buffers)
++
++        graph = torch.cuda.CUDAGraph()
++        with torch.inference_mode(), torch.cuda.graph(graph):
++            output_buffer = self._run_blocks(input_buffer, metadata_buffers)
++
++        graph_meta = {
++            "graph": graph,
++            "input_buffer": input_buffer,
++            "metadata_buffers": metadata_buffers,
++            "output_buffer": output_buffer,
++        }
++        self.graphs[key] = graph_meta
++        logger.info(
++            "Captured Qwen3 VL MUSA vision block CUDA graph: "
++            "seq_len=%d hidden=%d max_seqlen=%s cached_graphs=%d",
++            hidden_states.shape[0],
++            hidden_states.shape[1],
++            self._max_seqlen_key(metadata.get("max_seqlen")),
++            len(self.graphs),
++        )
++        return graph_meta
++
++    def run(
++        self,
++        hidden_states: torch.Tensor,
++        metadata: dict[str, torch.Tensor | None],
++    ) -> torch.Tensor | None:
++        if (
++            self.disabled
++            or not self.enabled()
++            or not self._is_musa_runtime()
++            or self._is_outer_cudagraph_capture_active()
++            or self._is_current_stream_capturing()
++        ):
++            return None
++
++        key = self._graph_key(hidden_states, metadata)
++        graph_meta = self.graphs.get(key)
++
++        try:
++            if graph_meta is None:
++                graph_meta = self._capture(key, hidden_states, metadata)
++                if graph_meta is None:
++                    return None
++
++            graph_meta["input_buffer"].copy_(hidden_states)
++            self._copy_metadata_buffers(graph_meta["metadata_buffers"], metadata)
++            graph_meta["graph"].replay()
++            return graph_meta["output_buffer"].clone()
++        except Exception:
++            self.disabled = True
++            logger.exception(
++                "Disabling Qwen3 VL MUSA vision block CUDA graph after failure"
++            )
++            return None
++
++
+ class Qwen3_VisionPatchMerger(nn.Module):
+     def __init__(
+         self,
+@@ -621,6 +835,7 @@ class Qwen3_VisionTransformer(nn.Module):
+                 for layer_idx in range(vision_config.depth)
+             ]
+         )
++        self._musa_vision_graph_runner: _Qwen3VisionBlockGraphRunner | None = None
+
+     @property
+     def dtype(self) -> torch.dtype:
+@@ -809,6 +1024,16 @@ class Qwen3_VisionTransformer(nn.Module):
+
+         pos_embeds = encoder_metadata["pos_embeds"]
+         hidden_states = hidden_states + pos_embeds
++
++        if _Qwen3VisionBlockGraphRunner.enabled():
++            if self._musa_vision_graph_runner is None:
++                self._musa_vision_graph_runner = _Qwen3VisionBlockGraphRunner(self)
++            graph_output = self._musa_vision_graph_runner.run(
++                hidden_states, encoder_metadata
++            )
++            if graph_output is not None:
++                return graph_output
++
+         hidden_states = hidden_states.unsqueeze(1)
+
+         deepstack_feature_lists = []

--- a/vllm_musa/patches/series/0103-MUSA-avoid-FA2-circular-import.patch
+++ b/vllm_musa/patches/series/0103-MUSA-avoid-FA2-circular-import.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Thu, 6 Aug 2026 11:32:00 +0800
+Subject: [PATCH] fix: avoid CUDA FA2 import on MUSA
+
+The upstream FA version probe imports vllm_flash_attn when it is called
+through an early-bound reference. MUSA uses MATE's FA3 interface instead,
+so return before probing CUDA-only extensions.
+
+diff --git a/vllm/v1/attention/backends/fa_utils.py b/vllm/v1/attention/backends/fa_utils.py
+index 474523780f..3ba8f00c08 100644
+--- a/vllm/v1/attention/backends/fa_utils.py
++++ b/vllm/v1/attention/backends/fa_utils.py
+@@ -59,6 +59,10 @@ def get_flash_attn_version(
+     head_size_v: int | None = None,
+     has_sinks: bool = False,
+ ) -> int | None:
++    if current_platform.is_musa():
++        # MUSA uses MATE's FA3 interface, not vllm_flash_attn's CUDA extensions.
++        return 3
++
+     if current_platform.is_xpu():
+         return 2
+     if current_platform.is_rocm():
+--
+2.43.0

--- a/vllm_musa/patches/series/0104-MUSA-enable-qwen35-shared-fold-tp-only.patch
+++ b/vllm_musa/patches/series/0104-MUSA-enable-qwen35-shared-fold-tp-only.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Thu, 6 Aug 2026 19:28:00 +0800
+Subject: [PATCH] MUSA: enable Qwen3.5 shared fold for TP-only MoE
+
+The vLLM EP process group is constructed with TP ranks even when expert
+parallelism is disabled.  Using its size as a fold guard therefore disables
+the fold on the normal TP8 Qwen3.5 path, although every rank owns the full
+routed expert stack.  Gate on the explicit expert-parallel setting instead.
+
+---
+ vllm/model_executor/models/qwen3_next.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/models/qwen3_next.py
+--- a/vllm/model_executor/models/qwen3_next.py
++++ b/vllm/model_executor/models/qwen3_next.py
+@@ -210,6 +210,6 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+                 OptimizationFeature.QWEN35_SHARED_EXPERT_FOLD
+             )
+-            and self.ep_size <= 1
++            and not parallel_config.enable_expert_parallel
+             and not self.enable_eplb
+             and config.shared_expert_intermediate_size == config.moe_intermediate_size
+             and _musa_shared_expert_foldable(self.shared_expert)
+--
+2.39.2

--- a/vllm_musa/patches/series/0105-MUSA-bind-qwen35-shared-gate-to-router.patch
+++ b/vllm_musa/patches/series/0105-MUSA-bind-qwen35-shared-gate-to-router.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Fri, 7 Aug 2026 18:00:00 +0800
+Subject: [PATCH] MUSA: bind Qwen3.5 folded shared gate to router
+
+The folded shared expert currently appends its routing column after top-k,
+which costs one extra captured launch per layer.  Give the routed-expert
+weight hook a reference to the owning router so it can move the existing
+shared-gate projection before top-k and let the MUSA top-k kernel write the
+shared column directly.
+
+---
+ vllm/model_executor/models/qwen3_next.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/models/qwen3_next.py
+--- a/vllm/model_executor/models/qwen3_next.py
++++ b/vllm/model_executor/models/qwen3_next.py
+@@ -240,2 +240,3 @@ class Qwen3NextSparseMoeBlock(nn.Module):
+             routed._musa_shared_mlp = self.shared_expert
++            routed._musa_shared_router = self.experts.router
+             routed._musa_shared_gate = self.shared_expert_gate

--- a/vllm_musa/patches/series/0106-MUSA-fuse-qwen35-qk-mrope-cache-update.patch
+++ b/vllm_musa/patches/series/0106-MUSA-fuse-qwen35-qk-mrope-cache-update.patch
@@ -1,0 +1,203 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Fri, 7 Aug 2026 13:20:24 +0000
+Subject: [PATCH] MUSA: fuse Qwen3.5 QK mRoPE cache update
+
+---
+ .../layers/attention/attention.py             |  4 +-
+ vllm/model_executor/models/qwen3_next.py      | 92 ++++++++++++++-----
+ 2 files changed, 71 insertions(+), 25 deletions(-)
+
+diff --git a/vllm/model_executor/layers/attention/attention.py b/vllm/model_executor/layers/attention/attention.py
+index 08b5d5b..fb64568 100644
+--- a/vllm/model_executor/layers/attention/attention.py
++++ b/vllm/model_executor/layers/attention/attention.py
+@@ -458,6 +458,7 @@ class Attention(nn.Module, AttentionLayerBase):
+         # shape does not match the query shape, so we optionally let the model
+         # definition specify the output tensor shape.
+         output_shape: torch.Size | None = None,
++        kv_cache_dummy_dep: torch.Tensor | None = None,
+     ) -> torch.Tensor:
+         """
+         The KV cache is stored inside this class and is accessed via
+@@ -501,7 +502,6 @@ class Attention(nn.Module, AttentionLayerBase):
+             key = key.view(-1, self.num_kv_heads, self.head_size)
+         if value is not None:
+             value = value.view(-1, self.num_kv_heads, self.head_size_v)
+-        kv_cache_dummy_dep = None
+         if self.use_direct_call:
+             # Skip this if sharing KV cache with an earlier attention layer.
+             if (
+@@ -509,6 +509,7 @@ class Attention(nn.Module, AttentionLayerBase):
+                 and self.kv_sharing_target_layer_name is None
+                 and key is not None
+                 and value is not None
++                and kv_cache_dummy_dep is None
+             ):
+                 kv_cache_dummy_dep = unified_kv_cache_update(
+                     key, value, self.layer_name
+@@ -529,6 +530,7 @@ class Attention(nn.Module, AttentionLayerBase):
+                 and self.kv_sharing_target_layer_name is None
+                 and key is not None
+                 and value is not None
++                and kv_cache_dummy_dep is None
+             ):
+                 kv_cache_dummy_dep = torch.ops.vllm.unified_kv_cache_update(
+                     key, value, encoded
+diff --git a/vllm/model_executor/models/qwen3_next.py b/vllm/model_executor/models/qwen3_next.py
+index 3e06d50..954e3f5 100644
+--- a/vllm/model_executor/models/qwen3_next.py
++++ b/vllm/model_executor/models/qwen3_next.py
+@@ -426,6 +426,7 @@ class Qwen3NextAttention(nn.Module):
+             and self.mrope_interleaved
+         )
+         self._musa_mrope_cos_sin_cache = None
++        self._musa_fused_qk_mrope_cache = False
+         if self._musa_fused_qk_mrope:
+             dtype = model_config.dtype if model_config else torch.bfloat16
+             self._musa_fused_qk_mrope = dtype == torch.bfloat16
+@@ -434,13 +435,24 @@ class Qwen3NextAttention(nn.Module):
+                     self.rotary_emb.cos_sin_cache, dtype
+                 )
+                 self._musa_mrope_section = tuple(int(x) for x in self.mrope_section)
++                self._musa_fused_qk_mrope_cache = getattr(
++                    self.attn.impl,
++                    "qwen3_qk_rope_kvcache_supported",
++                    lambda: False,
++                )()
+
+     def _project_qkv_gate(
+         self,
+         qkv: torch.Tensor,
+         positions: torch.Tensor,
+-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+-        """Return post-norm, post-RoPE (q, k, v) and the pre-sigmoid gate.
++    ) -> tuple[
++        torch.Tensor,
++        torch.Tensor,
++        torch.Tensor,
++        torch.Tensor | None,
++        torch.Tensor | None,
++    ]:
++        """Return post-norm Q/K/V, gate, and an optional KV-cache dependency.
+
+         Dispatches among the existing CUDA Triton kernel, the functional IR
+         operation, and the eager split + QK-RMSNorm + RoPE path. ``gate`` is
+@@ -467,11 +479,9 @@ class Qwen3NextAttention(nn.Module):
+                 self.head_dim,
+                 self.rotary_emb.rotary_dim,
+             )
+-            return q, k, v, gate
++            return q, k, v, gate, None
+
+         if self._musa_fused_qk_mrope and positions.ndim == 2:
+-            from vllm_musa.jit_kernel.csrc.norm import fused_qk_rmsnorm_mrope
+-
+             q_gate, k, v = qkv.split(
+                 [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
+             )
+@@ -480,26 +490,60 @@ class Qwen3NextAttention(nn.Module):
+             q, gate = torch.chunk(q_gate, 2, dim=-1)
+             gate = gate.reshape(*orig_shape, -1)
+             t, h, w = self._musa_mrope_section
+-            q, k = fused_qk_rmsnorm_mrope(
+-                q.contiguous(),
+-                k.view(-1, self.num_kv_heads, self.head_dim),
+-                self.q_norm.weight,
+-                self.k_norm.weight,
+-                positions,
+-                self._musa_mrope_cos_sin_cache,
+-                is_neox=bool(self.rotary_emb.is_neox_style),
+-                mrope_section_t=t,
+-                mrope_section_h=h,
+-                mrope_section_w=w,
+-                is_interleaved=True,
+-                eps=self.q_norm.variance_epsilon,
+-                gemma=True,
+-            )
++            q = q.contiguous()
++            k = k.view(-1, self.num_kv_heads, self.head_dim)
++            kv_cache_dummy_dep = None
++            if self._musa_fused_qk_mrope_cache:
++                from vllm_musa.kernels.qwen3_qk_rope_kv import (
++                    FUSED_QWEN3_QK_ROPE_KV_OP,
++                )
++
++                q_out = torch.empty_like(q)
++                k_out = torch.empty_like(k)
++                kv_cache_dummy_dep = FUSED_QWEN3_QK_ROPE_KV_OP(
++                    q,
++                    k,
++                    v.view(-1, self.num_kv_heads, self.head_dim),
++                    self.q_norm.weight,
++                    self.k_norm.weight,
++                    positions,
++                    self._musa_mrope_cos_sin_cache,
++                    q_out,
++                    k_out,
++                    bool(self.rotary_emb.is_neox_style),
++                    t,
++                    h,
++                    w,
++                    True,
++                    self.q_norm.variance_epsilon,
++                    True,
++                    self.attn.layer_name,
++                )
++                q, k = q_out, k_out
++            else:
++                from vllm_musa.jit_kernel.csrc.norm import fused_qk_rmsnorm_mrope
++
++                q, k = fused_qk_rmsnorm_mrope(
++                    q,
++                    k,
++                    self.q_norm.weight,
++                    self.k_norm.weight,
++                    positions,
++                    self._musa_mrope_cos_sin_cache,
++                    is_neox=bool(self.rotary_emb.is_neox_style),
++                    mrope_section_t=t,
++                    mrope_section_h=h,
++                    mrope_section_w=w,
++                    is_interleaved=True,
++                    eps=self.q_norm.variance_epsilon,
++                    gemma=True,
++                )
+             return (
+                 q.view(-1, self.num_heads * self.head_dim),
+                 k.view(-1, self.num_kv_heads * self.head_dim),
+                 v,
+                 gate,
++                kv_cache_dummy_dep,
+             )
+
+         if self.use_gated_qkv_rms_norm_rope:
+@@ -529,7 +573,7 @@ class Qwen3NextAttention(nn.Module):
+                 self.rotary_emb.is_neox_style,
+                 1.0,
+             )
+-            return q, k, v, gate
++            return q, k, v, gate, None
+
+         if self.attn_output_gate:
+             q_gate, k, v = qkv.split(
+@@ -551,7 +595,7 @@ class Qwen3NextAttention(nn.Module):
+             -1, self.num_kv_heads * self.head_dim
+         )
+         q, k = self.rotary_emb(positions, q, k)
+-        return q, k, v, gate
++        return q, k, v, gate, None
+
+     def forward(
+         self,
+@@ -560,8 +604,8 @@ class Qwen3NextAttention(nn.Module):
+         hidden_states: torch.Tensor,
+     ):
+         qkv, _ = self.qkv_proj(hidden_states)
+-        q, k, v, gate = self._project_qkv_gate(qkv, positions)
+-        attn_output = self.attn(q, k, v)
++        q, k, v, gate, kv_cache_dummy_dep = self._project_qkv_gate(qkv, positions)
++        attn_output = self.attn(q, k, v, kv_cache_dummy_dep=kv_cache_dummy_dep)
+         if gate is not None:
+             # ``gate`` may retain the interleaved packed-QKV strides. Match its
+             # logical head shape so Inductor can fuse the strided gate read into

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -7,6 +7,7 @@ pymtml. However, it should not initialize musa context.
 import os
 from collections.abc import Callable
 from functools import cache, wraps
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 # isort: off
@@ -32,9 +33,11 @@ import pymtml as pynvml
 from vllm_musa.optimization_contract import (
     ModelFamily,
     OptimizationFeature,
-    resolve_optimization_contract,
 )
 from vllm_musa.optimization_contract import policy as contract_policy
+from vllm_musa.optimization_contract import (
+    resolve_optimization_contract,
+)
 from vllm_musa.tuning import FUSED_ADD_RMSNORM_MIN_ROWS
 
 logger = init_logger(__name__)
@@ -811,9 +814,7 @@ class MUSAPlatformBase(Platform):
 
     @classmethod
     def get_device_communicator_cls(cls) -> str:
-        return (
-            "vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
-        )
+        return "vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
 
     @classmethod
     def supports_fp8(cls) -> bool:
@@ -927,6 +928,126 @@ class MtmlMUSAPlatform(MUSAPlatformBase):
         physical_device_id = cls.device_id_to_physical_device_id(device_id)
         handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
         return int(pynvml.nvmlDeviceGetMemoryInfo(handle).total)
+
+    @classmethod
+    @with_mtml_context
+    def get_device_numa_node(cls, device_id: int = 0) -> int | None:
+        """Get the NUMA node ID for a GPU device."""
+        physical_device_id = cls.device_id_to_physical_device_id(device_id)
+        handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+
+        try:
+            numa_node = pynvml.nvmlDeviceGetNumaNodeId(handle)
+            if cls._numa_node_has_cpus(numa_node):
+                return numa_node
+            logger.debug(
+                "NUMA node %d for GPU %d has no CPUs, falling back to "
+                "CPU-affinity-based detection",
+                numa_node,
+                device_id,
+            )
+        except Exception:
+            pass
+
+        try:
+            cpu_ids = cls._get_device_cpu_affinity(handle)
+            if cpu_ids:
+                numa_node = cls._get_numa_node_for_cpu(cpu_ids[0])
+                if numa_node is not None:
+                    logger.debug(
+                        "Determined NUMA node %d for GPU %d via CPU affinity",
+                        numa_node,
+                        device_id,
+                    )
+                    return numa_node
+        except Exception as e:
+            logger.warning("Failed to get NUMA node for GPU %d: %s", device_id, e)
+
+        return None
+
+    @classmethod
+    def _numa_node_has_cpus(cls, node_id: int) -> bool:
+        """Check whether a NUMA node has any CPUs assigned to it."""
+        cpulist_file = Path(f"/sys/devices/system/node/node{node_id}/cpulist")
+        try:
+            return cpulist_file.read_text().strip() != ""
+        except (OSError, ValueError):
+            return False
+
+    @classmethod
+    def _get_device_cpu_affinity(cls, handle) -> list[int]:
+        """Get the list of CPU IDs associated with a GPU via MTML."""
+        cpu_count = os.cpu_count()
+        if cpu_count is None:
+            return []
+
+        cpu_set_size = (cpu_count + 63) // 64
+        cpu_affinity_mask = pynvml.nvmlDeviceGetCpuAffinity(handle, cpu_set_size)
+
+        cpu_ids = []
+        for i, mask in enumerate(cpu_affinity_mask):
+            for bit in range(64):
+                cpu_id = i * 64 + bit
+                if cpu_id >= cpu_count:
+                    break
+                if mask & (1 << bit):
+                    cpu_ids.append(cpu_id)
+        return cpu_ids
+
+    @classmethod
+    def _get_numa_node_for_cpu(cls, cpu_id: int) -> int | None:
+        """Determine which NUMA node a CPU belongs to."""
+        node_path = Path("/sys/devices/system/node")
+        if not node_path.exists():
+            return None
+
+        for node_dir in node_path.iterdir():
+            if not node_dir.name.startswith("node"):
+                continue
+            try:
+                node_id = int(node_dir.name[4:])
+                cpulist_file = node_dir / "cpulist"
+                if cpulist_file.exists():
+                    cpulist = cpulist_file.read_text().strip()
+                    if cls._cpu_in_cpulist(cpu_id, cpulist):
+                        return node_id
+            except (ValueError, OSError):
+                continue
+        return None
+
+    @classmethod
+    def _cpu_in_cpulist(cls, cpu_id: int, cpulist: str) -> bool:
+        """Check if a CPU ID is in a cpulist string such as '0-3,8-11'."""
+        for part in cpulist.split(","):
+            part = part.strip()
+            if "-" in part:
+                start, end = part.split("-", 1)
+                if int(start) <= cpu_id <= int(end):
+                    return True
+            elif part.isdigit() and int(part) == cpu_id:
+                return True
+        return False
+
+    @classmethod
+    @with_mtml_context
+    def get_all_device_numa_nodes(cls) -> list[int] | None:
+        """Get NUMA nodes for all visible GPU devices."""
+        try:
+            numa_nodes = []
+            for device_id in range(cls.device_count()):
+                numa_node = cls.get_device_numa_node(device_id)
+                if numa_node is None:
+                    logger.warning(
+                        "Could not detect NUMA node for GPU %d, "
+                        "disabling automatic NUMA binding",
+                        device_id,
+                    )
+                    return None
+                numa_nodes.append(numa_node)
+            return numa_nodes
+        except Exception as e:
+            logger.warning("Failed to get NUMA nodes for GPUs: %s", e)
+            return None
 
     @classmethod
     @with_mtml_context

--- a/vllm_musa/v1/attention/backends/fa_utils.py
+++ b/vllm_musa/v1/attention/backends/fa_utils.py
@@ -2,18 +2,20 @@
 # 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Any
+
 import torch
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
-from vllm.v1.attention.backends.fa_utils import logger
+
+logger = init_logger(__name__)
 
 if current_platform.is_musa():
     from flash_attn_interface import (  # noqa: F401
-        flash_attn_varlen_func,
-        flash_attn_with_kvcache,
-        get_scheduler_metadata,
+        flash_attn_varlen_func as _musa_flash_attn_varlen_func,
     )
-    from vllm import _custom_ops as ops
 
+    from vllm import _custom_ops as ops
     from vllm_musa import _custom_ops as musa_ops
     from vllm_musa.utils.environ import envs
 
@@ -22,6 +24,18 @@ if current_platform.is_musa():
     _HAS_NATIVE_RESHAPE_CACHE_FLASH = hasattr(
         _MUSA_OPS_NAMESPACE, "musa_reshape_and_cache_flash_nhd"
     )
+
+    def flash_attn_varlen_func(*args: Any, **kwargs: Any) -> Any:
+        dropout_p = kwargs.pop("dropout_p", 0.0)
+        if dropout_p not in (0, 0.0, None):
+            raise ValueError("MUSA flash attention does not support non-zero dropout.")
+
+        kwargs.pop("fa_version", None)
+        alibi_slopes = kwargs.pop("alibi_slopes", None)
+        if alibi_slopes is not None:
+            raise ValueError("MUSA flash attention does not support ALiBi.")
+
+        return _musa_flash_attn_varlen_func(*args, **kwargs)
 
     def _can_use_musa_reshape_and_cache_flash_nhd(
         key,
@@ -105,15 +119,17 @@ if current_platform.is_musa():
 
 
 def get_flash_attn_version(
-    requires_alibi: bool = False, head_size: int | None = None
+    requires_alibi: bool = False,
+    head_size: int | None = None,
+    head_size_v: int | None = None,
+    has_sinks: bool = False,
 ) -> int | None:
     logger.info_once("MUSA platform use FLASH_ATTN with version 3.")
     return 3
 
 
 def flash_attn_supports_fp8() -> bool:
-    # mate's FMHA takes fp8 e4m3 q/k/v with per-(batch, kv-head) descale, which is
-    # the shape vllm builds for an fp8 KV cache. e5m2 has no mate kernel.
+    # MATE FMHA supports e4m3 Q/K/V with per-(batch, KV-head) descales.
     return True
 
 
@@ -121,8 +137,7 @@ def flash_attn_supports_sinks() -> bool:
     return True
 
 
-def flash_attn_supports_mla():
-    # XXX (MUSA): Requires adaptation for MLA models
+def flash_attn_supports_mla() -> bool:
     return True
 
 

--- a/vllm_musa/v1/attention/backends/fa_utils.py
+++ b/vllm_musa/v1/attention/backends/fa_utils.py
@@ -13,6 +13,8 @@ logger = init_logger(__name__)
 if current_platform.is_musa():
     from flash_attn_interface import (  # noqa: F401
         flash_attn_varlen_func as _musa_flash_attn_varlen_func,
+        flash_attn_with_kvcache,
+        get_scheduler_metadata,
     )
 
     from vllm import _custom_ops as ops

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -1666,7 +1666,38 @@ class FlashAttentionImpl(AttentionImpl):
                 and tuple(key_cache.shape[-2:]) == expected_tail
                 and tuple(value_cache.shape[-2:]) == expected_tail
             )
-            if flat_cache_supported:
+            h256_paged_specialization = (
+                gemma
+                and is_interleaved
+                and self.head_size == 256
+                and cos_sin_cache.shape[-1] == 64
+                and (mrope_section_t, mrope_section_h, mrope_section_w)
+                == (11, 11, 10)
+            )
+            paged_cache_supported = (
+                h256_paged_specialization
+                and key_cache.dim() == 4
+                and value_cache.dim() == 4
+                and tuple(key_cache.shape[-2:]) == expected_tail
+                and tuple(value_cache.shape[-2:]) == expected_tail
+                and key_cache.stride(3) == 1
+                and value_cache.stride(3) == 1
+                and key_cache.stride(2) == self.head_size
+                and value_cache.stride(2) == self.head_size
+                and key_cache.stride(1) == self.num_kv_heads * self.head_size
+                and value_cache.stride(1) == self.num_kv_heads * self.head_size
+            )
+            if flat_cache_supported or paged_cache_supported:
+                key_cache_out = (
+                    key_cache.view(-1, self.num_kv_heads * self.head_size)
+                    if flat_cache_supported
+                    else key_cache
+                )
+                value_cache_out = (
+                    value_cache.view(-1, self.num_kv_heads * self.head_size)
+                    if flat_cache_supported
+                    else value_cache
+                )
                 fused_qk_rmsnorm_mrope_cache_out(
                     q,
                     k,
@@ -1677,8 +1708,8 @@ class FlashAttentionImpl(AttentionImpl):
                     cos_sin_cache,
                     q_out,
                     k_out,
-                    key_cache.view(-1, self.num_kv_heads * self.head_size),
-                    value_cache.view(-1, self.num_kv_heads * self.head_size),
+                    key_cache_out,
+                    value_cache_out,
                     layer_slot_mapping,
                     is_neox,
                     mrope_section_t,

--- a/vllm_musa/v1/attention/backends/flash_attn.py
+++ b/vllm_musa/v1/attention/backends/flash_attn.py
@@ -1604,12 +1604,15 @@ class FlashAttentionImpl(AttentionImpl):
         )
 
     def qwen3_qk_rope_kvcache_supported(self) -> bool:
-        """Whether this layer is inside the initial dense Qwen3 envelope."""
+        """Whether this layer is inside a validated Qwen3 cache-out envelope."""
+        supported_shape = (
+            (self.num_heads, self.num_kv_heads, self.head_size)
+            in ((16, 8, 128), (32, 8, 128), (4, 1, 256), (32, 2, 256))
+        )
         return (
             get_flash_attn_version() == 3
             and get_kv_cache_layout() == "NHD"
-            and (self.num_heads, self.num_kv_heads) in ((16, 8), (32, 8))
-            and self.head_size == 128
+            and supported_shape
             and self.attn_type == AttentionType.DECODER
             and self.kv_cache_dtype in ("auto", "bfloat16", torch.bfloat16)
             and self.alibi_slopes is None
@@ -1633,6 +1636,13 @@ class FlashAttentionImpl(AttentionImpl):
         k_out: torch.Tensor,
         kv_cache: torch.Tensor,
         layer_slot_mapping: torch.Tensor | None,
+        is_neox: bool = True,
+        mrope_section_t: int = 64,
+        mrope_section_h: int = 0,
+        mrope_section_w: int = 0,
+        is_interleaved: bool = False,
+        eps: float = 1e-6,
+        gemma: bool = False,
     ) -> None:
         """Run the exact Qwen3 provider, falling back before cache fusion."""
         from vllm_musa.jit_kernel.csrc.norm import (
@@ -1670,13 +1680,13 @@ class FlashAttentionImpl(AttentionImpl):
                     key_cache.view(-1, self.num_kv_heads * self.head_size),
                     value_cache.view(-1, self.num_kv_heads * self.head_size),
                     layer_slot_mapping,
-                    True,
-                    64,
-                    0,
-                    0,
-                    False,
-                    1e-6,
-                    False,
+                    is_neox,
+                    mrope_section_t,
+                    mrope_section_h,
+                    mrope_section_w,
+                    is_interleaved,
+                    eps,
+                    gemma,
                 )
                 return
 
@@ -1689,13 +1699,13 @@ class FlashAttentionImpl(AttentionImpl):
             cos_sin_cache,
             q_out,
             k_out,
-            True,
-            64,
-            0,
-            0,
-            False,
-            1e-6,
-            False,
+            is_neox,
+            mrope_section_t,
+            mrope_section_h,
+            mrope_section_w,
+            is_interleaved,
+            eps,
+            gemma,
         )
         if layer_slot_mapping is not None:
             self.do_kv_cache_update(


### PR DESCRIPTION
## Changes

1. **Add NUMA-aware MUSA device binding**
   - Commits: `2071666`
   - Add GPU NUMA-node detection and CPU-affinity fallback for `--numa-bind`.

2. **Route multimodal encoder attention through MUSA FlashAttention**
   - Commits: `ed70961`, `e271d26`
   - Add the MUSA MM encoder attention implementation.
   - Route FA3 execution through the MUSA custom op.
   - Restore the required KV-cache and scheduler metadata helpers.

3. **Enable TP-only shared-expert folding for Qwen3.5 MoE**
   - Commits: `14993b3`, `d89241b`
   - Enable shared-expert folding when explicit expert parallelism is disabled.
   - Add regression coverage for the folding guard.

4. **Dispatch folded BF16 MoE decode to native MUSA GEMV**
   - Commit: `dddd409`
   - Add a shape- and batch-bounded S5000 BF16 native GEMV path.
   - Preserve Triton fallback for unsupported cases.

5. **Fuse shared-expert routing into the top-k operation**
   - Commits: `5230eec`, `219b133`, `30c6cd6`
   - Fuse shared-gate evaluation into top-k routing.
   - Fix `layer.top_k` handling.
   - Preserve routed top-k renormalization semantics.
   - Remove 48 launches per stable decode replay.

6. **Fuse Qwen3.5 QK/mRoPE and paged KV-cache update**
   - Commits: `e7bd355`, `756cc73`
   - Fuse QK RMSNorm, mRoPE, and KV-cache update.
   - Add 4-D paged-cache support with page-boundary, repeated-slot, and
     `slot=-1` handling.
   - Retain safe fallback for unsupported or HND layouts.
   - Reduce stable replay launches from 914 to 902.

7. **Remove redundant GDN decode output initialization**
   - Commit: `4f14b90`
   - Replace fully overwritten `torch.zeros` allocation with `torch.empty`.
   - Remove 25 redundant zero-fill launches per stable replay.

8. **Add opt-in Qwen3-VL vision-block CUDA graph**
   - Commit: `a6a0046`
   - Capture vision blocks, merger, and deepstack mergers.
   - Enable with `VLLM_MUSA_QWEN3_VL_VISION_CUDAGRAPH=1`.
   - `VLLM_MUSA_QWEN3_VL_VISION_CUDAGRAPH_MAX_GRAPHS` controls how many different input signatures are cached, with a default of 16.
   - This is a Qwen3-VL feature, not part of the Qwen3.5-122B decode path.

## Perf Test
### Start
VLLM_MUSA_QWEN3_VL_VISION_CUDAGRAPH=1 vllm serve /home/model/Qwen3.5-122B-A10B -tp 8 --port 8023 --max-num-seqs 32 -cc.cudagraph_mode=FULL_DECODE_ONLY --cudagraph-capture-sizes 1 2 3 4 5 6 7 8 9 10 --no-enable-chunked-prefill --no-enable-prefix-caching -ac.backend FLASH_ATTN --trust-remote-code --max-model-len 8192 --mamba-ssm-cache-dtype float32 --gpu-memory-utilization 0.85 -cc.mode=NONE --max-num-batched-tokens 8192  --mm-encoder-attn-backend FLASH_ATTN --numa-bind --mm-processor-cache-type shm --mm-processor-cache-gb 4  --mm-shm-cache-max-object-size-mb 128

**_key parameters_**
VLLM_MUSA_QWEN3_VL_VISION_CUDAGRAPH=1
--mm-encoder-attn-backend FLASH_ATTN 
--numa-bind 
--mm-processor-cache-type shm 
--mm-processor-cache-gb 4  
--mm-shm-cache-max-object-size-mb 128

### Batch size 1, input (720,1280)*4 image + 512 text, output 512
<img width="554" height="301" alt="image" src="https://github.com/user-attachments/assets/603dbc84-ed8c-47a1-9249-38546ecd45e9" />