### PR TITLE
chore: bump torchada to 0.1.82

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,5 @@
 # Runtime Python dependencies that are portable across MUSA images.
-torchada==0.1.81
+torchada==0.1.82
 mthreads-ml-py>=2.4.1
 numpy==1.26
 openai>=2.24.0

--- a/tests/test_inplace_porting_contract.py
+++ b/tests/test_inplace_porting_contract.py
@@ -23,7 +23,7 @@ SUPPORTED_MUSA_STACKS = {
             "torchaudio==2.11.0+musa5.2.0",
             "deep_ep==1.1.0+musa5.2.0torch2.11.0.post1",
         ),
-        "torchada": "torchada==0.1.81",
+        "torchada": "torchada==0.1.82",
     },
 }
 
@@ -63,7 +63,7 @@ def test_supported_musa_stack_contract_cases_are_explicit():
     )
     assert (
         SUPPORTED_MUSA_STACKS["torch==2.11.0.post1+musa5.2.0"]["torchada"]
-        == "torchada==0.1.81"
+        == "torchada==0.1.82"
     )
     assert (
         "torchvision==0.24.1.post1+musa5.2.0"


### PR DESCRIPTION
Ring attention can now use FA3 as the attention backend.