### PR TITLE
fix(musa): prevent DeepSeek-V4 MTP prefill hang

### DIFF
--- a/tests/test_flashmla_sparse_direct_out.py
+++ b/tests/test_flashmla_sparse_direct_out.py
@@ -145,6 +145,30 @@ def test_dsv4_tp8_sparse_prefill_writes_directly_to_out() -> None:
     assert torch.all(lse == 8)
 
 
+@pytest.mark.parametrize(("num_mps", "expected"), [(60, 20), (56, 18), (2, 1)])
+def test_dsv4_long_sparse_prefill_partitions_mps(
+    num_mps: int,
+    expected: int,
+) -> None:
+    q = SimpleNamespace(shape=(8192, 64, 512), device="musa")
+    with patch.object(
+        flashmla,
+        "_mate_resolve_num_mps",
+        lambda device, requested: num_mps,
+    ):
+        assert flashmla._dsv4_sparse_prefill_persistent_blocks(q) == expected
+
+
+def test_dsv4_short_sparse_prefill_keeps_all_mps() -> None:
+    q = SimpleNamespace(shape=(1024, 64, 512), device="musa")
+    with patch.object(
+        flashmla,
+        "_mate_resolve_num_mps",
+        lambda device, requested: 60,
+    ):
+        assert flashmla._dsv4_sparse_prefill_persistent_blocks(q) == 60
+
+
 @pytest.mark.parametrize(
     ("allow_direct_out", "heads"),
     [(False, 64), (True, 8)],

--- a/vllm_musa/patches/series/0109-fix-musa-serialize-DSV4-long-prefill-attention-overlap.patch
+++ b/vllm_musa/patches/series/0109-fix-musa-serialize-DSV4-long-prefill-attention-overlap.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Mon, 24 Aug 2026 13:18:26 +0800
+Subject: [PATCH] fix(musa): serialize DSV4 long-prefill attention overlap
+
+---
+ vllm/models/deepseek_v4/attention.py | 36 +++++++++++++++++++++++++---
+ 1 file changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/vllm/models/deepseek_v4/attention.py b/vllm/models/deepseek_v4/attention.py
+index b2d29e1973..7d85116c2d 100644
+--- a/vllm/models/deepseek_v4/attention.py
++++ b/vllm/models/deepseek_v4/attention.py
+@@ -66,6 +66,26 @@ from vllm.platforms import current_platform
+ 
+ 
+ _MUSA_DEEPSEEK_V4_SCORE_FP32_DEEPGEMM_MAX_TOKENS = 16
++_MUSA_DEEPSEEK_V4_AUX_OVERLAP_MAX_TOKENS = 1024
++
++
++def _musa_deepseek_v4_aux_overlap_enabled(num_tokens: int) -> bool:
++    """Keep MUSA aux-stream overlap away from long-prefill kernels.
++
++    Long DeepSeek-V4 prefills can launch multiple persistent kernels from
++    independent streams.  On MUSA that combination can consume all MPs and
++    prevent the command queues from making forward progress.  Decode and MTP
++    shapes remain below the existing multi-stream threshold and retain their
++    overlap path.
++    """
++    return (
++        not current_platform.is_musa()
++        or num_tokens
++        <= min(
++            envs.VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD,
++            _MUSA_DEEPSEEK_V4_AUX_OVERLAP_MAX_TOKENS,
++        )
++    )
+ 
+ 
+ def _musa_deepseek_v4_use_score_fp32_deepgemm(
+@@ -523,8 +543,11 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+             self.ln_events[0],
+             self.ln_events[1:4],
+             aux_streams,
+-            enable=hidden_states.shape[0]
+-            <= envs.VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD,
++            enable=(
++                hidden_states.shape[0]
++                <= envs.VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD
++                and _musa_deepseek_v4_aux_overlap_enabled(hidden_states.shape[0])
++            ),
+         )
+ 
+         return qr_kv, kv_score, indexer_kv_score, indexer_weights
+@@ -551,6 +574,8 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+         # overlap with default's GEMM + cache write.
+         if self.indexer is not None:
+             aux_streams = self.aux_stream_list
++            if not _musa_deepseek_v4_aux_overlap_enabled(hidden_states.shape[0]):
++                aux_streams = None
+             indexer = self.indexer
+             # Local ref so the closure keeps a non-None type for mypy.
+             assert self.compressor is not None
+@@ -599,6 +624,8 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+             aux_stream = (
+                 self.aux_stream_list[0] if self.aux_stream_list is not None else None
+             )
++            if not _musa_deepseek_v4_aux_overlap_enabled(hidden_states.shape[0]):
++                aux_stream = None
+             compressor = self.compressor
+ 
+             def wq_b_kv_insert() -> torch.Tensor:
+@@ -939,12 +966,15 @@ class DeepseekV4Indexer(nn.Module):
+ 
+         # compressor returns None and writes K to the indexer KV cache; the
+         # join orders that write before indexer_op (skip_k_cache_insert=True).
++        aux_stream = self.aux_stream
++        if not _musa_deepseek_v4_aux_overlap_enabled(hidden_states.shape[0]):
++            aux_stream = None
+         (q_quant, weights), k = maybe_execute_in_parallel(
+             wq_b_and_q_quant,
+             lambda: compressor(compressed_kv_score, positions, rotary_emb),
+             self.ln_events[0],
+             self.ln_events[1],
+-            self.aux_stream,
++            aux_stream,
+         )
+         return self.indexer_op(hidden_states, q_quant, k, weights)
+ 

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,13 +17,15 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **114 patches**. This branch includes the Qwen3.6 patches for common
+Currently **115 patches**. This branch includes the Qwen3.6 patches for common
 GDN decode metadata reuse, uniform-decode SSM slot-mapping removal, and the
 BF16 W1 tile specialization, plus the contract-bound DeepSeek-V4 MTP
 sparse-prefill headroom and mixed-prefill queue-fence patches. It additionally
 adds Qwen3.5-122B/Qwen3-VL MM encoder FlashAttention routing, TP-only shared
 expert folding and shared-gate binding, QK/mRoPE cache-out fusion, and opt-in
-vision-block graph capture. The series contains
+vision-block graph capture. It also serializes DeepSeek-V4 long-prefill
+attention branches on MUSA while preserving decode/MTP auxiliary-stream
+overlap. The series contains
 MUSA source edits against the immutable vLLM commit recorded as `VLLM_COMMIT`
 in `third_party/PINS` (release label `v0.24.0`), applied at build. Runtime
 object/registration patches (which patch live objects at import) are kept

--- a/vllm_musa/v1/attention/ops/flashmla.py
+++ b/vllm_musa/v1/attention/ops/flashmla.py
@@ -70,6 +70,9 @@ try:
 except Exception:
     _MATE_SPARSE_DIRECT_OUT_ABI_SUPPORTED = False
 
+_DSV4_SPARSE_PREFILL_OVERLAP_TOKEN_THRESHOLD = 1024
+_DSV4_SPARSE_PREFILL_OVERLAP_BRANCHES = 3
+
 _MATE_SPARSE_DIRECT_OUT_PARAM_NAMES = (
     "q_handle",
     "kv_handle",
@@ -287,6 +290,17 @@ def _has_expected_mate_sparse_direct_out_abi(kernel: Any) -> bool:
     )
 
 
+def _dsv4_sparse_prefill_persistent_blocks(q: torch.Tensor) -> int:
+    assert _mate_resolve_num_mps is not None
+    num_mps = _mate_resolve_num_mps(q.device, None)
+    if q.shape[0] <= _DSV4_SPARSE_PREFILL_OVERLAP_TOKEN_THRESHOLD:
+        return num_mps
+    # Long DSV4 prefill overlaps q projection, KV compression, and the DSA
+    # indexer. Give the persistent DSA branch only its share of the MPs so the
+    # other full-device branches can always make forward progress.
+    return max(num_mps // _DSV4_SPARSE_PREFILL_OVERLAP_BRANCHES, 1)
+
+
 @_mate_api
 def _flash_mla_sparse_fwd_direct_out(
     q: torch.Tensor,
@@ -319,7 +333,7 @@ def _flash_mla_sparse_fwd_direct_out(
         sm_scale=sm_scale,
         has_attn_sink=attn_sink is not None,
         is_persistence=True,
-        persistent_blocks=_mate_resolve_num_mps(q.device, None),
+        persistent_blocks=_dsv4_sparse_prefill_persistent_blocks(q),
     )
     if not _has_expected_mate_sparse_direct_out_abi(kernel):
         logger.warning_once(


### PR DESCRIPTION
## Summary

This PR fixes a DeepSeek-V4 MTP high-concurrency hang on MUSA 5.2.0. The
failure was caused by multiple high-occupancy/persistent attention kernels
running concurrently on the default stream and auxiliary streams during long
prefill. The command queues could stop making forward progress and eventually
produce `MUSA_ERROR_LAUNCH_TIMEOUT` / `ContextSwitchTimeout` coredumps.

## Root cause

DeepSeek-V4 attention launches independent Q/KV-compression/indexer branches on
auxiliary streams. Long prefill also launches persistent kernels. The earlier
MP-headroom change limited the MATE sparse-prefill kernel to `num_mps // 3`,
but coredump command-queue evidence showed that a separate 60-block persistent
DeepGEMM could still overlap with it. Limiting only one kernel was therefore
insufficient: the combined resident occupancy of multiple streams could still
exhaust MP resources and block forward progress.

The TP1 custom all-reduce timeout observed after the first failure was a
downstream cascade after another rank stopped progressing, not the original
trigger.

## Code change

The patch adds `_musa_deepseek_v4_aux_overlap_enabled(num_tokens)` in
`vllm/models/deepseek_v4/attention.py` and applies it to:

1. attention input GEMM parallel execution;
2. Q/KV insert versus indexer/compressor execution;
3. the learned-indexer internal Q/compressor execution.

On MUSA, all three sites use the default stream when `M > 1024`; for smaller
shapes the existing overlap is unchanged. The previous sparse-prefill MP
reservation remains in the preceding commit.

## Serve command

The final E2E service used the following command (the model path is the
test-team container path):

```bash
vllm serve /models/DeepSeek-V4-Flash-Base \
  --tensor-parallel-size 8 \
  --port 8512 \
  --host 0.0.0.0 \
  --served-model-name DeepSeek-V4-Flash-Base \
  --max-num-seqs 128 \
  --no-enable-prefix-caching \
  --async-scheduling \
  --attention-backend FLASHMLA \
  --trust-remote-code \
  --max-model-len 8192 \
  --gpu-memory-utilization 0.95 \
  --max-num-batched-tokens 8195 \
  --kv-cache-dtype fp8 \
  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","max_cudagraph_capture_size":320,"cudagraph_capture_sizes":[5,20,80,320],"cudagraph_copy_inputs":false}' \
  --speculative-config '{"method":"mtp","num_speculative_tokens":4}'
```

## 500-request stress test

The final commit was additionally tested using the long-run stress command:

```bash
python3 -m sglang.bench_serving \
  --backend vllm-chat \
  --host 127.0.0.1 \
  --port 8512 \
  --dataset-path /datasets/sharegpt/ShareGPT_V3_unfiltered_cleaned_split.json \
  --dataset-name random \
  --random-input-len 4096 \
  --random-output-len 1024 \
  --random-range-ratio 1 \
  --output-details \
  --warmup-requests 1 \
  --burstiness 102 \
  --request-rate 3 \
  --num-prompts 500 \
  --tokenizer /models/DeepSeek-V4-Flash-Base \
  --output-file /run_dir/.../final-500-855f6aab-20260824/result.json
```

Result:

| Metric | Value |
|---|---:|
| Successful requests | 500 / 500 |
| Effective errors | 0 |
| Duration | 3125.008 s |
| Input tokens | 2,048,000 |
| Output tokens | 512,000 |
| Input throughput | 655.36 tok/s |
| Output throughput | 163.84 tok/s |
| Mean TTFT | 1208.516 s |
| Mean TPOT | 728.446 ms |
| Mean acceptance length | 2.76 |
| Draft acceptance rate | 43.9% |

