### PR TITLE
[MUSA] Patch pre-0.2.6 MATE wheels for TorchDynamo

### DIFF
--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -272,6 +272,13 @@ RUN python -m pip install \
         --extra-index-url "${PYPI_INDEX_URL}" \
         -r requirements/musa_private.txt
 
+# MATE <0.2.6 emits invalid FX code for boolean augmented assignment.
+COPY docker/patches/apply_mate_dynamo_bool_patch.py \
+     docker/patches/mate-dynamo-bool-augassign.patch \
+     /tmp/vllm-musa-mate-patch/
+RUN python /tmp/vllm-musa-mate-patch/apply_mate_dynamo_bool_patch.py && \
+    rm -rf /tmp/vllm-musa-mate-patch
+
 FROM vllm_musa_deps AS vllm_musa_installed
 
 # setup.py's develop_dynamic_library() installs the vendored vLLM with

--- a/docker/patches/apply_mate_dynamo_bool_patch.py
+++ b/docker/patches/apply_mate_dynamo_bool_patch.py
@@ -1,0 +1,83 @@
+"""Apply the TorchDynamo compatibility patch to pre-0.2.6 MATE wheels."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from importlib.metadata import distribution
+from pathlib import Path
+
+from packaging.version import Version
+
+MATE_FIX_VERSION = Version("0.2.6")
+DEFAULT_PATCH = Path(__file__).with_name("mate-dynamo-bool-augassign.patch")
+
+
+def apply_patch(patch_file: Path) -> None:
+    mate_dist = distribution("mate")
+    mate_version = Version(mate_dist.version)
+    print(f"MATE version: {mate_version}", flush=True)
+
+    if mate_version >= MATE_FIX_VERSION:
+        print(
+            f"SKIP mate_dynamo_bool_patch version={mate_version} "
+            f"(fixed in >= {MATE_FIX_VERSION})",
+            flush=True,
+        )
+        return
+
+    site_packages = Path(mate_dist.locate_file(""))
+    target = site_packages / "mate" / "mha_interface.py"
+    if not target.is_file():
+        raise RuntimeError(f"MATE source file not found: {target}")
+    if not patch_file.is_file():
+        raise RuntimeError(f"MATE patch file not found: {patch_file}")
+
+    before = target.read_text()
+    has_new_marker = "enable_mubin = enable_mubin & q.is_musa" in before
+    has_old_marker = "enable_mubin &= " in before
+    if has_new_marker and not has_old_marker:
+        print(
+            f"PASS mate_dynamo_bool_patch already_applied target={target}", flush=True
+        )
+        return
+    if has_new_marker and has_old_marker:
+        raise RuntimeError(f"MATE patch appears partially applied: {target}")
+    if not has_old_marker:
+        raise RuntimeError(
+            f"MATE {mate_version} source does not match the expected pre-{MATE_FIX_VERSION} "
+            f"layout: {target}"
+        )
+
+    patch_file = patch_file.resolve()
+    subprocess.run(
+        ["git", "apply", "--check", str(patch_file)],
+        check=True,
+        cwd=site_packages,
+    )
+    subprocess.run(
+        ["git", "apply", str(patch_file)],
+        check=True,
+        cwd=site_packages,
+    )
+
+    after = target.read_text()
+    if "enable_mubin &= " in after:
+        raise RuntimeError(f"MATE patch was incomplete: {target}")
+    if "enable_mubin = enable_mubin & q.is_musa" not in after:
+        raise RuntimeError(f"MATE patch postcondition failed: {target}")
+    print(
+        f"PASS mate_dynamo_bool_patch version={mate_version} target={target}",
+        flush=True,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--patch-file", type=Path, default=DEFAULT_PATCH)
+    args = parser.parse_args()
+    apply_patch(args.patch_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/patches/mate-dynamo-bool-augassign.patch
+++ b/docker/patches/mate-dynamo-bool-augassign.patch
@@ -1,0 +1,123 @@
+diff --git a/mate/mha_interface.py b/mate/mha_interface.py
+index 9f4db34..24b2e0d 100644
+--- a/mate/mha_interface.py
++++ b/mate/mha_interface.py
+@@ -41,20 +41,26 @@ def _check_valid_asm_input(
+ ):
+     enable_mubin = True
+ 
+-    enable_mubin &= q.is_musa
+-    enable_mubin &= k.is_musa
+-    enable_mubin &= v.is_musa
++    enable_mubin = enable_mubin & q.is_musa
++    enable_mubin = enable_mubin & k.is_musa
++    enable_mubin = enable_mubin & v.is_musa
+ 
+-    enable_mubin &= q.dtype == torch.float16 or q.dtype == torch.bfloat16
+-    enable_mubin &= k.dtype == torch.float16 or k.dtype == torch.bfloat16
+-    enable_mubin &= v.dtype == torch.float16 or v.dtype == torch.bfloat16
++    enable_mubin = enable_mubin & (
++        q.dtype == torch.float16 or q.dtype == torch.bfloat16
++    )
++    enable_mubin = enable_mubin & (
++        k.dtype == torch.float16 or k.dtype == torch.bfloat16
++    )
++    enable_mubin = enable_mubin & (
++        v.dtype == torch.float16 or v.dtype == torch.bfloat16
++    )
+ 
+-    enable_mubin &= q.dtype == k.dtype and q.dtype == v.dtype
++    enable_mubin = enable_mubin & (q.dtype == k.dtype and q.dtype == v.dtype)
+ 
+-    enable_mubin &= q.dim() == 3 or q.dim() == 4
+-    enable_mubin &= k.dim() == 3 or k.dim() == 4
+-    enable_mubin &= v.dim() == 3 or v.dim() == 4
+-    enable_mubin &= q.dim() == k.dim() and q.dim() == v.dim()
++    enable_mubin = enable_mubin & (q.dim() == 3 or q.dim() == 4)
++    enable_mubin = enable_mubin & (k.dim() == 3 or k.dim() == 4)
++    enable_mubin = enable_mubin & (v.dim() == 3 or v.dim() == 4)
++    enable_mubin = enable_mubin & (q.dim() == k.dim() and q.dim() == v.dim())
+ 
+     headdim_qk = q.shape[-1]
+     headdim_v = v.shape[-1]
+@@ -62,23 +68,23 @@ def _check_valid_asm_input(
+     is_192_128 = headdim_qk == 192 and headdim_v == 128
+     is_128_128_or_less = headdim_qk == headdim_v and headdim_qk <= 128
+ 
+-    enable_mubin &= is_192_128 or is_128_128_or_less
++    enable_mubin = enable_mubin & (is_192_128 or is_128_128_or_less)
+ 
+-    enable_mubin &= page_table is None
++    enable_mubin = enable_mubin & (page_table is None)
+ 
+-    enable_mubin &= seqused_q is None
+-    enable_mubin &= seqused_k is None
++    enable_mubin = enable_mubin & (seqused_q is None)
++    enable_mubin = enable_mubin & (seqused_k is None)
+ 
+     window_size_left, window_size_right = window_size
+-    enable_mubin &= window_size_left is None or window_size_left < 0
+-    enable_mubin &= window_size_right is None or window_size_right <= 0
++    enable_mubin = enable_mubin & (window_size_left is None or window_size_left < 0)
++    enable_mubin = enable_mubin & (window_size_right is None or window_size_right <= 0)
+ 
+-    enable_mubin &= qv is None
+-    enable_mubin &= softcap == 0.0
+-    enable_mubin &= learnable_sink is None
+-    enable_mubin &= attention_chunk == 0
++    enable_mubin = enable_mubin & (qv is None)
++    enable_mubin = enable_mubin & (softcap == 0.0)
++    enable_mubin = enable_mubin & (learnable_sink is None)
++    enable_mubin = enable_mubin & (attention_chunk == 0)
+ 
+-    enable_mubin &= cp_world_size == 1
++    enable_mubin = enable_mubin & (cp_world_size == 1)
+ 
+     if not enable_mubin:
+         return enable_mubin
+@@ -88,26 +94,34 @@ def _check_valid_asm_input(
+         total_seq_kv, nr_heads_kv, _ = k.shape
+         _, _, headdim_v = v.shape
+ 
+-        enable_mubin &= k.shape == (total_seq_kv, nr_heads_kv, headdim_qk)
+-        enable_mubin &= v.shape == (total_seq_kv, nr_heads_kv, headdim_v)
++        enable_mubin = enable_mubin & (
++            k.shape == (total_seq_kv, nr_heads_kv, headdim_qk)
++        )
++        enable_mubin = enable_mubin & (
++            v.shape == (total_seq_kv, nr_heads_kv, headdim_v)
++        )
+ 
+-        enable_mubin &= cu_seqlens_q.is_musa
+-        enable_mubin &= cu_seqlens_k.is_musa
++        enable_mubin = enable_mubin & cu_seqlens_q.is_musa
++        enable_mubin = enable_mubin & cu_seqlens_k.is_musa
+ 
+-        enable_mubin &= cu_seqlens_q is not None
+-        enable_mubin &= cu_seqlens_k is not None
+-        enable_mubin &= cu_seqlens_k.numel() == cu_seqlens_q.numel()
++        enable_mubin = enable_mubin & (cu_seqlens_q is not None)
++        enable_mubin = enable_mubin & (cu_seqlens_k is not None)
++        enable_mubin = enable_mubin & (cu_seqlens_k.numel() == cu_seqlens_q.numel())
+ 
+-        enable_mubin &= max_seqlen_q is not None
+-        enable_mubin &= max_seqlen_k is not None
++        enable_mubin = enable_mubin & (max_seqlen_q is not None)
++        enable_mubin = enable_mubin & (max_seqlen_k is not None)
+ 
+     if q.dim() == 4:
+         batch, seq_q, nr_heads, headdim_qk = q.shape
+         _, seq_kv, nr_heads_kv, _ = k.shape
+         _, _, _, headdim_v = v.shape
+ 
+-        enable_mubin &= k.shape == (batch, seq_kv, nr_heads_kv, headdim_qk)
+-        enable_mubin &= v.shape == (batch, seq_kv, nr_heads_kv, headdim_v)
++        enable_mubin = enable_mubin & (
++            k.shape == (batch, seq_kv, nr_heads_kv, headdim_qk)
++        )
++        enable_mubin = enable_mubin & (
++            v.shape == (batch, seq_kv, nr_heads_kv, headdim_v)
++        )
+ 
+     return enable_mubin
+ 

--- a/tests/test_docker_mate_patch.py
+++ b/tests/test_docker_mate_patch.py
@@ -1,0 +1,92 @@
+"""Tests for the version-gated MATE Docker compatibility patch."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+HELPER_PATH = ROOT / "docker/patches/apply_mate_dynamo_bool_patch.py"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="Git is required by the Docker compatibility step",
+)
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("mate_docker_patch", HELPER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture(tmp_path: Path, source: str):
+    site_packages = tmp_path / "site-packages"
+    target = site_packages / "mate" / "mha_interface.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(source)
+    patch_file = tmp_path / "mate.patch"
+    patch_file.write_text("""diff --git a/mate/mha_interface.py b/mate/mha_interface.py
+--- a/mate/mha_interface.py
++++ b/mate/mha_interface.py
+@@ -1 +1 @@
+-enable_mubin &= q.is_musa
++enable_mubin = enable_mubin & q.is_musa
+""")
+    return site_packages, target, patch_file
+
+
+def _fake_distribution(monkeypatch, helper, version: str, site_packages: Path):
+    dist = SimpleNamespace(version=version, locate_file=lambda _: site_packages)
+    monkeypatch.setattr(helper, "distribution", lambda _: dist)
+
+
+def test_applies_to_mate_before_026(tmp_path, monkeypatch):
+    helper = _load_helper()
+    site_packages, target, patch_file = _fixture(
+        tmp_path, "enable_mubin &= q.is_musa\n"
+    )
+    _fake_distribution(monkeypatch, helper, "0.2.4", site_packages)
+
+    helper.apply_patch(patch_file)
+
+    assert target.read_text() == "enable_mubin = enable_mubin & q.is_musa\n"
+
+
+def test_skips_mate_026_and_newer(tmp_path, monkeypatch):
+    helper = _load_helper()
+    site_packages, target, patch_file = _fixture(
+        tmp_path, "enable_mubin &= q.is_musa\n"
+    )
+    _fake_distribution(monkeypatch, helper, "0.2.6", site_packages)
+
+    helper.apply_patch(patch_file)
+
+    assert target.read_text() == "enable_mubin &= q.is_musa\n"
+
+
+def test_rejects_partially_applied_patch(tmp_path, monkeypatch):
+    helper = _load_helper()
+    site_packages, _target, patch_file = _fixture(
+        tmp_path,
+        "enable_mubin = enable_mubin & q.is_musa\n" "enable_mubin &= k.is_musa\n",
+    )
+    _fake_distribution(monkeypatch, helper, "0.2.5", site_packages)
+
+    with pytest.raises(RuntimeError, match="partially applied"):
+        helper.apply_patch(patch_file)
+
+
+def test_rejects_unknown_pre026_layout(tmp_path, monkeypatch):
+    helper = _load_helper()
+    site_packages, _target, patch_file = _fixture(tmp_path, "enable_mubin = True\n")
+    _fake_distribution(monkeypatch, helper, "0.2.5", site_packages)
+
+    with pytest.raises(RuntimeError, match="expected pre-0.2.6 layout"):
+        helper.apply_patch(patch_file)


### PR DESCRIPTION
## Summary

- Apply a version-gated compatibility patch to the installed MATE wheel during `docker/musa.Dockerfile` builds.
- Patch MATE versions older than 0.2.6, skip 0.2.6 and newer, and fail closed on partially patched or unexpected source layouts.
- Add focused tests for the apply, skip, partial-state, and unknown-layout paths.

The current `v0.24.0-dev` branch uses torch 2.11 and MATE 0.2.4. MATE's `_check_valid_asm_input` uses augmented boolean assignment with symbolic shape predicates; TorchDynamo can emit invalid FX Python such as `True &= le`. MATE 0.2.6 will contain this fix, so the Docker image applies the same source change until that version is adopted.

This only affects images built through `docker/musa.Dockerfile`; non-Docker installation paths are unchanged.

## Validation

- Source: `vllm-musa@1db898d6dfa765071bd51022bd7a90d88291da76`, based on `origin/v0.24.0-dev@2128760a319d6e5ceb0f4d320e2033a2f81355c2`.
- `python -m pytest -q tests/test_docker_mate_patch.py`: `4 passed`.
- Changed-file pre-commit checks passed; the bundled patch exactly matches the MATE source diff and passes `git apply --check` against the matching MATE source.
- The helper applied successfully to actual MATE 0.2.4 and 0.2.5 installations.
- `vllm_musa_deps` built successfully from `registry.mthreads.com/mcconline/inference/vllm:v0.24.0-ph1-5.2.0-torch2.11.0.post1-20260814`; the resulting image reported:

  ```text
  PASS mate_dynamo_bool_patch version=0.2.4 target=/usr/local/lib/python3.10/dist-packages/mate/mha_interface.py
  PASS deps_image torch=2.11.0.post1+musa5.2.0 mate=0.2.4 patched=True
  ```

- Qwen-Image-Edit-2511 was validated with the same MATE source diff on one S5000 in TP1, default compiled mode, without eager mode or CPU offload. The server reached healthy state and a 512x512 image-edit request returned HTTP 200 with a valid PNG.
