### PR TITLE
fix: enable MUSA sampled speculative decoding without fallback

### DIFF
--- a/tests/test_sampled_spec_rejection_source.py
+++ b/tests/test_sampled_spec_rejection_source.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Source contracts for MUSA sampled speculative rejection support."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERIES = ROOT / "vllm_musa" / "patches" / "series"
+REJECTION_PATCH = SERIES / "0028-MUSA-vllm.v1.sample.rejection_sampler.patch"
+MODEL_RUNNER_PATCH = SERIES / "0035-MUSA-vllm.v1.worker.gpu_model_runner.patch"
+
+
+def test_sampled_spec_decode_has_no_environment_guard() -> None:
+    patch_sources = "\n".join(
+        path.read_text() for path in sorted(SERIES.glob("*.patch"))
+    )
+
+    assert "VLLM_MUSA_SPEC_DECODE_RANDOM_FALLBACK" not in patch_sources
+    assert "_musa_sample_first_target_token" not in patch_sources
+
+
+def test_rejection_sampler_keeps_musa_random_kernel_compatibility() -> None:
+    source = REJECTION_PATCH.read_text()
+
+    assert ").to(torch.int32)" in source
+    assert "if synthetic_conditional_rates is None:" in source
+    assert "if is_greedy == 0:" in source
+    assert "if is_greedy != 0:" in source
+    assert "rejection_random_sample_kernel" in source
+
+
+def test_rejection_sampler_uses_correct_top_p_mask_on_musa() -> None:
+    source = REJECTION_PATCH.read_text()
+
+    assert "if current_platform.is_musa():" in source
+    assert "return apply_top_k_top_p_pytorch(logits, top_k, top_p)" in source
+
+
+def test_model_runner_does_not_skip_non_greedy_drafter() -> None:
+    source = MODEL_RUNNER_PATCH.read_text()
+
+    assert "not self.input_batch.sampling_metadata.all_greedy" not in source
+    assert "input_fits_in_drafter = False" not in source

--- a/vllm_musa/patches/series/0028-MUSA-vllm.v1.sample.rejection_sampler.patch
+++ b/vllm_musa/patches/series/0028-MUSA-vllm.v1.sample.rejection_sampler.patch
@@ -1,100 +1,109 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: musa <musa@local>
-Date: Wed, 3 Jun 2026 11:47:36 +0000
+Date: Mon, 17 Aug 2026 12:17:05 +0000
 Subject: [PATCH] MUSA: vllm.v1.sample.rejection_sampler
 
 ---
- vllm/v1/sample/rejection_sampler.py | 95 +++++++++++++++++++++++++++--
- 1 file changed, 91 insertions(+), 4 deletions(-)
+ tests/v1/sample/test_rejection_sampler.py | 55 +++++++++++++++++++++++
+ vllm/v1/sample/rejection_sampler.py       | 32 +++++++++++--
+ 2 files changed, 83 insertions(+), 4 deletions(-)
 
+diff --git a/tests/v1/sample/test_rejection_sampler.py b/tests/v1/sample/test_rejection_sampler.py
+index 10c4d448f7..4863d19dd8 100644
+--- a/tests/v1/sample/test_rejection_sampler.py
++++ b/tests/v1/sample/test_rejection_sampler.py
+@@ -14,6 +14,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
+ from vllm.v1.sample.rejection_sampler import (
+     PLACEHOLDER_TOKEN_ID,
+     RejectionSampler,
++    apply_sampling_constraints,
+     sample_recovered_tokens,
+ )
+ from vllm.v1.sample.sampler import Sampler, SamplerOutput
+@@ -742,6 +743,60 @@ def test_top_p(rejection_sampler, top_p):
+         unmasked_indices=top_p_indices,
+         sampling_metadata=sampling_metadata,
+     )
+-
+-
++
++
++@pytest.mark.skipif(
++    not current_platform.is_musa(),
++    reason="MUSA rejection sampling uses a platform-specific top-p fallback",
++)
++def test_musa_rejection_top_p_mask_matches_pytorch_reference():
++    """Keep MUSA rejection sampling off the divergent Triton top-p mask."""
++    vocab_size = 100
++    batch_size = 100
++    num_draft_tokens = 3
++    num_tokens = batch_size * num_draft_tokens
++    top_p = 0.5
++
++    generator = torch.Generator(device=DEVICE_TYPE).manual_seed(0)
++    target_logits = torch.randn(
++        (num_tokens, vocab_size),
++        generator=generator,
++        device=DEVICE_TYPE,
++    )
++    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE_TYPE)
++    sampling_metadata = create_sampling_metadata(
++        all_greedy=False,
++        temperature=temperature,
++        top_p=torch.full(
++            (batch_size,), top_p, dtype=torch.float32, device=DEVICE_TYPE
++        ),
++    )
++    cu_num_draft_tokens = torch.arange(
++        num_draft_tokens,
++        num_tokens + 1,
++        num_draft_tokens,
++        dtype=torch.int32,
++        device=DEVICE_TYPE,
++    )
++
++    actual = apply_sampling_constraints(
++        target_logits.clone(),
++        cu_num_draft_tokens,
++        sampling_metadata,
++    )
++
++    logits_sort, logits_idx = target_logits.sort(dim=-1, descending=False)
++    probs_sum = logits_sort.softmax(dim=-1).cumsum(dim=-1)
++    top_p_mask = probs_sum <= 1 - top_p
++    top_p_mask[:, -1] = False
++    logits_sort.masked_fill_(top_p_mask, -float("inf"))
++    expected = target_logits.clone().scatter_(
++        dim=-1,
++        index=logits_idx,
++        src=logits_sort,
++    )
++
++    assert torch.equal(torch.isfinite(actual), torch.isfinite(expected))
++
++
+ ########################### Tests for Logit Processors ###################
 diff --git a/vllm/v1/sample/rejection_sampler.py b/vllm/v1/sample/rejection_sampler.py
-index 8b4d8c9dc..b11a3aacf 100644
+index 8b4d8c9dce..2f46f17980 100644
 --- a/vllm/v1/sample/rejection_sampler.py
 +++ b/vllm/v1/sample/rejection_sampler.py
-@@ -157,6 +157,23 @@ class RejectionSampler(nn.Module):
-         target_logits = self.apply_logits_processors(
-             target_logits, sampling_metadata, metadata
-         )
-+        if (
-+            not sampling_metadata.all_greedy
-+            and sampling_metadata.max_num_logprobs is None
-+            and _musa_spec_decode_random_fallback_enabled()
-+        ):
-+            output_token_ids = _musa_sample_first_target_token(
-+                self.sampler,
-+                target_logits,
-+                metadata,
-+                sampling_metadata,
-+            )
-+            if output_token_ids is not None:
-+                return SamplerOutput(
-+                    sampled_token_ids=output_token_ids,
-+                    logprobs_tensors=None,
-+                )
-+
-         # [num_tokens, vocab_size]
-         # NOTE(woosuk): `target_logits` can be updated in place inside the
-         # `apply_sampling_constraints` function.
-@@ -391,6 +408,58 @@ class RejectionSampler(nn.Module):
-         return result
- 
- 
-+def _musa_spec_decode_random_fallback_enabled() -> bool:
-+    value = __import__("os").environ.get(
-+        "VLLM_MUSA_SPEC_DECODE_RANDOM_FALLBACK",
-+        "1",
-+    )
-+    if value.lower() in ("0", "false", "no", "off"):
-+        return False
-+    try:
-+        from vllm.platforms import current_platform
-+
-+        return current_platform.is_musa()
-+    except Exception:
-+        return False
-+
-+
-+def _musa_sample_first_target_token(
-+    sampler: Sampler,
-+    target_logits: torch.Tensor,
-+    metadata: SpecDecodeMetadata,
-+    sampling_metadata: SamplingMetadata,
-+) -> torch.Tensor | None:
-+    # MUSA random rejection sampling is not correctness-stable yet. Preserve
-+    # the distribution by sampling only the first target-token logits and
-+    # returning placeholders for all speculative positions, effectively
-+    # disabling speculative acceptance for non-greedy requests.
-+    if any(num_tokens <= 0 for num_tokens in metadata.num_draft_tokens):
-+        return None
-+
-+    starts: list[int] = []
-+    offset = 0
-+    for num_tokens in metadata.num_draft_tokens:
-+        starts.append(offset)
-+        offset += num_tokens
-+
-+    start_indices = torch.tensor(
-+        starts,
-+        dtype=torch.long,
-+        device=target_logits.device,
-+    )
-+    first_target_logits = target_logits.index_select(0, start_indices)
-+    sampled, _ = sampler.sample(first_target_logits, sampling_metadata)
-+
-+    output_token_ids = torch.full(
-+        (len(metadata.num_draft_tokens), metadata.max_spec_len + 1),
-+        PLACEHOLDER_TOKEN_ID,
-+        dtype=torch.int32,
-+        device=target_logits.device,
-+    )
-+    output_token_ids[:, 0] = sampled.to(torch.int32)
-+    return output_token_ids
-+
-+
- def rejection_sample(
-     # [num_tokens]
-     draft_token_ids: torch.Tensor,
-@@ -435,7 +504,21 @@ def rejection_sample(
+@@ -11,6 +11,7 @@ import torch
+ import torch.nn as nn
+
+ from vllm.logger import init_logger
++from vllm.platforms import current_platform
+ from vllm.triton_utils import tl, triton
+ from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
+ from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
+@@ -18,6 +19,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
+ from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
+ from vllm.v1.sample.ops.penalties import apply_all_penalties
+ from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
++from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p_pytorch
+ from vllm.v1.sample.sampler import Sampler
+ from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+ from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
+@@ -435,7 +437,21 @@ def rejection_sample(
      if sampling_metadata.all_greedy:
          is_greedy = None
      else:
@@ -114,10 +123,18 @@ index 8b4d8c9dc..b11a3aacf 100644
 +        synthetic_conditional_rates = torch.empty(
 +            1, dtype=torch.float32, device=device
 +        )
- 
+
      # Generate uniform probabilities before either kernel because synthetic
      # mode needs them in the greedy kernel too.  Skip only when all requests
-@@ -727,8 +810,10 @@ def rejection_greedy_sample_kernel(
+@@ -562,3 +578,7 @@ def apply_sampling_constraints(
+     # NOTE(woosuk): `apply_top_k_top_p` uses sorting to calculate the mask,
+     # which is slow for large vocab sizes. This may cause performance issues.
++    # MUSA Triton's top-p mask can retain tokens outside the requested support.
++    # Use the PyTorch implementation for rejection-sampling correctness.
++    if current_platform.is_musa():
++        return apply_top_k_top_p_pytorch(logits, top_k, top_p)
+     return apply_top_k_top_p(logits, top_k, top_p)
+@@ -727,8 +747,10 @@ def rejection_greedy_sample_kernel(
      req_idx = tl.program_id(0)
      # FIXME(woosuk): Because is_greedy_ptr is not None at profiling run,
      # re-compilation may happen during runtime when is_greedy_ptr is None.
@@ -129,8 +146,8 @@ index 8b4d8c9dc..b11a3aacf 100644
 +    if is_greedy == 0:
          # Early exit for non-greedy sampling requests.
          return
- 
-@@ -787,8 +872,10 @@ def rejection_random_sample_kernel(
+
+@@ -787,8 +809,10 @@ def rejection_random_sample_kernel(
      SYNTHETIC_MODE: tl.constexpr,
  ):
      req_idx = tl.program_id(0)
@@ -141,4 +158,6 @@ index 8b4d8c9dc..b11a3aacf 100644
 +    if is_greedy != 0:
          # Early exit for greedy sampling requests.
          return
- 
+
+--
+2.34.1

--- a/vllm_musa/patches/series/0035-MUSA-vllm.v1.worker.gpu_model_runner.patch
+++ b/vllm_musa/patches/series/0035-MUSA-vllm.v1.worker.gpu_model_runner.patch
@@ -4,16 +4,16 @@ Date: Tue, 9 Jun 2026 15:41:52 +0800
 Subject: [PATCH] MUSA: vllm.v1.worker.gpu_model_runner
 
 ---
- vllm/v1/worker/gpu_model_runner.py | 112 ++++++++++++++++++++++++-----
- 1 file changed, 96 insertions(+), 16 deletions(-)
+ vllm/v1/worker/gpu_model_runner.py | 98 +++++++++++++++++++++++++++++++------
+ 1 file changed, 82 insertions(+), 16 deletions(-)
 
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 74938a823..8dba0cea5 100644
+index 74938a823..dfff0fd5a 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
 @@ -540,6 +540,9 @@ class GPUModelRunner(
          self.encoder_cudagraph_manager: EncoderCudaGraphManager | None = None
- 
+
          self.use_aux_hidden_state_outputs = False
 +        # / PR #34880: tracks whether the draft model supports
 +        # FULL-mode CUDA-graph capture (Eagle + padded drafter batch).
@@ -46,7 +46,7 @@ index 74938a823..8dba0cea5 100644
 @@ -801,6 +812,25 @@ class GPUModelRunner(
          self.query_pos = self._make_buffer(arange_size, dtype=torch.int64)
          self._arange_scratch = np.empty(arange_size, dtype=np.int64)
- 
+
 +        # MUSA-3406: reusable CPU/GPU buffers for speculative metadata indices.
 +        # Avoid per-step torch.from_numpy(...).to(device) pageable uploads in
 +        # _calc_spec_decode_metadata on the TP8 DeepSeek-V4 decode path.
@@ -72,7 +72,7 @@ index 74938a823..8dba0cea5 100644
 @@ -2795,17 +2825,48 @@ class GPUModelRunner(
          # [0, 1, 2, 5, 6, 9]
          target_logits_indices += self._arange_scratch[: cu_num_draft_tokens[-1]]
- 
+
 -        cu_num_draft_tokens = async_tensor_h2d(cu_num_draft_tokens, device=self.device)
 -        cu_num_sampled_tokens = async_tensor_h2d(
 -            cu_num_sampled_tokens, device=self.device
@@ -126,48 +126,27 @@ index 74938a823..8dba0cea5 100644
 +            bonus_logits_indices = async_tensor_h2d(
 +                bonus_logits_indices, device=self.device
 +            )
- 
+
          # Compute the draft token ids.
          # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
-@@ -4513,6 +4574,20 @@ class GPUModelRunner(
-             input_fits_in_drafter = self._input_fits_in_drafter(
-                 spec_decode_common_attn_metadata
-             )
-+            if (
-+                current_platform.is_musa()
-+                and not self.input_batch.sampling_metadata.all_greedy
-+                and __import__("os").environ.get(
-+                    "VLLM_MUSA_SPEC_DECODE_RANDOM_FALLBACK",
-+                    "1",
-+                ).lower()
-+                not in ("0", "false", "no", "off")
-+            ):
-+                # The MUSA random rejection-sampling kernel is not
-+                # correctness-stable yet. Do not run the drafter for
-+                # non-greedy requests; the target model already sampled one
-+                # correct token for this step.
-+                input_fits_in_drafter = False
-             use_gpu_toks = (
-                 spec_config.use_eagle()
-                 or spec_config.uses_draft_model()
-@@ -5822,6 +5897,7 @@ class GPUModelRunner(
+@@ -5822,6 +5883,7 @@ class GPUModelRunner(
          )
- 
+
          attn_metadata: PerLayerAttnMetadata | None = None
 +        spec_decode_cm: 'CommonAttentionMetadata | None' = None
- 
+
          slot_mappings_by_group, slot_mappings = self._get_slot_mappings(
              num_tokens_padded=num_tokens_padded,
-@@ -5876,7 +5952,7 @@ class GPUModelRunner(
+@@ -5876,7 +5938,7 @@ class GPUModelRunner(
                  self.input_batch.block_table.commit_block_table(num_reqs_padded)
- 
+
                  pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
 -                attn_metadata, _ = self._build_attention_metadata(
 +                attn_metadata, spec_decode_cm = self._build_attention_metadata(
                      num_tokens=num_tokens_unpadded,
                      num_tokens_padded=num_tokens_padded if pad_attn else None,
                      num_reqs=num_reqs_padded,
-@@ -5983,13 +6059,16 @@ class GPUModelRunner(
+@@ -5983,13 +6045,16 @@ class GPUModelRunner(
                      | Gemma4Proposer,
                  )
                  assert self.speculative_config is not None
@@ -188,8 +167,8 @@ index 74938a823..8dba0cea5 100644
                      )
                      or (
                          not is_graph_capturing
-@@ -6009,6 +6088,7 @@ class GPUModelRunner(
- 
+@@ -6009,6 +6074,7 @@ class GPUModelRunner(
+
                  self.drafter.dummy_run(
                      num_tokens,
 +                    common_attn_metadata=spec_decode_cm,


### PR DESCRIPTION
## Summary

Remove the MUSA sampled-speculative fallback that disabled draft decoding for non-greedy requests.

This restores normal sampled speculative decoding for Qwen3.5 MTP and removes the runtime dependency on:

## Behavior

Before:

- temperature=0: draft model and greedy rejection sampling run normally.
- temperature!=0 without the environment variable: draft model is skipped and speculative positions are filled with placeholders, resulting in zero draft acceptance.
- VLLM_MUSA_SPEC_DECODE_RANDOM_FALLBACK=0: sampled rejection path is enabled, but MUSA Triton top-p masking may produce an incorrect support set.

After:

- temperature=0: normal draft generation and greedy rejection sampling.
- temperature!=0: normal draft generation and random rejection sampling.
- VLLM_MUSA_SPEC_DECODE_RANDOM_FALLBACK is no longer required.
- Ordinary non-speculative sampling is unaffected. The PyTorch top-k/top-p path is used only inside the MUSA rejection-sampling path.