### PR TITLE
docs: add v0.24.0 serving cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 <p align="center">
-  <img src="assets/logo.png" alt="vLLM MUSA" width="60%">
+  <img src="assets/logo.png" alt="vLLM-MUSA" width="60%">
 </p>
 
-<h2 align="center">
-vLLM Hardware Plugin for Moore Threads MUSA
-</h2>
+<h2 align="center">High-performance LLM serving on Moore Threads MUSA</h2>
 
 <p align="center">
-  English | <a href="README_CN.md">中文</a>
+  <a href="README_CN.md">中文</a> ·
+  <a href="https://github.com/MooreThreads/vllm-musa/issues">Issues</a> ·
+  <a href="docs/cookbook/README.md">Serving recipes</a> ·
+  <a href="docs/installation.md">Documentation</a>
 </p>
 
 <p align="center">
@@ -15,324 +16,82 @@ vLLM Hardware Plugin for Moore Threads MUSA
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10-blue.svg" alt="Python 3.10"></a>
 </p>
 
----
-
 ## About
 
-The vLLM Hardware Plugin for Moore Threads MUSA integrates [Moore Threads](https://www.mthreads.com/) (MUSA) GPUs with [vLLM](https://docs.vllm.ai/en/latest/) to enable high-performance large language model inference. It follows the [[RFC]: Hardware pluggable](https://github.com/vllm-project/vllm/issues/11162) and [[RFC]: Enhancing vLLM Plugin Architecture](https://github.com/vllm-project/vllm/issues/19161) principles, providing a modular interface for Moore Threads MUSA hardware.
+vLLM-MUSA is the Moore Threads backend for [vLLM](https://github.com/vllm-project/vllm),
+providing an OpenAI-compatible inference and serving engine for MUSA GPUs.
 
-The plugin leverages the following key components:
+- v0.24.0 release line with the vLLM V1 engine.
+- Validated with the PyTorch 2.11.x MUSA stack.
+- MUSA-native attention, communication, custom ops, and compilation support.
+- Per-checkpoint recipes for Qwen and DeepSeek-V4-Flash on S5000.
 
-- **[torchada](https://github.com/MooreThreads/torchada)**: CUDA→MUSA compatibility layer for PyTorch — run CUDA code on MUSA with zero code changes
-- **[mthreads-ml-py](https://github.com/MooreThreads/mthreads-ml-py)**: Moore Threads Management Library (MTML) Python bindings for device management and queries
-- **[MATE](https://github.com/MooreThreads/mate)**: MUSA AI Tensor Engine — high-performance computing library optimized for LLM inference on MUSA architecture
-- **[torch_musa](https://github.com/MooreThreads/torch_musa)**: PyTorch backend for Moore Threads (MUSA) GPUs — extends PyTorch with native MUSA device support
+## Getting started
 
-## Requirements
+### Install
 
-- **Python**: 3.10 — the pinned MUSA wheels are published for CPython 3.10 on
-  x86_64, so other versions cannot resolve them
-- **Hardware**: Moore Threads (MUSA) GPU with MUSA toolkit installed
-- **Dependencies**:
-  - [torchada](https://github.com/MooreThreads/torchada) — CUDA→MUSA compatibility layer
-  - [mthreads-ml-py](https://github.com/MooreThreads/mthreads-ml-py) — MTML Python bindings (pymtml)
-  - [MATE](https://github.com/MooreThreads/mate) — MUSA AI Tensor Engine
-  - [torch_musa](https://github.com/MooreThreads/torch_musa) — PyTorch backend for MUSA GPUs
-
-## Getting Started
-
-### Supported Versions
-
-| vLLM Version | PyTorch Version | Engine  | Status       |
-|--------------|-----------------|---------|--------------|
-| v0.24.0       | 2.11.x          | V1 only | ✅ Supported |
-
-> **Note**: This plugin uses vLLM's V1 engine architecture (the V0 engine is not supported). Within the V1 engine, vLLM v0.24.0 auto-selects its **Model Runner V2** for certain architectures (e.g. Qwen3, DeepSeek-V2, Llama) and the V1 model runner for others; both are supported on MUSA. Set `VLLM_USE_V2_MODEL_RUNNER=1` or `0` to force one.
-
-### Docker image
-
-The Docker flow installs the MUSA SDK, the MUSA wheels, `vllm-musa`, the
-vendored vLLM, and `pytest` into one image, and is the least error-prone way to
-get a working environment. Its working directory is `/vllm-workspace`, matching
-the upstream vLLM runtime image. The default target also matches
-`vllm-openai` and starts `vllm serve`:
+Use the v0.24.0 release image:
 
 ```bash
-bash docker/build_image.sh
+export VLLM_MUSA_IMAGE=registry.mthreads.com/mcconline/inference/vllm/vllm-openai:v0.24.0
+docker pull "${VLLM_MUSA_IMAGE}"
 ```
 
-Use `--target final` to build the shell/test image without the serving
-entrypoint.
+- [Installation and source build](docs/installation.md)
+- [Docker build guide](docker/README.md)
+- [Configuration reference](docs/configuration.md)
 
-See [docker/README.md](docker/README.md) for version compatibility and build
-options. To install onto a host that already has the MUSA SDK, use the source
-install below.
+### Quickstart
 
-### Package indexes
+```bash
+vllm serve /path/to/model \
+  --trust-remote-code \
+  --served-model-name my-model
+```
 
-`vllm-musa` resolves its dependencies from **two** indexes:
+The command above assumes that `vllm` is installed and on the current
+environment's `PATH`. For the release image, use the container launch shape
+in the [Docker guide](docker/README.md).
 
-| Index | URL | Provides |
+The OpenAI-compatible endpoint is available at `http://localhost:8000/v1`.
+For recommended tensor-parallel, scheduler, and speculative-decoding settings,
+use the [serving cookbook](docs/cookbook/README.md).
+
+## Documentation
+
+- [Serving cookbook](docs/cookbook/README.md)
+- [Installation](docs/installation.md)
+- [Python and OpenAI-compatible usage](docs/usage.md)
+- [Configuration](docs/configuration.md)
+- [Development](docs/development.md)
+- [MUSA developer guide](docs/mdm-developer-guide.md)
+
+## Supported release
+
+| vLLM-MUSA | PyTorch/MUSA | Engine |
 |---|---|---|
-| Moore Threads | `https://dl.mthreads.com/repo/api/pypi/pypi/simple` | the MUSA wheels pinned in `requirements/musa_private.txt` — `torch`, `torch_musa`, `mate`, `flash_attn_3`, `flash_mla`, `deep-gemm`, `tilelang_musa`, `triton`, `apache-tvm-ffi`, … |
-| Public PyPI | `https://pypi.org/simple`, or a mirror | the ordinary third-party wheels in `requirements/build.txt` and `requirements/common.txt` |
+| v0.24.0 | 2.11.x | V1 |
 
-Most of the MUSA wheels are not published on public PyPI, so installing
-`requirements/musa.txt` with pip's default index fails with
-`No matching distribution found for torch==2.11.0.post1+musa5.2.0`.
-
-The MUSA wheels must be **resolved** with the Moore Threads index as the sole
-`--index-url`, which is why the install below starts with a pass that installs
-only them.
-
-Pass 3 below does pass both indexes. That is safe only because pass 1 has already
-installed every MUSA wheel at its pinned version, so nothing MUSA is re-resolved
-there and the merged index only supplies the ordinary dependencies.
-
-### Install from Source
-
-1. Clone the repository:
-
-    ```bash
-    git clone https://github.com/MooreThreads/vllm-musa.git
-    cd vllm-musa
-    ```
-
-2. Select the two indexes:
-
-    ```bash
-    export MUSA_PIP_INDEX_URL=https://dl.mthreads.com/repo/api/pypi/pypi/simple
-    export PYPI_INDEX_URL=https://pypi.org/simple
-    ```
-
-3. Install the Python dependencies in three passes:
-
-    ```bash
-    # 1. The MUSA wheels, from the Moore Threads index only. This pass runs
-    #    first and with --no-deps because torchada and transformers declare an
-    #    unpinned `torch`: resolving them first would pull the public CUDA torch
-    #    and the multi-GB nvidia-cuda-* stack over the MUSA one.
-    pip install --no-deps --index-url "${MUSA_PIP_INDEX_URL}" \
-        -r requirements/musa_private.txt
-
-    # 2. The ordinary third-party wheels, from public PyPI. Pass 1 already
-    #    satisfies `torch`.
-    pip install --index-url "${PYPI_INDEX_URL}" \
-        -r requirements/build.txt -r requirements/common.txt
-
-    # 3. The MUSA wheels' own ordinary dependencies (sympy, networkx, ...).
-    #    Pass 1 pinned every MUSA wheel, so none are re-resolved here.
-    pip install --index-url "${MUSA_PIP_INDEX_URL}" \
-        --extra-index-url "${PYPI_INDEX_URL}" \
-        -r requirements/musa_private.txt
-    ```
-
-4. Install vLLM Hardware Plugin for Moore Threads MUSA. The vendored vLLM takes
-   its dependencies from public PyPI, so keep that index selected here:
-
-    ```bash
-    export PIP_INDEX_URL="${PYPI_INDEX_URL}"
-
-    # Standard installation (installs vLLM MUSA plugin and vLLM)
-    pip install . --no-build-isolation -v
-
-    # Or editable installation for development
-    pip install -e . --no-build-isolation -v
-    ```
-
-5. Verify the installation:
-
-    ```bash
-    # Check plugin registration
-    python -c "from vllm_musa import musa_platform_plugin; print('Plugin loaded successfully')"
-
-    # Check MTML device management
-    python -c "from vllm_musa.platform import mtml_available; print(f'MTML available: {mtml_available}')"
-    ```
-
-### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `MUSA_VISIBLE_DEVICES` | Control which MUSA devices are visible (similar to `CUDA_VISIBLE_DEVICES`) |
-| `VLLM_WORKER_MULTIPROC_METHOD=spawn` | Recommended for multi-process workers |
-| `VLLM_MUSA_CUSTOM_OP_USE_NATIVE` | Use vLLM custom ops native implementation (default: `False`) |
-| `VLLM_MUSA_WORKER_TERMINATION_TIMEOUT_S` | Control vLLM v1 worker shutdown timeout (default: `4s`) |
-| `VLLM_MUSA_USE_CCACHE` | Enable ccache for native extension builds when `ccache` is installed (default: `1`) |
-| `VLLM_MUSA_CCACHE` | Override the ccache executable used by `setup.py` (default: first `ccache` in `PATH`) |
-| `VLLM_MUSA_CCACHE_DIR` | Override the ccache directory used by `setup.py` (default: `<repo>/.ccache`) |
-| `VLLM_MUSA_CCACHE_MAXSIZE` | Optional ccache max-size value passed through as `CCACHE_MAXSIZE` |
-| `VLLM_MUSA_REAL_MCC` | Override the real MUSA compiler wrapped by ccache (default: detected `mcc`) |
-
-### ccache for native rebuilds
-
-When `ccache` is available in `PATH`, source installs automatically route the
-host C++ compiler and MUSA `mcc` through ccache. The generated `mcc` wrapper
-normalizes MUSA-only inputs such as `.mu` sources to cacheable `.cu` copies and
-hides `-x musa` from ccache while still passing it to `mcc`. The default cache
-lives in `<repo>/.ccache`, so a second
-`pip install -e . --no-build-isolation -v` from the same checkout can reuse
-cached `.cu`, `.mu`, and C++ object compilation.
-
-Useful commands:
-
-```bash
-ccache --zero-stats
-pip install -e . --no-build-isolation -v
-ccache --show-stats
-```
-
-## Usage
-
-Once installed, the plugin is **automatically detected** by vLLM. Simply run vLLM as usual:
-
-```python
-from vllm import LLM, SamplingParams
-
-# vLLM will automatically use the MUSA platform
-llm = LLM(model="your-model-path", trust_remote_code=True)
-
-sampling_params = SamplingParams(temperature=0.7, top_p=0.9, max_tokens=100)
-outputs = llm.generate(["Hello, how are you?"], sampling_params)
-
-for output in outputs:
-    print(output.outputs[0].text)
-```
-
-### OpenAI-Compatible Server
-
-```bash
-# Start the server
-vllm serve /path/to/model/
-
-# Test completions API
-curl http://localhost:8000/v1/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model": "/path/to/model/", "prompt": "Hello!", "max_tokens": 50}'
-
-# Test chat completions API
-curl http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model": "/path/to/model/", "messages": [{"role": "user", "content": "What is 2+2?"}], "max_tokens": 50}'
-```
-
-## Testing
-
-Run the test suite:
-
-```bash
-# Run all tests
-make test
-
-# Run specific test file
-pytest tests/test_musa.py -v
-pytest tests/test_patches.py -v
-
-# Run with coverage
-make test-cov
-```
-
-## Project Structure
-
-```
-vllm-musa/
-├── pyproject.toml              # Project configuration
-├── README.md                   # Documentation (English)
-├── README_CN.md                # Documentation (中文)
-├── LICENSE                     # Apache 2.0 License
-├── requirements/               # Dependency pins (build, common, musa_private)
-├── docker/                     # Image build flow (musa.Dockerfile, build_image.sh)
-├── third_party/                # PINS + the upstream vLLM cloned at build time
-├── build_utils/                # Build helpers (ccache wrapper)
-├── tools/                      # Sync, verify, and patch-validation utilities
-├── example/                    # Usage examples
-├── csrc/                       # C/C++ source files
-├── docs/                       # Additional documentation
-├── vllm_musa/                  # Main package
-│   ├── __init__.py             # Plugin entry point
-│   ├── platform.py             # MUSA platform implementation
-│   └── patches/                # Patches against upstream vLLM
-│       ├── __init__.py         # Patch application logic
-│       ├── series/             # Build-time source patch series
-│       └── *.patch.py          # Import-time object patches
-└── tests/                      # Test suite
-    ├── conftest.py             # Pytest fixtures
-    ├── test_musa.py            # Platform tests
-    └── test_patches.py         # Patch system tests
-```
-
-## Patches
-
-The plugin carries two kinds of change to upstream vLLM. Source edits — the vast
-majority — are applied to the pinned vLLM clone **at build time** as a
-`git format-patch` series under `vllm_musa/patches/series/`, so the installed
-vLLM is already patched. A small set of live-object monkey-patches that have no
-source-diff form run **at import time** (`vllm_musa/patches/*.patch.py`); these
-are the only runtime patches. For details on both mechanisms, see
-[patches/README.md](vllm_musa/patches/README.md).
+The V1 engine may automatically select Model Runner V2 for supported model
+architectures; both runners are supported on MUSA.
 
 ## Contributing
 
-We welcome and value any contributions and collaborations. Please set up pre-commit hooks to ensure code quality before submitting:
+See the [development guide](docs/development.md) for editable installs, tests,
+patch workflow, and issue reports. Contributions and bug reports are welcome
+through [GitHub Issues](https://github.com/MooreThreads/vllm-musa/issues).
 
-```bash
-# Install pre-commit
-pip install pre-commit
+## Related projects
 
-# Install the git hooks
-pre-commit install
-
-# (Optional) Run against all files
-pre-commit run --all-files
-```
-
-Once installed, the hooks will automatically run on every commit, checking for:
-- Trailing whitespace and file formatting
-- Import sorting (isort)
-- Code formatting (black)
-- Linting (ruff)
-- Spelling errors (codespell)
-- Common issues (merge conflicts, debug statements, large files, etc.)
-
-You can also run checks manually:
-
-```bash
-make pre-commit    # Run pre-commit hooks on all files
-make test          # Run tests
-make test-cov      # Run tests with coverage
-```
-
-## Contact Us
-
-- For technical questions and feature requests, please use GitHub [Issues](https://github.com/MooreThreads/vllm-musa/issues).
-- When reporting a bug, please include your environment information by running `vllm_collect_env` (or `python -m vllm_musa.collect_env`) and pasting the output in your issue.
-
-## Related Projects
-
-| Project | Description |
-|---------|-------------|
-| [vLLM](https://github.com/vllm-project/vllm) | High-throughput LLM serving engine |
-| [torchada](https://github.com/MooreThreads/torchada) | CUDA→MUSA compatibility layer for PyTorch |
-| [torch_musa](https://github.com/MooreThreads/torch_musa) | PyTorch support for Moore Threads GPUs |
-| [MATE](https://github.com/MooreThreads/mate) | MUSA AI Tensor Engine for LLM acceleration |
-| [mthreads-ml-py](https://github.com/MooreThreads/mthreads-ml-py) | MTML Python bindings |
+- [Moore Threads](https://www.mthreads.com/)
+- [vLLM](https://github.com/vllm-project/vllm)
+- [vLLM documentation](https://docs.vllm.ai/en/latest/)
+- [vLLM-Omni](https://github.com/vllm-project/vllm-omni)
+- [torchada](https://github.com/MooreThreads/torchada)
+- [torch_musa](https://github.com/MooreThreads/torch_musa)
+- [MATE](https://github.com/MooreThreads/mate)
+- [mthreads-ml-py](https://github.com/MooreThreads/mthreads-ml-py)
 
 ## License
 
-This project is licensed under the [Apache License 2.0](LICENSE).
-
-```
-Copyright (c) 2026 Moore Threads Technology Co., Ltd. All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-```
+vLLM-MUSA is released under the [Apache License 2.0](LICENSE).

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,329 +1,96 @@
 <p align="center">
-  <img src="assets/logo.png" alt="vLLM MUSA" width="60%">
+  <img src="assets/logo.png" alt="vLLM-MUSA" width="60%">
 </p>
 
-<h2 align="center">
-摩尔线程 MUSA 的 vLLM 硬件插件
-</h2>
+<h2 align="center">面向摩尔线程（Moore Threads）MUSA 的高性能大语言模型服务</h2>
 
 <p align="center">
-  <a href="README.md">English</a> | 中文
+  <a href="README.md">英文版</a> ·
+  <a href="https://github.com/MooreThreads/vllm-musa/issues">问题反馈</a> ·
+  <a href="docs/cookbook/README.md">服务配置示例（英文）</a> ·
+  <a href="docs/installation-cn.md">文档</a>
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="许可证"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10-blue.svg" alt="Python 3.10"></a>
 </p>
 
----
+## 项目简介
 
-## 关于
+vLLM-MUSA 是摩尔线程为 [vLLM](https://github.com/vllm-project/vllm) 提供的后端，
+为 MUSA GPU 提供 OpenAI 兼容接口的推理服务引擎。
 
-摩尔线程 MUSA 的 vLLM 硬件插件将[摩尔线程](https://www.mthreads.com/) (MUSA) GPU 与 [vLLM](https://docs.vllm.ai/en/latest/) 集成，以实现高性能大语言模型推理。该插件遵循 [[RFC]: Hardware pluggable](https://github.com/vllm-project/vllm/issues/11162) 和 [[RFC]: Enhancing vLLM Plugin Architecture](https://github.com/vllm-project/vllm/issues/19161) 设计原则，为摩尔线程 MUSA 硬件提供模块化接口。
+- v0.24.0 系列版本，采用 vLLM V1 引擎。
+- 已在 PyTorch 2.11.x MUSA 软件栈上完成验证。
+- 提供 MUSA 原生注意力机制、通信、自定义算子和编译支持。
+- 针对 S5000 上 Qwen 和 DeepSeek-V4-Flash 的各个模型检查点提供配置示例。
 
-本插件基于以下核心组件：
+## 快速开始
 
-- **[torchada](https://github.com/MooreThreads/torchada)**：CUDA→MUSA 兼容层 — 无需修改代码即可在 MUSA 上运行 CUDA 代码
-- **[mthreads-ml-py](https://github.com/MooreThreads/mthreads-ml-py)**：摩尔线程管理库 (MTML) Python 绑定，用于设备管理和查询
-- **[MATE](https://github.com/MooreThreads/mate)**：MUSA AI 张量引擎 — 针对 MUSA 架构优化的高性能 LLM 推理库
-- **[torch_musa](https://github.com/MooreThreads/torch_musa)**：摩尔线程 (MUSA) GPU 的 PyTorch 后端 — 为 PyTorch 提供原生 MUSA 设备支持
+### 安装
 
-## 环境要求
-
-- **Python**：3.10 — 本套件所固定的 MUSA wheel 仅发布了 x86_64 上的 CPython 3.10
-  版本，其他 Python 版本无法解析这些依赖
-- **硬件**：安装了 MUSA 工具包的摩尔线程 (MUSA) GPU
-- **依赖项**：
-  - [torchada](https://github.com/MooreThreads/torchada) — CUDA→MUSA 兼容层
-  - [mthreads-ml-py](https://github.com/MooreThreads/mthreads-ml-py) — MTML Python 绑定 (pymtml)
-  - [MATE](https://github.com/MooreThreads/mate) — MUSA AI 张量引擎
-  - [torch_musa](https://github.com/MooreThreads/torch_musa) — MUSA GPU 的 PyTorch 后端
-
-## 快速上手
-
-### 支持的版本
-
-| vLLM 版本 | PyTorch 版本 | 引擎    | 状态         |
-|-----------|--------------|---------|--------------|
-| v0.24.0    | 2.11.x       | 仅 V1   | ✅ 已支持    |
-
-> **注意**：本插件使用 vLLM 的 V1 引擎架构（不支持 V0 引擎）。在 V1 引擎内部，vLLM v0.24.0 会为部分架构（如 Qwen3、DeepSeek-V2、Llama）自动选用 **Model Runner V2**，其余架构使用 V1 model runner；两者在 MUSA 上均受支持。设置 `VLLM_USE_V2_MODEL_RUNNER=1` 或 `0` 可强制指定其一。
-
-### Docker 镜像
-
-Docker 流程会把 MUSA SDK、MUSA wheel、`vllm-musa`、内置的 vLLM 以及 `pytest`
-一次性装入同一镜像，是最不容易出错的方式。镜像工作目录为 `/vllm-workspace`，
-与上游 vLLM runtime 镜像保持一致。默认 target 也与 `vllm-openai` 一致，启动
-`vllm serve`：
+使用 v0.24.0 正式镜像：
 
 ```bash
-bash docker/build_image.sh
+export VLLM_MUSA_IMAGE=registry.mthreads.com/mcconline/inference/vllm/vllm-openai:v0.24.0
+docker pull "${VLLM_MUSA_IMAGE}"
 ```
 
-如需不带 serving entrypoint 的 shell/test 镜像，请增加 `--target final`。
+- [安装与源码构建指南](docs/installation-cn.md)
+- [Docker 构建指南（英文）](docker/README.md)
+- [配置参考（英文）](docs/configuration.md)
 
-版本兼容性和构建选项参见 [docker/README.md](docker/README.md)。若要安装到已具备
-MUSA SDK 的主机上，请使用下面的源码安装。
+### 快速启动
 
-### 软件包索引
+```bash
+vllm serve /path/to/model \
+  --trust-remote-code \
+  --served-model-name my-model
+```
 
-`vllm-musa` 的依赖来自**两个**索引：
+上面的命令假设 `vllm` 已安装并位于当前环境的 `PATH` 中；使用正式镜像
+时，请参阅 [Docker 构建指南（英文）](docker/README.md) 中的容器启动方式。
 
-| 索引 | URL | 提供内容 |
+OpenAI 兼容接口地址为 `http://localhost:8000/v1`。
+推荐的张量并行、调度器和推测解码参数请参阅
+[服务配置示例（英文）](docs/cookbook/README.md)。
+
+## 文档
+
+- [服务配置示例（英文）](docs/cookbook/README.md)
+- [安装](docs/installation-cn.md)
+- [Python 与 OpenAI 兼容接口用法](docs/usage-cn.md)
+- [配置（英文）](docs/configuration.md)
+- [开发指南（英文）](docs/development.md)
+- [MUSA 开发者指南（英文）](docs/mdm-developer-guide.md)
+
+## 支持版本
+
+| vLLM-MUSA | PyTorch/MUSA | 引擎 |
 |---|---|---|
-| 摩尔线程 | `https://dl.mthreads.com/repo/api/pypi/pypi/simple` | `requirements/musa_private.txt` 中约束的 MUSA wheel — `torch`、`torch_musa`、`mate`、`flash_attn_3`、`flash_mla`、`deep-gemm`、`tilelang_musa`、`triton`、`apache-tvm-ffi` 等 |
-| 公共 PyPI | `https://pypi.org/simple` 或其镜像 | `requirements/build.txt` 与 `requirements/common.txt` 中的普通第三方 wheel |
+| v0.24.0 | 2.11.x | V1 |
 
-大部分 MUSA wheel 并未发布到公共 PyPI，因此用 pip 默认索引安装
-`requirements/musa.txt` 会失败并报
-`No matching distribution found for torch==2.11.0.post1+musa5.2.0`。
-
-MUSA wheel 必须在摩尔线程索引作为**唯一** `--index-url` 的前提下解析，因此下面的
-安装步骤以“只装 MUSA wheel”的一步开始。
-
-下面的第 3 步确实同时传入了两个索引。这样做是安全的，因为第 1 步已经按固定版本装好
-了所有 MUSA wheel，该步不会重新解析任何 MUSA wheel，合并索引只用于补齐普通依赖。
-
-### 从源码安装
-
-1. 克隆仓库：
-
-    ```bash
-    git clone https://github.com/MooreThreads/vllm-musa.git
-    cd vllm-musa
-    ```
-
-2. 选定两个索引：
-
-    ```bash
-    export MUSA_PIP_INDEX_URL=https://dl.mthreads.com/repo/api/pypi/pypi/simple
-    export PYPI_INDEX_URL=https://pypi.org/simple
-    ```
-
-3. 分三步安装 Python 依赖：
-
-    ```bash
-    # 1. MUSA wheel，仅从摩尔线程索引安装。该步必须最先执行且带 --no-deps：
-    #    torchada 和 transformers 声明的 `torch` 没有版本约束，若先解析它们会拉取
-    #    公共 CUDA 版 torch 及数 GB 的 nvidia-cuda-* 依赖，覆盖 MUSA 版。
-    pip install --no-deps --index-url "${MUSA_PIP_INDEX_URL}" \
-        -r requirements/musa_private.txt
-
-    # 2. 普通第三方 wheel，从公共 PyPI 安装。第 1 步已满足 `torch`。
-    pip install --index-url "${PYPI_INDEX_URL}" \
-        -r requirements/build.txt -r requirements/common.txt
-
-    # 3. 补齐 MUSA wheel 自身的普通依赖（sympy、networkx 等）。第 1 步已固定所有
-    #    MUSA wheel，这里不会重新解析它们。
-    pip install --index-url "${MUSA_PIP_INDEX_URL}" \
-        --extra-index-url "${PYPI_INDEX_URL}" \
-        -r requirements/musa_private.txt
-    ```
-
-4. 安装摩尔线程 MUSA 的 vLLM 硬件插件。内置 vLLM 的依赖来自公共 PyPI，因此这里
-   保持选用该索引：
-
-    ```bash
-    export PIP_INDEX_URL="${PYPI_INDEX_URL}"
-
-    # 标准安装（安装 vLLM MUSA 插件和 vLLM）
-    pip install . --no-build-isolation -v
-
-    # 或可编辑安装（用于开发）
-    pip install -e . --no-build-isolation -v
-    ```
-
-5. 验证安装：
-
-    ```bash
-    # 检查插件注册
-    python -c "from vllm_musa import musa_platform_plugin; print('插件加载成功')"
-
-    # 检查 MTML 设备管理
-    python -c "from vllm_musa.platform import mtml_available; print(f'MTML 可用: {mtml_available}')"
-    ```
-
-### 环境变量
-
-| 变量 | 描述 |
-|------|------|
-| `MUSA_VISIBLE_DEVICES` | 控制可见的 MUSA 设备（类似于 `CUDA_VISIBLE_DEVICES`） |
-| `VLLM_WORKER_MULTIPROC_METHOD=spawn` | 多进程 worker 推荐设置 |
-| `VLLM_MUSA_CUSTOM_OP_USE_NATIVE` | 使用 vLLM 自定义算子的原生实现（默认：`False`） |
-| `VLLM_MUSA_WORKER_TERMINATION_TIMEOUT_S` | 控制 vLLM v1 worker 关闭超时时间（默认： `4s`） |
-| `VLLM_MUSA_USE_CCACHE` | 当系统安装了 `ccache` 时，为原生扩展构建启用 ccache（默认：`1`） |
-| `VLLM_MUSA_CCACHE` | 覆盖 `setup.py` 所使用的 ccache 可执行文件（默认：`PATH` 中的第一个 `ccache`） |
-| `VLLM_MUSA_CCACHE_DIR` | 覆盖 `setup.py` 所使用的 ccache 目录（默认：`<repo>/.ccache`） |
-| `VLLM_MUSA_CCACHE_MAXSIZE` | 可选的 ccache 最大容量，将作为 `CCACHE_MAXSIZE` 透传 |
-| `VLLM_MUSA_REAL_MCC` | 覆盖被 ccache 包装的真实 MUSA 编译器（默认：自动探测到的 `mcc`） |
-
-### 用于原生重新构建的 ccache
-
-当 `PATH` 中存在 `ccache` 时，源码安装会自动让宿主 C++ 编译器和 MUSA `mcc` 走
-ccache。生成的 `mcc` wrapper 会把 `.mu` 等 MUSA 专有输入规范化为可缓存的 `.cu`
-副本，并对 ccache 隐藏 `-x musa`，同时仍将其传给 `mcc`。默认缓存目录为
-`<repo>/.ccache`，因此在同一份检出中第二次执行
-`pip install -e . --no-build-isolation -v` 可以复用已缓存的 `.cu`、`.mu` 和 C++
-目标文件。
-
-常用命令：
-
-```bash
-ccache --zero-stats
-pip install -e . --no-build-isolation -v
-ccache --show-stats
-```
-
-## 使用方法
-
-安装后，插件会被 vLLM **自动检测**。直接像往常一样运行 vLLM 即可：
-
-```python
-from vllm import LLM, SamplingParams
-
-# vLLM 会自动使用 MUSA 平台
-llm = LLM(model="your-model-path", trust_remote_code=True)
-
-sampling_params = SamplingParams(temperature=0.7, top_p=0.9, max_tokens=100)
-outputs = llm.generate(["你好，最近怎么样？"], sampling_params)
-
-for output in outputs:
-    print(output.outputs[0].text)
-```
-
-### OpenAI 兼容服务器
-
-```bash
-# 启动服务器
-vllm serve /path/to/model/
-
-# 测试 completions API
-curl http://localhost:8000/v1/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model": "/path/to/model/", "prompt": "你好！", "max_tokens": 50}'
-
-# 测试 chat completions API
-curl http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model": "/path/to/model/", "messages": [{"role": "user", "content": "1+1等于几？"}], "max_tokens": 50}'
-```
-
-## 测试
-
-运行测试套件：
-
-```bash
-# 运行所有测试
-make test
-
-# 运行特定测试文件
-pytest tests/test_musa.py -v
-pytest tests/test_patches.py -v
-
-# 运行覆盖率测试
-make test-cov
-```
-
-## 项目结构
-
-```
-vllm-musa/
-├── pyproject.toml              # 项目配置
-├── README.md                   # 文档（英文）
-├── README_CN.md                # 文档（中文）
-├── LICENSE                     # Apache 2.0 许可证
-├── requirements/               # 依赖版本约束（build、common、musa_private）
-├── docker/                     # 镜像构建流程（musa.Dockerfile、build_image.sh）
-├── third_party/                # PINS 及构建时克隆的上游 vLLM
-├── build_utils/                # 构建辅助（ccache wrapper）
-├── tools/                      # 同步、校验与补丁验证工具
-├── example/                    # 使用示例
-├── csrc/                       # C/C++ 源文件
-├── docs/                       # 附加文档
-├── vllm_musa/                  # 主包
-│   ├── __init__.py             # 插件入口
-│   ├── platform.py             # MUSA 平台实现
-│   └── patches/                # 针对上游 vLLM 的补丁
-│       ├── __init__.py         # 补丁应用逻辑
-│       ├── series/             # 构建时的源码补丁序列
-│       └── *.patch.py          # 导入时的对象补丁
-└── tests/                      # 测试套件
-    ├── conftest.py             # Pytest fixtures
-    ├── test_musa.py            # 平台测试
-    └── test_patches.py         # 补丁系统测试
-```
-
-## 补丁
-
-本插件对上游 vLLM 的改动分为两类。绝大多数是源码改动，它们以
-`git format-patch` 序列的形式存放在 `vllm_musa/patches/series/`，并在**构建时**
-应用到固定版本的 vLLM 克隆上，因此安装完成的 vLLM 已经是打好补丁的。另有少量无法
-表示为源码 diff 的实时对象 monkey-patch，在**导入时**运行
-（`vllm_musa/patches/*.patch.py`），它们是仅有的运行时补丁。两种机制的详情请参阅
-[patches/README.md](vllm_musa/patches/README.md)。
+V1 引擎会在支持的模型架构上自动选择模型运行器 V2；MUSA 同时支持两种
+运行器。
 
 ## 贡献
 
-我们欢迎并重视任何形式的贡献与协作。提交前请设置 pre-commit hooks 以确保代码质量：
-
-```bash
-# 安装 pre-commit
-pip install pre-commit
-
-# 安装 git hooks
-pre-commit install
-
-# （可选）对所有文件运行检查
-pre-commit run --all-files
-```
-
-安装后，hooks 会在每次提交时自动运行，检查以下内容：
-- 尾部空白和文件格式
-- 导入排序（isort）
-- 代码格式化（black）
-- 代码检查（ruff）
-- 拼写检查（codespell）
-- 常见问题（合并冲突、调试语句、大文件等）
-
-也可以手动运行检查：
-
-```bash
-make pre-commit    # 对所有文件运行 pre-commit hooks
-make test          # 运行测试
-make test-cov      # 运行覆盖率测试
-```
-
-## 联系我们
-
-- 如有技术问题或功能需求，请通过 GitHub [Issues](https://github.com/MooreThreads/vllm-musa/issues) 提交。
-- 提交 Bug 时，请运行 `vllm_collect_env`（或 `python -m vllm_musa.collect_env`）并将输出粘贴到 Issue 中，以帮助我们定位问题。
+可编辑安装、测试、补丁流程和问题反馈方式请参阅 [开发指南（英文）](docs/development.md)。
+欢迎通过 [GitHub 问题反馈](https://github.com/MooreThreads/vllm-musa/issues)
+提交问题或参与贡献。
 
 ## 相关项目
 
-| 项目 | 描述 |
-|------|------|
-| [vLLM](https://github.com/vllm-project/vllm) | 高吞吐量 LLM 推理引擎 |
-| [torchada](https://github.com/MooreThreads/torchada) | PyTorch 的 CUDA→MUSA 兼容层 |
-| [torch_musa](https://github.com/MooreThreads/torch_musa) | 摩尔线程 GPU 的 PyTorch 支持 |
-| [MATE](https://github.com/MooreThreads/mate) | 用于 LLM 加速的 MUSA AI 张量引擎 |
-| [mthreads-ml-py](https://github.com/MooreThreads/mthreads-ml-py) | MTML Python 绑定 |
+- [Moore Threads](https://www.mthreads.com/)
+- [vLLM](https://github.com/vllm-project/vllm)
+- [vLLM 文档](https://docs.vllm.ai/en/latest/)
+- [vLLM-Omni](https://github.com/vllm-project/vllm-omni)
+- [torchada](https://github.com/MooreThreads/torchada)
+- [torch_musa](https://github.com/MooreThreads/torch_musa)
+- [MATE](https://github.com/MooreThreads/mate)
+- [mthreads-ml-py](https://github.com/MooreThreads/mthreads-ml-py)
 
 ## 许可证
 
-本项目采用 [Apache License 2.0](LICENSE) 许可证。
-
-```
-Copyright (c) 2026 Moore Threads Technology Co., Ltd. All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-```
+vLLM-MUSA 采用 [Apache 2.0 许可证](LICENSE)。

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,6 +11,7 @@ The resulting image contains:
 - the MUSA/MT Python wheels (`torch`, `torch_musa`, `mate`, `flash_attn_3`,
   `flash_mla`, `deep-gemm`, `tilelang_musa`, `apache-tvm-ffi`,
   `torch_c_dlpack_ext`),
+- `torchada` and the other common runtime dependencies from the public index,
 - `vllm-musa` and the vendored upstream vLLM, built from source,
 - `vllm-rs` and its Python tool-parser extension when `BUILD_VLLM_RS=1`,
 - `mooncake-transfer-engine-musa`,
@@ -38,7 +39,14 @@ retains `CMD ["/bin/bash"]` for tests and interactive use.
 
 ## Quick start
 
-From the repository root:
+For v0.24.0 deployments, use the release `vllm-openai` image:
+
+```bash
+export VLLM_MUSA_IMAGE=registry.mthreads.com/mcconline/inference/vllm/vllm-openai:v0.24.0
+docker pull "${VLLM_MUSA_IMAGE}"
+```
+
+To build the same serving target from source, run from the repository root:
 
 ```bash
 bash docker/build_image.sh
@@ -50,10 +58,46 @@ With the defaults this produces:
 vllm-musa:ubuntu22.04_py3.10_musa_runtime_5.2_pytorch_release_2.11.0.post1_musa5.2.0
 ```
 
-The image accepts the model and engine arguments directly:
+The release image accepts the model and engine arguments directly. This block
+is self-contained; set the visible-device list explicitly through
+`MUSA_VISIBLE_DEVICES`, which is authoritative for vLLM-MUSA. The Docker host
+must provide the MUSA container runtime; this generic example relies on the
+host's runtime configuration rather than selecting a runtime by name.
 
 ```bash
-docker run --rm <MUSA GPU flags> <image> <model> --host 0.0.0.0
+export VLLM_MUSA_IMAGE=registry.mthreads.com/mcconline/inference/vllm/vllm-openai:v0.24.0
+MODEL_PATH=/path/to/model
+VISIBLE_DEVICES=0
+docker run --rm --privileged --ipc=host --network=host \
+  --env MUSA_VISIBLE_DEVICES="${VISIBLE_DEVICES}" \
+  --env MTHREADS_VISIBLE_DEVICES="${VISIBLE_DEVICES}" \
+  -v "${MODEL_PATH}:${MODEL_PATH}:ro" \
+  "${VLLM_MUSA_IMAGE}" "${MODEL_PATH}" --host 0.0.0.0
+```
+
+If the host does not configure a MUSA-compatible default runtime, follow the
+host platform's container-runtime setup before starting the image. Keep the
+MUSA visibility setting scoped to the GPUs assigned to this container.
+Because these examples use `--ipc=host`, shared-memory capacity comes from the
+host IPC namespace; a separate `--shm-size` setting is not applied.
+Treat this as an isolated-host/test shape. The `--privileged` flag is shown for
+broad host compatibility and grants wide device access. For production,
+replace it with the platform's least-privilege MUSA device policy (and explicit
+RDMA devices when using Mooncake); the visibility variables scope vLLM's
+logical devices but do not reduce Docker privileges.
+
+To build and run a local serving image instead of using the release image:
+
+```bash
+MODEL_PATH=/path/to/model
+VISIBLE_DEVICES=0
+export VLLM_MUSA_SOURCE_IMAGE=vllm-musa:v0.24.0-local
+IMAGE_TAG="${VLLM_MUSA_SOURCE_IMAGE}" bash docker/build_image.sh
+docker run --rm --privileged --ipc=host --network=host \
+  --env MUSA_VISIBLE_DEVICES="${VISIBLE_DEVICES}" \
+  --env MTHREADS_VISIBLE_DEVICES="${VISIBLE_DEVICES}" \
+  -v "${MODEL_PATH}:${MODEL_PATH}:ro" \
+  "${VLLM_MUSA_SOURCE_IMAGE}" "${MODEL_PATH}" --host 0.0.0.0
 ```
 
 Every setting is an environment variable — override by exporting it or prefixing
@@ -80,7 +124,7 @@ IMAGE_TAG=vllm-musa:test bash docker/build_image.sh --target final
 Verify the workspace and test-runner contract with:
 
 ```bash
-docker run --rm --entrypoint /bin/bash vllm-musa:v0.24.0-dev \
+docker run --rm --entrypoint /bin/bash vllm-musa:test \
   -lc 'test "$PWD" = /vllm-workspace && python -m pytest --version'
 ```
 
@@ -189,7 +233,7 @@ On a MUSA GPU you should see `musa available: True`.
 Mooncake over RoCE also requires host networking and explicit RDMA device
 access. See the
 [container and RDMA prerequisites](../docs/example/README.md#container-and-rdma-prerequisites)
-for the validated runtime flags.
+for the documented container shape and host-runtime prerequisite.
 
 ## How it works (build stages)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,69 @@
+# Configuration
+
+## Runtime environment
+
+```bash
+export MUSA_VISIBLE_DEVICES=0
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export VLLM_PLUGINS=musa,musa_custom_ops
+```
+
+`MUSA_VISIBLE_DEVICES` is authoritative. Keep it aligned with the devices
+assigned to the process; do not infer the MUSA list from a CUDA-only setting.
+Its syntax is similar to `CUDA_VISIBLE_DEVICES`, but MUSA remains the source of
+truth on this platform.
+
+Optional runtime variables:
+
+| Variable | Purpose |
+|---|---|
+| `VLLM_MUSA_CUSTOM_OP_USE_NATIVE` | Select the native custom-op path (default: false; vLLM-MUSA may force it on for quantized PIECEWISE graphs) |
+| `VLLM_USE_V2_MODEL_RUNNER` | Force Model Runner V2 (`1`) or V1 (`0`) |
+| `VLLM_MUSA_WORKER_TERMINATION_TIMEOUT_S` | Set the V1 worker shutdown timeout (default: 4 seconds) |
+| `VLLM_USE_DEEP_GEMM` | Enable DeepGEMM where supported |
+| `VLLM_USE_DEEP_GEMM_E8M0` | Select E8M0 scale handling |
+| `VLLM_DEEP_GEMM_WARMUP` | Control DeepGEMM warmup behavior |
+
+Use the model recipe as the source of truth before overriding a variable.
+
+For quantized models captured with `PIECEWISE` graphs, vLLM-MUSA can force the
+native custom-op path to preserve FP8 buffer lifetime and output correctness.
+Do not force `VLLM_MUSA_CUSTOM_OP_USE_NATIVE=0` for that combination unless you
+have separately verified semantic output; eager, `FULL_DECODE_ONLY`, and BF16
+paths are not subject to this specific override.
+
+V0 is not supported by this release line. V1 is the default engine; supported
+architectures such as Qwen3, DeepSeek-V2, and Llama can select Model Runner V2
+automatically. Set
+`VLLM_USE_V2_MODEL_RUNNER=0` to force V1 or `1` to force V2 when diagnosing a
+model-specific issue.
+
+## Native builds and ccache
+
+The following variables are available for native extension builds:
+
+| Variable | Purpose |
+|---|---|
+| `VLLM_MUSA_USE_CCACHE` | Enable or disable ccache (default: `1` when available) |
+| `VLLM_MUSA_CCACHE` | Choose the ccache executable (default: first in `PATH`) |
+| `VLLM_MUSA_CCACHE_DIR` | Set the cache directory (default: `<repo>/.ccache`) |
+| `VLLM_MUSA_CCACHE_MAXSIZE` | Set the cache size |
+| `VLLM_MUSA_REAL_MCC` | Choose the underlying MUSA compiler (default: detected `mcc`) |
+
+When ccache is available, source installs route both the host C++ compiler and
+MUSA `mcc` through it. The generated wrapper normalizes MUSA-only inputs such
+as `.mu` sources for caching while preserving the flags passed to `mcc`.
+
+Inspect cache behavior with:
+
+```bash
+ccache --zero-stats
+pip install -e . --no-build-isolation -v
+ccache --show-stats
+```
+
+## Scheduler and graph settings
+
+Model pages in [the cookbook](cookbook/README.md) pin the scheduler, memory,
+attention, and graph settings that belong together. Change one setting at a
+time and re-check startup logs before using a different profile in production.

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1,0 +1,59 @@
+# vLLM-MUSA serving recipes
+
+Copy-ready configurations for serving supported models with vLLM-MUSA v0.24.0
+on S5000 GPUs.
+
+> [!TIP]
+> Start with the recipe unchanged. Adjust the model path and served-model name
+> for your deployment before changing scheduler, memory, or graph options.
+
+The profiles are tuned for the documented 4K-input/1K-output workload and
+bounded concurrency. Recheck first-token latency, per-token latency, and
+decode interference when your traffic shape or concurrency target differs.
+
+## Before you start
+
+- Run inside the v0.24.0 release image
+  `registry.mthreads.com/mcconline/inference/vllm/vllm-openai:v0.24.0`, or an
+  equivalent installation.
+- Mount the checkpoint under `/mnt/models` or update the path in the command.
+- Keep TP1 when a model fits on one GPU; increase TP only when memory requires
+  it.
+
+## Qwen
+
+The listed Qwen checkpoints fit on one S5000 and use TP1.
+
+| Model | Precision | Speculative decoding | Recipe |
+|---|---|---|---|
+| Qwen3-8B | FP8 | Off | [Open recipe](qwen/qwen3-8b-fp8.md) |
+| Qwen3.5-27B | BF16 | Off | [Open recipe](qwen/qwen3.5-27b-bf16.md) |
+| Qwen3.5-27B | FP8 | MTP1 | [Open recipe](qwen/qwen3.5-27b-fp8.md) |
+| Qwen3.5-35B-A3B | BF16 | Off | [Open recipe](qwen/qwen3.5-35b-a3b-bf16.md) |
+| Qwen3.5-35B-A3B | FP8 | MTP3 | [Open recipe](qwen/qwen3.5-35b-a3b-fp8.md) |
+| Qwen3.6-27B | BF16 | Off | [Open recipe](qwen/qwen3.6-27b-bf16.md) |
+| Qwen3.6-27B | FP8 | MTP1 | [Open recipe](qwen/qwen3.6-27b-fp8.md) |
+| Qwen3.6-35B-A3B | BF16 | Off | [Open recipe](qwen/qwen3.6-35b-a3b-bf16.md) |
+| Qwen3.6-35B-A3B | FP8 | MTP3 | [Open recipe](qwen/qwen3.6-35b-a3b-fp8.md) |
+
+## DeepSeek
+
+| Model | Hardware | Recommended profile | Alternative |
+|---|---|---|---|
+| [DeepSeek-V4-Flash](deepseek/deepseek-v4-flash.md) | 8x S5000, TP8 | Fixed MTP4 | MTP-off |
+
+## Verify a server
+
+The recipes expose an OpenAI-compatible endpoint on port 8000.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+response = client.chat.completions.create(
+    model="<served-model-name>",
+    messages=[{"role": "user", "content": "Hello"}],
+    temperature=0,
+)
+print(response.choices[0].message.content)
+```

--- a/docs/cookbook/deepseek/deepseek-v4-flash.md
+++ b/docs/cookbook/deepseek/deepseek-v4-flash.md
@@ -1,0 +1,127 @@
+# DeepSeek-V4-Flash
+
+## Overview
+
+DeepSeek-V4-Flash is served on eight S5000 GPUs with tensor parallelism. This
+recipe provides a fixed-MTP4 profile for decode-latency-sensitive traffic and
+an MTP-off profile for deployments that do not use speculative decoding.
+
+> [!TIP]
+> Start with **MTP4** when decode latency is the priority, especially at small
+> batches. Keep chunked prefill enabled so long prefills do not block active
+> decode requests for their full duration.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 8x S5000 |
+| Tensor parallelism | TP8 |
+| Attention backend | FlashMLA |
+| KV cache | FP8 |
+| Maximum context | 6,144 tokens |
+| Maximum sequences | 64 |
+| Recommended profile | Fixed MTP4 |
+| Alternative | MTP-off |
+
+## Prerequisites
+
+- vLLM-MUSA v0.24.0.
+- Eight S5000 GPUs available to the server process.
+- The checkpoint mounted at `/mnt/models/DeepSeek-V4-Flash-Base`, or an
+  equivalent path substituted in the command.
+
+## Launching the server
+
+### MTP4
+
+This profile uses a fixed four-token MTP draft.
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+export VLLM_USE_DEEP_GEMM=1
+export VLLM_USE_DEEP_GEMM_E8M0=0
+export VLLM_DEEP_GEMM_WARMUP=skip
+export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
+
+vllm serve /mnt/models/DeepSeek-V4-Flash-Base \
+  --trust-remote-code \
+  --tensor-parallel-size 8 \
+  --served-model-name deepseek-v4-flash-base \
+  --max-model-len 6144 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8195 \
+  --gpu-memory-utilization 0.95 \
+  --kv-cache-dtype fp8 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --attention-backend FLASHMLA \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":4}' \
+  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","max_cudagraph_capture_size":320,"cudagraph_capture_sizes":[5,10,20,40,80,160,320],"cudagraph_copy_inputs":false}' \
+  --async-scheduling
+```
+
+### MTP-off
+
+Use this profile when speculative decoding is not desired. At higher
+concurrency, the requested context and graph footprint can exceed available
+memory on some 8x S5000 deployments. Reduce `max-num-seqs` and the graph
+capture ceiling together, then revalidate before production use.
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+export VLLM_USE_DEEP_GEMM=1
+export VLLM_USE_DEEP_GEMM_E8M0=0
+export VLLM_DEEP_GEMM_WARMUP=skip
+export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
+
+vllm serve /mnt/models/DeepSeek-V4-Flash-Base \
+  --trust-remote-code \
+  --tensor-parallel-size 8 \
+  --served-model-name deepseek-v4-flash-base \
+  --max-model-len 6144 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8195 \
+  --gpu-memory-utilization 0.95 \
+  --kv-cache-dtype fp8 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --attention-backend FLASHMLA \
+  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","max_cudagraph_capture_size":64,"cudagraph_capture_sizes":[1,2,4,8,16,32,64],"cudagraph_copy_inputs":false}' \
+  --async-scheduling
+```
+
+## Verifying the server
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+response = client.chat.completions.create(
+    model="deepseek-v4-flash-base",
+    messages=[{"role": "user", "content": "Hello"}],
+    temperature=0,
+)
+print(response.choices[0].message.content)
+```
+
+## Configuration notes
+
+- Keep TP8 for this checkpoint.
+- Keep chunked prefill enabled. Disabling it can reduce isolated prefill
+  latency, but long prefills may then cause severe decode inter-token stalls.
+- `max-num-batched-tokens=8195` preserves the intended 4K-input workload
+  envelope.
+- `async-scheduling` keeps the scheduler off the critical path. If combining
+  this profile with pipeline parallelism or structured outputs, revalidate the
+  exact deployment workload.
+- MTP4 uses speculative batch sizes while MTP-off uses ordinary request batch
+  sizes. `FULL_DECODE_ONLY` keeps graph capture focused on decode.
+- On lower-memory S5000 variants, reduce `max-num-seqs` and the matching graph
+  capture ceiling before lowering `max-num-batched-tokens`.
+
+Return to the [cookbook index](../README.md).

--- a/docs/cookbook/qwen/README.md
+++ b/docs/cookbook/qwen/README.md
@@ -1,0 +1,40 @@
+# Qwen serving recipes
+
+Qwen recipes use one S5000 GPU whenever the checkpoint fits. Choose the page
+that matches both the model version and weight precision.
+
+> [!NOTE]
+> FP8 and BF16 checkpoints have different memory and speculative-decoding
+> settings. Do not reuse a command across precisions without updating the
+> model-specific options.
+
+## Dense models
+
+| Model | Precision | Speculative decoding | Recipe |
+|---|---|---|---|
+| Qwen3-8B | FP8 | Off | [Open recipe](qwen3-8b-fp8.md) |
+| Qwen3.5-27B | BF16 | Off | [Open recipe](qwen3.5-27b-bf16.md) |
+| Qwen3.5-27B | FP8 | MTP1 | [Open recipe](qwen3.5-27b-fp8.md) |
+| Qwen3.6-27B | BF16 | Off | [Open recipe](qwen3.6-27b-bf16.md) |
+| Qwen3.6-27B | FP8 | MTP1 | [Open recipe](qwen3.6-27b-fp8.md) |
+
+## MoE models
+
+| Model | Precision | Speculative decoding | Recipe |
+|---|---|---|---|
+| Qwen3.5-35B-A3B | BF16 | Off | [Open recipe](qwen3.5-35b-a3b-bf16.md) |
+| Qwen3.5-35B-A3B | FP8 | MTP3 | [Open recipe](qwen3.5-35b-a3b-fp8.md) |
+| Qwen3.6-35B-A3B | BF16 | Off | [Open recipe](qwen3.6-35b-a3b-bf16.md) |
+| Qwen3.6-35B-A3B | FP8 | MTP3 | [Open recipe](qwen3.6-35b-a3b-fp8.md) |
+
+## Common deployment choices
+
+| Setting | Recommended value |
+|---|---|
+| Hardware | 1x S5000 |
+| Tensor parallelism | TP1 |
+| API | OpenAI-compatible server on port 8000 |
+| Model path | `/mnt/models/<checkpoint>` |
+
+See the [cookbook index](../README.md) for client usage and the DeepSeek
+recipe.

--- a/docs/cookbook/qwen/qwen3-8b-fp8.md
+++ b/docs/cookbook/qwen/qwen3-8b-fp8.md
@@ -1,0 +1,53 @@
+# Qwen3-8B-FP8
+
+## Overview
+
+FP8 dense-model recipe for a single S5000 GPU.
+
+> [!TIP]
+> Use TP1 and keep speculative decoding disabled for this checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | FP8 |
+| Tensor parallelism | TP1 |
+| Speculative decoding | Off |
+| Maximum context | 5,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /mnt/models/Qwen3-8B-FP8 \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name qwen3-8b-fp8 \
+  --max-model-len 5192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 4096 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 2048 \
+  --gpu-memory-utilization 0.90 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+```
+
+## Configuration notes
+
+- Chunked prefill and asynchronous scheduling are enabled.
+- Prefix caching is disabled.
+- Replace `/mnt/models/Qwen3-8B-FP8` if the checkpoint is mounted elsewhere.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-27b-bf16.md
+++ b/docs/cookbook/qwen/qwen3.5-27b-bf16.md
@@ -1,0 +1,53 @@
+# Qwen3.5-27B-BF16
+
+## Overview
+
+BF16 dense-model recipe for a single S5000 GPU.
+
+> [!TIP]
+> Use TP1 and keep speculative decoding disabled for this checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | BF16 |
+| Tensor parallelism | TP1 |
+| Speculative decoding | Off |
+| Maximum context | 5,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /mnt/models/Qwen3.5-27B-BF16 \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name qwen35-27b-bf16 \
+  --max-model-len 5192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 2048 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 4096 \
+  --gpu-memory-utilization 0.90 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"compile_sizes":[1,4,16,64],"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+```
+
+## Configuration notes
+
+- The 2,048-token scheduler budget favors predictable prefill admission.
+- Chunked prefill and asynchronous scheduling are enabled.
+- Replace `/mnt/models/Qwen3.5-27B-BF16` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-27b-fp8.md
+++ b/docs/cookbook/qwen/qwen3.5-27b-fp8.md
@@ -1,0 +1,54 @@
+# Qwen3.5-27B-FP8
+
+## Overview
+
+FP8 dense-model recipe with one-token MTP speculative decoding.
+
+> [!TIP]
+> Use this TP1 profile when serving the FP8 checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | FP8 |
+| Tensor parallelism | TP1 |
+| Speculative decoding | MTP1 |
+| Maximum context | 5,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /mnt/models/Qwen3.5-27B-FP8 \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name qwen35-27b-fp8 \
+  --max-model-len 5192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 4096 \
+  --gpu-memory-utilization 0.90 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"cudagraph_capture_sizes":[2,8,32,128],"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+  --speculative-config '{"attention_backend":"FLASH_ATTN","method":"mtp","num_speculative_tokens":1}'
+```
+
+## Configuration notes
+
+- MTP1 uses the FlashAttention backend for draft attention.
+- Graph capture sizes account for the additional draft token.
+- Replace `/mnt/models/Qwen3.5-27B-FP8` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-35b-a3b-bf16.md
+++ b/docs/cookbook/qwen/qwen3.5-35b-a3b-bf16.md
@@ -1,0 +1,53 @@
+# Qwen3.5-35B-A3B-BF16
+
+## Overview
+
+BF16 MoE recipe for a single S5000 GPU.
+
+> [!TIP]
+> Use TP1 and keep speculative decoding disabled for this checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | BF16 |
+| Architecture | MoE, 35B-A3B |
+| Tensor parallelism | TP1 |
+| Speculative decoding | Off |
+| Maximum context | 5,192 tokens |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /mnt/models/Qwen3.5-35B-A3B-BF16 \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name qwen35-35b-a3b-bf16 \
+  --max-model-len 5192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 2048 \
+  --gpu-memory-utilization 0.95 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.95 for this BF16 MoE checkpoint.
+- Chunked prefill and asynchronous scheduling are enabled.
+- Replace `/mnt/models/Qwen3.5-35B-A3B-BF16` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-35b-a3b-fp8.md
+++ b/docs/cookbook/qwen/qwen3.5-35b-a3b-fp8.md
@@ -1,0 +1,54 @@
+# Qwen3.5-35B-A3B-FP8
+
+## Overview
+
+FP8 MoE recipe with three-token MTP speculative decoding.
+
+> [!TIP]
+> Use this TP1 profile for small-batch serving of the FP8 checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | FP8 |
+| Architecture | MoE, 35B-A3B |
+| Tensor parallelism | TP1 |
+| Speculative decoding | MTP3 |
+| Maximum context | 5,192 tokens |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /mnt/models/Qwen3.5-35B-A3B-FP8 \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name qwen35-35b-a3b-fp8 \
+  --max-model-len 5192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 32768 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 2048 \
+  --gpu-memory-utilization 0.90 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"cudagraph_capture_sizes":[4,16,64,256],"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+```
+
+## Configuration notes
+
+- MTP3 uses graph sizes scaled for three draft tokens.
+- The 32,768-token scheduler budget supports the selected profile.
+- Replace `/mnt/models/Qwen3.5-35B-A3B-FP8` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.6-27b-bf16.md
+++ b/docs/cookbook/qwen/qwen3.6-27b-bf16.md
@@ -1,0 +1,53 @@
+# Qwen3.6-27B-BF16
+
+## Overview
+
+BF16 dense-model recipe for a single S5000 GPU.
+
+> [!TIP]
+> Use TP1 and keep speculative decoding disabled for this checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | BF16 |
+| Tensor parallelism | TP1 |
+| Speculative decoding | Off |
+| Maximum context | 5,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /mnt/models/Qwen3.6-27B \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name qwen36-27b-bf16 \
+  --max-model-len 5192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 2048 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 4096 \
+  --gpu-memory-utilization 0.90 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"compile_sizes":[1,4,16,64],"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+```
+
+## Configuration notes
+
+- The 2,048-token scheduler budget favors predictable prefill admission.
+- Chunked prefill and asynchronous scheduling are enabled.
+- Replace `/mnt/models/Qwen3.6-27B` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.6-27b-fp8.md
+++ b/docs/cookbook/qwen/qwen3.6-27b-fp8.md
@@ -1,0 +1,54 @@
+# Qwen3.6-27B-FP8
+
+## Overview
+
+FP8 dense-model recipe with one-token MTP speculative decoding.
+
+> [!TIP]
+> Use this TP1 profile when serving the FP8 checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | FP8 |
+| Tensor parallelism | TP1 |
+| Speculative decoding | MTP1 |
+| Maximum context | 5,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /mnt/models/Qwen3.6-27B-FP8 \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name qwen36-27b-fp8 \
+  --max-model-len 5192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 4096 \
+  --gpu-memory-utilization 0.90 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"cudagraph_capture_sizes":[2,8,32,128],"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+  --speculative-config '{"attention_backend":"FLASH_ATTN","method":"mtp","num_speculative_tokens":1}'
+```
+
+## Configuration notes
+
+- MTP1 uses the FlashAttention backend for draft attention.
+- Graph capture sizes account for the additional draft token.
+- Replace `/mnt/models/Qwen3.6-27B-FP8` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.6-35b-a3b-bf16.md
+++ b/docs/cookbook/qwen/qwen3.6-35b-a3b-bf16.md
@@ -1,0 +1,53 @@
+# Qwen3.6-35B-A3B-BF16
+
+## Overview
+
+BF16 MoE recipe for a single S5000 GPU.
+
+> [!TIP]
+> Use TP1 and keep speculative decoding disabled for this checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | BF16 |
+| Architecture | MoE, 35B-A3B |
+| Tensor parallelism | TP1 |
+| Speculative decoding | Off |
+| Maximum context | 5,192 tokens |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /mnt/models/Qwen3.6-35B-A3B \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name qwen36-35b-a3b-bf16 \
+  --max-model-len 5192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 2048 \
+  --gpu-memory-utilization 0.95 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.95 for this BF16 MoE checkpoint.
+- Chunked prefill and asynchronous scheduling are enabled.
+- Replace `/mnt/models/Qwen3.6-35B-A3B` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.6-35b-a3b-fp8.md
+++ b/docs/cookbook/qwen/qwen3.6-35b-a3b-fp8.md
@@ -1,0 +1,54 @@
+# Qwen3.6-35B-A3B-FP8
+
+## Overview
+
+FP8 MoE recipe with three-token MTP speculative decoding.
+
+> [!TIP]
+> Use this TP1 profile for small-batch serving of the FP8 checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | FP8 |
+| Architecture | MoE, 35B-A3B |
+| Tensor parallelism | TP1 |
+| Speculative decoding | MTP3 |
+| Maximum context | 5,192 tokens |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /mnt/models/Qwen3.6-35B-A3B-FP8 \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name qwen36-35b-a3b-fp8 \
+  --max-model-len 5192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 4096 \
+  --gpu-memory-utilization 0.90 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"cudagraph_capture_sizes":[4,16,64,256],"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+  --speculative-config '{"attention_backend":"FLASH_ATTN","method":"mtp","num_speculative_tokens":3}'
+```
+
+## Configuration notes
+
+- MTP3 uses the FlashAttention backend for draft attention.
+- Graph capture sizes are scaled for three draft tokens.
+- Replace `/mnt/models/Qwen3.6-35B-A3B-FP8` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,80 @@
+# Development
+
+## Repository layout
+
+| Path | Role |
+|---|---|
+| `vllm_musa/` | MUSA plugin and platform implementation |
+| `vllm_musa/patches/series/` | Build-time vLLM patch series |
+| `vllm_musa/patches/*.patch.py` | Import-time runtime patches |
+| `requirements/` | Dependency pins |
+| `docker/` | Image build flow |
+| `tools/` | Validation utilities |
+| `csrc/` | Native MUSA sources |
+| `tests/` | Plugin and patch tests |
+| `docs/cookbook/` | Copy-ready serving recipes |
+| `pyproject.toml` | Package metadata and build configuration |
+| `third_party/` | Pinned upstream source and dependency revisions |
+| `build_utils/` | Build helpers and patch application utilities |
+| `example/` | Small runnable examples |
+
+## Project background
+
+vLLM-MUSA is maintained by [Moore Threads](https://www.mthreads.com/) as a
+hardware backend for [vLLM](https://github.com/vllm-project/vllm). The upstream
+design discussions for a pluggable hardware backend and MUSA enablement are
+tracked in [vLLM RFC #11162](https://github.com/vllm-project/vllm/issues/11162)
+and [RFC #19161](https://github.com/vllm-project/vllm/issues/19161).
+
+The runtime stack is split across these companion projects:
+
+| Project | Role |
+|---|---|
+| [torch_musa](https://github.com/MooreThreads/torch_musa) | PyTorch MUSA device/runtime implementation |
+| [torchada](https://github.com/MooreThreads/torchada) | CUDA-to-MUSA compatibility layer |
+| [MATE](https://github.com/MooreThreads/mate) | MUSA attention and tensor kernels |
+| [mthreads-ml-py](https://github.com/MooreThreads/mthreads-ml-py) | MUSA ML runtime bindings |
+
+## Editable development
+
+```bash
+pip install -e . --no-build-isolation -v
+```
+
+## Tests and checks
+
+```bash
+make test
+make test-cov
+pytest tests/test_musa.py -v
+pytest tests/test_patches.py -v
+make pre-commit
+```
+
+Install the hooks once:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The standard pre-commit suite covers formatting, linting, import hygiene, and
+repository policy checks. Run the focused pytest commands above when changing
+the plugin or patch series.
+
+## Patch workflow
+
+Most upstream changes are applied to the pinned vLLM source at build time as a
+`git format-patch` series. A small set of changes without a source-diff form
+is applied to live Python objects at import time. See
+[vllm_musa/patches/README.md](../vllm_musa/patches/README.md) for ordering and
+details.
+
+## Issue reports
+
+Open a [GitHub issue](https://github.com/MooreThreads/vllm-musa/issues) with the
+model, serving command, MUSA/driver versions, relevant logs, and output from
+`vllm_collect_env` or `python -m vllm_musa.collect_env`.
+
+See [mdm-developer-guide.md](mdm-developer-guide.md) for the broader developer
+workflow.

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -30,10 +30,12 @@ ports. When it runs in a container, use the host network namespace and expose
 the host RoCE devices. `--network host` alone is not sufficient; the container
 also needs the verbs and `rdma_cm` character devices plus locked-memory access.
 
-The following non-privileged runtime shape was validated on S5000 with RoCE:
+The following non-privileged container shape is intended for S5000 with RoCE
+on a host whose Docker daemon provides the MUSA runtime by default. It does
+not select a runtime by name; configure the host runtime before using it.
 
 ```bash
-IMAGE=vllm-musa:latest
+IMAGE=registry.mthreads.com/mcconline/inference/vllm/vllm-openai:v0.24.0
 # Run this block in bash; the device numbers are hexadecimal in stat output.
 read -r VERBS_MAJOR_HEX _ < \
   <(stat -c '%t %T' /dev/infiniband/uverbs0)
@@ -45,9 +47,9 @@ RDMA_CM_MINOR=$((16#${RDMA_CM_MINOR_HEX}))
 # Optional: export MC_TE_FILTERS=mlx5_<n>,mlx5_<m> to restrict HCA selection.
 docker run --rm --name vllm-musa-mooncake \
   --detach \
-  --runtime=mthreads \
   --network host \
   --shm-size 256g \
+  --env MUSA_VISIBLE_DEVICES=0,1 \
   --env MTHREADS_VISIBLE_DEVICES=0,1 \
   --env MC_FORCE_HCA=1 \
   --env MC_TE_FILTERS \
@@ -69,15 +71,13 @@ the container so it releases the GPUs and `--rm` removes it:
 docker stop vllm-musa-mooncake
 ```
 
-Use `ls /sys/class/infiniband` or `ibdev2netdev` on the leased host to obtain
-the real HCA names; do not copy a node-specific list. The `stat` expressions
+Use `ls /sys/class/infiniband` or `ibdev2netdev` on the host to obtain the
+available HCA names; do not copy a node-specific list. The `stat` expressions
 derive the verbs and `rdma_cm` device numbers for the current host, so the
-command does not assume the `10:121` minor observed on the validation node.
+command does not depend on a particular device minor.
 Unset `MC_TE_FILTERS` to let Mooncake discover all available HCAs, or export it
-before the command for the official comma-separated HCA allow-list. The
-validation benchmark used `MC_TE_FILTERS=mlx5_2,mlx5_3`; that node-specific
-value is intentionally not embedded in the launch command. `MC_FORCE_HCA=1`
-makes an RDMA validation fail instead of silently falling back to TCP.
+before the command with a comma-separated HCA allow-list. `MC_FORCE_HCA=1`
+makes an RDMA setup fail instead of silently falling back to TCP.
 
 Before starting vLLM, verify that the same HCA devices are visible inside the
 detached container:

--- a/docs/installation-cn.md
+++ b/docs/installation-cn.md
@@ -1,0 +1,96 @@
+# 安装
+
+这里介绍 vLLM-MUSA 的详细安装方式；模型启动参数请先查看
+[服务配置示例（英文）](cookbook/README.md)。
+
+## 环境要求
+
+- x86_64 Linux、CPython 3.10（固定版本的 MUSA wheel 针对这一组合发布）。
+- 配备兼容 MUSA 驱动和工具包的摩尔线程（Moore Threads）GPU。
+- vLLM-MUSA v0.24.0 及对应的 PyTorch/MUSA wheel。
+
+本版本已使用 PyTorch 2.11.x 验证。驱动、工具包和 wheel 应来自同一版本系列。
+
+## 软件包索引
+
+安装过程使用两个软件包索引：
+
+| 索引 | 提供内容 |
+|---|---|
+| 摩尔线程 | `requirements/musa_private.txt` 中固定的 `torch`、`torch_musa`、`mate`、`flash_attn_3`、`flash_mla`、`deep-gemm`、`tilelang_musa`、`triton` 等 MUSA wheel |
+| 公共 PyPI | `torchada`、普通构建/运行依赖以及内置 vLLM 所需的依赖 |
+
+请先使用摩尔线程索引和 `--no-deps` 安装 MUSA wheel；否则未固定版本的
+`torch` 可能会解析为公共 CUDA wheel，而不是 MUSA wheel。
+
+## 容器
+
+v0.24.0 推荐直接使用正式镜像：
+
+```bash
+export VLLM_MUSA_IMAGE=registry.mthreads.com/mcconline/inference/vllm/vllm-openai:v0.24.0
+docker pull "${VLLM_MUSA_IMAGE}"
+```
+
+镜像以 `vllm serve` 为入口点；在模型路径后追加
+[服务配置示例（英文）](cookbook/README.md)中的引擎参数，并为 `docker run`
+配置部署环境所需的 MUSA 运行时和模型卷参数。
+
+需要源码构建时，在仓库根目录运行 `bash docker/build_image.sh`。若只需要
+用于测试或交互的命令行镜像，请使用 `--target final`。构建参数和兼容性说明见
+[docker/README.md](../docker/README.md)。
+
+## 源码安装
+
+MUSA wheel 位于摩尔线程软件包索引中。对于 v0.24.0 系列版本，请克隆对应的
+源码分支（也可以替换为部署所用的确切 release tag 或 commit），再安装
+MUSA wheel 和公共依赖：
+
+```bash
+git clone --branch v0.24.0-dev --single-branch \
+  https://github.com/MooreThreads/vllm-musa.git
+cd vllm-musa
+
+export MUSA_PIP_INDEX_URL=https://dl.mthreads.com/repo/api/pypi/pypi/simple
+export PYPI_INDEX_URL=https://pypi.org/simple
+
+pip install --no-deps --index-url "${MUSA_PIP_INDEX_URL}" \
+  -r requirements/musa_private.txt
+pip install --index-url "${PYPI_INDEX_URL}" \
+  -r requirements/build.txt -r requirements/common.txt
+pip install --index-url "${MUSA_PIP_INDEX_URL}" \
+  --extra-index-url "${PYPI_INDEX_URL}" \
+  -r requirements/musa_private.txt
+
+export PIP_INDEX_URL="${PYPI_INDEX_URL}"
+pip install . --no-build-isolation -v
+```
+
+开发时使用可编辑安装：
+
+```bash
+pip install -e . --no-build-isolation -v
+```
+
+验证插件：
+
+```bash
+python -c "from vllm_musa import musa_platform_plugin; print('MUSA plugin loaded')"
+python -c "from vllm_musa.platform import mtml_available; print(mtml_available)"
+```
+
+`requirements/musa_private.txt` 是 MUSA 软件栈的版本来源，不要用同名的公共
+CUDA wheel 替换。
+
+## 设备可见性
+
+启动服务前设置 `MUSA_VISIBLE_DEVICES`；它是插件使用的权威设备列表：
+
+```bash
+export MUSA_VISIBLE_DEVICES=0
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export VLLM_PLUGINS=musa,musa_custom_ops
+```
+
+ccache、原生编译器和构建排障说明见
+[配置参考（英文）](configuration.md)。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,103 @@
+# Installation
+
+This page contains the detailed installation paths for vLLM-MUSA. For a
+model-specific launch command, start with the [serving cookbook](cookbook/README.md).
+
+## Requirements
+
+- x86_64 Linux and CPython 3.10 (the pinned MUSA wheels target this
+  interpreter/platform pair).
+- A Moore Threads GPU with a compatible MUSA driver and toolkit.
+- vLLM-MUSA v0.24.0 and its matching PyTorch/MUSA wheels.
+
+The release is validated with PyTorch 2.11.x. Keep the driver, toolkit, and
+wheel versions from the same release family.
+
+## Package indexes
+
+The install uses two package indexes:
+
+| Index | Provides |
+|---|---|
+| Moore Threads | `torch`, `torch_musa`, `mate`, `flash_attn_3`, `flash_mla`, `deep-gemm`, `tilelang_musa`, `triton`, and the other MUSA wheels pinned in `requirements/musa_private.txt` |
+| Public PyPI | `torchada`, ordinary build/runtime dependencies, and vendored vLLM dependencies |
+
+Install the MUSA wheels from the Moore Threads index first with `--no-deps`.
+Otherwise an unpinned package such as `torch` can resolve to a public CUDA
+build instead of the MUSA build.
+
+## Container
+
+The recommended installation path for v0.24.0 is the release image:
+
+```bash
+export VLLM_MUSA_IMAGE=registry.mthreads.com/mcconline/inference/vllm/vllm-openai:v0.24.0
+docker pull "${VLLM_MUSA_IMAGE}"
+```
+
+The image uses `vllm serve` as its entrypoint, so pass the model path followed
+by the engine arguments from the [serving cookbook](cookbook/README.md). Apply
+your deployment's standard MUSA runtime and model-volume flags to
+`docker run`.
+
+To build an image from source instead, run `bash docker/build_image.sh` from
+the repository root. Use `--target final` for a shell/test image. Build
+arguments and image compatibility notes are maintained in
+[docker/README.md](../docker/README.md).
+
+## Source install
+
+MUSA wheels are hosted on the Moore Threads package index. For the v0.24.0
+release line, clone the matching source branch (or replace it with the exact
+release tag or commit used by your deployment), then install the MUSA wheels
+before the public dependencies:
+
+```bash
+git clone --branch v0.24.0-dev --single-branch \
+  https://github.com/MooreThreads/vllm-musa.git
+cd vllm-musa
+
+export MUSA_PIP_INDEX_URL=https://dl.mthreads.com/repo/api/pypi/pypi/simple
+export PYPI_INDEX_URL=https://pypi.org/simple
+
+pip install --no-deps --index-url "${MUSA_PIP_INDEX_URL}" \
+  -r requirements/musa_private.txt
+pip install --index-url "${PYPI_INDEX_URL}" \
+  -r requirements/build.txt -r requirements/common.txt
+pip install --index-url "${MUSA_PIP_INDEX_URL}" \
+  --extra-index-url "${PYPI_INDEX_URL}" \
+  -r requirements/musa_private.txt
+
+export PIP_INDEX_URL="${PYPI_INDEX_URL}"
+pip install . --no-build-isolation -v
+```
+
+For an editable install:
+
+```bash
+pip install -e . --no-build-isolation -v
+```
+
+Verify that the plugin can be imported:
+
+```bash
+python -c "from vllm_musa import musa_platform_plugin; print('MUSA plugin loaded')"
+python -c "from vllm_musa.platform import mtml_available; print(mtml_available)"
+```
+
+`requirements/musa_private.txt` is the source of truth for the MUSA stack; do
+not substitute a public CUDA wheel with the same package name.
+
+## Device visibility
+
+Set `MUSA_VISIBLE_DEVICES` before starting a server. It is the authoritative
+device list used by the plugin:
+
+```bash
+export MUSA_VISIBLE_DEVICES=0
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export VLLM_PLUGINS=musa,musa_custom_ops
+```
+
+For ccache, native compiler selection, and build troubleshooting, see
+[Configuration](configuration.md).

--- a/docs/usage-cn.md
+++ b/docs/usage-cn.md
@@ -1,0 +1,45 @@
+# 使用方式
+
+安装完成后，vLLM 会自动发现 MUSA 插件。
+
+## Python 接口
+
+```python
+from vllm import LLM, SamplingParams
+
+llm = LLM(model="your-model-path", trust_remote_code=True)
+sampling_params = SamplingParams(temperature=0.7, top_p=0.9, max_tokens=100)
+outputs = llm.generate(["Hello, how are you?"], sampling_params)
+
+for output in outputs:
+    print(output.outputs[0].text)
+```
+
+## OpenAI 兼容服务
+
+启动服务：
+
+```bash
+vllm serve /path/to/model \
+  --trust-remote-code \
+  --served-model-name my-model
+```
+
+测试补全接口：
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"my-model","prompt":"Hello!","max_tokens":50}'
+```
+
+测试聊天补全接口：
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"my-model","messages":[{"role":"user","content":"What is 2+2?"}],"max_tokens":50}'
+```
+
+模型专属的张量并行、调度器、图捕获和推测解码参数，请参阅
+[服务配置示例（英文）](cookbook/README.md)。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,45 @@
+# Usage
+
+After installation, vLLM discovers the MUSA plugin automatically.
+
+## Python API
+
+```python
+from vllm import LLM, SamplingParams
+
+llm = LLM(model="your-model-path", trust_remote_code=True)
+sampling_params = SamplingParams(temperature=0.7, top_p=0.9, max_tokens=100)
+outputs = llm.generate(["Hello, how are you?"], sampling_params)
+
+for output in outputs:
+    print(output.outputs[0].text)
+```
+
+## OpenAI-compatible server
+
+Start the server:
+
+```bash
+vllm serve /path/to/model \
+  --trust-remote-code \
+  --served-model-name my-model
+```
+
+Test the completions API:
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"my-model","prompt":"Hello!","max_tokens":50}'
+```
+
+Test the chat-completions API:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"my-model","messages":[{"role":"user","content":"What is 2+2?"}],"max_tokens":50}'
+```
+
+For model-specific TP, scheduler, graph, and speculative-decoding settings,
+use the [serving cookbook](cookbook/README.md).


### PR DESCRIPTION
## Summary

- Add one copy-ready serving recipe per supported Qwen checkpoint.
- Use TP1 for Qwen checkpoints that fit on one S5000.
- Add two DeepSeek-V4-Flash TP8 profiles:
  - Fixed MTP4 as the recommended decode-latency configuration.
  - MTP-off when speculative decoding is not desired.
- Shorten the English and Chinese root README files to project landing pages.
- Move installation, runtime configuration, and developer/test details into
  dedicated docs pages.
- Add bilingual installation/usage entry points so the shortened root README
  does not lose the previous setup and API guidance.

Release image:

```text
registry.mthreads.com/mcconline/inference/vllm/vllm-openai:v0.24.0
```

The registry tag is the release-time source of truth; its immutable digest
will be recorded after the image is published.

## Cookbook format

The public pages remain plain Markdown while following the vLLM Recipes
structure:

- Overview and recommended-configuration callout.
- At-a-glance deployment table.
- Complete, self-contained `vllm serve` commands.
- OpenAI-compatible client example and concise configuration notes.
- Short root README navigation with bilingual installation and developer links.

Benchmark data, tuning history, and internal evidence are intentionally kept
outside the public cookbook.

## Validation

- All embedded JSON configurations parse successfully.
- Every Qwen recipe uses TP1.
- The DSV4 commands align with the merged PR #174/#191 runtime contract.
- Fixed MTP4 completed the fresh TP8 runtime, semantic, provenance, and
  repeated-cell validation matrix.
- GitHub GFM renders the callouts, tables, and code blocks correctly.
- Markdown links, code fences, shell syntax, and `git diff --check` pass.
