### PR TITLE
fix the issue where the ep service exits and the deepep resources are not properly released

### DIFF
--- a/vllm_musa/patches/series/0110-MUSA-deepep-buffer-shutdown-cleanup.patch
+++ b/vllm_musa/patches/series/0110-MUSA-deepep-buffer-shutdown-cleanup.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: musa <musa@local>
+Date: Mon, 24 Aug 2026 11:00:00 +0000
+Subject: [PATCH] MUSA: make DeepEP Buffer shutdown cleanup compatible
+
+--- a/vllm/distributed/device_communicators/all2all.py
++++ b/vllm/distributed/device_communicators/all2all.py
+@@ -189,11 +189,23 @@
+         raise NotImplementedError
+
+     def destroy(self):
++        # Detach handles before native teardown. The MUSA DeepEP Buffer
++        # relies on its C++ destructor and does not expose ``destroy``.
+         with self.handle_cache._lock:
+-            for _, handle in self.handle_cache._cache.items():
+-                handle.destroy()
++            handles = list(self.handle_cache._cache.values())
+             self.handle_cache._cache.clear()
+
++        while handles:
++            handle = handles.pop()
++            try:
++                destroy = getattr(handle, "destroy", None)
++                if callable(destroy):
++                    destroy()
++            finally:
++                # Drop legacy MUSA Buffer references while all worker ranks
++                # are still in the explicit shutdown path.
++                del handle
++
+
+ class DeepEPHTAll2AllManager(DeepEPAll2AllManagerBase):
+     """
+
+--
+2.34.1


### PR DESCRIPTION
When using the command "ctrl+c" to terminate the service started by "vllm serve /model -tp 2 -dp 2 -ep --all2all-backend deepep_low_latency", the following error log will be generated
<img width="631" height="133" alt="image" src="https://github.com/user-attachments/assets/c1616004-7ba7-4453-b5e7-98e41c34c9bc" />
Fix by actively destroying deepep resources
Can add the startup parameter --shutdown-timeout 10