### PR TITLE
feat(musa): add TileLang grouped softmax top-k router

### DIFF
--- a/tests/test_grouped_topk_tilelang.py
+++ b/tests/test_grouped_topk_tilelang.py
@@ -1,0 +1,863 @@
+"""MUSA correctness coverage for the TileLang grouped softmax top-k kernel."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torchada  # noqa: F401
+import torch
+
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_musa(),
+    reason="MUSA grouped top-k test",
+)
+
+
+MODEL_SHAPES = (
+    (64, 1, 1, 6),
+    (160, 8, 3, 6),
+    (256, 8, 4, 8),
+    (256, 1, 1, 8),
+)
+GENERIC_SHAPES = (
+    (48, 3, 2, 5),
+    (96, 6, 2, 7),
+    (128, 4, 3, 9),
+    (128, 32, 3, 9),
+    (128, 64, 4, 7),
+)
+PARALLEL_BOUNDARY_SHAPES = (
+    (512, 16, 4, 32),
+    (128, 128, 7, 7),
+)
+SERIAL_SHAPES = (
+    (513, 3, 2, 7),
+    (258, 129, 4, 7),
+    (96, 3, 2, 40),
+    (96, 3, 3, 40),
+)
+TOKEN_COUNTS = (
+    1,
+    2,
+    3,
+    4,
+    5,
+    7,
+    8,
+    15,
+    16,
+    17,
+    31,
+    32,
+    33,
+    63,
+    64,
+    65,
+    127,
+    128,
+    129,
+    255,
+    256,
+    257,
+    511,
+    512,
+    513,
+    1023,
+    1024,
+    1025,
+    2047,
+    2048,
+    2049,
+    3071,
+    3072,
+)
+
+
+def _make_unique_logits(
+    num_tokens: int,
+    num_experts: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    # Each 128-value block occupies a distinct BF16 exponent. The values are
+    # exactly representable in both FP16 and BF16, remain unique through the
+    # largest exercised expert count, and stay in a softmax-safe range.
+    value_ids = torch.arange(num_experts, device="musa", dtype=torch.int64)
+    mantissa = (value_ids % 128).to(torch.float32) / 128.0
+    exponent = -(value_ids // 128).to(torch.float32)
+    values = -(1.0 + mantissa) * torch.pow(2.0, exponent)
+    expert_ids = torch.arange(num_experts, device="musa", dtype=torch.int64)
+    token_ids = torch.arange(num_tokens, device="musa", dtype=torch.int64)
+    permutation = (
+        expert_ids.unsqueeze(0) * 131 + token_ids.unsqueeze(1) * 17
+    ) % num_experts
+    return values[permutation].to(dtype)
+
+
+def _dense(
+    weights: torch.Tensor,
+    ids: torch.Tensor,
+    num_experts: int,
+) -> torch.Tensor:
+    output = torch.zeros(
+        (weights.shape[0], num_experts),
+        device=weights.device,
+        dtype=weights.dtype,
+    )
+    return output.scatter_add(1, ids.long(), weights)
+
+
+def _torch_reference(
+    gating_output: torch.Tensor,
+    topk: int,
+    num_expert_group: int,
+    topk_group: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router import (
+        _grouped_topk_general,
+    )
+
+    hidden_states = torch.empty(
+        (gating_output.shape[0], 1),
+        device=gating_output.device,
+        dtype=gating_output.dtype,
+    )
+    return _grouped_topk_general(
+        hidden_states,
+        gating_output,
+        topk,
+        renormalize,
+        num_expert_group,
+        topk_group,
+        "softmax",
+        routed_scaling_factor,
+        None,
+        0,
+    )
+
+
+def _cpu_fp64_reference(
+    gating_output: torch.Tensor,
+    topk: int,
+    num_expert_group: int,
+    topk_group: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute grouped softmax top-k independently on CPU in float64."""
+    logits = gating_output.detach().to(device="cpu", dtype=torch.float64)
+    num_tokens, num_experts = logits.shape
+    experts_per_group = num_experts // num_expert_group
+    weights = torch.empty((num_tokens, topk), dtype=torch.float64)
+    ids = torch.empty((num_tokens, topk), dtype=torch.int64)
+
+    for token_id in range(num_tokens):
+        scores = torch.softmax(logits[token_id], dim=-1)
+        group_scores = scores.reshape(num_expert_group, experts_per_group).amax(dim=-1)
+        selected_groups = torch.argsort(
+            group_scores, descending=True, stable=True
+        )[:topk_group]
+        group_mask = torch.zeros(num_expert_group, dtype=torch.bool)
+        group_mask[selected_groups] = True
+        expert_mask = group_mask.repeat_interleave(experts_per_group)
+        candidate_ids = torch.arange(num_experts)[expert_mask]
+        candidate_order = torch.argsort(
+            scores[candidate_ids], descending=True, stable=True
+        )[:topk]
+        selected_ids = candidate_ids[candidate_order]
+        selected_weights = scores[selected_ids]
+        if renormalize:
+            selected_weights = selected_weights / selected_weights.sum()
+        if routed_scaling_factor != 1.0:
+            selected_weights = selected_weights * routed_scaling_factor
+        ids[token_id] = selected_ids
+        weights[token_id] = selected_weights
+
+    return weights, ids
+
+
+def _cpu_torch_topk_reference(
+    gating_output: torch.Tensor,
+    topk: int,
+    num_expert_group: int,
+    topk_group: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the fallback expression with CPU tensors and CPU ``torch.topk``.
+
+    This intentionally calls ``torch.topk`` directly; it is not an independent
+    reimplementation of top-k selection.  FP32 is used to mirror the MUSA
+    fallback's explicit input casts before softmax/top-k.
+    """
+    logits = gating_output.detach().to(device="cpu", dtype=torch.float32)
+    scores = torch.softmax(logits, dim=-1)
+    num_tokens, num_experts = scores.shape
+    experts_per_group = num_experts // num_expert_group
+    group_scores = scores.reshape(
+        num_tokens, num_expert_group, experts_per_group
+    ).amax(dim=-1)
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=True).indices
+    group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+    group_mask.scatter_(1, group_idx, True)
+    score_mask = group_mask.unsqueeze(-1).expand(
+        num_tokens, num_expert_group, experts_per_group
+    ).reshape(num_tokens, num_experts)
+    tmp_scores = scores.masked_fill(~score_mask, float("-inf"))
+    topk_weights, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=True)
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+    if routed_scaling_factor != 1.0:
+        topk_weights = topk_weights * routed_scaling_factor
+    return topk_weights, topk_ids
+
+
+def _tilelang_result(
+    gating_output: torch.Tensor,
+    topk: int,
+    num_expert_group: int,
+    topk_group: int,
+    renormalize: bool,
+    routed_scaling_factor: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from vllm_musa.jit_kernel.tilelang.grouped_topk import (
+        grouped_topk_softmax_tilelang,
+    )
+
+    return grouped_topk_softmax_tilelang(
+        gating_output,
+        topk,
+        num_expert_group,
+        topk_group,
+        renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=routed_scaling_factor != 1.0,
+    )
+
+
+def _assert_matches_reference(
+    actual: tuple[torch.Tensor, torch.Tensor],
+    expected: tuple[torch.Tensor, torch.Tensor],
+    num_experts: int,
+) -> None:
+    actual_weights, actual_ids = actual
+    expected_weights, expected_ids = expected
+    assert actual_weights.dtype == expected_weights.dtype == torch.float32
+    assert actual_ids.dtype == expected_ids.dtype == torch.int32
+    torch.testing.assert_close(
+        _dense(actual_weights, actual_ids, num_experts),
+        _dense(expected_weights, expected_ids, num_experts),
+        rtol=2e-4,
+        atol=2e-6,
+    )
+
+
+def _assert_matches_cpu_reference(
+    actual: tuple[torch.Tensor, torch.Tensor],
+    expected: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    actual_weights, actual_ids = actual
+    expected_weights, expected_ids = expected
+    assert torch.equal(actual_ids.cpu().to(torch.int64), expected_ids)
+    torch.testing.assert_close(
+        actual_weights.cpu().to(torch.float64), expected_weights.to(torch.float64),
+        rtol=3e-5,
+        atol=3e-6,
+    )
+
+
+def _assert_tie_compatible_with_cpu_reference(
+    actual: tuple[torch.Tensor, torch.Tensor],
+    cpu_reference: tuple[torch.Tensor, torch.Tensor],
+    cpu_logits: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+) -> None:
+    """Validate an alternate, but score-equivalent, top-k tie resolution.
+
+    The CPU reference fixes ties by ascending id. The legacy MUSA fallback
+    uses ``torch.topk``, whose tied-index order is not an API guarantee. This
+    helper permits only a cutoff-tie substitution: selected score multisets,
+    normalized weights, and selected-group eligibility must still agree with
+    the independent CPU implementation.
+    """
+    actual_weights, actual_ids = actual
+    expected_weights, expected_ids = cpu_reference
+    num_experts = cpu_logits.shape[1]
+    experts_per_group = num_experts // num_expert_group
+    actual_ids_cpu = actual_ids.cpu().to(torch.int64)
+    expected_ids_cpu = expected_ids.to(torch.int64)
+    logits = cpu_logits.to(torch.float64)
+
+    actual_scores = logits.gather(1, actual_ids_cpu)
+    expected_scores = logits.gather(1, expected_ids_cpu)
+    torch.testing.assert_close(
+        actual_scores.sort(dim=-1, descending=True).values,
+        expected_scores.sort(dim=-1, descending=True).values,
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        actual_weights.cpu().to(torch.float64).sort(dim=-1, descending=True).values,
+        expected_weights.sort(dim=-1, descending=True).values,
+        rtol=3e-5,
+        atol=3e-6,
+    )
+
+    group_scores = logits.reshape(-1, num_expert_group, experts_per_group).amax(
+        dim=-1
+    )
+    group_cutoff = group_scores.topk(topk_group, dim=-1).values.amin(
+        dim=-1, keepdim=True
+    )
+    actual_groups = actual_ids_cpu // experts_per_group
+    assert (group_scores.gather(1, actual_groups) >= group_cutoff).all()
+    for ids, groups in zip(actual_ids_cpu, actual_groups, strict=True):
+        assert torch.unique(ids).numel() == ids.numel()
+        assert torch.unique(groups).numel() <= topk_group
+
+
+@pytest.mark.parametrize("num_experts,num_groups,topk_group,topk", MODEL_SHAPES)
+@pytest.mark.parametrize("dtype", (torch.float32, torch.float16, torch.bfloat16))
+@pytest.mark.parametrize("renormalize", (False, True))
+@pytest.mark.parametrize("routed_scaling_factor", (1.0, 2.5))
+def test_grouped_topk_tilelang_matches_independent_cpu_fp64(
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    topk: int,
+    dtype: torch.dtype,
+    renormalize: bool,
+    routed_scaling_factor: float,
+) -> None:
+    logits = _make_unique_logits(7, num_experts, dtype)
+    cpu_logits = logits.cpu()
+    actual = _tilelang_result(
+        logits,
+        topk,
+        num_groups,
+        topk_group,
+        renormalize,
+        routed_scaling_factor,
+    )
+    expected = _cpu_fp64_reference(
+        cpu_logits,
+        topk,
+        num_groups,
+        topk_group,
+        renormalize,
+        routed_scaling_factor,
+    )
+    _assert_matches_cpu_reference(actual, expected)
+
+
+@pytest.mark.parametrize("num_experts,num_groups,topk_group,topk", MODEL_SHAPES)
+def test_grouped_topk_tilelang_matches_cpu_torch_topk_on_unique_logits(
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    topk: int,
+) -> None:
+    """Compare TileLang with CPU ``torch.topk(sorted=True)`` on unique logits."""
+    logits = _make_unique_logits(7, num_experts, torch.float32)
+    cpu_logits = logits.cpu()
+    actual = _tilelang_result(
+        logits, topk, num_groups, topk_group, True, routed_scaling_factor=1.0
+    )
+    expected = _cpu_torch_topk_reference(
+        cpu_logits, topk, num_groups, topk_group, True, 1.0
+    )
+    _assert_matches_cpu_reference(actual, expected)
+
+
+@pytest.mark.parametrize("num_experts,num_groups,topk_group,topk", MODEL_SHAPES)
+@pytest.mark.parametrize("num_tokens", TOKEN_COUNTS)
+@pytest.mark.parametrize("dtype", (torch.float32, torch.float16, torch.bfloat16))
+@pytest.mark.parametrize("renormalize", (False, True))
+def test_grouped_topk_tilelang_model_shapes_match_torch(
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    topk: int,
+    num_tokens: int,
+    dtype: torch.dtype,
+    renormalize: bool,
+) -> None:
+    logits = _make_unique_logits(num_tokens, num_experts, dtype)
+    actual = _tilelang_result(
+        logits,
+        topk,
+        num_groups,
+        topk_group,
+        renormalize,
+    )
+    expected = _torch_reference(
+        logits,
+        topk,
+        num_groups,
+        topk_group,
+        renormalize,
+        1.0,
+    )
+    _assert_matches_reference(actual, expected, num_experts)
+
+
+@pytest.mark.parametrize("num_experts,num_groups,topk_group,topk", GENERIC_SHAPES)
+@pytest.mark.parametrize("num_tokens", (1, 33, 257))
+@pytest.mark.parametrize("dtype", (torch.float32, torch.float16, torch.bfloat16))
+@pytest.mark.parametrize("renormalize", (False, True))
+def test_grouped_topk_tilelang_generic_shapes_match_torch(
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    topk: int,
+    num_tokens: int,
+    dtype: torch.dtype,
+    renormalize: bool,
+) -> None:
+    logits = _make_unique_logits(num_tokens, num_experts, dtype)
+    actual = _tilelang_result(logits, topk, num_groups, topk_group, renormalize)
+    expected = _torch_reference(
+        logits,
+        topk,
+        num_groups,
+        topk_group,
+        renormalize,
+        1.0,
+    )
+    _assert_matches_reference(actual, expected, num_experts)
+
+
+@pytest.mark.parametrize(
+    "num_experts,num_groups,topk_group,topk",
+    PARALLEL_BOUNDARY_SHAPES + SERIAL_SHAPES,
+)
+@pytest.mark.parametrize("num_tokens", (1, 3))
+@pytest.mark.parametrize("renormalize", (False, True))
+def test_grouped_topk_tilelang_parallel_and_serial_limits_match_torch(
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    topk: int,
+    num_tokens: int,
+    renormalize: bool,
+) -> None:
+    logits = _make_unique_logits(num_tokens, num_experts, torch.bfloat16)
+    actual = _tilelang_result(logits, topk, num_groups, topk_group, renormalize)
+    expected = _torch_reference(
+        logits,
+        topk,
+        num_groups,
+        topk_group,
+        renormalize,
+        1.0,
+    )
+    _assert_matches_reference(actual, expected, num_experts)
+
+
+@pytest.mark.skipif(
+    os.environ.get("VLLM_MUSA_RUN_EXHAUSTIVE_GROUPED_TOPK") != "1",
+    reason="set VLLM_MUSA_RUN_EXHAUSTIVE_GROUPED_TOPK=1 for token counts 1--3072",
+)
+def test_grouped_topk_tilelang_every_token_count() -> None:
+    for num_tokens in range(1, 3073):
+        logits = _make_unique_logits(num_tokens, 160, torch.bfloat16)
+        actual = _tilelang_result(logits, 6, 8, 3, True, 16.0)
+        expected = _torch_reference(logits, 6, 8, 3, True, 16.0)
+        _assert_matches_reference(actual, expected, 160)
+
+
+def test_grouped_topk_tilelang_handles_noncontiguous_parallel_input() -> None:
+    storage = _make_unique_logits(66, 320, torch.bfloat16)
+    logits = storage[::2, ::2]
+    assert logits.shape == (33, 160)
+    assert not logits.is_contiguous()
+    actual = _tilelang_result(logits, 6, 8, 3, True, 16.0)
+    expected = _torch_reference(logits, 6, 8, 3, True, 16.0)
+    _assert_matches_reference(actual, expected, 160)
+
+
+def test_grouped_topk_tilelang_handles_noncontiguous_serial_input() -> None:
+    storage = _make_unique_logits(6, 1026, torch.bfloat16)
+    logits = storage[::2, ::2]
+    assert logits.shape == (3, 513)
+    assert not logits.is_contiguous()
+    actual = _tilelang_result(logits, 7, 3, 2, True)
+    expected = _torch_reference(logits, 7, 3, 2, True, 1.0)
+    _assert_matches_reference(actual, expected, 513)
+
+
+@pytest.mark.parametrize(
+    "num_experts,num_groups,topk_group,topk", MODEL_SHAPES + GENERIC_SHAPES
+)
+def test_grouped_topk_tilelang_unique_logits_are_deterministic_and_group_limited(
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    topk: int,
+) -> None:
+    logits = _make_unique_logits(17, num_experts, torch.bfloat16)
+    weights, ids = _tilelang_result(logits, topk, num_groups, topk_group, True)
+    repeated_weights, repeated_ids = _tilelang_result(
+        logits,
+        topk,
+        num_groups,
+        topk_group,
+        True,
+    )
+
+    torch.testing.assert_close(repeated_weights, weights)
+    torch.testing.assert_close(repeated_ids, ids)
+    expected = _torch_reference(logits, topk, num_groups, topk_group, True, 1.0)
+    _assert_matches_reference((weights, ids), expected, num_experts)
+
+    scores = torch.softmax(logits.float(), dim=-1)
+    group_scores = scores.reshape(17, num_groups, -1).amax(dim=-1)
+    group_cutoff = group_scores.topk(topk_group).values.amin(dim=-1, keepdim=True)
+    groups = ids.long() // (num_experts // num_groups)
+    assert (group_scores.gather(1, groups) >= group_cutoff).all()
+    for token_ids, token_groups in zip(ids, groups, strict=True):
+        assert torch.unique(token_ids).numel() == topk
+        assert torch.unique(token_groups).numel() <= topk_group
+
+
+@pytest.mark.parametrize("renormalize", (False, True))
+def test_grouped_topk_tilelang_applies_routed_scaling_factor(
+    renormalize: bool,
+) -> None:
+    logits = _make_unique_logits(33, 160, torch.bfloat16)
+    base_weights, base_ids = _tilelang_result(logits, 6, 8, 3, renormalize)
+    scaled_weights, scaled_ids = _tilelang_result(
+        logits,
+        6,
+        8,
+        3,
+        renormalize,
+        2.5,
+    )
+    torch.testing.assert_close(scaled_ids, base_ids)
+    torch.testing.assert_close(scaled_weights, base_weights * 2.5)
+    if renormalize:
+        torch.testing.assert_close(
+            scaled_weights.sum(dim=-1),
+            torch.full((33,), 2.5, device="musa", dtype=torch.float32),
+        )
+
+
+@pytest.mark.parametrize(
+    "num_experts,num_groups,topk_group,routed_topk",
+    MODEL_SHAPES + ((96, 6, 2, 7), (96, 3, 2, 40)),
+)
+@pytest.mark.parametrize("num_tokens", (1, 33, 257))
+@pytest.mark.parametrize("renormalize", (False, True))
+@pytest.mark.parametrize("apply_routed_scale", (False, True))
+def test_grouped_topk_tilelang_shared_expert_and_routed_scale(
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    routed_topk: int,
+    num_tokens: int,
+    renormalize: bool,
+    apply_routed_scale: bool,
+) -> None:
+    """Cover the kernel ABI slot that appends one fused shared expert."""
+    from vllm_musa.jit_kernel.tilelang.grouped_topk import (
+        grouped_topk_softmax_tilelang,
+    )
+
+    scaling_factor = 2.5
+    logits = _make_unique_logits(num_tokens, num_experts, torch.bfloat16)
+    routed_weights, routed_ids = grouped_topk_softmax_tilelang(
+        logits,
+        routed_topk,
+        num_groups,
+        topk_group,
+        renormalize,
+        routed_scaling_factor=scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scale,
+    )
+    shared_weights, shared_ids = grouped_topk_softmax_tilelang(
+        logits,
+        routed_topk + 1,
+        num_groups,
+        topk_group,
+        renormalize,
+        num_fused_shared_experts=1,
+        routed_scaling_factor=scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scale,
+    )
+
+    torch.testing.assert_close(shared_ids[:, :-1], routed_ids)
+    torch.testing.assert_close(shared_weights[:, :-1], routed_weights)
+    torch.testing.assert_close(
+        shared_ids[:, -1],
+        torch.full((num_tokens,), num_experts, device="musa", dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        shared_weights[:, -1], routed_weights.sum(dim=-1) / scaling_factor
+    )
+
+
+@pytest.mark.parametrize("num_experts,num_groups,topk_group,topk", MODEL_SHAPES)
+def test_grouped_topk_tilelang_handles_very_negative_logits(
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    topk: int,
+) -> None:
+    logits = _make_unique_logits(17, num_experts, torch.float32) - 20000.0
+    actual = _tilelang_result(logits, topk, num_groups, topk_group, True, 16.0)
+    expected = _torch_reference(logits, topk, num_groups, topk_group, True, 16.0)
+    _assert_matches_reference(actual, expected, num_experts)
+
+
+def test_grouped_topk_tilelang_handles_empty_input() -> None:
+    weights, ids = _tilelang_result(
+        torch.empty((0, 48), device="musa", dtype=torch.bfloat16),
+        5,
+        3,
+        2,
+        True,
+    )
+    assert weights.shape == ids.shape == (0, 5)
+    assert weights.dtype == torch.float32
+    assert ids.dtype == torch.int32
+
+
+@pytest.mark.parametrize(
+    "num_experts,num_groups,topk_group,topk",
+    (
+        (0, 1, 1, 1),
+        (48, 0, 1, 1),
+        (48, 5, 1, 1),
+        (48, 3, 0, 1),
+        (48, 3, 4, 1),
+        (48, 3, 2, 33),
+    ),
+)
+def test_grouped_topk_tilelang_rejects_invalid_configurations(
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    topk: int,
+) -> None:
+    logits = torch.empty((1, num_experts), device="musa", dtype=torch.bfloat16)
+    with pytest.raises(ValueError):
+        _tilelang_result(logits, topk, num_groups, topk_group, True)
+
+
+def test_grouped_topk_tilelang_rejects_unsupported_shared_expert_count() -> None:
+    from vllm_musa.jit_kernel.tilelang.grouped_topk import (
+        grouped_topk_softmax_tilelang,
+    )
+
+    logits = torch.empty((1, 48), device="musa", dtype=torch.bfloat16)
+    with pytest.raises(ValueError):
+        grouped_topk_softmax_tilelang(
+            logits,
+            7,
+            3,
+            2,
+            True,
+            num_fused_shared_experts=2,
+            routed_scaling_factor=1.0,
+        )
+
+
+def _make_dispatch_logits(num_tokens: int, num_experts: int) -> torch.Tensor:
+    return _make_unique_logits(num_tokens, num_experts, torch.bfloat16)
+
+
+@pytest.mark.parametrize("num_experts,num_groups,topk_group,topk", MODEL_SHAPES)
+@pytest.mark.parametrize("num_tokens", (1, 33, 3072))
+def test_grouped_topk_router_dispatches_tilelang(
+    monkeypatch: pytest.MonkeyPatch,
+    num_experts: int,
+    num_groups: int,
+    topk_group: int,
+    topk: int,
+    num_tokens: int,
+) -> None:
+    import vllm_musa.jit_kernel.tilelang as tilelang_kernels
+    from vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router import (
+        grouped_topk,
+    )
+
+    called = False
+    original = tilelang_kernels.grouped_topk_softmax_tilelang
+
+    def traced_tilelang(*args: object, **kwargs: object) -> tuple[torch.Tensor, torch.Tensor]:
+        nonlocal called
+        called = True
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        tilelang_kernels,
+        "grouped_topk_softmax_tilelang",
+        traced_tilelang,
+    )
+    logits = _make_dispatch_logits(num_tokens, num_experts)
+    hidden_states = torch.empty(
+        (num_tokens, 1), device="musa", dtype=torch.bfloat16
+    )
+    actual = grouped_topk(
+        hidden_states,
+        logits,
+        topk,
+        True,
+        num_groups,
+        topk_group,
+        "softmax",
+        16.0,
+    )
+    expected = original(
+        logits,
+        topk,
+        num_groups,
+        topk_group,
+        True,
+        routed_scaling_factor=16.0,
+        apply_routed_scaling_factor_on_output=True,
+    )
+    assert called
+    torch.testing.assert_close(actual[0], expected[0])
+    torch.testing.assert_close(actual[1], expected[1])
+
+
+def test_grouped_topk_router_matches_cpu_fp64_and_forced_torch_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router as router
+
+    logits = _make_unique_logits(17, 160, torch.bfloat16)
+    cpu_logits = logits.cpu()
+    hidden_states = torch.empty((17, 32), device="musa", dtype=torch.bfloat16)
+    cpu_reference = _cpu_fp64_reference(
+        cpu_logits,
+        topk=6,
+        num_expert_group=8,
+        topk_group=3,
+        renormalize=True,
+        routed_scaling_factor=2.5,
+    )
+    tilelang_result = router.grouped_topk(
+        hidden_states,
+        logits,
+        6,
+        True,
+        8,
+        3,
+        "softmax",
+        2.5,
+    )
+    _assert_matches_cpu_reference(tilelang_result, cpu_reference)
+
+    monkeypatch.setattr(
+        router,
+        "_can_use_musa_tilelang_grouped_topk",
+        lambda *args: False,
+    )
+    fallback_result = router.grouped_topk(
+        hidden_states,
+        logits,
+        6,
+        True,
+        8,
+        3,
+        "softmax",
+        2.5,
+    )
+    _assert_tie_compatible_with_cpu_reference(
+        fallback_result,
+        cpu_reference,
+        cpu_logits,
+        num_expert_group=8,
+        topk_group=3,
+    )
+
+
+@pytest.mark.parametrize(
+    "scoring_func,has_bias,num_fused_shared_experts",
+    (
+        ("sigmoid", False, 0),
+        ("softmax", True, 0),
+        ("softmax", False, 1),
+    ),
+)
+def test_grouped_topk_router_does_not_dispatch_unsupported_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    scoring_func: str,
+    has_bias: bool,
+    num_fused_shared_experts: int,
+) -> None:
+    import vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router as router
+
+    fallback_weights = torch.empty((1, 1), device="musa", dtype=torch.float32)
+    fallback_ids = torch.empty((1, 1), device="musa", dtype=torch.int32)
+
+    def fail_tilelang(**kwargs: object) -> tuple[torch.Tensor, torch.Tensor]:
+        raise AssertionError("unsupported routing semantics reached TileLang")
+
+    def fake_fallback(
+        *args: object,
+        **kwargs: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return fallback_weights, fallback_ids
+
+    monkeypatch.setattr(
+        "vllm_musa.jit_kernel.tilelang.grouped_topk_softmax_tilelang",
+        fail_tilelang,
+    )
+    monkeypatch.setattr(router, "_grouped_topk_general", fake_fallback)
+    logits = _make_dispatch_logits(1, 160)
+    hidden_states = torch.empty((1, 1), device="musa", dtype=torch.bfloat16)
+    bias = torch.zeros(160, device="musa") if has_bias else None
+
+    actual = router.grouped_topk(
+        hidden_states,
+        logits,
+        6,
+        True,
+        8,
+        3,
+        scoring_func,
+        1.0,
+        bias,
+        num_fused_shared_experts,
+    )
+    assert actual[0] is fallback_weights
+    assert actual[1] is fallback_ids
+
+
+def test_grouped_topk_router_falls_back_when_tilelang_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vllm_musa.model_executor.layers.fused_moe.router.grouped_topk_router as router
+
+    fallback_weights = torch.empty((1, 1), device="musa", dtype=torch.float32)
+    fallback_ids = torch.empty((1, 1), device="musa", dtype=torch.int32)
+
+    def unavailable_tilelang(**kwargs: object) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+    def fake_fallback(
+        *args: object,
+        **kwargs: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return fallback_weights, fallback_ids
+
+    monkeypatch.setattr(
+        "vllm_musa.jit_kernel.tilelang.grouped_topk_softmax_tilelang",
+        unavailable_tilelang,
+    )
+    monkeypatch.setattr(router, "_grouped_topk_general", fake_fallback)
+    logits = _make_dispatch_logits(1, 160)
+    hidden_states = torch.empty((1, 1), device="musa", dtype=torch.bfloat16)
+
+    actual = router.grouped_topk(hidden_states, logits, 6, True, 8, 3)
+    assert actual[0] is fallback_weights
+    assert actual[1] is fallback_ids

--- a/vllm_musa/jit_kernel/tilelang/grouped_topk.py
+++ b/vllm_musa/jit_kernel/tilelang/grouped_topk.py
@@ -1,0 +1,483 @@
+"""TileLang MUSA implementation of grouped softmax top-k routing."""
+
+import functools
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from vllm_musa.jit_kernel.tilelang.utils import (
+    MUSA_COMMON_PASS_CONFIGS,
+    MUSA_COMPILE_FLAGS,
+    tilelang_dtype,
+)
+
+__all__ = ["grouped_topk_softmax_tilelang"]
+
+
+_PARALLEL_MAX_EXPERTS = 512
+_PARALLEL_MAX_GROUPS = 128
+_PARALLEL_MAX_ROUTED_TOPK = 32
+
+_PASS_CONFIGS = dict(MUSA_COMMON_PASS_CONFIGS)
+for _unsafe_key in (
+    "TL_DISABLE_INDEX_TYPE_PROMOTION",
+    "TL_DISABLE_SAFE_MEMORY_ACCESS",
+):
+    if hasattr(tilelang.PassConfigKey, _unsafe_key):
+        _PASS_CONFIGS.pop(getattr(tilelang.PassConfigKey, _unsafe_key), None)
+
+
+def _check_config(
+    num_experts: int,
+    num_expert_group: int,
+    topk_group: int,
+    output_topk: int,
+    num_fused_shared_experts: int,
+) -> int:
+    if num_experts <= 0:
+        raise ValueError("num_experts must be positive")
+    if num_expert_group <= 0 or num_experts % num_expert_group != 0:
+        raise ValueError("num_expert_group must be positive and divide num_experts")
+    if not 1 <= topk_group <= num_expert_group:
+        raise ValueError("topk_group must be in [1, num_expert_group]")
+    if num_fused_shared_experts not in (0, 1):
+        raise ValueError("TileLang grouped top-k supports zero or one shared expert")
+
+    routed_topk = output_topk - num_fused_shared_experts
+    selected_capacity = topk_group * (num_experts // num_expert_group)
+    if not 1 <= routed_topk <= selected_capacity:
+        raise ValueError(
+            "routed top-k must be positive and no larger than the experts "
+            "in selected groups"
+        )
+    return routed_topk
+
+
+@functools.lru_cache(maxsize=None)
+@tilelang.jit(
+    out_idx=[],
+    target="musa",
+    pass_configs=_PASS_CONFIGS,
+    compile_flags=MUSA_COMPILE_FLAGS,
+)
+def _grouped_topk_parallel_kernel(
+    input_dtype: str,
+    num_experts: int,
+    num_expert_group: int,
+    topk_group: int,
+    output_topk: int,
+    num_fused_shared_experts: int,
+    renormalize: bool,
+    apply_routed_scaling_factor: bool,
+):
+    num_tokens = T.dynamic("num_tokens")
+    stride_m = T.dynamic("stride_m")
+    stride_n = T.dynamic("stride_n")
+    routed_topk = output_topk - num_fused_shared_experts
+    experts_per_group = num_experts // num_expert_group
+    threads = 32
+    aligned_experts = ((num_experts + threads - 1) // threads) * threads
+    aligned_groups = ((num_expert_group + threads - 1) // threads) * threads
+
+    @T.prim_func
+    def grouped_topk_parallel(
+        gating_output: T.StridedTensor(
+            (num_tokens, num_experts),
+            (stride_m, stride_n),
+            input_dtype,
+        ),
+        topk_weights: T.Tensor((num_tokens, output_topk), "float32"),
+        topk_ids: T.Tensor((num_tokens, output_topk), "int32"),
+        routed_scaling_factor: T.float32,
+    ):
+        with T.Kernel(num_tokens, threads=threads) as token_id:
+            tx = T.get_thread_binding()
+            logits = T.alloc_fragment((aligned_experts,), "float32")
+            exp_scores = T.alloc_fragment((aligned_experts,), "float32")
+            candidate_scores = T.alloc_fragment((aligned_experts,), "float32")
+            row_max = T.alloc_fragment((1,), "float32")
+            row_sum = T.alloc_fragment((1,), "float32")
+            group_scores = T.alloc_fragment((aligned_groups,), "float32")
+            group_max = T.alloc_fragment((1,), "float32")
+            group_idx = T.alloc_reducer((1,), T.int32, "min", replication="all")
+            expert_max = T.alloc_fragment((1,), "float32")
+            expert_idx = T.alloc_reducer((1,), T.int32, "min", replication="all")
+            group_mask = T.alloc_shared((aligned_groups,), "int32")
+            selected_ids = T.alloc_shared((routed_topk,), "int32")
+            selected_weights = T.alloc_shared((routed_topk,), "float32")
+            selected_sum = T.alloc_shared((1,), "float32")
+            output_scale = T.alloc_var("float32")
+
+            for expert in T.Parallel(aligned_experts):
+                if expert < num_experts:
+                    logits[expert] = T.cast(gating_output[token_id, expert], "float32")
+                else:
+                    logits[expert] = -T.infinity(T.float32)
+
+            T.reduce_max(logits, row_max)
+            if not renormalize:
+                for expert in T.Parallel(aligned_experts):
+                    if expert < num_experts:
+                        exp_scores[expert] = T.exp(logits[expert] - row_max[0])
+                    else:
+                        exp_scores[expert] = 0.0
+                T.reduce_sum(exp_scores, row_sum)
+
+            if topk_group < num_expert_group:
+                for group in T.Parallel(aligned_groups):
+                    if group < num_expert_group:
+                        group_scores[group] = -T.infinity(T.float32)
+                        for offset in T.serial(experts_per_group):
+                            group_scores[group] = T.max(
+                                group_scores[group],
+                                T.cast(
+                                    gating_output[
+                                        token_id,
+                                        group * experts_per_group + offset,
+                                    ],
+                                    "float32",
+                                ),
+                            )
+                    else:
+                        group_scores[group] = -T.infinity(T.float32)
+                    group_mask[group] = 0
+                T.sync_threads()
+
+                for _ in T.serial(topk_group):
+                    T.reduce_max(group_scores, group_max)
+                    T.fill(group_idx, T.max_value(T.int32))
+                    for group in T.Parallel(aligned_groups):
+                        if (
+                            group < num_expert_group
+                            and group_scores[group] == group_max[0]
+                        ):
+                            group_idx[0] = T.min(group_idx[0], group)
+                    T.finalize_reducer(group_idx)
+                    for group in T.Parallel(aligned_groups):
+                        if group < num_expert_group and group == group_idx[0]:
+                            group_mask[group] = 1
+                            group_scores[group] = -T.infinity(T.float32)
+                    T.sync_threads()
+
+            for expert in T.Parallel(aligned_experts):
+                if topk_group == num_expert_group:
+                    if expert < num_experts:
+                        candidate_scores[expert] = logits[expert]
+                    else:
+                        candidate_scores[expert] = -T.infinity(T.float32)
+                else:
+                    if (
+                        expert < num_experts
+                        and group_mask[expert // experts_per_group] != 0
+                    ):
+                        candidate_scores[expert] = logits[expert]
+                    else:
+                        candidate_scores[expert] = -T.infinity(T.float32)
+
+            for kth in T.serial(routed_topk):
+                T.reduce_max(candidate_scores, expert_max)
+                T.fill(expert_idx, T.max_value(T.int32))
+                for expert in T.Parallel(aligned_experts):
+                    if topk_group == num_expert_group:
+                        if (
+                            expert < num_experts
+                            and candidate_scores[expert] == expert_max[0]
+                        ):
+                            expert_idx[0] = T.min(expert_idx[0], expert)
+                    else:
+                        if (
+                            expert < num_experts
+                            and group_mask[expert // experts_per_group] != 0
+                            and candidate_scores[expert] == expert_max[0]
+                        ):
+                            expert_idx[0] = T.min(expert_idx[0], expert)
+                T.finalize_reducer(expert_idx)
+                if tx == 0:
+                    selected_ids[kth] = expert_idx[0]
+                    selected_weights[kth] = T.exp(expert_max[0] - row_max[0])
+                    if not renormalize:
+                        selected_weights[kth] /= T.max(row_sum[0], 1e-20)
+                T.sync_threads()
+                for expert in T.Parallel(aligned_experts):
+                    if expert == expert_idx[0]:
+                        candidate_scores[expert] = -T.infinity(T.float32)
+
+            if tx == 0:
+                selected_sum[0] = 0.0
+                for kth in T.serial(routed_topk):
+                    selected_sum[0] += selected_weights[kth]
+            T.sync_threads()
+
+            output_scale = 1.0
+            if renormalize:
+                output_scale = 1.0 / T.max(selected_sum[0], 1e-20)
+            if apply_routed_scaling_factor:
+                output_scale *= routed_scaling_factor
+
+            for kth in T.Parallel(output_topk):
+                if kth < routed_topk:
+                    topk_ids[token_id, kth] = selected_ids[kth]
+                    topk_weights[token_id, kth] = selected_weights[kth] * output_scale
+                else:
+                    topk_ids[token_id, kth] = num_experts
+                    topk_weights[token_id, kth] = (
+                        selected_sum[0] / routed_scaling_factor * output_scale
+                    )
+
+    return grouped_topk_parallel
+
+
+@functools.lru_cache(maxsize=None)
+@tilelang.jit(
+    out_idx=[],
+    target="musa",
+    pass_configs=_PASS_CONFIGS,
+    compile_flags=MUSA_COMPILE_FLAGS,
+)
+def _grouped_topk_serial_kernel(
+    input_dtype: str,
+    num_experts: int,
+    num_expert_group: int,
+    topk_group: int,
+    output_topk: int,
+    num_fused_shared_experts: int,
+    renormalize: bool,
+    apply_routed_scaling_factor: bool,
+):
+    num_tokens = T.dynamic("num_tokens")
+    stride_m = T.dynamic("stride_m")
+    stride_n = T.dynamic("stride_n")
+    routed_topk = output_topk - num_fused_shared_experts
+    experts_per_group = num_experts // num_expert_group
+
+    @T.prim_func
+    def grouped_topk_serial(
+        gating_output: T.StridedTensor(
+            (num_tokens, num_experts),
+            (stride_m, stride_n),
+            input_dtype,
+        ),
+        topk_weights: T.Tensor((num_tokens, output_topk), "float32"),
+        topk_ids: T.Tensor((num_tokens, output_topk), "int32"),
+        routed_scaling_factor: T.float32,
+    ):
+        with T.Kernel(num_tokens, threads=32) as token_id:
+            tx = T.get_thread_binding()
+            if tx == 0:
+                row_max = T.alloc_local((1,), "float32")
+                row_sum = T.alloc_local((1,), "float32")
+                group_score = T.alloc_local((1,), "float32")
+                previous_group_score = T.alloc_local((1,), "float32")
+                previous_group = T.alloc_local((1,), "int32")
+                best_group_score = T.alloc_local((1,), "float32")
+                best_group = T.alloc_local((1,), "int32")
+                previous_expert_score = T.alloc_local((1,), "float32")
+                previous_expert = T.alloc_local((1,), "int32")
+                best_expert_score = T.alloc_local((1,), "float32")
+                best_expert = T.alloc_local((1,), "int32")
+                selected_sum = T.alloc_local((1,), "float32")
+
+                row_max[0] = -T.infinity(T.float32)
+                for expert in T.serial(num_experts):
+                    row_max[0] = T.max(
+                        row_max[0],
+                        T.cast(gating_output[token_id, expert], "float32"),
+                    )
+                if not renormalize:
+                    row_sum[0] = 0.0
+                    for expert in T.serial(num_experts):
+                        row_sum[0] += T.exp(
+                            T.cast(gating_output[token_id, expert], "float32")
+                            - row_max[0]
+                        )
+
+                if topk_group == num_expert_group:
+                    previous_group_score[0] = -T.infinity(T.float32)
+                    previous_group[0] = num_expert_group
+                else:
+                    previous_group_score[0] = T.infinity(T.float32)
+                    previous_group[0] = -1
+                    for group_rank in T.serial(topk_group):
+                        best_group_score[0] = -T.infinity(T.float32)
+                        best_group[0] = num_expert_group
+                        for group in T.serial(num_expert_group):
+                            group_score[0] = -T.infinity(T.float32)
+                            for offset in T.serial(experts_per_group):
+                                group_score[0] = T.max(
+                                    group_score[0],
+                                    T.cast(
+                                        gating_output[
+                                            token_id,
+                                            group * experts_per_group + offset,
+                                        ],
+                                        "float32",
+                                    ),
+                                )
+                            if (
+                                group_rank == 0
+                                or group_score[0] < previous_group_score[0]
+                                or (
+                                    group_score[0] == previous_group_score[0]
+                                    and group > previous_group[0]
+                                )
+                            ):
+                                if group_score[0] > best_group_score[0] or (
+                                    group_score[0] == best_group_score[0]
+                                    and group < best_group[0]
+                                ):
+                                    best_group_score[0] = group_score[0]
+                                    best_group[0] = group
+                        previous_group_score[0] = best_group_score[0]
+                        previous_group[0] = best_group[0]
+
+                previous_expert_score[0] = T.infinity(T.float32)
+                previous_expert[0] = -1
+                selected_sum[0] = 0.0
+                for kth in T.serial(routed_topk):
+                    best_expert_score[0] = -T.infinity(T.float32)
+                    best_expert[0] = num_experts
+                    for group in T.serial(num_expert_group):
+                        group_score[0] = -T.infinity(T.float32)
+                        for offset in T.serial(experts_per_group):
+                            group_score[0] = T.max(
+                                group_score[0],
+                                T.cast(
+                                    gating_output[
+                                        token_id,
+                                        group * experts_per_group + offset,
+                                    ],
+                                    "float32",
+                                ),
+                            )
+                        if group_score[0] > previous_group_score[0] or (
+                            group_score[0] == previous_group_score[0]
+                            and group <= previous_group[0]
+                        ):
+                            for offset in T.serial(experts_per_group):
+                                expert = group * experts_per_group + offset
+                                expert_score = T.cast(
+                                    gating_output[token_id, expert], "float32"
+                                )
+                                if (
+                                    kth == 0
+                                    or expert_score < previous_expert_score[0]
+                                    or (
+                                        expert_score == previous_expert_score[0]
+                                        and expert > previous_expert[0]
+                                    )
+                                ):
+                                    if expert_score > best_expert_score[0] or (
+                                        expert_score == best_expert_score[0]
+                                        and expert < best_expert[0]
+                                    ):
+                                        best_expert_score[0] = expert_score
+                                        best_expert[0] = expert
+
+                    previous_expert_score[0] = best_expert_score[0]
+                    previous_expert[0] = best_expert[0]
+                    topk_ids[token_id, kth] = best_expert[0]
+                    topk_weights[token_id, kth] = T.exp(
+                        best_expert_score[0] - row_max[0]
+                    )
+                    if not renormalize:
+                        topk_weights[token_id, kth] /= T.max(row_sum[0], 1e-20)
+                    selected_sum[0] += topk_weights[token_id, kth]
+
+                if num_fused_shared_experts == 1:
+                    topk_ids[token_id, routed_topk] = num_experts
+                    topk_weights[token_id, routed_topk] = (
+                        selected_sum[0] / routed_scaling_factor
+                    )
+
+                if renormalize:
+                    output_scale = T.alloc_local((1,), "float32")
+                    output_scale[0] = 1.0 / T.max(selected_sum[0], 1e-20)
+                    for kth in T.serial(output_topk):
+                        topk_weights[token_id, kth] *= output_scale[0]
+                if apply_routed_scaling_factor:
+                    for kth in T.serial(output_topk):
+                        topk_weights[token_id, kth] *= routed_scaling_factor
+
+    return grouped_topk_serial
+
+
+_grouped_topk_parallel_kernel.mode = "lazy"
+_grouped_topk_serial_kernel.mode = "lazy"
+
+
+def grouped_topk_softmax_tilelang(
+    gating_output: torch.Tensor,
+    topk: int,
+    num_expert_group: int,
+    topk_group: int,
+    renormalize: bool,
+    *,
+    num_fused_shared_experts: int = 0,
+    routed_scaling_factor: float | None = None,
+    apply_routed_scaling_factor_on_output: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run grouped softmax top-k with a TileLang MUSA kernel."""
+
+    if gating_output.device.type != "musa":
+        raise ValueError("TileLang grouped top-k requires a MUSA tensor")
+    if gating_output.dim() != 2:
+        raise ValueError("gating_output must be a 2D tensor")
+    input_dtype = tilelang_dtype(gating_output.dtype)
+    num_tokens, num_experts = gating_output.shape
+    routed_topk = _check_config(
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+    )
+    if num_fused_shared_experts == 1 and (
+        routed_scaling_factor is None or routed_scaling_factor == 0
+    ):
+        raise ValueError("a non-zero routed_scaling_factor is required")
+    if (
+        renormalize
+        and apply_routed_scaling_factor_on_output
+        and routed_scaling_factor is None
+    ):
+        raise ValueError("cannot apply a missing routed_scaling_factor")
+
+    topk_weights = torch.empty(
+        (num_tokens, topk),
+        dtype=torch.float32,
+        device=gating_output.device,
+    )
+    topk_ids = torch.empty(
+        (num_tokens, topk),
+        dtype=torch.int32,
+        device=gating_output.device,
+    )
+    if num_tokens == 0:
+        return topk_weights, topk_ids
+
+    use_parallel = (
+        num_experts <= _PARALLEL_MAX_EXPERTS
+        and num_expert_group <= _PARALLEL_MAX_GROUPS
+        and routed_topk <= _PARALLEL_MAX_ROUTED_TOPK
+    )
+    kernel_factory = (
+        _grouped_topk_parallel_kernel if use_parallel else _grouped_topk_serial_kernel
+    )
+    kernel = kernel_factory(
+        input_dtype,
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        renormalize,
+        apply_routed_scaling_factor_on_output,
+    )
+    kernel(
+        gating_output,
+        topk_weights,
+        topk_ids,
+        float(routed_scaling_factor if routed_scaling_factor is not None else 1.0),
+    )
+    return topk_weights, topk_ids

--- a/vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -254,7 +254,7 @@ def is_power_of_two(n):
     backend=current_platform.simple_compile_backend,
     options=maybe_disable_graph_partition(current_platform.simple_compile_backend),
 )
-def grouped_topk(
+def _grouped_topk_general(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
     topk: int,
@@ -355,6 +355,91 @@ def grouped_topk(
     if routed_scaling_factor != 1.0:
         topk_weights = topk_weights * routed_scaling_factor
     return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+def _can_use_musa_tilelang_grouped_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    num_expert_group: int,
+    topk_group: int,
+    scoring_func: str,
+    e_score_correction_bias: torch.Tensor | None,
+    num_fused_shared_experts: int,
+) -> bool:
+    return (
+        current_platform.is_musa()
+        and scoring_func == "softmax"
+        and e_score_correction_bias is None
+        and num_fused_shared_experts == 0
+        and gating_output.device.type == "musa"
+        and hidden_states.device == gating_output.device
+        and hidden_states.dim() == 2
+        and gating_output.dim() == 2
+        and hidden_states.shape[0] == gating_output.shape[0]
+        and gating_output.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and 0 < num_expert_group
+        and 0 < topk_group <= num_expert_group
+        and gating_output.shape[1] % num_expert_group == 0
+        and 0 < topk <= topk_group * (gating_output.shape[1] // num_expert_group)
+    )
+
+
+def grouped_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_expert_group: int = 0,
+    topk_group: int = 0,
+    scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: torch.Tensor | None = None,
+    num_fused_shared_experts: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Dispatch MUSA grouped top-k before entering the compiled Torch fallback."""
+    if _can_use_musa_tilelang_grouped_topk(
+        hidden_states,
+        gating_output,
+        topk,
+        num_expert_group,
+        topk_group,
+        scoring_func,
+        e_score_correction_bias,
+        num_fused_shared_experts,
+    ):
+        from vllm_musa.jit_kernel.tilelang.grouped_topk import (
+            grouped_topk_softmax_tilelang,
+        )
+
+        try:
+            result = grouped_topk_softmax_tilelang(
+                gating_output=gating_output,
+                topk=topk,
+                num_expert_group=num_expert_group,
+                topk_group=topk_group,
+                renormalize=renormalize,
+                routed_scaling_factor=routed_scaling_factor,
+                apply_routed_scaling_factor_on_output=routed_scaling_factor != 1.0,
+            )
+            return result
+        # TileLang selects its serial kernel when this shape does not fit the
+        # parallel kernel's resource limits. Keep the compiled implementation
+        # as a fallback only for unavailable TileLang capabilities.
+        except NotImplementedError:
+            pass
+    return _grouped_topk_general(
+        hidden_states,
+        gating_output,
+        topk,
+        renormalize,
+        num_expert_group,
+        topk_group,
+        scoring_func,
+        routed_scaling_factor,
+        e_score_correction_bias,
+        num_fused_shared_experts,
+    )
 
 
 import vllm.model_executor.layers.fused_moe.router.grouped_topk_router


### PR DESCRIPTION
 > Depends on #188. This PR will be rebased onto `v0.28.0-dev` after #188 merges.
## Summary

This PR adds a TileLang implementation of grouped softmax top-k routing for MUSA, primarily targeting DeepSeek-V2 family models that use softmax grouped top-k routing, while preserving the general Torch/MATE routing path for other MoE semantics and adding grouped top-k correctness and fallback coverage

### Implementation

- Add `grouped_topk_softmax_tilelang` under the MUSA TileLang JIT package and export it from the MUSA JIT entry points.
- Dispatch supported MUSA softmax grouped-top-k configurations to the TileLang implementation, while preserving the existing general routing path for unsupported semantics.
- Add a one-program-per-token parallel kernel for:
  - `num_experts <= 512`
  - `num_expert_group <= 128`
  - `routed top-k <= 32`
- Add a general serial TileLang kernel for valid configurations outside the parallel-kernel limits, rather than restricting support to a fixed model-configuration table.
- Compute softmax inputs and all reductions in FP32.
- Accept FP32, FP16, and BF16 router logits.
- Return FP32 routing weights and INT32 expert IDs.
- Support non-contiguous router logits through explicit dynamic strides.
- Preserve the existing routing implementation for sigmoid scoring, correction-bias routing, fused shared experts, and unsupported TileLang configurations.

## Test Coverage

`tests/test_grouped_topk_tilelang.py` covers:

- DeepSeek-V2-Lite-like and generic grouped-top-k shapes.
- Parallel-kernel boundaries and serial-kernel fallback shapes.
- FP16, BF16, and FP32 router logits.
- Multiple token counts, including small, irregular, and large token counts.
- Renormalized and non-renormalized routing weights.
- Routed scaling factors.
- Non-contiguous router-logit tensors.
- Numerical comparison against the existing Torch routing path.
- Independent CPU FP64 reference validation.
- Tie-compatible validation for top-k cutoff ties.
- Dispatcher coverage for supported TileLang configurations.
- Fallback coverage for unsupported routing semantics:
  - sigmoid scoring;
  - correction bias;
  - fused shared experts;
  - unavailable TileLang kernels.

### Validation

- `pytest -vv tests/test_grouped_topk_tilelang.py`
```text
1073 passed, 1 warning in 426.86s (0:07:06)
```

## Operator Performance

Grouped top-k router latency:

| Configuration | TileLang grouped top-k | Torch fallback | Improvement |
|---|---:|---:|---:|
| Overall | 9.732 ms | 10.518 ms | 7.5% lower latency |
| Routing operator | 6.897 us | 32.528 us | 78.8% lower latency |

## End-to-End Latency Benchmark

Environment:

```text
GPU: 1x MTT S5000
Driver: 5.2.0-server
Model: DeepSeek-V2-Lite-Chat-FP8
torch / tilelang: 2.9.1 / 0.1.8+musa.3
vLLM-MUSA: 0.24.0-dev
```

| Batch / Input / Output | Backend | Output throughput (tok/s) | Mean TTFT (ms) | Mean TPOT (ms) |
|---|---|---:|---:|---:|
| 1 / 128 / 128 | Fallback | 78.71 | 101.78 | 11.76 |
|  | Tilelang grouped topk | 82.83 (+5.23%) | 90.02 (-11.56%) | 11.21 (-4.68%) |
| 1 / 2048 / 1024 | Fallback | 77.85 | 157.61 | 12.64 |
|  | Tilelang grouped topk | 81.14 (+4.22%) | 156.25 (-0.87%) | 12.12 (-4.11%) |
| 1 / 8192 / 2048 | Fallback | 73.21 | 537.05 | 13.37 |
|  | Tilelang grouped topk | 76.13 (+3.98%) | 531.16 (-1.10%) | 12.85 (-3.89%) |
| 4 / 512 / 128 | Fallback | 171.01 | 230.52 | 20.68 |
|  | Tilelang grouped topk | 178.97 (+4.65%) | 203.16 (-11.87%) | 19.84 (-4.06%) |
| 4 / 2048 / 1024 | Fallback | 193.77 | 288.56 | 20.25 |
|  | Tilelang grouped topk | 198.25 (+2.31%) | 284.57 (-1.38%) | 19.78 (-2.36%) |
| 4 / 8192 / 2048 | Fallback | 183.08 | 1315.28 | 21.16 |
|  | Tilelang grouped topk | 188.01 (+2.69%) | 1295.79 (-1.48%) | 20.59 (-2.66%) |
| 8 / 512 / 128 | Fallback | 302.38 | 228.67 | 23.56 |
|  | Tilelang grouped topk | 311.79 (+3.11%) | 214.44 (-6.22%) | 22.85 (-3.01%) |
| 8 / 2048 / 1024 | Fallback | 331.41 | 531.08 | 23.49 |
|  | Tilelang grouped topk | 343.35 (+3.60%) | 527.75 (-0.63%) | 22.65 (-3.56%) |
| 8 / 8192 / 2048 | Fallback | 301.97 | 1845.57 | 25.53 |
|  | Tilelang grouped topk | 309.78 (+2.59%) | 1842.29 (-0.18%) | 24.86 (-2.61%) |
| 16 / 512 / 128 | Fallback | 517.13 | 306.12 | 26.86 |
|  | Tilelang grouped topk | 538.08 (+4.05%) | 284.09 (-7.20%) | 25.82 (-3.87%) |
| 16 / 2048 / 1024 | Fallback | 562.68 | 890.88 | 27.36 |
|  | Tilelang grouped topk | 570.78 (+1.44%) | 882.74 (-0.91%) | 26.96 (-1.45%) |
| 16 / 8192 / 2048 | Fallback | 480.81 | 2873.06 | 31.75 |
|  | Tilelang grouped topk | 488.78 (+1.66%) | 2862.13 (-0.38%) | 31.21 (-1.69%) |
| 32 / 2048 / 1024 | Fallback | 946.76 | 1780.45 | 31.50 |
|  | Tilelang grouped topk | 971.12 (+2.57%) | 1738.80 (-2.34%) | 30.70 (-2.55%) |

## Accuracy Benchmark

GSM8K accuracy results for `DeepSeek-V2-Lite-Chat-FP8`:

| Runtime | Device | GSM8K score |
|---|---|---:|
| CUDA reference | H20 | 68.3090% |
| MUSA + Torch top-k fallback | MTT S5000 | 68.8400% |
| MUSA + TileLang grouped top-k | MTT S5000 | 68.9158% |

The TileLang grouped-top-k path preserves accuracy relative to the existing MUSA Torch top-k fallback in this evaluation.

## Notes

The end-to-end benchmark was collected on `vLLM-MUSA 0.24.0-dev`