### PR TITLE
perf(musa): select AOT and JIT tiles by active MP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,7 @@ __marimo__/
 third_party/*
 !third_party/PINS
 vllm/
+
+# Local MUSA benchmark evidence (host/device identity, receipts, and timings).
+# Keep qualification bundles ticket-linked and out of the public source tree.
+generated/

--- a/benchmarks/fused_moe/benchmark_dispatch_crossover.py
+++ b/benchmarks/fused_moe/benchmark_dispatch_crossover.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Cold-cache crossover sweep for MUSA FP8 fused-MoE backends.
+"""Cold-cache crossover sweep for MUSA fused-MoE backends.
 
 All dimensions are the actual per-rank kernel dimensions. A coarse sweep only
 produces a candidate interval; rerun densely around both crossings and confirm
@@ -33,11 +33,44 @@ import torch.nn.functional as F
 
 from mate.testing.utils import bench_gpu_time_with_musa_event
 
-from vllm_musa.model_executor.layers.fused_moe import fused_moe
-from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "kernel_tactics"
+sys.path.insert(0, str(SCRIPT_DIR))
+from _benchmark_utils import verify_lease_device_fence  # noqa: E402
+
+from vllm_musa.model_executor.layers.fused_moe import fused_moe  # noqa: E402
+from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (  # noqa: E402
     MusaFusedMoeBackend,
     MusaFusedMoeShape,
 )
+
+try:
+    from vllm_musa.tuning import (
+        prime_musa_kernel_hardware,
+        query_musa_kernel_hardware,
+    )
+except ImportError:
+    # The benchmark is intentionally runnable against an image whose native
+    # extension predates the Python hardware-query helper.  Keep the fallback
+    # read-only and shape the object to the current selector contract.
+    from types import SimpleNamespace
+
+    def query_musa_kernel_hardware(device_index: int) -> Any:
+        properties = torch.musa.get_device_properties(device_index)
+        capability = (
+            int(getattr(properties, "major", 0)),
+            int(getattr(properties, "minor", 0)),
+        )
+        multiprocessor_count = int(properties.multi_processor_count)
+        return SimpleNamespace(
+            device_capability=capability,
+            multiprocessor_count=multiprocessor_count,
+            cache_key=f"fallback:{capability[0]}.{capability[1]}:mp{multiprocessor_count}",
+        )
+
+    def prime_musa_kernel_hardware(device_index: int) -> Any:
+        # Older images have no frozen-hardware helper.  The fallback still
+        # returns the same query result used to build the policy key.
+        return query_musa_kernel_hardware(device_index)
 
 
 @dataclass(frozen=True)
@@ -47,7 +80,7 @@ class Shape:
     hidden_size: int
     intermediate_size: int
     top_k: int
-    block_size: int
+    block_size: int | None
 
 
 @dataclass
@@ -86,6 +119,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--hidden-size", type=int, required=True)
     parser.add_argument("--intermediate-size", type=int, required=True)
     parser.add_argument("--top-k", type=int, required=True)
+    parser.add_argument(
+        "--weight-dtype",
+        choices=("fp8", "bf16"),
+        default="fp8",
+        help="Weight format to benchmark; BF16 supports gemv and upstream only.",
+    )
     parser.add_argument("--block-size", type=int, choices=(128,), default=128)
     parser.add_argument(
         "--tokens",
@@ -155,6 +194,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--regression-margin", type=float, default=0.03)
     parser.add_argument("--max-iqr-ratio", type=float, default=0.10)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--expected-multiprocessor-count", type=int, required=True)
+    parser.add_argument(
+        "--source-revision",
+        default=None,
+        help=(
+            "Exact source SHA when the benchmark is run from an archive without "
+            "a .git directory; otherwise read .source-revision if present."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -174,7 +224,7 @@ def command_output(command: list[str]) -> str | None:
         return None
 
 
-def repo_provenance() -> dict[str, Any]:
+def repo_provenance(source_revision: str | None = None) -> dict[str, Any]:
     module_path = Path(inspect.getfile(fused_moe)).resolve()
     repo = next(
         (
@@ -185,7 +235,27 @@ def repo_provenance() -> dict[str, Any]:
         None,
     )
     if repo is None:
-        return {"module_path": str(module_path), "repo": None}
+        marker = source_revision
+        if marker is None:
+            marker_path = next(
+                (
+                    parent / ".source-revision"
+                    for parent in (module_path.parent, *module_path.parents)
+                    if (parent / ".source-revision").is_file()
+                ),
+                None,
+            )
+            if marker_path is not None:
+                marker = marker_path.read_text(encoding="utf-8").strip() or None
+        return {
+            "module_path": str(module_path),
+            "repo": None,
+            "head": marker,
+            "source_revision": marker,
+            "source_kind": "archive",
+            "status": None,
+            "dirty_patch_sha256": None,
+        }
     head = command_output(["git", "-C", str(repo), "rev-parse", "HEAD"])
     status = command_output(["git", "-C", str(repo), "status", "--short"])
     try:
@@ -230,6 +300,24 @@ def quantized_weight(shape: tuple[int, ...], seed: int) -> torch.Tensor:
             generator=generator,
         ).mul_(8.0)
         output[start:end].copy_(source.to(torch.float8_e4m3fn))
+    return output
+
+
+def bf16_weight(shape: tuple[int, ...], seed: int) -> torch.Tensor:
+    generator = torch.Generator(device="musa")
+    generator.manual_seed(seed)
+    output = torch.empty(shape, device="musa", dtype=torch.bfloat16)
+    chunk_experts = max(1, min(shape[0], 8))
+    for start in range(0, shape[0], chunk_experts):
+        end = min(start + chunk_experts, shape[0])
+        output[start:end].copy_(
+            torch.randn(
+                (end - start, *shape[1:]),
+                device="musa",
+                dtype=torch.bfloat16,
+                generator=generator,
+            )
+        )
     return output
 
 
@@ -359,10 +447,11 @@ def backend_kwargs(
     w2: torch.Tensor,
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
-    w1_scale: torch.Tensor,
-    w2_scale: torch.Tensor,
-    block_size: int,
+    w1_scale: torch.Tensor | None,
+    w2_scale: torch.Tensor | None,
+    block_size: int | None,
 ) -> dict[str, Any]:
+    use_fp8 = w1.dtype == torch.float8_e4m3fn
     return {
         "hidden_states": hidden_states,
         "w1": w1,
@@ -371,7 +460,7 @@ def backend_kwargs(
         "topk_ids": topk_ids,
         "activation": "silu",
         "apply_router_weight_on_input": False,
-        "use_fp8_w8a8": True,
+        "use_fp8_w8a8": use_fp8,
         "use_int8_w8a8": False,
         "use_int8_w8a16": False,
         "use_int4_w4a16": False,
@@ -385,7 +474,7 @@ def backend_kwargs(
         "w2_zp": None,
         "a1_scale": None,
         "a2_scale": None,
-        "block_shape": [block_size, block_size],
+        "block_shape": [block_size, block_size] if use_fp8 else None,
         "w1_bias": None,
         "w2_bias": None,
     }
@@ -397,18 +486,26 @@ def build_backends(kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, bo
         for key, value in kwargs.items()
         if key not in {"apply_router_weight_on_input", "block_shape"}
     }
+    bf16_gemv_gate = {
+        key: value for key, value in kwargs.items() if key != "block_shape"
+    }
     grouped_gate = dict(kwargs)
     deepgemm_prefill_gate = {
         key: value
         for key, value in kwargs.items()
         if key not in {"topk_weights", "global_num_experts", "w1_zp", "w2_zp"}
     }
+    use_fp8 = bool(kwargs["use_fp8_w8a8"])
     capabilities = {
-        "gemv": fused_moe._can_use_musa_native_fp8_moe_gemv(**gemv_gate),
-        "grouped_gemm": fused_moe._can_use_musa_fp8_moe_grouped_gemm(**grouped_gate),
-        "deepgemm_prefill": fused_moe._can_use_moe_deepgemm_prefill(
-            **deepgemm_prefill_gate
+        "gemv": (
+            fused_moe._can_use_musa_native_fp8_moe_gemv(**gemv_gate)
+            if use_fp8
+            else fused_moe._can_use_musa_native_bf16_moe_gemv(**bf16_gemv_gate)
         ),
+        "grouped_gemm": use_fp8
+        and fused_moe._can_use_musa_fp8_moe_grouped_gemm(**grouped_gate),
+        "deepgemm_prefill": use_fp8
+        and fused_moe._can_use_moe_deepgemm_prefill(**deepgemm_prefill_gate),
         "upstream": True,
     }
 
@@ -459,6 +556,7 @@ def dispatcher_smoke(
     kwargs: dict[str, Any],
     requested_backends: list[str],
     direct_outputs: dict[str, torch.Tensor],
+    capabilities: dict[str, bool],
 ) -> dict[str, Any]:
     dispatchable_backends = [
         backend
@@ -472,7 +570,27 @@ def dispatcher_smoke(
     outputs: dict[str, torch.Tensor] = {}
     errors: dict[str, str] = {}
     identities: dict[str, Any] = {}
+    resolved_backends: dict[str, str] = {}
     call_counts = {"gemv": 0, "grouped_gemm": 0, "upstream": 0}
+
+    def expected_backend(requested: str) -> str:
+        """Return the backend the production forced-dispatch contract allows.
+
+        The BF16 Qwen matcher is deliberately limited to the decode prefix
+        (M<=12).  A forced GEMV request outside that prefix must fall back to
+        upstream; treating that intentional fallback as an identity failure
+        made every otherwise-valid crossover receipt fail qualification.
+        """
+        if requested == "upstream":
+            return "upstream"
+        if not capabilities.get(requested, False):
+            return "upstream"
+        if requested == "gemv":
+            is_bf16 = kwargs["hidden_states"].dtype == torch.bfloat16
+            is_qwen_shape = kwargs["w1"].shape[0] in (256, 257)
+            if is_bf16 and is_qwen_shape and kwargs["hidden_states"].shape[0] > 12:
+                return "upstream"
+        return requested
 
     def counted_gemv(*args: Any, **inner_kwargs: Any) -> torch.Tensor:
         call_counts["gemv"] += 1
@@ -496,6 +614,15 @@ def dispatcher_smoke(
             for name in call_counts:
                 call_counts[name] = 0
             fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND = MusaFusedMoeBackend(backend)
+            resolved = expected_backend(backend)
+            resolved_backends[backend] = resolved
+            fallback_reason = (
+                "shape_matcher_max_tokens"
+                if backend == "gemv"
+                and resolved == "upstream"
+                and kwargs["hidden_states"].shape[0] > 12
+                else None
+            )
             try:
                 outputs[backend] = fused_moe._musa_fused_experts_impl_dispatch(
                     **kwargs
@@ -503,7 +630,9 @@ def dispatcher_smoke(
                 synchronize()
                 identities[backend] = {
                     "call_counts": dict(call_counts),
-                    "passed": call_counts[backend] == 1
+                    "expected_backend": resolved,
+                    "fallback_reason": fallback_reason,
+                    "passed": call_counts[resolved] == 1
                     and sum(call_counts.values()) == 1,
                 }
             except Exception as exc:
@@ -518,13 +647,19 @@ def dispatcher_smoke(
 
     comparisons: dict[str, Any] = {}
     for backend, output in outputs.items():
-        direct_output = direct_outputs.get(backend)
+        resolved = resolved_backends.get(backend, backend)
+        direct_output = direct_outputs.get(resolved)
         if direct_output is None:
-            comparisons[backend] = {"passed": False, "error": "direct output missing"}
+            comparisons[backend] = {
+                "passed": False,
+                "error": "direct output missing",
+                "expected_backend": resolved,
+            }
             continue
         diff = (output.float() - direct_output.float()).abs()
         comparisons[backend] = {
             "passed": bool(torch.equal(output, direct_output)),
+            "expected_backend": resolved,
             "max_abs_diff": float(diff.max().item()),
             "mean_abs_diff": float(diff.mean().item()),
             **comparison_metrics(output, direct_output),
@@ -782,7 +917,7 @@ def main() -> int:
         hidden_size=args.hidden_size,
         intermediate_size=args.intermediate_size,
         top_k=args.top_k,
-        block_size=args.block_size,
+        block_size=args.block_size if args.weight_dtype == "fp8" else None,
     )
     tokens = sorted({int(value) for value in args.tokens.split(",") if value})
     if args.sweep_kind == "dense" and tokens:
@@ -797,6 +932,11 @@ def main() -> int:
     }
     if unknown:
         raise ValueError(f"unsupported backends: {sorted(unknown)}")
+    if args.weight_dtype == "bf16" and set(requested_backends) != {
+        "gemv",
+        "upstream",
+    }:
+        raise ValueError("BF16 requires exactly gemv and upstream backends")
     if "upstream" not in requested_backends:
         raise ValueError("upstream is mandatory as the correctness reference")
     if not tokens or min(tokens) <= 0:
@@ -816,23 +956,47 @@ def main() -> int:
     if args.rounds <= 0 or args.rounds % len(requested_backends) != 0:
         raise ValueError("rounds must be a positive multiple of backend count")
 
-    w1 = quantized_weight(
+    weight_factory = quantized_weight if args.weight_dtype == "fp8" else bf16_weight
+    w1 = weight_factory(
         (shape.experts, 2 * shape.intermediate_size, shape.hidden_size), args.seed
     )
-    w2 = quantized_weight(
+    w2 = weight_factory(
         (shape.experts, shape.hidden_size, shape.intermediate_size), args.seed + 1
     )
-    w1_scale = block_scales(w1, shape.block_size, args.seed + 2)
-    w2_scale = block_scales(w2, shape.block_size, args.seed + 3)
-    capability = tuple(int(value) for value in torch.musa.get_device_capability())
-    device_name = torch.musa.get_device_name(0)
-    multiprocessor_count = int(
-        torch.musa.get_device_properties(0).multi_processor_count
-    )
-    if capability != (3, 1) or "S5000" not in device_name.upper():
+    if args.weight_dtype == "fp8":
+        assert shape.block_size is not None
+        w1_scale = block_scales(w1, shape.block_size, args.seed + 2)
+        w2_scale = block_scales(w2, shape.block_size, args.seed + 3)
+    else:
+        w1_scale = None
+        w2_scale = None
+    hardware = query_musa_kernel_hardware(0)
+    primed_hardware = prime_musa_kernel_hardware(0)
+    if (
+        primed_hardware.device_capability != hardware.device_capability
+        or primed_hardware.multiprocessor_count != hardware.multiprocessor_count
+    ):
         raise RuntimeError(
-            "this policy sweep is valid only on MTT S5000/MP31, got "
-            f"device={device_name!r} capability={capability}"
+            "frozen MUSA hardware fingerprint changed during benchmark setup: "
+            f"queried={hardware!r} primed={primed_hardware!r}"
+        )
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+        args.expected_multiprocessor_count,
+    )
+    capability = primed_hardware.device_capability
+    device_name = torch.musa.get_device_name(0)
+    multiprocessor_count = primed_hardware.multiprocessor_count
+    if multiprocessor_count != args.expected_multiprocessor_count:
+        raise RuntimeError(
+            "runtime hardware fingerprint does not match the requested MP gate: "
+            f"expected={args.expected_multiprocessor_count} actual={multiprocessor_count}"
+        )
+    if capability != (3, 1):
+        raise RuntimeError(
+            "this policy sweep requires the supported MUSA architecture, got "
+            f"capability={capability}"
         )
     policy_key = MusaFusedMoeShape(
         device_capability=capability,
@@ -847,10 +1011,10 @@ def main() -> int:
         activation="silu",
         expert_parallel=False,
         hidden_dtype=str(torch.bfloat16),
-        weight_dtype=str(torch.float8_e4m3fn),
-        scale_dtype=str(torch.float32),
-        w1_scale_shape=tuple(w1_scale.shape),
-        w2_scale_shape=tuple(w2_scale.shape),
+        weight_dtype=str(w1.dtype),
+        scale_dtype=str(w1_scale.dtype) if w1_scale is not None else "none",
+        w1_scale_shape=tuple(w1_scale.shape) if w1_scale is not None else (),
+        w2_scale_shape=tuple(w2_scale.shape) if w2_scale is not None else (),
         gemv_block=os.environ.get("VLLM_MUSA_GEMV_MOE_BLOCK", "auto"),
         graph_mode="eager",
     )
@@ -860,6 +1024,7 @@ def main() -> int:
         "argv": sys.argv,
         "shape": asdict(shape),
         "shape_dimensions_are_per_rank": True,
+        "weight_dtype": args.weight_dtype,
         "policy_key": asdict(policy_key),
         "route_mode": args.route_mode,
         "folded_shared_expert": args.folded_shared_expert,
@@ -905,18 +1070,32 @@ def main() -> int:
             "VLLM_MUSA_MOE_DEEPGEMM_PREFILL_MIN_TOKENS", "2500"
         ),
         "device_name": device_name,
+        "hardware_cache_key": primed_hardware.cache_key,
+        "primed_hardware": {
+            "device_capability": capability,
+            "multiprocessor_count": multiprocessor_count,
+        },
         "device_capability": capability,
         "multiprocessor_count": multiprocessor_count,
         "torch_musa_runtime": getattr(torch.version, "musa", None),
         "packages": package_versions(),
-        "repo": repo_provenance(),
+        "repo": repo_provenance(args.source_revision),
         "mthreads_gmi": command_output(["mthreads-gmi", "-q"]),
+        "lease_device_fence": lease_device_fence,
         "mcc_version": command_output(["mcc", "--version"]),
         "estimated_static_bytes": (
             w1.numel() * w1.element_size()
             + w2.numel() * w2.element_size()
-            + w1_scale.numel() * w1_scale.element_size()
-            + w2_scale.numel() * w2_scale.element_size()
+            + (
+                w1_scale.numel() * w1_scale.element_size()
+                if w1_scale is not None
+                else 0
+            )
+            + (
+                w2_scale.numel() * w2_scale.element_size()
+                if w2_scale is not None
+                else 0
+            )
         ),
     }
     results: list[Result] = []
@@ -965,16 +1144,23 @@ def main() -> int:
             except Exception as exc:
                 oracle_errors[backend] = f"{type(exc).__name__}: {exc}"
         try:
-            oracle = dequantized_fp32_reference(
-                hidden_states=oracle_hidden_states,
-                w1=w1,
-                w2=w2,
-                topk_weights=oracle_topk_weights,
-                topk_ids=oracle_topk_ids,
-                w1_scale=w1_scale,
-                w2_scale=w2_scale,
-                block_size=shape.block_size,
-            )
+            if args.weight_dtype == "bf16":
+                oracle = oracle_outputs["upstream"].float()
+                oracle_reference = "upstream-bf16"
+            else:
+                assert w1_scale is not None and w2_scale is not None
+                assert shape.block_size is not None
+                oracle = dequantized_fp32_reference(
+                    hidden_states=oracle_hidden_states,
+                    w1=w1,
+                    w2=w2,
+                    topk_weights=oracle_topk_weights,
+                    topk_ids=oracle_topk_ids,
+                    w1_scale=w1_scale,
+                    w2_scale=w2_scale,
+                    block_size=shape.block_size,
+                )
+                oracle_reference = "dequantized-fp32-no-activation-quantization"
             comparisons: dict[str, Any] = {}
             for backend, output in oracle_outputs.items():
                 difference = (output.float() - oracle).abs()
@@ -1003,7 +1189,7 @@ def main() -> int:
                 "selected_experts": sorted(
                     int(value) for value in oracle_topk_ids.unique().cpu().tolist()
                 ),
-                "reference": "dequantized-fp32-no-activation-quantization",
+                "reference": oracle_reference,
                 "gemv_passed": gemv_oracle_pass,
                 "comparisons": comparisons,
                 "errors": oracle_errors,
@@ -1015,7 +1201,11 @@ def main() -> int:
                 "tokens": args.oracle_probe_tokens,
                 "route_mode": "deterministic_coverage",
                 "seed": oracle_seed,
-                "reference": "dequantized-fp32-no-activation-quantization",
+                "reference": (
+                    "upstream-bf16"
+                    if args.weight_dtype == "bf16"
+                    else "dequantized-fp32-no-activation-quantization"
+                ),
                 "gemv_passed": False,
                 "errors": {
                     **oracle_errors,
@@ -1071,7 +1261,7 @@ def main() -> int:
                 errors[backend] = f"{type(exc).__name__}: {exc}"
 
         dispatcher_evidence[str(token_count)] = dispatcher_smoke(
-            kwargs, requested_backends, outputs
+            kwargs, requested_backends, outputs, capabilities
         )
         if "deepgemm_prefill" in requested_backends:
             deepgemm_implementation[str(token_count)] = deepgemm_prefill_implementation(

--- a/benchmarks/fused_moe/benchmark_dispatch_graph.py
+++ b/benchmarks/fused_moe/benchmark_dispatch_graph.py
@@ -1,23 +1,33 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E402, I001
 
-"""Validate the native FP8 MoE GEMV dispatcher under CUDAGraph replay."""
+"""Validate native FP8/BF16 MoE dispatcher paths under CUDAGraph replay."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
+from typing import Any
 
 # isort: off
 import torchada  # noqa: F401  # must patch before torch ecosystem imports
 import torch
 # isort: on
 
+KERNEL_TACTICS_DIR = Path(__file__).resolve().parents[1] / "kernel_tactics"
+if str(KERNEL_TACTICS_DIR) not in sys.path:
+    sys.path.insert(0, str(KERNEL_TACTICS_DIR))
+
+from _benchmark_utils import source_identity, verify_lease_device_fence
+
 from benchmark_dispatch_crossover import (
     backend_kwargs,
     block_scales,
+    comparison_metrics,
     package_versions,
     quantized_weight,
     repo_provenance,
@@ -29,6 +39,26 @@ from vllm_musa.model_executor.layers.fused_moe import fused_moe
 from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (
     MusaFusedMoeBackend,
 )
+from vllm_musa.tuning import prime_musa_kernel_hardware
+
+
+def _make_bf16_weights(
+    *, experts: int, intermediate_size: int, hidden_size: int, seed: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Create deterministic BF16 weights with the same layout as FP8 cases."""
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    w1 = torch.randn(
+        (experts, 2 * intermediate_size, hidden_size),
+        generator=generator,
+        dtype=torch.float32,
+    ).to(device="musa", dtype=torch.bfloat16)
+    w2 = torch.randn(
+        (experts, hidden_size, intermediate_size),
+        generator=generator,
+        dtype=torch.float32,
+    ).to(device="musa", dtype=torch.bfloat16)
+    return w1, w2
 
 
 def parse_args() -> argparse.Namespace:
@@ -41,6 +71,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=20260720)
     parser.add_argument("--replays", type=int, default=8)
     parser.add_argument("--folded-shared-expert", action="store_true")
+    parser.add_argument("--weight-dtype", choices=("fp8", "bf16"), default="fp8")
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--expected-multiprocessor-count", type=int, required=True)
+    parser.add_argument(
+        "--graph-bucket-num-reqs",
+        type=int,
+        help=(
+            "Inject a validated FULL graph bucket for production-policy replay; "
+            "omit to exercise the fail-closed untracked-capture path."
+        ),
+    )
     parser.add_argument(
         "--requested",
         choices=("auto", "gemv"),
@@ -63,24 +105,72 @@ def main() -> int:
         raise ValueError("folded shared expert requires experts >= 2 and top-k >= 2")
     if args.replays <= 0:
         raise ValueError("replays must be positive")
+    if args.weight_dtype == "bf16" and args.experts == 257:
+        if not args.folded_shared_expert or args.top_k != 9:
+            raise ValueError(
+                "the E=257 Qwen3.5 BF16 contract requires "
+                "--folded-shared-expert and top-k=9"
+            )
+        if args.graph_bucket_num_reqs not in (1, 2, 4, 8):
+            raise ValueError(
+                "the MP48 E=257 BF16 graph gate requires an exact "
+                "graph-bucket-num-reqs in {1,2,4,8}"
+            )
+        if args.graph_bucket_num_reqs != args.tokens:
+            raise ValueError("FULL decode graph buckets require num_reqs == num_tokens")
+    lease_device_fence = verify_lease_device_fence(
+        expected_physical_device=args.expected_physical_device,
+        expected_device_uuid=args.expected_device_uuid,
+    )
     capability = tuple(int(value) for value in torch.musa.get_device_capability())
     device_name = torch.musa.get_device_name(0)
     multiprocessor_count = int(
         torch.musa.get_device_properties(0).multi_processor_count
     )
-    if capability != (3, 1) or "S5000" not in device_name.upper():
+    multiprocessor_count_passed = (
+        multiprocessor_count == args.expected_multiprocessor_count
+    )
+    if not multiprocessor_count_passed:
         raise RuntimeError(
-            "this graph validation is valid only on MTT S5000/MP31, got "
-            f"device={device_name!r} capability={capability}"
+            "graph validation MP mismatch: "
+            f"expected={args.expected_multiprocessor_count}, "
+            f"actual={multiprocessor_count}"
         )
-    w1 = quantized_weight(
-        (args.experts, 2 * args.intermediate_size, args.hidden_size), args.seed
-    )
-    w2 = quantized_weight(
-        (args.experts, args.hidden_size, args.intermediate_size), args.seed + 1
-    )
-    w1_scale = block_scales(w1, 128, args.seed + 2)
-    w2_scale = block_scales(w2, 128, args.seed + 3)
+    if capability != (3, 1):
+        raise RuntimeError(
+            "this graph validation requires the supported MUSA architecture, "
+            f"got capability={capability}"
+        )
+    primed_hardware = prime_musa_kernel_hardware(0)
+    if (
+        primed_hardware.device_capability != capability
+        or primed_hardware.multiprocessor_count != multiprocessor_count
+    ):
+        raise RuntimeError(
+            "worker-style MUSA hardware priming disagrees with the runtime "
+            f"device: primed={primed_hardware!r}, capability={capability}, "
+            f"multiprocessor_count={multiprocessor_count}"
+        )
+    if args.weight_dtype == "fp8":
+        w1 = quantized_weight(
+            (args.experts, 2 * args.intermediate_size, args.hidden_size), args.seed
+        )
+        w2 = quantized_weight(
+            (args.experts, args.hidden_size, args.intermediate_size), args.seed + 1
+        )
+        w1_scale = block_scales(w1, 128, args.seed + 2)
+        w2_scale = block_scales(w2, 128, args.seed + 3)
+        block_size: int | None = 128
+    else:
+        w1, w2 = _make_bf16_weights(
+            experts=args.experts,
+            intermediate_size=args.intermediate_size,
+            hidden_size=args.hidden_size,
+            seed=args.seed,
+        )
+        w1_scale = None
+        w2_scale = None
+        block_size = None
     generator = torch.Generator(device="musa")
     generator.manual_seed(args.seed + 4)
     hidden_states = torch.randn(
@@ -97,6 +187,11 @@ def main() -> int:
         args.seed + 5,
         args.folded_shared_expert,
     )
+    # The native BF16 GEMV contract is intentionally stricter than the FP8
+    # path: route indices are int32. Keep the graph inputs in the exact
+    # production dtype instead of letting torch.topk's int64 result force the
+    # dispatcher to upstream.
+    topk_ids = topk_ids.to(dtype=torch.int32)
     kwargs = backend_kwargs(
         hidden_states=hidden_states,
         w1=w1,
@@ -105,27 +200,171 @@ def main() -> int:
         topk_ids=topk_ids,
         w1_scale=w1_scale,
         w2_scale=w2_scale,
-        block_size=128,
+        block_size=block_size,
     )
+    # The production dispatcher needs the global expert count to distinguish
+    # Qwen3.5 folded (E=257) from ordinary MoE (E=256). The lower-level helper
+    # intentionally defaults this metadata to None for generic crossover
+    # experiments, so make it explicit in the graph harness.
+    kwargs["global_num_experts"] = args.experts
+    kwargs["apply_router_weight_on_input"] = False
 
     old_backend = fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND
+    # Production callers enter through the upstream module slot patched by
+    # vllm-musa at import time. Keep that slot intact and invoke it below;
+    # replacing it with a counter would bypass the dispatcher we are trying to
+    # validate.
+    production_dispatch = fused_moe._upstream_fused_moe.fused_experts_impl
+    production_dispatch_installed = (
+        production_dispatch is fused_moe._musa_fused_experts_impl_dispatch
+    )
+    if not production_dispatch_installed:
+        raise RuntimeError(
+            "vllm-musa fused-MoE production dispatcher is not installed at "
+            "vllm.model_executor.layers.fused_moe.fused_moe.fused_experts_impl"
+        )
     original_gemv = fused_moe.fused_experts_impl
     original_upstream = fused_moe._upstream_fused_moe._musa_original_fused_experts_impl
+    original_graph_bucket_query = fused_moe.query_musa_forward_graph_bucket
+    original_shape_builder = fused_moe._musa_fused_moe_shape
+    original_qwen35_gate = fused_moe._can_use_qwen35_bf16_moe_decode_gemv
+    original_native_bf16_gate = fused_moe._can_use_musa_native_bf16_moe_gemv
+    original_device_fingerprint = fused_moe._musa_device_fingerprint
+    original_thresholds_for_shape = fused_moe.thresholds_for_shape
     calls = {"gemv": 0, "upstream": 0}
+    selection_trace: list[dict[str, Any]] = []
+    shape_trace: list[dict[str, Any]] = []
+    capability_trace: list[dict[str, Any]] = []
+    device_fingerprint_trace: list[dict[str, Any]] = []
+    backend_call_trace: list[dict[str, Any]] = []
+    policy_trace: list[dict[str, Any]] = []
+    captured_gemv_launch_kwargs: dict[str, Any] = {}
 
     def counted_gemv(*inner_args, **inner_kwargs):
         calls["gemv"] += 1
+        captured_gemv_launch_kwargs.clear()
+        captured_gemv_launch_kwargs.update(
+            {
+                key: inner_kwargs[key]
+                for key in (
+                    "inplace",
+                    "_allow_deepgemm_prefill",
+                    "_gemv_block",
+                    "_gemv_blocks",
+                )
+                if key in inner_kwargs
+            }
+        )
+        backend_call_trace.append(
+            {
+                "backend": "gemv",
+                "launch_kwargs": dict(captured_gemv_launch_kwargs),
+            }
+        )
         return original_gemv(*inner_args, **inner_kwargs)
 
     def counted_upstream(*inner_args, **inner_kwargs):
         calls["upstream"] += 1
+        backend_call_trace.append({"backend": "upstream"})
         return original_upstream(*inner_args, **inner_kwargs)
 
+    original_select_backend = fused_moe.select_fused_moe_backend
+
+    def traced_select_backend(*inner_args, **inner_kwargs):
+        selected = original_select_backend(*inner_args, **inner_kwargs)
+        shape = inner_kwargs.get("shape")
+        selection_trace.append(
+            {
+                "selected": selected.value,
+                "shape": None if shape is None else repr(shape),
+                "num_tokens": inner_kwargs.get("num_tokens"),
+                "stream_is_capturing": inner_kwargs.get("stream_is_capturing"),
+            }
+        )
+        return selected
+
+    def traced_qwen35_gate(*inner_args, **inner_kwargs):
+        supported = original_qwen35_gate(*inner_args, **inner_kwargs)
+        capability_trace.append(
+            {
+                "gate": "qwen35_bf16_decode_gemv",
+                "supported": bool(supported),
+                "global_num_experts": inner_kwargs.get("global_num_experts"),
+                "topk_ids_dtype": str(inner_kwargs["topk_ids"].dtype),
+                "topk_weights_dtype": str(inner_kwargs["topk_weights"].dtype),
+            }
+        )
+        return supported
+
+    def traced_native_bf16_gate(*inner_args, **inner_kwargs):
+        supported = original_native_bf16_gate(*inner_args, **inner_kwargs)
+        capability_trace.append(
+            {
+                "gate": "native_bf16_moe_gemv",
+                "supported": bool(supported),
+                "global_num_experts": inner_kwargs.get("global_num_experts"),
+                "apply_router_weight_on_input": inner_kwargs.get(
+                    "apply_router_weight_on_input"
+                ),
+                "topk_ids_dtype": str(inner_kwargs["topk_ids"].dtype),
+                "topk_weights_dtype": str(inner_kwargs["topk_weights"].dtype),
+            }
+        )
+        return supported
+
+    def traced_device_fingerprint(device_index: int):
+        device_capability, traced_mp_count = original_device_fingerprint(device_index)
+        device_fingerprint_trace.append(
+            {
+                "device_index": device_index,
+                "device_capability": list(device_capability),
+                "multiprocessor_count": traced_mp_count,
+            }
+        )
+        return device_capability, traced_mp_count
+
+    def traced_thresholds_for_shape(shape):
+        thresholds = original_thresholds_for_shape(shape)
+        policy_trace.append(
+            {
+                "source": thresholds.source,
+                "gemv_max_tokens": thresholds.gemv_max_tokens,
+                "grouped_gemm_min_tokens": thresholds.grouped_gemm_min_tokens,
+            }
+        )
+        return thresholds
+
+    def traced_shape_builder(*inner_args, **inner_kwargs):
+        shape = original_shape_builder(*inner_args, **inner_kwargs)
+        shape_trace.append({"shape": repr(shape)})
+        return shape
+
     try:
+        if args.graph_bucket_num_reqs is not None:
+            if args.graph_bucket_num_reqs <= 0:
+                raise ValueError("graph-bucket-num-reqs must be positive")
+            from vllm_musa.tuning import MusaForwardGraphBucket
+
+            graph_bucket = MusaForwardGraphBucket(
+                num_tokens=args.tokens,
+                num_reqs=args.graph_bucket_num_reqs,
+                uniform=True,
+                runtime_mode="FULL",
+                has_lora=False,
+                num_active_loras=0,
+                present=True,
+            )
+            fused_moe.query_musa_forward_graph_bucket = lambda: graph_bucket
         fused_moe._MUSA_FUSED_MOE_REQUESTED_BACKEND = MusaFusedMoeBackend(
             args.requested
         )
         fused_moe.fused_experts_impl = counted_gemv
+        fused_moe.select_fused_moe_backend = traced_select_backend
+        fused_moe._musa_fused_moe_shape = traced_shape_builder
+        fused_moe._can_use_qwen35_bf16_moe_decode_gemv = traced_qwen35_gate
+        fused_moe._can_use_musa_native_bf16_moe_gemv = traced_native_bf16_gate
+        fused_moe._musa_device_fingerprint = traced_device_fingerprint
+        fused_moe.thresholds_for_shape = traced_thresholds_for_shape
         fused_moe._upstream_fused_moe._musa_original_fused_experts_impl = (
             counted_upstream
         )
@@ -144,7 +383,7 @@ def main() -> int:
         stream.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(stream):
             with torch.cuda.graph(graph):
-                captured_output = fused_moe._musa_fused_experts_impl_dispatch(**kwargs)
+                captured_output = production_dispatch(**kwargs)
         torch.cuda.current_stream().wait_stream(stream)
         synchronize()
         capture_calls = dict(calls)
@@ -168,29 +407,47 @@ def main() -> int:
                 args.seed + 100 + replay_index,
                 args.folded_shared_expert,
             )
+            replacement_ids = replacement_ids.to(dtype=torch.int32)
             topk_ids.copy_(replacement_ids)
             topk_weights.copy_(replacement_weights)
             if args.expected_backend == "gemv":
-                expected = (
+                expected_backend_output = (
                     original_gemv(
                         **kwargs,
-                        inplace=False,
-                        _allow_deepgemm_prefill=False,
+                        **captured_gemv_launch_kwargs,
                     )
                     .detach()
                     .clone()
                 )
             else:
-                expected = original_upstream(**kwargs).detach().clone()
+                expected_backend_output = original_upstream(**kwargs).detach().clone()
+            upstream_reference = original_upstream(**kwargs).detach().clone()
             graph.replay()
             synchronize()
-            difference = (captured_output.float() - expected.float()).abs()
+            difference = (
+                captured_output.float() - expected_backend_output.float()
+            ).abs()
+            reference_metrics = comparison_metrics(captured_output, upstream_reference)
+            reference_passed = bool(
+                args.weight_dtype != "bf16"
+                or (
+                    reference_metrics["relative_l2_error"] <= 0.01
+                    and reference_metrics["cosine_similarity"] >= 0.9999
+                    and reference_metrics["max_row_relative_l2"] <= 0.02
+                    and reference_metrics["min_row_cosine"] >= 0.9998
+                    and reference_metrics["max_abs_diff_over_reference_absmax"] <= 0.05
+                )
+            )
             comparisons.append(
                 {
                     "replay": replay_index,
                     "route_mode": route_mode,
-                    "bitwise_equal": bool(torch.equal(captured_output, expected)),
+                    "bitwise_equal": bool(
+                        torch.equal(captured_output, expected_backend_output)
+                    ),
                     "max_abs_diff": float(difference.max().item()),
+                    "upstream_reference_passed": reference_passed,
+                    "upstream_reference_metrics": reference_metrics,
                 }
             )
     finally:
@@ -199,38 +456,107 @@ def main() -> int:
         fused_moe._upstream_fused_moe._musa_original_fused_experts_impl = (
             original_upstream
         )
+        fused_moe.query_musa_forward_graph_bucket = original_graph_bucket_query
+        fused_moe.select_fused_moe_backend = original_select_backend
+        fused_moe._musa_fused_moe_shape = original_shape_builder
+        fused_moe._can_use_qwen35_bf16_moe_decode_gemv = original_qwen35_gate
+        fused_moe._can_use_musa_native_bf16_moe_gemv = original_native_bf16_gate
+        fused_moe._musa_device_fingerprint = original_device_fingerprint
+        fused_moe.thresholds_for_shape = original_thresholds_for_shape
 
     expected_capture_calls = {
         "gemv": int(args.expected_backend == "gemv"),
         "upstream": int(args.expected_backend == "upstream"),
     }
+    expected_gemv_stage_blocks = None
+    if (
+        args.expected_backend == "gemv"
+        and args.weight_dtype == "bf16"
+        and args.experts == 257
+        and multiprocessor_count == 48
+    ):
+        expected_gemv_stage_blocks = ((32, 4), (32, 4))
+    gemv_stage_tactic_passed = bool(
+        expected_gemv_stage_blocks is None
+        or captured_gemv_launch_kwargs.get("_gemv_blocks") == expected_gemv_stage_blocks
+    )
+    selection_observed = bool(
+        args.expected_backend == "upstream"
+        or (
+            len(selection_trace) == 1
+            and selection_trace[0]["selected"] == args.expected_backend
+        )
+    )
+    capability_passed = bool(
+        args.weight_dtype != "bf16"
+        or args.expected_backend != "gemv"
+        or (
+            {item["gate"] for item in capability_trace}
+            == {"qwen35_bf16_decode_gemv", "native_bf16_moe_gemv"}
+            and all(item["supported"] for item in capability_trace)
+        )
+    )
     passed = bool(
         capture_calls == expected_capture_calls
-        and all(item["bitwise_equal"] for item in comparisons)
+        and selection_observed
+        and capability_passed
+        and multiprocessor_count_passed
+        and gemv_stage_tactic_passed
+        and all(
+            item["bitwise_equal"] and item["upstream_reference_passed"]
+            for item in comparisons
+        )
     )
     payload = {
         "passed": passed,
         "requested": args.requested,
         "expected_backend": args.expected_backend,
+        "weight_dtype": args.weight_dtype,
         "shape": {
             "experts": args.experts,
             "hidden_size": args.hidden_size,
             "intermediate_size": args.intermediate_size,
             "top_k": args.top_k,
             "tokens": args.tokens,
+            "block_size": block_size,
         },
         "folded_shared_expert": args.folded_shared_expert,
         "seed": args.seed,
         "replays": args.replays,
+        "graph_bucket_num_reqs": args.graph_bucket_num_reqs,
         "device": {
             "name": device_name,
             "capability": capability,
             "multiprocessor_count": multiprocessor_count,
         },
+        "primed_hardware": {
+            "device_capability": primed_hardware.device_capability,
+            "multiprocessor_count": primed_hardware.multiprocessor_count,
+            "cache_key": primed_hardware.cache_key,
+        },
+        "lease_device_fence": lease_device_fence,
         "packages": package_versions(),
         "repo": repo_provenance(),
+        "source": source_identity(Path(__file__)),
         "expected_capture_calls": expected_capture_calls,
         "capture_calls": capture_calls,
+        "expected_gemv_stage_blocks": expected_gemv_stage_blocks,
+        "gemv_stage_tactic_passed": gemv_stage_tactic_passed,
+        "selection_observed": selection_observed,
+        "capability_passed": capability_passed,
+        "expected_multiprocessor_count": args.expected_multiprocessor_count,
+        "multiprocessor_count_passed": multiprocessor_count_passed,
+        "production_dispatch": {
+            "installed": production_dispatch_installed,
+            "module": production_dispatch.__module__,
+            "name": production_dispatch.__name__,
+        },
+        "capability_trace": capability_trace,
+        "device_fingerprint_trace": device_fingerprint_trace,
+        "backend_call_trace": backend_call_trace,
+        "policy_trace": policy_trace,
+        "selection_trace": selection_trace,
+        "shape_trace": shape_trace,
         "comparisons": comparisons,
     }
     serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"

--- a/benchmarks/kernel_tactics/README.md
+++ b/benchmarks/kernel_tactics/README.md
@@ -1,0 +1,42 @@
+# MP-aware kernel tactic campaign
+
+This directory contains the op-first campaign used to discover MUSA kernel
+configuration candidates before spending time on model-level A/B runs.
+
+The workflow is intentionally fail-closed:
+
+1. Start with `mp_tactic_campaign.json`, which contains public Qwen, DSV4, and
+   RMSNorm shape/route recipes. Device and fleet qualification context is
+   supplied at run time; it is not embedded in the recipe.
+2. Acquire a development-pool SOL lease and expose exactly one MUSA device.
+   Set `MUSA_VISIBLE_DEVICES=0`, `CUDA_VISIBLE_DEVICES=0`, and the image's
+   `MTHREADS_VISIBLE_DEVICES=0`; the first two must be identical.
+3. Run `run_mp_tactic_campaign.py --mode quick|full --expected-mp N`.
+   The runner records the expanded command, source identity, runtime MP, device
+   fence, and per-cell result hashes in the selected output directory.
+4. Reduce one or more bundles with `summarize_mp_tactic_campaign.py`.  A row
+   is promotion-eligible only when correctness, cold-cache p95, seed/route
+   agreement, any locally requested host replication, and device-isolation
+   checks all pass.
+5. Fill the prediction inputs (`op_time_share`, `production_hit_rate`) from a
+   current profiler capture.  The reducer computes the Amdahl estimate, but it
+   never treats an op win as an E2E claim.
+
+## Timing contract
+
+The GEMV and fused-add-RMSNorm benches use paired alternating order, one
+launch per sample, an 8,000 MiB int32 L2 eviction buffer zeroed immediately
+before each timed launch, MUSA events, p50/p90/p99, and finite/non-poison
+output checks.  GEMV rows retain the exact seeded `topk_ids` digest and expert
+load histogram.  DSV4's one-token split-tile arm is recorded as the effective
+selector arm, so a requested-but-ignored block cannot become a false winner.
+
+`dsv4-mhc-jit-fuse` additionally separates TileLang compile time from warm
+kernel timing and always includes the production resolver configuration as a
+paired baseline, even in a reduced quick sweep.
+
+The campaign files do not change production dispatch.  A production map must
+be added only after the generated evidence and a final representative E2E
+gate are reviewed. Always write run output below the workspace `generated/`
+directory (or another explicitly private path); do not commit result JSON,
+device UUIDs, hostnames, package receipts, or timing samples.

--- a/benchmarks/kernel_tactics/_benchmark_utils.py
+++ b/benchmarks/kernel_tactics/_benchmark_utils.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Small provenance and reporting helpers shared by kernel tactic benches."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def command_output(command: list[str], *, cwd: Path | None = None) -> str | None:
+    try:
+        return subprocess.check_output(
+            command,
+            cwd=cwd,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=30,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, round((len(ordered) - 1) * fraction))
+    return ordered[index]
+
+
+def verify_lease_device_fence(
+    expected_physical_device: int,
+    expected_device_uuid: str,
+    expected_multiprocessor_count: int | None = None,
+) -> dict[str, Any]:
+    """Fail closed unless visibility, physical GPU, and optional MP match."""
+    if expected_physical_device < 0:
+        raise ValueError("expected physical device must be non-negative")
+    expected_uuid = expected_device_uuid.strip().lower()
+    if not expected_uuid:
+        raise ValueError("expected device UUID must not be empty")
+
+    visibility = {
+        name: os.environ.get(name)
+        for name in (
+            "MTHREADS_VISIBLE_DEVICES",
+            "MUSA_VISIBLE_DEVICES",
+            "CUDA_VISIBLE_DEVICES",
+        )
+    }
+    expected_visible = str(expected_physical_device)
+    mismatched = {
+        name: value for name, value in visibility.items() if value != expected_visible
+    }
+    if mismatched:
+        raise RuntimeError(
+            "lease device fence failed: visibility must all equal "
+            f"{expected_visible}, got {visibility}"
+        )
+
+    query_mode = "csv-query"
+    query = command_output(
+        [
+            "mthreads-gmi",
+            "--query-gpu=index,uuid,name",
+            "--format=csv,noheader",
+        ]
+    )
+    if query is None:
+        query_mode = "legacy-full-query"
+        query = command_output(["mthreads-gmi", "-q"])
+        if query is None:
+            raise RuntimeError(
+                "lease device fence failed: both mthreads-gmi queries failed"
+            )
+        block = re.search(
+            rf"^GPU{expected_physical_device}\b(?P<body>.*?)(?=^GPU\d+\b|\Z)",
+            query,
+            re.MULTILINE | re.DOTALL,
+        )
+        uuid_match = (
+            re.search(r"GPU UUID\s*:\s*(\S+)", block.group("body"))
+            if block is not None
+            else None
+        )
+        name_match = (
+            re.search(r"Product Name\s*:\s*(.+)", block.group("body"))
+            if block is not None
+            else None
+        )
+        if block is None or uuid_match is None or name_match is None:
+            raise RuntimeError(
+                "lease device fence failed: expected one matching legacy "
+                f"mthreads-gmi block for GPU{expected_physical_device}"
+            )
+        actual_index = expected_visible
+        actual_uuid = uuid_match.group(1).strip()
+        device_name = name_match.group(1).strip()
+        query_receipt = f"{actual_index}, {actual_uuid}, {device_name}"
+    else:
+        parsed_rows = [
+            [field.strip() for field in line.split(",")]
+            for line in query.splitlines()
+            if line.strip()
+        ]
+        matching_rows = [
+            fields
+            for fields in parsed_rows
+            if len(fields) == 3 and fields[0] == expected_visible
+        ]
+        if len(matching_rows) != 1:
+            raise RuntimeError(
+                "lease device fence failed: expected one matching "
+                f"mthreads-gmi row {query!r}"
+            )
+        actual_index, actual_uuid, device_name = matching_rows[0]
+        query_receipt = ", ".join(matching_rows[0])
+    if actual_index != expected_visible or actual_uuid.lower() != expected_uuid:
+        raise RuntimeError(
+            "lease device fence failed: expected "
+            f"index={expected_visible}, uuid={expected_uuid}; got "
+            f"index={actual_index}, uuid={actual_uuid.lower()}"
+        )
+    if expected_multiprocessor_count is not None:
+        if expected_multiprocessor_count <= 0:
+            raise ValueError("expected multiprocessor count must be positive")
+        try:
+            import torch
+
+            actual_multiprocessor_count = int(
+                torch.musa.get_device_properties(
+                    expected_physical_device
+                ).multi_processor_count
+            )
+        except (AttributeError, RuntimeError, TypeError, ImportError) as exc:
+            raise RuntimeError(
+                "lease device fence failed: cannot query MUSA multiprocessor count"
+            ) from exc
+        if actual_multiprocessor_count != expected_multiprocessor_count:
+            raise RuntimeError(
+                "lease device fence failed: expected "
+                f"multiprocessor_count={expected_multiprocessor_count}; got "
+                f"{actual_multiprocessor_count}"
+            )
+    else:
+        actual_multiprocessor_count = None
+    return {
+        "passed": True,
+        "expected_physical_device": expected_physical_device,
+        "expected_device_uuid": expected_uuid,
+        "actual_physical_device": int(actual_index),
+        "actual_device_uuid": actual_uuid.lower(),
+        "device_name": device_name,
+        "visibility": visibility,
+        "mthreads_gmi_query_mode": query_mode,
+        "mthreads_gmi_query": query_receipt,
+        "expected_multiprocessor_count": expected_multiprocessor_count,
+        "actual_multiprocessor_count": actual_multiprocessor_count,
+    }
+
+
+def effective_gemv_block(
+    family_name: str,
+    tokens: int,
+    stage: str,
+    requested: tuple[int, int],
+) -> tuple[tuple[int, int], bool, str | None]:
+    """Describe selector arms that supersede a requested GEMV block."""
+    if family_name == "dsv4_fp8" and tokens == 1:
+        selected = (4, 32) if stage == "w1" else (32, 4)
+        return selected, requested == selected, "dsv4-one-token-split-tile"
+    return requested, True, None
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def source_identity(script: Path) -> dict[str, Any]:
+    resolved_script = script.resolve()
+    repo = next(
+        (
+            parent
+            for parent in (resolved_script.parent, *resolved_script.parents)
+            if (parent / ".git").exists() or (parent / ".source-revision").exists()
+        ),
+        resolved_script.parent,
+    )
+    has_git = (repo / ".git").exists()
+    head = command_output(["git", "rev-parse", "HEAD"], cwd=repo) if has_git else None
+    status = command_output(["git", "status", "--short"], cwd=repo) if has_git else None
+    marker_path = repo / ".source-revision"
+    archive_marker = None
+    if marker_path.is_file():
+        archive_marker = marker_path.read_text().strip() or None
+        if head is None:
+            head = archive_marker
+    diff_sha256 = None
+    if has_git:
+        try:
+            diff = subprocess.check_output(
+                ["git", "diff", "--binary", "HEAD"],
+                cwd=repo,
+                stderr=subprocess.STDOUT,
+                timeout=30,
+            )
+            diff_sha256 = hashlib.sha256(diff).hexdigest()
+        except (OSError, subprocess.SubprocessError):
+            pass
+    return {
+        "repo": str(repo),
+        "head": head,
+        "dirty": bool(status),
+        "status": status or "",
+        "diff_sha256": diff_sha256,
+        "archive_marker": archive_marker,
+    }
+
+
+def provenance(script: Path) -> dict[str, Any]:
+    return {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "hostname": socket.gethostname(),
+        "argv": sys.argv,
+        "source": source_identity(script),
+        "packages": {
+            name: _package_version(name)
+            for name in (
+                "torch",
+                "torch_musa",
+                "torchada",
+                "vllm",
+                "vllm-musa",
+                "mate",
+            )
+        },
+        "mthreads_gmi": command_output(["mthreads-gmi", "-q"]),
+        "mcc_version": command_output(["mcc", "--version"]),
+    }
+
+
+def emit_payload(payload: dict[str, Any], output: Path | None) -> None:
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(serialized)
+    print(serialized, end="")

--- a/benchmarks/kernel_tactics/_rmsnorm_inductor_candidate.py
+++ b/benchmarks/kernel_tactics/_rmsnorm_inductor_candidate.py
@@ -1,0 +1,64 @@
+"""Benchmark-local Triton RMSNorm candidate with no production registration."""
+
+from __future__ import annotations
+
+# Apply CUDA-to-MUSA compatibility before importing Torch symbols.
+# isort: off
+import torchada  # noqa: F401
+import torch
+from torch import Tensor
+from torch.library import wrap_triton
+# isort: on
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _rms_norm_kernel(
+    output_ptr,
+    input_ptr,
+    weight_ptr,
+    n_cols: tl.constexpr,
+    epsilon: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+    input_row = input_ptr + row * n_cols
+    output_row = output_ptr + row * n_cols
+
+    values = tl.load(input_row + offsets, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(values * values, axis=0) / n_cols
+    inverse_rms = tl.rsqrt(variance + epsilon)
+    weight = tl.load(weight_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    normalized = values * inverse_rms * weight
+    tl.store(output_row + offsets, normalized, mask=mask)
+
+
+def rms_norm_triton(
+    x: Tensor,
+    weight: Tensor,
+    epsilon: float,
+    *,
+    num_warps: int,
+) -> Tensor:
+    """Launch the exploratory candidate with a fresh output tensor."""
+    hidden_size = x.shape[-1]
+    output = torch.empty_like(x)
+    block_size = triton.next_power_of_2(hidden_size)
+    grid = (x.numel() // hidden_size,)
+    wrap_triton(_rms_norm_kernel)[grid](
+        output,
+        x,
+        weight,
+        hidden_size,
+        epsilon,
+        BLOCK_SIZE=block_size,
+        num_warps=num_warps,
+        num_stages=1,
+    )
+    return output
+
+
+__all__ = ["rms_norm_triton"]

--- a/benchmarks/kernel_tactics/benchmark_dense_fp8_gemv_blocks.py
+++ b/benchmarks/kernel_tactics/benchmark_dense_fp8_gemv_blocks.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paired cold-cache block sweep for the production dense FP8 GEMV AOT op."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+SUPPORTED_BLOCKS = (
+    (4, 32),
+    (8, 16),
+    (8, 32),
+    (16, 8),
+    (16, 16),
+    (32, 1),
+    (32, 4),
+    (32, 8),
+    (128, 1),
+)
+
+
+@dataclass(frozen=True)
+class Family:
+    name: str
+    output_size: int
+    reduction_size: int
+    production_tokens: tuple[int, ...]
+
+
+FAMILIES = {
+    "dsv4_o_proj": Family(
+        name="dsv4_o_proj",
+        output_size=1024,
+        reduction_size=4096,
+        production_tokens=(1, 2, 4, 8, 16, 32, 64),
+    ),
+    "dsv4_shared_gate_up": Family(
+        name="dsv4_shared_gate_up",
+        output_size=512,
+        reduction_size=4096,
+        production_tokens=(1,),
+    ),
+}
+
+
+def parse_block(value: str) -> tuple[int, int]:
+    try:
+        block_n, block_k = (int(part) for part in value.lower().split("x", 1))
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"invalid block {value!r}; expected NxK"
+        ) from exc
+    block = (block_n, block_k)
+    if block not in SUPPORTED_BLOCKS:
+        raise argparse.ArgumentTypeError(
+            f"unsupported dense GEMV block {value!r}; expected one of "
+            + ", ".join(f"{n}x{k}" for n, k in SUPPORTED_BLOCKS)
+        )
+    return block
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--family", choices=sorted(FAMILIES), required=True)
+    parser.add_argument("--tokens", type=int, nargs="+")
+    parser.add_argument(
+        "--blocks",
+        type=parse_block,
+        nargs="+",
+        default=SUPPORTED_BLOCKS,
+    )
+    parser.add_argument("--dry-runs", type=int, default=4)
+    parser.add_argument("--repeats", type=int, default=32)
+    parser.add_argument("--inner-iters", type=int, default=1)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def production_block(
+    family: str, tokens: int, multiprocessor_count: int | None = None
+) -> tuple[int, int] | None:
+    if family != "dsv4_o_proj":
+        return None
+    if multiprocessor_count == 48:
+        if tokens == 1:
+            return (8, 32)
+        if tokens == 8:
+            return (16, 8)
+        if tokens in (32, 64):
+            return (32, 4)
+    elif multiprocessor_count == 56:
+        if tokens == 8:
+            return (16, 16)
+        if tokens == 64:
+            return (32, 4)
+    elif multiprocessor_count == 60:
+        if tokens == 8:
+            return (8, 16)
+        if tokens == 64:
+            return (32, 4)
+    if tokens in (1, 2, 8):
+        return (4, 32)
+    if tokens in (4, 32, 64):
+        return (8, 16)
+    if tokens == 16:
+        return (32, 4)
+    return None
+
+
+def _load_runtime() -> tuple[Any, Any]:
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    from vllm_musa import _custom_ops as musa_ops
+    # isort: on
+
+    return torch, musa_ops
+
+
+def _fp8_constant(torch: Any, shape: tuple[int, ...], device: Any) -> Any:
+    return torch.full(shape, 0x20, dtype=torch.uint8, device=device).view(
+        torch.float8_e4m3fn
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    if min(args.dry_runs, args.repeats, args.inner_iters, args.l2_flush_mb) <= 0:
+        raise ValueError("timing arguments must be positive")
+    if args.inner_iters != 1:
+        raise ValueError("cold-L2 evidence requires --inner-iters 1")
+
+    family = FAMILIES[args.family]
+    tokens_list = args.tokens or list(family.production_tokens)
+    if min(tokens_list) <= 0:
+        raise ValueError("tokens must be positive")
+    if any(tokens not in family.production_tokens for tokens in tokens_list):
+        raise ValueError(
+            f"tokens must be production buckets {family.production_tokens} for "
+            f"{family.name}"
+        )
+
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+    )
+    torch, musa_ops = _load_runtime()
+    if not torch.musa.is_available() or torch.musa.device_count() != 1:
+        raise RuntimeError("dense GEMV benchmark requires exactly one visible MUSA GPU")
+    device = torch.device("musa")
+    properties = torch.musa.get_device_properties(0)
+    torch.manual_seed(args.seed)
+
+    weight = _fp8_constant(
+        torch,
+        (family.output_size, family.reduction_size),
+        device,
+    )
+    weight_scale = torch.ones(
+        (family.output_size // 128, family.reduction_size // 128),
+        dtype=torch.float32,
+        device=device,
+    )
+    flush = torch.empty(
+        args.l2_flush_mb * 1024 * 1024 // 4,
+        dtype=torch.int32,
+        device=device,
+    )
+    rows: list[dict[str, Any]] = []
+
+    for tokens in tokens_list:
+        activation = (
+            torch.randn(
+                (tokens, family.reduction_size),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            * 0.01
+        )
+        output = torch.empty(
+            (tokens, family.output_size),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+
+        def launch(block: tuple[int, int]) -> None:
+            for _ in range(args.inner_iters):
+                musa_ops.musa_fused_gemv(
+                    activation,
+                    weight,
+                    None,
+                    weight_scale,
+                    use_swigelu=False,
+                    use_rms_norm=False,
+                    output=output,
+                    block_n=block[0],
+                    block_k=block[1],
+                )
+
+        baseline = (0, 0)
+        launch(baseline)
+        torch.musa.synchronize()
+        baseline_output = output.clone()
+
+        for candidate in args.blocks:
+            block_n, block_k = candidate
+            if family.output_size % block_n or family.reduction_size % (block_k * 16):
+                continue
+            launch(candidate)
+            torch.musa.synchronize()
+            candidate_output = output.clone()
+            torch.testing.assert_close(
+                candidate_output.float(),
+                baseline_output.float(),
+                rtol=2e-2,
+                atol=2e-2,
+            )
+            correctness = bool(torch.isfinite(candidate_output).all().item())
+            output_absmax = float(candidate_output.float().abs().max().item())
+            correctness = correctness and output_absmax > 1e-12
+
+            for dry_run in range(args.dry_runs):
+                launch(baseline if dry_run % 2 == 0 else candidate)
+            torch.musa.synchronize()
+
+            baseline_samples: list[float] = []
+            candidate_samples: list[float] = []
+            for repeat in range(args.repeats):
+                order = (
+                    (baseline, candidate) if repeat % 2 == 0 else (candidate, baseline)
+                )
+                measured: dict[tuple[int, int], float] = {}
+                for block in order:
+                    flush.zero_()
+                    start = torch.musa.Event(enable_timing=True)
+                    end = torch.musa.Event(enable_timing=True)
+                    start.record()
+                    launch(block)
+                    end.record()
+                    end.synchronize()
+                    measured[block] = float(start.elapsed_time(end))
+                baseline_samples.append(measured[baseline])
+                candidate_samples.append(measured[candidate])
+
+            ratios = [
+                candidate_ms / baseline_ms
+                for baseline_ms, candidate_ms in zip(
+                    baseline_samples, candidate_samples
+                )
+            ]
+            baseline_median = statistics.median(baseline_samples)
+            candidate_median = statistics.median(candidate_samples)
+            candidate_seconds = candidate_median / 1000.0
+            flops = 2 * tokens * family.output_size * family.reduction_size
+            algorithmic_bytes = (
+                family.output_size * family.reduction_size
+                + tokens * (family.output_size + family.reduction_size) * 2
+                + weight_scale.numel() * 4
+            )
+            rows.append(
+                {
+                    "family": family.name,
+                    "tokens": tokens,
+                    "activation_shape": list(activation.shape),
+                    "weight_shape": list(weight.shape),
+                    "weight_scale_shape": list(weight_scale.shape),
+                    "baseline_block": [0, 0],
+                    "baseline_effective_block": (
+                        list(
+                            production_block(
+                                family.name,
+                                tokens,
+                                int(properties.multi_processor_count),
+                            )
+                        )
+                        if production_block(
+                            family.name,
+                            tokens,
+                            int(properties.multi_processor_count),
+                        )
+                        is not None
+                        else None
+                    ),
+                    "candidate_block": list(candidate),
+                    "requested_block_applied": True,
+                    "baseline_samples_ms": baseline_samples,
+                    "candidate_samples_ms": candidate_samples,
+                    "ratio_samples": ratios,
+                    "baseline_median_ms": baseline_median,
+                    "candidate_median_ms": candidate_median,
+                    "median_ratio": statistics.median(ratios),
+                    "geomean_ratio": math.exp(
+                        sum(math.log(value) for value in ratios) / len(ratios)
+                    ),
+                    "ratio_p95": percentile(ratios, 0.95),
+                    "ratio_p99": percentile(ratios, 0.99),
+                    "speedup_pct": (baseline_median / candidate_median - 1.0) * 100.0,
+                    "theory": {
+                        "flops": flops,
+                        "algorithmic_bytes": algorithmic_bytes,
+                        "candidate_tflops": flops / candidate_seconds / 1e12,
+                        "candidate_gbps": algorithmic_bytes / candidate_seconds / 1e9,
+                    },
+                    "output_absmax": output_absmax,
+                    "correctness_pass": correctness,
+                    "cache_policy": "cold-l2-per-sample",
+                }
+            )
+
+    payload = {
+        "schema": "musa-dense-fp8-gemv-aot-paired-ab.v1",
+        "family": family.name,
+        "device_name": torch.musa.get_device_name(0),
+        "device_capability": [int(properties.major), int(properties.minor)],
+        "multiprocessor_count": int(properties.multi_processor_count),
+        "lease_device_fence": lease_device_fence,
+        "benchmark": {
+            "dry_runs": args.dry_runs,
+            "repeats": args.repeats,
+            "inner_iters": args.inner_iters,
+            "l2_flush_mb": args.l2_flush_mb,
+            "l2_flush_bytes": flush.numel() * flush.element_size(),
+            "flush_before_every_timed_launch": True,
+            "paired_alternating_order": True,
+        },
+        "kernel_source": "csrc/musa/gemv.mu::musa_fused_gemv",
+        "provenance": provenance(Path(__file__)),
+        "rows": rows,
+        "skipped": [],
+    }
+    emit_payload(payload, args.output)
+    return 0 if all(row["correctness_pass"] for row in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_dsv4_e2e_tactics.py
+++ b/benchmarks/kernel_tactics/benchmark_dsv4_e2e_tactics.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fixed-worker eager E2E run for one MP60 DSV4 GEMV tactic state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+GEMV_BLOCK_ENV = "VLLM_MUSA_GEMV_MOE_BLOCK"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--mode", choices=("baseline", "candidate"), required=True)
+    parser.add_argument(
+        "--tactic",
+        choices=("gemv-mp60",),
+        required=True,
+    )
+    parser.add_argument("--tensor-parallel-size", type=int, default=8)
+    parser.add_argument("--repeats", type=int, default=4)
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--max-model-len", type=int, default=2048)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.95)
+    return parser.parse_args()
+
+
+def _set_mode(tactic: str, mode: str) -> None:
+    os.environ.pop(GEMV_BLOCK_ENV, None)
+    if mode == "baseline":
+        if tactic == "gemv-mp60":
+            os.environ[GEMV_BLOCK_ENV] = "16x8"
+        else:  # pragma: no cover - argparse owns this contract
+            raise ValueError(f"unknown tactic: {tactic}")
+    elif mode == "candidate":
+        pass
+    else:  # pragma: no cover - internal contract
+        raise ValueError(f"unknown mode: {mode}")
+
+
+def _token_ids(outputs: list[Any]) -> list[list[int]]:
+    return [list(output.outputs[0].token_ids) for output in outputs]
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def main() -> int:
+    args = parse_args()
+    if args.repeats <= 0 or args.max_tokens <= 0:
+        raise ValueError("repeats and max tokens must be positive")
+
+    # Must precede LLM worker spawn. Driver-side environment changes made
+    # afterward are not visible to existing tensor-parallel worker processes.
+    _set_mode(args.tactic, args.mode)
+
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    from vllm import LLM, SamplingParams
+    # isort: on
+
+    properties = torch.musa.get_device_properties(0)
+    if torch.musa.device_count() != args.tensor_parallel_size:
+        raise RuntimeError("visible MUSA devices must equal tensor parallel size")
+    expected_mp = 60
+    if int(properties.multi_processor_count) != expected_mp:
+        raise RuntimeError(f"this exact E2E tactic requires MP{expected_mp}")
+
+    batch_size = 2
+    llm = LLM(
+        model=args.model,
+        tensor_parallel_size=args.tensor_parallel_size,
+        tokenizer_mode="deepseek_v4",
+        trust_remote_code=True,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        max_model_len=args.max_model_len,
+        kv_cache_dtype="fp8",
+        enforce_eager=True,
+        enable_chunked_prefill=False,
+        enable_prefix_caching=False,
+        max_num_seqs=batch_size,
+        seed=20260828,
+    )
+    sampling = SamplingParams(
+        temperature=0.0,
+        max_tokens=args.max_tokens,
+        min_tokens=args.max_tokens,
+        ignore_eos=True,
+    )
+    prompts = ["The future of artificial intelligence is"] * batch_size
+
+    def run() -> dict[str, Any]:
+        torch.musa.synchronize()
+        started = time.perf_counter()
+        outputs = llm.generate(prompts, sampling, use_tqdm=False)
+        torch.musa.synchronize()
+        elapsed = time.perf_counter() - started
+        token_ids = _token_ids(outputs)
+        output_tokens = sum(len(ids) for ids in token_ids)
+        return {
+            "mode": args.mode,
+            "elapsed_seconds": elapsed,
+            "output_tokens": output_tokens,
+            "output_tokens_per_second": output_tokens / elapsed,
+            "token_ids": token_ids,
+            "texts": [output.outputs[0].text for output in outputs],
+        }
+
+    warmups = [run(), run()]
+    samples = [run() for _ in range(args.repeats)]
+    elapsed = [sample["elapsed_seconds"] for sample in samples]
+    variants = {tuple(tuple(ids) for ids in sample["token_ids"]) for sample in samples}
+    payload = {
+        "schema": "musa-dsv4-e2e-kernel-tactic-fixed-worker.v1",
+        "source_sha": os.environ.get("MUSA100006_SOURCE_SHA", "unknown"),
+        "model": args.model,
+        "device": {
+            "name": torch.musa.get_device_name(0),
+            "capability": [int(properties.major), int(properties.minor)],
+            "multiprocessor_count": int(properties.multi_processor_count),
+            "count": torch.musa.device_count(),
+        },
+        "execution": {
+            "tensor_parallel_size": args.tensor_parallel_size,
+            "enforce_eager": True,
+            "batch_size": len(prompts),
+            "max_tokens": args.max_tokens,
+            "repeats": args.repeats,
+            "mode": args.mode,
+            "tactic": args.tactic,
+            "baseline_block": "16x8",
+            "candidate_stage_blocks": {"w1": "8x16", "w2": "16x8"},
+            "baseline_weighted_rmsnorm_threads": 128,
+            "candidate_weighted_rmsnorm_threads": 256,
+        },
+        "warmups": warmups,
+        "samples": samples,
+        "summary": {
+            "median_elapsed_seconds": statistics.median(elapsed),
+            "p95_elapsed_seconds": _percentile(elapsed, 0.95),
+            "min_elapsed_seconds": min(elapsed),
+            "max_elapsed_seconds": max(elapsed),
+            "unique_output_variants": len(variants),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_dsv4_mhc_jit.py
+++ b/benchmarks/kernel_tactics/benchmark_dsv4_mhc_jit.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Cold-cache microbenchmark for the DSV4 MHC pre-fuse TileLang JIT.
+
+The benchmark deliberately times the already-compiled fuse kernel only.  JIT
+compile time is reported separately, and the output records the production
+resolver's configuration alongside every forced alternative.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hidden-size", type=int, default=4096)
+    parser.add_argument(
+        "--production-path",
+        choices=("standalone", "fused_post_prenorm"),
+        default="standalone",
+    )
+    parser.add_argument(
+        "--tokens", type=int, nargs="+", default=[1, 8, 32, 64, 128, 256]
+    )
+    parser.add_argument(
+        "--splits",
+        type=int,
+        nargs="*",
+        default=[],
+        help="extra diagnostic splits; the production split is always included",
+    )
+    parser.add_argument("--threads", type=int, nargs="+", default=[128, 256])
+    parser.add_argument("--hidden-blocks", type=int, nargs="+", default=[512, 1024])
+    parser.add_argument(
+        "--pass-configs",
+        nargs="+",
+        default=["safe", "burst", "aggressive_index32"],
+    )
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--repeats", type=int, default=8)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--seed", type=int, default=20260827)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def _load_runtime() -> tuple[Any, Any, Any, Any]:
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    from vllm_musa.deepseek_v4_jit.tilelang_kernels import (
+        mhc_pre_big_fuse_decode_split_kernel,
+        mhc_pre_big_fuse_kernel,
+    )
+    from vllm_musa.deepseek_v4_mhc import (
+        _get_mhc_pre_deepgemm_split_k,
+        _resolve_mhc_pre_big_fuse_config,
+    )
+    # isort: on
+
+    return (
+        torch,
+        mhc_pre_big_fuse_decode_split_kernel,
+        mhc_pre_big_fuse_kernel,
+        (_get_mhc_pre_deepgemm_split_k, _resolve_mhc_pre_big_fuse_config),
+    )
+
+
+def production_split_for_path(
+    production_path: str,
+    num_tokens: int,
+    hidden_size: int,
+    split_resolver: Any,
+) -> int:
+    if production_path == "fused_post_prenorm":
+        if num_tokens > 16:
+            raise ValueError("fused_post_prenorm supports M<=16")
+        return 8 if num_tokens < 8 else 4
+    if production_path == "standalone":
+        return int(split_resolver(num_tokens, hidden_size * 4))
+    raise ValueError(f"unsupported production path: {production_path}")
+
+
+def _invoke(
+    kernel: Any,
+    gemm_out_mul: Any,
+    gemm_out_sqrsum: Any,
+    hc_scale: Any,
+    hc_base: Any,
+    residual: Any,
+    post_mix: Any,
+    comb_mix: Any,
+    layer_input: Any,
+) -> None:
+    kernel(
+        gemm_out_mul,
+        gemm_out_sqrsum,
+        hc_scale,
+        hc_base,
+        residual,
+        post_mix,
+        comb_mix,
+        layer_input,
+    )
+
+
+@dataclass
+class _CompiledConfig:
+    config: tuple[int, int, str]
+    kernel: Any
+    post_mix: Any
+    comb_mix: Any
+    layer_input: Any
+    compile_seconds: float
+    candidate_samples: list[float] = field(default_factory=list)
+    baseline_samples: list[float] = field(default_factory=list)
+    max_abs_diff_vs_production: float | None = None
+    output_absmax: float = 0.0
+
+
+@dataclass(frozen=True)
+class _InvocationArgs:
+    d_part: Any
+    s_part: Any
+    hc_scale: Any
+    hc_base: Any
+    residual: Any
+
+
+def _timed_invoke(torch: Any, flush: Any, run: _CompiledConfig, args: Any) -> float:
+    flush.zero_()
+    torch.musa.synchronize()
+    start = torch.musa.Event(enable_timing=True)
+    end = torch.musa.Event(enable_timing=True)
+    start.record()
+    _invoke(
+        run.kernel,
+        args.d_part,
+        args.s_part,
+        args.hc_scale,
+        args.hc_base,
+        args.residual,
+        run.post_mix,
+        run.comb_mix,
+        run.layer_input,
+    )
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end))
+
+
+def main() -> int:
+    args = parse_args()
+    if min(args.tokens) <= 0 or (args.splits and min(args.splits) <= 0):
+        raise ValueError("tokens and splits must be positive")
+    if min(args.warmup, args.repeats, args.l2_flush_mb) <= 0:
+        raise ValueError("timing arguments must be positive")
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+    )
+    torch, decode_factory, big_factory, resolver = _load_runtime()
+    if not torch.musa.is_available() or torch.musa.device_count() != 1:
+        raise RuntimeError("MHC benchmark requires one visible MUSA device")
+    device = torch.device("musa")
+    properties = torch.musa.get_device_properties(0)
+    mp = int(properties.multi_processor_count)
+    hidden_size = int(args.hidden_size)
+    hc_mult3 = 24
+    flush = torch.empty(
+        args.l2_flush_mb * 1024 * 1024 // 4,
+        dtype=torch.int32,
+        device=device,
+    )
+    generator = torch.Generator(device="cpu").manual_seed(args.seed)
+    rows: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    split_resolver, config_resolver = resolver
+
+    for num_tokens in args.tokens:
+        if hidden_size != 4096:
+            skipped.append(
+                {"tokens": num_tokens, "reason": "current MHC JIT contract is H4096"}
+            )
+            continue
+        try:
+            production_split = production_split_for_path(
+                args.production_path,
+                num_tokens,
+                hidden_size,
+                split_resolver,
+            )
+            config_resolver(num_tokens, production_split)
+        except Exception as exc:  # pragma: no cover - device-side contract
+            skipped.append({"tokens": num_tokens, "reason": str(exc)})
+            continue
+
+        split_values = sorted(set(args.splits) | {production_split})
+        # The production provider passes residual_flat [M, 4, 4096] and a
+        # [split_k, M, 24] partial.  Keep the same layout for direct fuse A/B.
+        residual = torch.randn(
+            (num_tokens, 4, hidden_size), generator=generator, dtype=torch.bfloat16
+        ).to(device)
+        fn_mul = torch.randn(
+            (max(split_values), num_tokens, hc_mult3),
+            generator=generator,
+            dtype=torch.float32,
+        ).to(device)
+        sqrsum = torch.rand(
+            (max(split_values), num_tokens),
+            generator=generator,
+            dtype=torch.float32,
+        ).to(device)
+        hc_scale = torch.randn((3,), generator=generator, dtype=torch.float32).to(
+            device
+        )
+        hc_base = torch.randn((hc_mult3,), generator=generator, dtype=torch.float32).to(
+            device
+        )
+        for split_k in split_values:
+            if hidden_size * 4 % split_k or (hidden_size * 4 // split_k) % 128:
+                skipped.append(
+                    {
+                        "tokens": num_tokens,
+                        "production_path": args.production_path,
+                        "split_k": split_k,
+                        "reason": "invalid split size",
+                    }
+                )
+                continue
+            # Slice the common allocation so each config receives its own
+            # correctly shaped partial tensor.
+            d_part = fn_mul[:split_k]
+            s_part = sqrsum[:split_k]
+            split_production_config = config_resolver(num_tokens, split_k)
+            requested_configs = {
+                (threads, hidden_block, pass_config)
+                for threads in args.threads
+                for hidden_block in args.hidden_blocks
+                if hidden_size * 4 % hidden_block == 0
+                for pass_config in args.pass_configs
+            }
+            # Always include the production resolver arm even when a quick
+            # campaign intentionally requested a reduced candidate set.
+            requested_configs.add(tuple(split_production_config))
+            configs = list(requested_configs)
+            configs.sort(key=lambda item: item != tuple(split_production_config))
+            reference_config = tuple(split_production_config)
+            compiled: list[_CompiledConfig] = []
+            for threads, hidden_block, pass_config in configs:
+                is_decode = num_tokens <= 64
+                factory = decode_factory if is_decode else big_factory
+                config = (threads, hidden_block, pass_config)
+                compile_started = time.perf_counter()
+                try:
+                    kernel = factory(
+                        hidden_size,
+                        1e-6,
+                        1e-6,
+                        1e-6,
+                        1.0,
+                        20,
+                        n_splits=split_k,
+                        hc_mult=4,
+                        threads=threads,
+                        hidden_block=hidden_block,
+                        pass_config=pass_config,
+                    )
+                    post_mix = torch.empty(
+                        (num_tokens, 4), dtype=torch.float32, device=device
+                    )
+                    comb_mix = torch.empty(
+                        (num_tokens, 16), dtype=torch.float32, device=device
+                    )
+                    layer_input = torch.empty(
+                        (num_tokens, hidden_size),
+                        dtype=torch.bfloat16,
+                        device=device,
+                    )
+                    _invoke(
+                        kernel,
+                        d_part,
+                        s_part,
+                        hc_scale,
+                        hc_base,
+                        residual,
+                        post_mix,
+                        comb_mix,
+                        layer_input,
+                    )
+                    torch.musa.synchronize()
+                except Exception as exc:  # pragma: no cover - device-side contract
+                    skipped.append(
+                        {
+                            "tokens": num_tokens,
+                            "split_k": split_k,
+                            "config": config,
+                            "reason": str(exc),
+                        }
+                    )
+                    continue
+                compiled.append(
+                    _CompiledConfig(
+                        config=config,
+                        kernel=kernel,
+                        post_mix=post_mix,
+                        comb_mix=comb_mix,
+                        layer_input=layer_input,
+                        compile_seconds=time.perf_counter() - compile_started,
+                    )
+                )
+
+            production = next(
+                (run for run in compiled if run.config == reference_config), None
+            )
+            if production is None:
+                for run in compiled:
+                    skipped.append(
+                        {
+                            "tokens": num_tokens,
+                            "split_k": split_k,
+                            "config": run.config,
+                            "reason": "production resolver config failed to compile",
+                        }
+                    )
+                continue
+
+            for run in compiled:
+                for _ in range(args.warmup):
+                    _invoke(
+                        run.kernel,
+                        d_part,
+                        s_part,
+                        hc_scale,
+                        hc_base,
+                        residual,
+                        run.post_mix,
+                        run.comb_mix,
+                        run.layer_input,
+                    )
+            torch.musa.synchronize()
+
+            invocation_args = _InvocationArgs(
+                d_part=d_part,
+                s_part=s_part,
+                hc_scale=hc_scale,
+                hc_base=hc_base,
+                residual=residual,
+            )
+            candidates = [run for run in compiled if run is not production]
+            for repeat in range(args.repeats):
+                for candidate in candidates:
+                    pair = (
+                        (production, candidate)
+                        if repeat % 2 == 0
+                        else (candidate, production)
+                    )
+                    first_ms = _timed_invoke(torch, flush, pair[0], invocation_args)
+                    second_ms = _timed_invoke(torch, flush, pair[1], invocation_args)
+                    if repeat % 2 == 0:
+                        candidate.baseline_samples.append(first_ms)
+                        candidate.candidate_samples.append(second_ms)
+                    else:
+                        candidate.candidate_samples.append(first_ms)
+                        candidate.baseline_samples.append(second_ms)
+
+            torch.musa.synchronize()
+            _invoke(
+                production.kernel,
+                d_part,
+                s_part,
+                hc_scale,
+                hc_base,
+                residual,
+                production.post_mix,
+                production.comb_mix,
+                production.layer_input,
+            )
+            torch.musa.synchronize()
+            reference_outputs = (
+                production.layer_input.detach().cpu().clone(),
+                production.post_mix.detach().cpu().clone(),
+                production.comb_mix.detach().cpu().clone(),
+            )
+            for run in compiled:
+                if run is not production:
+                    _invoke(
+                        run.kernel,
+                        d_part,
+                        s_part,
+                        hc_scale,
+                        hc_base,
+                        residual,
+                        run.post_mix,
+                        run.comb_mix,
+                        run.layer_input,
+                    )
+                    torch.musa.synchronize()
+                output = run.layer_input.float()
+                output_absmax = float(output.abs().max().item())
+                max_abs_diff = max(
+                    float(
+                        (
+                            run.layer_input.detach().cpu().float()
+                            - reference_outputs[0].float()
+                        )
+                        .abs()
+                        .max()
+                        .item()
+                    ),
+                    float(
+                        (
+                            run.post_mix.detach().cpu().float()
+                            - reference_outputs[1].float()
+                        )
+                        .abs()
+                        .max()
+                        .item()
+                    ),
+                    float(
+                        (
+                            run.comb_mix.detach().cpu().float()
+                            - reference_outputs[2].float()
+                        )
+                        .abs()
+                        .max()
+                        .item()
+                    ),
+                )
+                if run is production:
+                    run.baseline_samples = [
+                        _timed_invoke(torch, flush, production, invocation_args)
+                        for _ in range(args.repeats)
+                    ]
+                    run.candidate_samples = list(run.baseline_samples)
+                rows.append(
+                    {
+                        "tokens": num_tokens,
+                        "production_path": args.production_path,
+                        "split_k": split_k,
+                        "threads": run.config[0],
+                        "hidden_block": run.config[1],
+                        "pass_config": run.config[2],
+                        "production_split_k": production_split,
+                        "is_production_split": split_k == production_split,
+                        "production_config": list(split_production_config),
+                        "is_production_config": run is production,
+                        "median_ms": float(statistics.median(run.candidate_samples)),
+                        "p90_ms": percentile(run.candidate_samples, 0.90),
+                        "p99_ms": percentile(run.candidate_samples, 0.99),
+                        "baseline_median_ms": float(
+                            statistics.median(run.baseline_samples)
+                        ),
+                        "candidate_samples_ms": list(run.candidate_samples),
+                        "baseline_samples_ms": list(run.baseline_samples),
+                        "compile_seconds": run.compile_seconds,
+                        "output_absmax": output_absmax,
+                        "max_abs_diff_vs_production": None
+                        if run is production
+                        else max_abs_diff,
+                        "correctness_pass": bool(
+                            torch.isfinite(output).all().item()
+                            and output_absmax > 1e-12
+                            and (run is production or max_abs_diff <= 5e-2)
+                        ),
+                        "cache_policy": "cold-l2-per-sample",
+                    }
+                )
+
+    # Paired samples are already aligned above; compute the ratio distribution
+    # per row after all launches for a key have completed.
+    grouped: dict[tuple[int, int], list[dict[str, Any]]] = {}
+    for row in rows:
+        grouped.setdefault((row["tokens"], row["split_k"]), []).append(row)
+    for group in grouped.values():
+        reference = next((row for row in group if row["is_production_config"]), None)
+        if reference is None:
+            for row in group:
+                row["correctness_pass"] = False
+                row["median_ratio"] = None
+                row["speedup_pct"] = None
+            continue
+        for row in group:
+            if row["is_production_config"]:
+                ratios = [1.0] * args.repeats
+            else:
+                # Candidate/base medians are paired at launch time; the raw
+                # pair list is retained in the row for audit and reduction.
+                candidate_ms = row.get("candidate_samples_ms")
+                baseline_samples = row.get("baseline_samples_ms")
+                ratios = (
+                    [c / b for c, b in zip(candidate_ms, baseline_samples)]
+                    if candidate_ms and baseline_samples
+                    else [row["median_ms"] / row["baseline_median_ms"]]
+                )
+            row["median_ratio"] = statistics.median(ratios)
+            row["ratio_p95"] = percentile(ratios, 0.95)
+            row["ratio_p99"] = percentile(ratios, 0.99)
+            row["speedup_pct"] = (1.0 / row["median_ratio"] - 1.0) * 100.0
+
+    payload = {
+        "schema": "musa-dsv4-mhc-jit-aot-paired-ab.v1",
+        "device_name": torch.musa.get_device_name(0),
+        "multiprocessor_count": mp,
+        "lease_device_fence": lease_device_fence,
+        "hidden_size": hidden_size,
+        "production_path": args.production_path,
+        "benchmark": {
+            "warmup": args.warmup,
+            "repeats": args.repeats,
+            "l2_flush_mb": args.l2_flush_mb,
+            "flush_before_every_timed_launch": True,
+            "cache_policy": "cold-l2-per-sample",
+            "production_resolver": "vllm_musa.deepseek_v4_mhc._resolve_mhc_pre_big_fuse_config",
+        },
+        "kernel_sources": [
+            "vllm_musa/deepseek_v4_jit/tilelang_kernels.py::mhc_pre_big_fuse_decode_split_kernel",
+            "vllm_musa/deepseek_v4_jit/tilelang_kernels.py::mhc_pre_big_fuse_kernel",
+        ],
+        "provenance": provenance(Path(__file__)),
+        "rows": rows,
+        "skipped": skipped,
+    }
+    emit_payload(payload, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_dsv4_mhc_post_jit.py
+++ b/benchmarks/kernel_tactics/benchmark_dsv4_mhc_post_jit.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paired cold-cache benchmark for the production DSV4 MHC-post JIT kernel."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+PRODUCTION_CONFIG = (256, 256)
+
+
+def parse_config(value: str) -> tuple[int, int]:
+    """Parse ``hidden_block x threads`` and reject partial-write configs."""
+    try:
+        hidden_block, threads = (int(part) for part in value.lower().split("x", 1))
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"config must be HIDDEN_BLOCKxTHREADS, got {value!r}"
+        ) from exc
+    if hidden_block <= 0 or threads <= 0 or threads < hidden_block:
+        raise argparse.ArgumentTypeError(
+            "config requires positive values and threads >= hidden_block"
+        )
+    return hidden_block, threads
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hidden-size", type=int, default=4096)
+    parser.add_argument(
+        "--tokens",
+        type=int,
+        nargs="+",
+        default=[20, 80, 320],
+        help="production standalone post buckets after the M<=16 fused path",
+    )
+    parser.add_argument(
+        "--configs",
+        type=parse_config,
+        nargs="+",
+        default=[(64, 64), (128, 128), PRODUCTION_CONFIG, (512, 512)],
+        metavar="BLOCKxTHREADS",
+    )
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=32)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def _load_runtime() -> tuple[Any, Any]:
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    from vllm_musa.deepseek_v4_jit.tilelang_kernels import mhc_post_kernel
+    # isort: on
+
+    return torch, mhc_post_kernel
+
+
+@dataclass
+class _Run:
+    config: tuple[int, int]
+    kernel: Any
+    output: Any
+    compile_seconds: float
+    candidate_samples: list[float] = field(default_factory=list)
+    baseline_samples: list[float] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _Inputs:
+    x: Any
+    residual: Any
+    post_mix: Any
+    comb_mix: Any
+
+
+def _invoke(run: _Run, inputs: _Inputs) -> None:
+    run.kernel(
+        inputs.x,
+        inputs.residual,
+        inputs.post_mix,
+        inputs.comb_mix,
+        run.output,
+    )
+
+
+def _timed_invoke(torch: Any, flush: Any, run: _Run, inputs: _Inputs) -> float:
+    flush.zero_()
+    torch.musa.synchronize()
+    start = torch.musa.Event(enable_timing=True)
+    end = torch.musa.Event(enable_timing=True)
+    start.record()
+    _invoke(run, inputs)
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end))
+
+
+def main() -> int:
+    args = parse_args()
+    if min(args.tokens) <= 0 or args.hidden_size <= 0:
+        raise ValueError("tokens and hidden size must be positive")
+    if min(args.warmup, args.repeats, args.l2_flush_mb) <= 0:
+        raise ValueError("timing arguments must be positive")
+
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+    )
+    torch, kernel_factory = _load_runtime()
+    if not torch.musa.is_available() or torch.musa.device_count() != 1:
+        raise RuntimeError("MHC-post benchmark requires one visible MUSA device")
+    device = torch.device("musa")
+    properties = torch.musa.get_device_properties(0)
+    hidden_size = int(args.hidden_size)
+    configs = list(dict.fromkeys([PRODUCTION_CONFIG, *args.configs]))
+    flush = torch.empty(
+        args.l2_flush_mb * 1024 * 1024 // 4,
+        dtype=torch.int32,
+        device=device,
+    )
+    generator = torch.Generator(device="cpu").manual_seed(args.seed)
+    rows: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+
+    for num_tokens in args.tokens:
+        inputs = _Inputs(
+            x=torch.randn(
+                (num_tokens, hidden_size),
+                generator=generator,
+                dtype=torch.bfloat16,
+            ).to(device),
+            residual=torch.randn(
+                (num_tokens, 4, hidden_size),
+                generator=generator,
+                dtype=torch.bfloat16,
+            ).to(device),
+            post_mix=torch.randn(
+                (num_tokens, 4), generator=generator, dtype=torch.float32
+            ).to(device),
+            comb_mix=torch.randn(
+                (num_tokens, 4, 4), generator=generator, dtype=torch.float32
+            ).to(device),
+        )
+        compiled: list[_Run] = []
+        for hidden_block, threads in configs:
+            config = (hidden_block, threads)
+            if hidden_size % hidden_block:
+                skipped.append(
+                    {
+                        "tokens": num_tokens,
+                        "config": list(config),
+                        "reason": "hidden size is not divisible by hidden block",
+                    }
+                )
+                continue
+            started = time.perf_counter()
+            try:
+                kernel = kernel_factory(
+                    hidden_size,
+                    hidden_block=hidden_block,
+                    threads=threads,
+                )
+                run = _Run(
+                    config=config,
+                    kernel=kernel,
+                    output=torch.empty(
+                        (num_tokens, 4, hidden_size),
+                        dtype=torch.bfloat16,
+                        device=device,
+                    ),
+                    compile_seconds=time.perf_counter() - started,
+                )
+                _invoke(run, inputs)
+                torch.musa.synchronize()
+            except Exception as exc:  # pragma: no cover - device-side contract
+                skipped.append(
+                    {
+                        "tokens": num_tokens,
+                        "config": list(config),
+                        "reason": str(exc),
+                    }
+                )
+                continue
+            compiled.append(run)
+
+        production = next(
+            (run for run in compiled if run.config == PRODUCTION_CONFIG), None
+        )
+        if production is None:
+            raise RuntimeError("production MHC-post config failed to compile")
+        for run in compiled:
+            for _ in range(args.warmup):
+                _invoke(run, inputs)
+        torch.musa.synchronize()
+
+        for repeat in range(args.repeats):
+            for candidate in (run for run in compiled if run is not production):
+                pair = (
+                    (production, candidate)
+                    if repeat % 2 == 0
+                    else (candidate, production)
+                )
+                first_ms = _timed_invoke(torch, flush, pair[0], inputs)
+                second_ms = _timed_invoke(torch, flush, pair[1], inputs)
+                if repeat % 2 == 0:
+                    candidate.baseline_samples.append(first_ms)
+                    candidate.candidate_samples.append(second_ms)
+                else:
+                    candidate.candidate_samples.append(first_ms)
+                    candidate.baseline_samples.append(second_ms)
+
+        _invoke(production, inputs)
+        torch.musa.synchronize()
+        reference = production.output.detach().cpu().float()
+        for run in compiled:
+            if run is production:
+                run.baseline_samples = [
+                    _timed_invoke(torch, flush, run, inputs)
+                    for _ in range(args.repeats)
+                ]
+                run.candidate_samples = list(run.baseline_samples)
+                ratios = [1.0] * args.repeats
+                max_abs_diff = 0.0
+            else:
+                _invoke(run, inputs)
+                torch.musa.synchronize()
+                max_abs_diff = float(
+                    (run.output.detach().cpu().float() - reference).abs().max().item()
+                )
+                ratios = [
+                    candidate / baseline
+                    for candidate, baseline in zip(
+                        run.candidate_samples, run.baseline_samples
+                    )
+                ]
+            output_absmax = float(run.output.float().abs().max().item())
+            median_ratio = statistics.median(ratios)
+            rows.append(
+                {
+                    "tokens": num_tokens,
+                    "hidden_block": run.config[0],
+                    "threads": run.config[1],
+                    "production_config": list(PRODUCTION_CONFIG),
+                    "is_production_config": run is production,
+                    "median_ms": float(statistics.median(run.candidate_samples)),
+                    "baseline_median_ms": float(
+                        statistics.median(run.baseline_samples)
+                    ),
+                    "median_ratio": median_ratio,
+                    "ratio_p95": percentile(ratios, 0.95),
+                    "ratio_p99": percentile(ratios, 0.99),
+                    "speedup_pct": (1.0 / median_ratio - 1.0) * 100.0,
+                    "candidate_samples_ms": list(run.candidate_samples),
+                    "baseline_samples_ms": list(run.baseline_samples),
+                    "compile_seconds": run.compile_seconds,
+                    "output_absmax": output_absmax,
+                    "max_abs_diff_vs_production": max_abs_diff,
+                    "correctness_pass": bool(
+                        torch.isfinite(run.output).all().item()
+                        and output_absmax > 1e-12
+                        and max_abs_diff <= 5e-2
+                    ),
+                    "cache_policy": "cold-l2-per-sample",
+                }
+            )
+
+    emit_payload(
+        {
+            "schema": "musa-dsv4-mhc-post-jit-paired-ab.v1",
+            "device_name": torch.musa.get_device_name(0),
+            "device_capability": [int(properties.major), int(properties.minor)],
+            "multiprocessor_count": int(properties.multi_processor_count),
+            "lease_device_fence": lease_device_fence,
+            "hidden_size": hidden_size,
+            "benchmark": {
+                "warmup": args.warmup,
+                "repeats": args.repeats,
+                "l2_flush_mb": args.l2_flush_mb,
+                "flush_before_every_timed_launch": True,
+                "paired_alternating_order": True,
+                "production_config": list(PRODUCTION_CONFIG),
+            },
+            "kernel_source": (
+                "vllm_musa/deepseek_v4_jit/tilelang_kernels.py::mhc_post_kernel"
+            ),
+            "provenance": provenance(Path(__file__)),
+            "rows": rows,
+            "skipped": skipped,
+        },
+        args.output,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_dsv4_weighted_rmsnorm_jit.py
+++ b/benchmarks/kernel_tactics/benchmark_dsv4_weighted_rmsnorm_jit.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paired cold-cache DSV4 weighted-RMSNorm JIT thread sweep."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+PRODUCTION_THREADS = 128
+VALID_THREADS = (64, 128, 256)
+
+
+def parse_threads(value: str) -> int:
+    try:
+        threads = int(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"threads must be an integer: {value!r}"
+        ) from exc
+    if threads not in VALID_THREADS:
+        raise argparse.ArgumentTypeError(f"threads must be one of {VALID_THREADS}")
+    return threads
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokens", type=int, nargs="+", default=[20, 80, 320])
+    parser.add_argument("--hidden-size", type=int, default=4096)
+    parser.add_argument(
+        "--threads",
+        type=parse_threads,
+        nargs="+",
+        default=list(VALID_THREADS),
+    )
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=32)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def _load_runtime() -> tuple[Any, Any]:
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    from vllm_musa.deepseek_v4_jit.tilelang_kernels import (
+        mhc_weighted_rmsnorm_mudnn_like_kernel,
+    )
+    # isort: on
+
+    return torch, mhc_weighted_rmsnorm_mudnn_like_kernel
+
+
+@dataclass
+class _Run:
+    threads: int
+    kernel: Any
+    output: Any
+    compile_seconds: float
+    candidate_samples: list[float] = field(default_factory=list)
+    baseline_samples: list[float] = field(default_factory=list)
+
+
+def _invoke(run: _Run, x: Any, weight: Any) -> None:
+    run.kernel(x, weight, run.output, 1e-6)
+
+
+def _timed_invoke(
+    torch: Any,
+    flush: Any,
+    run: _Run,
+    x: Any,
+    weight: Any,
+) -> float:
+    run.output.fill_(float("nan"))
+    flush.zero_()
+    torch.musa.synchronize()
+    start = torch.musa.Event(enable_timing=True)
+    end = torch.musa.Event(enable_timing=True)
+    start.record()
+    _invoke(run, x, weight)
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end))
+
+
+def main() -> int:
+    args = parse_args()
+    if min(args.tokens) <= 0 or args.hidden_size != 4096:
+        raise ValueError("production DSV4 sweep requires positive M and H=4096")
+    if min(args.warmup, args.repeats, args.l2_flush_mb) <= 0:
+        raise ValueError("timing arguments must be positive")
+
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+    )
+    torch, kernel_factory = _load_runtime()
+    if not torch.musa.is_available() or torch.musa.device_count() != 1:
+        raise RuntimeError(
+            "weighted-RMSNorm benchmark requires one visible MUSA device"
+        )
+    device = torch.device("musa")
+    properties = torch.musa.get_device_properties(0)
+    flush = torch.empty(
+        args.l2_flush_mb * 1024 * 1024 // 4,
+        dtype=torch.int32,
+        device=device,
+    )
+    generator = torch.Generator(device="cpu").manual_seed(args.seed)
+    configs = list(dict.fromkeys([PRODUCTION_THREADS, *args.threads]))
+    rows: list[dict[str, Any]] = []
+
+    for num_tokens in args.tokens:
+        x = torch.randn(
+            (num_tokens, args.hidden_size),
+            generator=generator,
+            dtype=torch.bfloat16,
+        ).to(device)
+        weight = torch.randn(
+            (args.hidden_size,), generator=generator, dtype=torch.bfloat16
+        ).to(device)
+        runs: list[_Run] = []
+        for threads in configs:
+            started = time.perf_counter()
+            kernel = kernel_factory(args.hidden_size, threads=threads)
+            runs.append(
+                _Run(
+                    threads=threads,
+                    kernel=kernel,
+                    output=torch.empty_like(x),
+                    compile_seconds=time.perf_counter() - started,
+                )
+            )
+        production = next(run for run in runs if run.threads == PRODUCTION_THREADS)
+        for run in runs:
+            for _ in range(args.warmup):
+                _invoke(run, x, weight)
+        torch.musa.synchronize()
+
+        for repeat in range(args.repeats):
+            for candidate in (run for run in runs if run is not production):
+                pair = (
+                    (production, candidate)
+                    if repeat % 2 == 0
+                    else (candidate, production)
+                )
+                first_ms = _timed_invoke(torch, flush, pair[0], x, weight)
+                second_ms = _timed_invoke(torch, flush, pair[1], x, weight)
+                if repeat % 2 == 0:
+                    candidate.baseline_samples.append(first_ms)
+                    candidate.candidate_samples.append(second_ms)
+                else:
+                    candidate.candidate_samples.append(first_ms)
+                    candidate.baseline_samples.append(second_ms)
+
+        _invoke(production, x, weight)
+        torch.musa.synchronize()
+        reference = production.output.detach().cpu().float()
+        for run in runs:
+            if run is production:
+                run.baseline_samples = [
+                    _timed_invoke(torch, flush, run, x, weight)
+                    for _ in range(args.repeats)
+                ]
+                run.candidate_samples = list(run.baseline_samples)
+                ratios = [1.0] * args.repeats
+            else:
+                ratios = [
+                    candidate / baseline
+                    for candidate, baseline in zip(
+                        run.candidate_samples, run.baseline_samples
+                    )
+                ]
+            run.output.fill_(float("nan"))
+            _invoke(run, x, weight)
+            torch.musa.synchronize()
+            max_abs_diff = float(
+                (run.output.detach().cpu().float() - reference).abs().max().item()
+            )
+            output_absmax = float(run.output.float().abs().max().item())
+            median_ratio = statistics.median(ratios)
+            rows.append(
+                {
+                    "tokens": num_tokens,
+                    "hidden_size": args.hidden_size,
+                    "dtype": "torch.bfloat16",
+                    "threads": run.threads,
+                    "production_threads": PRODUCTION_THREADS,
+                    "is_production_config": run is production,
+                    "median_ms": float(statistics.median(run.candidate_samples)),
+                    "baseline_median_ms": float(
+                        statistics.median(run.baseline_samples)
+                    ),
+                    "median_ratio": median_ratio,
+                    "ratio_p95": percentile(ratios, 0.95),
+                    "ratio_p99": percentile(ratios, 0.99),
+                    "speedup_pct": (1.0 / median_ratio - 1.0) * 100.0,
+                    "candidate_samples_ms": list(run.candidate_samples),
+                    "baseline_samples_ms": list(run.baseline_samples),
+                    "compile_seconds": run.compile_seconds,
+                    "output_absmax": output_absmax,
+                    "max_abs_diff_vs_production": max_abs_diff,
+                    "correctness_pass": bool(
+                        torch.isfinite(run.output).all().item()
+                        and output_absmax > 1e-12
+                        and max_abs_diff <= 5e-2
+                    ),
+                    "cache_policy": "cold-l2-per-sample",
+                }
+            )
+
+    emit_payload(
+        {
+            "schema": "musa-dsv4-weighted-rmsnorm-jit-paired-ab.v1",
+            "device_name": torch.musa.get_device_name(0),
+            "device_capability": [int(properties.major), int(properties.minor)],
+            "multiprocessor_count": int(properties.multi_processor_count),
+            "lease_device_fence": lease_device_fence,
+            "benchmark": {
+                "warmup": args.warmup,
+                "repeats": args.repeats,
+                "l2_flush_mb": args.l2_flush_mb,
+                "flush_before_every_timed_launch": True,
+                "paired_alternating_order": True,
+                "inner_iters": 1,
+                "production_threads": PRODUCTION_THREADS,
+            },
+            "kernel_source": (
+                "vllm_musa/deepseek_v4_jit/tilelang_kernels.py::"
+                "mhc_weighted_rmsnorm_mudnn_like_kernel"
+            ),
+            "provenance": provenance(Path(__file__)),
+            "rows": rows,
+            "skipped": [],
+        },
+        args.output,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py
+++ b/benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Cold-L2 paired sweep for local group-128 FP8 quantization kernels."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+
+@dataclass(frozen=True)
+class Mode:
+    name: str
+    input_multiplier: int
+    clamp: bool
+
+
+MODES = {
+    "quant": Mode("quant", 1, False),
+    "silu": Mode("silu", 2, False),
+    "silu_clamp": Mode("silu_clamp", 2, True),
+}
+PRODUCTION_TOKENS = (
+    1,
+    2,
+    4,
+    5,
+    6,
+    8,
+    12,
+    16,
+    20,
+    24,
+    30,
+    32,
+    36,
+    48,
+    64,
+    80,
+    96,
+    120,
+    128,
+    192,
+    256,
+    288,
+    320,
+    384,
+    480,
+    512,
+    768,
+    1536,
+    1920,
+    2048,
+    4096,
+)
+PRODUCTION_HIDDEN_SIZES = (
+    128,
+    256,
+    512,
+    1024,
+    1536,
+    2048,
+    2560,
+    3072,
+    3584,
+    4096,
+    5120,
+    7168,
+    8192,
+)
+SUPPORTED_GROUPS_PER_BLOCK = (1, 2, 4, 8, 16)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--modes", choices=tuple(MODES), nargs="+", required=True)
+    parser.add_argument("--tokens", type=int, nargs="+", required=True)
+    parser.add_argument("--hidden-sizes", type=int, nargs="+", required=True)
+    parser.add_argument(
+        "--groups-per-block",
+        type=int,
+        nargs="+",
+        default=list(SUPPORTED_GROUPS_PER_BLOCK),
+    )
+    parser.add_argument("--group-size", type=int, default=128)
+    parser.add_argument("--dry-runs", type=int, default=4)
+    parser.add_argument("--repeats", type=int, default=32)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--swiglu-limit", type=float, default=7.0)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def production_groups_per_block(num_groups: int) -> int:
+    if num_groups <= 0:
+        raise ValueError("num_groups must be positive")
+    for candidate in reversed(SUPPORTED_GROUPS_PER_BLOCK):
+        if num_groups % candidate == 0:
+            return candidate
+    return 1
+
+
+def _load_runtime() -> Any:
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    from vllm_musa import _custom_ops as _musa_ops  # noqa: F401
+    # isort: on
+
+    return torch
+
+
+def _allocate_outputs(torch: Any, tokens: int, hidden_size: int, device: Any):
+    output_q = torch.empty(
+        (tokens, hidden_size), dtype=torch.float8_e4m3fn, device=device
+    )
+    output_s = torch.empty(
+        (tokens, hidden_size // 128), dtype=torch.float32, device=device
+    )
+    return output_q, output_s
+
+
+def main() -> int:
+    args = parse_args()
+    if min(args.dry_runs, args.repeats, args.l2_flush_mb) <= 0:
+        raise ValueError("timing arguments must be positive")
+    if args.group_size != 128:
+        raise ValueError("local vec kernels require --group-size 128")
+    if any(value not in PRODUCTION_TOKENS for value in args.tokens):
+        raise ValueError(f"tokens must be production buckets {PRODUCTION_TOKENS}")
+    if any(value not in PRODUCTION_HIDDEN_SIZES for value in args.hidden_sizes):
+        raise ValueError(
+            f"hidden sizes must be production buckets {PRODUCTION_HIDDEN_SIZES}"
+        )
+    if any(value not in SUPPORTED_GROUPS_PER_BLOCK for value in args.groups_per_block):
+        raise ValueError("groups per block must be in " f"{SUPPORTED_GROUPS_PER_BLOCK}")
+
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+    )
+    torch = _load_runtime()
+    if not torch.musa.is_available() or torch.musa.device_count() != 1:
+        raise RuntimeError("FP8 quant benchmark requires exactly one visible GPU")
+    device = torch.device("musa")
+    properties = torch.musa.get_device_properties(0)
+    torch.manual_seed(args.seed)
+    flush = torch.empty(
+        args.l2_flush_mb * 1024 * 1024, dtype=torch.uint8, device=device
+    )
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    rows: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+
+    for mode_name in args.modes:
+        mode = MODES[mode_name]
+        for hidden_size in args.hidden_sizes:
+            groups_per_token = hidden_size // args.group_size
+            for tokens in args.tokens:
+                num_groups = tokens * groups_per_token
+                baseline_groups = production_groups_per_block(num_groups)
+                input_tensor = torch.randn(
+                    (tokens, mode.input_multiplier * hidden_size),
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
+                input_tensor.mul_(0.5)
+                baseline_q, baseline_s = _allocate_outputs(
+                    torch, tokens, hidden_size, device
+                )
+                candidate_q, candidate_s = _allocate_outputs(
+                    torch, tokens, hidden_size, device
+                )
+
+                def launch(groups_per_block: int, output_q: Any, output_s: Any) -> None:
+                    if mode.name == "quant":
+                        torch.ops._C_musa_ops.per_token_group_quant_8bit_vec(
+                            input_tensor,
+                            output_q,
+                            output_s,
+                            args.group_size,
+                            1e-10,
+                            fp8_info.min,
+                            fp8_info.max,
+                            groups_per_block,
+                        )
+                    elif mode.clamp:
+                        torch.ops._C_musa_ops.silu_and_mul_clamp_per_token_group_fp8_quant(
+                            input_tensor,
+                            output_q,
+                            output_s,
+                            args.group_size,
+                            1e-10,
+                            fp8_info.min,
+                            fp8_info.max,
+                            args.swiglu_limit,
+                            groups_per_block,
+                        )
+                    else:
+                        torch.ops._C_musa_ops.silu_and_mul_per_token_group_fp8_quant(
+                            input_tensor,
+                            output_q,
+                            output_s,
+                            args.group_size,
+                            1e-10,
+                            fp8_info.min,
+                            fp8_info.max,
+                            groups_per_block,
+                        )
+
+                launch(0, baseline_q, baseline_s)
+                torch.musa.synchronize()
+                reference_q = baseline_q.clone()
+                reference_s = baseline_s.clone()
+
+                for candidate_groups in args.groups_per_block:
+                    if mode.name == "quant" and num_groups % candidate_groups:
+                        skipped.append(
+                            {
+                                "mode": mode.name,
+                                "tokens": tokens,
+                                "hidden_size": hidden_size,
+                                "candidate_groups_per_block": candidate_groups,
+                                "reason": "num_groups_not_divisible",
+                            }
+                        )
+                        continue
+
+                    candidate_q.fill_(fp8_info.min)
+                    candidate_s.fill_(float("nan"))
+                    launch(candidate_groups, candidate_q, candidate_s)
+                    torch.musa.synchronize()
+                    q_equal = bool(
+                        torch.equal(reference_q.float(), candidate_q.float())
+                    )
+                    scale_equal = bool(torch.equal(reference_s, candidate_s))
+                    finite = bool(torch.isfinite(candidate_s).all().item())
+                    correctness_pass = q_equal and scale_equal and finite
+
+                    for dry_run in range(args.dry_runs):
+                        if dry_run % 2:
+                            launch(candidate_groups, candidate_q, candidate_s)
+                        else:
+                            launch(0, baseline_q, baseline_s)
+                    torch.musa.synchronize()
+
+                    baseline_samples: list[float] = []
+                    candidate_samples: list[float] = []
+                    paired_ratios: list[float] = []
+                    for repeat in range(args.repeats):
+                        order = (0, candidate_groups)
+                        if repeat % 2:
+                            order = (candidate_groups, 0)
+                        measured: dict[int, float] = {}
+                        for groups in order:
+                            flush.zero_()
+                            start = torch.musa.Event(enable_timing=True)
+                            end = torch.musa.Event(enable_timing=True)
+                            start.record()
+                            if groups == 0:
+                                launch(groups, baseline_q, baseline_s)
+                            else:
+                                launch(groups, candidate_q, candidate_s)
+                            end.record()
+                            end.synchronize()
+                            measured[groups] = float(start.elapsed_time(end))
+                        baseline_ms = measured[0]
+                        candidate_ms = measured[candidate_groups]
+                        baseline_samples.append(baseline_ms)
+                        candidate_samples.append(candidate_ms)
+                        paired_ratios.append(candidate_ms / baseline_ms)
+
+                    baseline_median = statistics.median(baseline_samples)
+                    candidate_median = statistics.median(candidate_samples)
+                    rows.append(
+                        {
+                            "mode": mode.name,
+                            "tokens": tokens,
+                            "hidden_size": hidden_size,
+                            "groups_per_token": groups_per_token,
+                            "num_groups": num_groups,
+                            "baseline_groups_per_block": baseline_groups,
+                            "candidate_groups_per_block": candidate_groups,
+                            "correctness_pass": correctness_pass,
+                            "q_equal": q_equal,
+                            "scale_equal": scale_equal,
+                            "finite": finite,
+                            "baseline_median_ms": baseline_median,
+                            "candidate_median_ms": candidate_median,
+                            "median_ratio": statistics.median(paired_ratios),
+                            "ratio_p95": percentile(paired_ratios, 0.95),
+                            "speedup_pct": (baseline_median / candidate_median - 1.0)
+                            * 100.0,
+                            "baseline_samples_ms": baseline_samples,
+                            "candidate_samples_ms": candidate_samples,
+                            "paired_ratios": paired_ratios,
+                        }
+                    )
+
+    payload = {
+        "schema": "vllm-musa-fp8-quant-groups.v1",
+        "benchmark": "fp8-quant-groups",
+        "device_name": torch.musa.get_device_name(0),
+        "device_capability": list(torch.musa.get_device_capability(0)),
+        "multiprocessor_count": int(properties.multi_processor_count),
+        "lease_device_fence": lease_device_fence,
+        "group_size": args.group_size,
+        "timing": {
+            "dry_runs": args.dry_runs,
+            "repeats": args.repeats,
+            "inner_iters": 1,
+            "l2_flush_mb": args.l2_flush_mb,
+            "paired_alternating_order": True,
+        },
+        "kernel_sources": [
+            "csrc/musa/quantization/per_token_group_quant_8bit_vec.cu",
+            "csrc/musa/quantization/silu_and_mul_per_token_group_fp8_quant.cu",
+        ],
+        "provenance": provenance(Path(__file__)),
+        "rows": rows,
+        "skipped": skipped,
+    }
+    emit_payload(payload, args.output)
+    return 0 if all(row["correctness_pass"] for row in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_fused_add_rmsnorm_blocks.py
+++ b/benchmarks/kernel_tactics/benchmark_fused_add_rmsnorm_blocks.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Interleaved cold-cache sweep of existing fused-add-RMSNorm AOT blocks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+
+# isort: off
+import torchada  # noqa: F401  # patch before torch ecosystem imports
+import torch
+# isort: on
+
+from vllm_musa import _custom_ops as musa_ops
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rows",
+        type=int,
+        nargs="+",
+        default=(1, 16, 32, 56, 60, 64, 112, 120, 128, 256, 512),
+    )
+    parser.add_argument("--hidden-size", type=int, default=4096)
+    parser.add_argument(
+        "--blocks", type=int, nargs="+", default=(0, 128, 256, 512, 1024)
+    )
+    parser.add_argument("--dry-runs", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=30)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--eps", type=float, default=1e-6)
+    parser.add_argument("--seed", type=int, default=20260824)
+    return parser.parse_args()
+
+
+def percentile(samples: list[float], fraction: float) -> float:
+    ordered = sorted(samples)
+    index = min(len(ordered) - 1, round((len(ordered) - 1) * fraction))
+    return ordered[index]
+
+
+def reference(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    residual_fp32 = x.float() + residual.float()
+    residual_out = residual_fp32.to(x.dtype)
+    normalized = residual_fp32 * torch.rsqrt(
+        residual_fp32.pow(2).mean(dim=-1, keepdim=True) + eps
+    )
+    return (normalized * weight.float()).to(x.dtype), residual_out
+
+
+def main() -> int:
+    args = parse_args()
+    manual_override = os.environ.get("VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X")
+    if manual_override is not None:
+        raise RuntimeError(
+            "unset VLLM_MUSA_FUSED_ADD_RMSNORM_BLOCK_X for an unbiased block sweep"
+        )
+    valid_blocks = {0, 128, 256, 512, 1024}
+    if not args.rows or min(args.rows) <= 0:
+        raise ValueError("rows must contain positive integers")
+    if set(args.blocks) - valid_blocks:
+        raise ValueError(f"blocks must be drawn from {sorted(valid_blocks)}")
+    if args.hidden_size <= 0 or args.hidden_size % 8:
+        raise ValueError("hidden-size must be positive and divisible by 8")
+    if min(args.dry_runs, args.repeats, args.l2_flush_mb) <= 0:
+        raise ValueError("timing parameters must be positive")
+
+    properties = torch.musa.get_device_properties(0)
+    flush_elements = args.l2_flush_mb * 1024 * 1024 // 4
+    flush_buffer = torch.empty(flush_elements, dtype=torch.float32, device="musa")
+    rows_out = []
+
+    for num_rows in args.rows:
+        torch.manual_seed(args.seed + num_rows)
+        base_x = torch.randn(
+            (num_rows, args.hidden_size), dtype=torch.bfloat16, device="musa"
+        )
+        base_residual = torch.randn_like(base_x)
+        weight = torch.randn((args.hidden_size,), dtype=torch.bfloat16, device="musa")
+        expected, expected_residual = reference(base_x, base_residual, weight, args.eps)
+        working = {
+            block: (torch.empty_like(base_x), torch.empty_like(base_residual))
+            for block in args.blocks
+        }
+
+        def reset_and_run(block: int) -> None:
+            x, residual = working[block]
+            x.copy_(base_x)
+            residual.copy_(base_residual)
+            musa_ops.musa_fused_add_rms_norm(
+                x, residual, weight, args.eps, block_x=block
+            )
+
+        correctness = {}
+        for block in args.blocks:
+            reset_and_run(block)
+            torch.musa.synchronize()
+            output, residual_out = working[block]
+            torch.testing.assert_close(
+                output.float(), expected.float(), rtol=2e-2, atol=2e-2
+            )
+            torch.testing.assert_close(
+                residual_out.float(),
+                expected_residual.float(),
+                rtol=0.0,
+                atol=0.0,
+            )
+            correctness[block] = bool(
+                torch.isfinite(output).all().item()
+                and torch.isfinite(residual_out).all().item()
+            )
+
+        for dry_run in range(args.dry_runs):
+            order = (
+                args.blocks[dry_run % len(args.blocks) :]
+                + args.blocks[: dry_run % len(args.blocks)]
+            )
+            for block in order:
+                flush_buffer.add_(1)
+                reset_and_run(block)
+        torch.musa.synchronize()
+
+        samples = {block: [] for block in args.blocks}
+        for repeat in range(args.repeats):
+            offset = repeat % len(args.blocks)
+            order = args.blocks[offset:] + args.blocks[:offset]
+            for block in order:
+                x, residual = working[block]
+                x.copy_(base_x)
+                residual.copy_(base_residual)
+                flush_buffer.add_(1)
+                start = torch.musa.Event(enable_timing=True)
+                end = torch.musa.Event(enable_timing=True)
+                start.record()
+                musa_ops.musa_fused_add_rms_norm(
+                    x, residual, weight, args.eps, block_x=block
+                )
+                end.record()
+                end.synchronize()
+                samples[block].append(float(start.elapsed_time(end)))
+
+        for block in args.blocks:
+            block_samples = samples[block]
+            rows_out.append(
+                {
+                    "rows": num_rows,
+                    "hidden_size": args.hidden_size,
+                    "block_x": block,
+                    "samples_ms": block_samples,
+                    "median_ms": statistics.median(block_samples),
+                    "p95_ms": percentile(block_samples, 0.95),
+                    "iqr_ms": percentile(block_samples, 0.75)
+                    - percentile(block_samples, 0.25),
+                    "correctness_pass": correctness[block],
+                }
+            )
+
+    print(
+        json.dumps(
+            {
+                "schema": "musa-fused-add-rmsnorm-aot-block-sweep.v1",
+                "device_name": torch.musa.get_device_name(0),
+                "device_capability": [int(properties.major), int(properties.minor)],
+                "multiprocessor_count": int(properties.multi_processor_count),
+                "dtype": "bfloat16",
+                "eps": args.eps,
+                "blocks": args.blocks,
+                "manual_override": manual_override,
+                "benchmark": {
+                    "dry_runs": args.dry_runs,
+                    "repeats": args.repeats,
+                    "interleaved": True,
+                    "l2_flush_mb": args.l2_flush_mb,
+                },
+                "rows": rows_out,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if all(row["correctness_pass"] for row in rows_out) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_fused_add_rmsnorm_paired_ab.py
+++ b/benchmarks/kernel_tactics/benchmark_fused_add_rmsnorm_paired_ab.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paired same-card A/B timing for existing fused-add-RMSNorm AOT blocks."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import statistics
+from pathlib import Path
+
+# isort: off
+import torchada  # noqa: F401  # patch before torch ecosystem imports
+import torch
+# isort: on
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+from vllm_musa import _custom_ops as musa_ops
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, nargs="+", default=(16, 56, 112, 120))
+    parser.add_argument("--hidden-size", type=int, default=4096)
+    parser.add_argument("--pairs", type=int, nargs=2, action="append")
+    parser.add_argument("--repeats", type=int, default=40)
+    parser.add_argument("--dry-runs", type=int, default=8)
+    parser.add_argument("--inner-iters", type=int, default=1)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--eps", type=float, default=1e-6)
+    parser.add_argument("--seed", type=int, default=20260824)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    pairs = args.pairs or [[0, 256], [0, 512]]
+    valid_blocks = {0, 128, 256, 512, 1024}
+    if not args.rows or min(args.rows) <= 0:
+        raise ValueError("rows must contain positive integers")
+    if any(set(pair) - valid_blocks for pair in pairs):
+        raise ValueError(f"pairs must use blocks from {sorted(valid_blocks)}")
+    if args.hidden_size <= 0 or args.hidden_size % 8:
+        raise ValueError("hidden-size must be positive and divisible by 8")
+    if min(args.repeats, args.dry_runs, args.inner_iters, args.l2_flush_mb) <= 0:
+        raise ValueError("timing parameters must be positive")
+    if args.inner_iters != 1:
+        raise ValueError(
+            "cold-L2 evidence requires --inner-iters 1; batching launches after "
+            "one flush measures warm-cache work"
+        )
+
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+    )
+    properties = torch.musa.get_device_properties(0)
+    flush_buffer = torch.empty(
+        args.l2_flush_mb * 1024 * 1024 // 4, dtype=torch.int32, device="musa"
+    )
+    output_rows = []
+
+    for row_count in args.rows:
+        torch.manual_seed(args.seed + row_count)
+        base_x = torch.randn(
+            (row_count, args.hidden_size), dtype=torch.bfloat16, device="musa"
+        )
+        base_residual = torch.randn_like(base_x)
+        weight = torch.randn((args.hidden_size,), dtype=torch.bfloat16, device="musa")
+        work = {
+            block: (
+                torch.empty(
+                    (args.inner_iters, *base_x.shape),
+                    dtype=base_x.dtype,
+                    device=base_x.device,
+                ),
+                torch.empty(
+                    (args.inner_iters, *base_residual.shape),
+                    dtype=base_residual.dtype,
+                    device=base_residual.device,
+                ),
+            )
+            for pair in pairs
+            for block in pair
+        }
+
+        def prepare(block: int) -> None:
+            x, residual = work[block]
+            x.copy_(base_x)
+            residual.copy_(base_residual)
+
+        def launch(block: int) -> None:
+            x, residual = work[block]
+            for inner in range(args.inner_iters):
+                musa_ops.musa_fused_add_rms_norm(
+                    x[inner], residual[inner], weight, args.eps, block_x=block
+                )
+
+        for block in sorted(work):
+            prepare(block)
+            launch(block)
+        torch.musa.synchronize()
+
+        for pair in pairs:
+            baseline, candidate = pair
+            prepare(baseline)
+            launch(baseline)
+            prepare(candidate)
+            launch(candidate)
+            torch.musa.synchronize()
+            torch.testing.assert_close(
+                work[candidate][0].float(),
+                work[baseline][0].float(),
+                rtol=2e-2,
+                atol=2e-2,
+            )
+            torch.testing.assert_close(
+                work[candidate][1].float(),
+                work[baseline][1].float(),
+                rtol=0.0,
+                atol=0.0,
+            )
+            baseline_samples: list[float] = []
+            candidate_samples: list[float] = []
+            correctness = True
+            for dry in range(args.dry_runs):
+                block = pair[dry % 2]
+                prepare(block)
+                launch(block)
+            torch.musa.synchronize()
+            for repeat in range(args.repeats):
+                order = (
+                    (baseline, candidate) if repeat % 2 == 0 else (candidate, baseline)
+                )
+                measured: dict[int, float] = {}
+                for block in order:
+                    prepare(block)
+                    flush_buffer.zero_()
+                    start = torch.musa.Event(enable_timing=True)
+                    end = torch.musa.Event(enable_timing=True)
+                    start.record()
+                    launch(block)
+                    end.record()
+                    end.synchronize()
+                    measured[block] = float(start.elapsed_time(end)) / args.inner_iters
+                    x, residual = work[block]
+                    correctness = correctness and bool(
+                        torch.isfinite(x).all().item()
+                        and torch.isfinite(residual).all().item()
+                    )
+                baseline_samples.append(measured[baseline])
+                candidate_samples.append(measured[candidate])
+
+            prepare(candidate)
+            launch(candidate)
+            torch.musa.synchronize()
+            candidate_x = work[candidate][0].float()
+            output_absmax = float(candidate_x.abs().max().item())
+            # A constant normalized row is valid; use only all-zero output as
+            # the uninitialized-output guard.
+            output_std = float(candidate_x.std().item())
+            poison_output = output_absmax <= 1e-12
+            correctness = correctness and not poison_output
+            ratios = [c / b for b, c in zip(baseline_samples, candidate_samples)]
+            baseline_p50 = statistics.median(baseline_samples)
+            candidate_p50 = statistics.median(candidate_samples)
+            candidate_seconds = candidate_p50 / 1000.0
+            estimated_flops = row_count * args.hidden_size * 4
+            algorithmic_bytes = row_count * args.hidden_size * 5 * 2
+            output_rows.append(
+                {
+                    "rows": row_count,
+                    "hidden_size": args.hidden_size,
+                    "baseline_block_x": baseline,
+                    "candidate_block_x": candidate,
+                    "baseline_samples_ms": baseline_samples,
+                    "candidate_samples_ms": candidate_samples,
+                    "ratio_samples": ratios,
+                    "baseline_median_ms": baseline_p50,
+                    "candidate_median_ms": candidate_p50,
+                    "baseline_p90_ms": percentile(baseline_samples, 0.90),
+                    "baseline_p99_ms": percentile(baseline_samples, 0.99),
+                    "candidate_p90_ms": percentile(candidate_samples, 0.90),
+                    "candidate_p99_ms": percentile(candidate_samples, 0.99),
+                    "median_ratio": statistics.median(ratios),
+                    "geomean_ratio": math.exp(
+                        sum(math.log(x) for x in ratios) / len(ratios)
+                    ),
+                    "ratio_p95": percentile(ratios, 0.95),
+                    "ratio_p99": percentile(ratios, 0.99),
+                    "ratio_iqr": percentile(ratios, 0.75) - percentile(ratios, 0.25),
+                    "speedup_pct": (baseline_p50 / candidate_p50 - 1.0) * 100.0,
+                    "theory": {
+                        "estimated_flops": estimated_flops,
+                        "algorithmic_bytes": algorithmic_bytes,
+                        "candidate_tflops": estimated_flops / candidate_seconds / 1e12,
+                        "candidate_gbps": algorithmic_bytes / candidate_seconds / 1e9,
+                    },
+                    "output_absmax": output_absmax,
+                    "output_std": output_std,
+                    "poison_output": poison_output,
+                    "correctness_pass": correctness,
+                }
+            )
+
+    payload = {
+        "schema": "musa-fused-add-rmsnorm-aot-paired-ab.v2",
+        "device_name": torch.musa.get_device_name(0),
+        "device_capability": [int(properties.major), int(properties.minor)],
+        "multiprocessor_count": int(properties.multi_processor_count),
+        "dtype": "bfloat16",
+        "benchmark": {
+            "repeats": args.repeats,
+            "dry_runs": args.dry_runs,
+            "inner_iters": args.inner_iters,
+            "paired_alternating_order": True,
+            "l2_flush_mb": args.l2_flush_mb,
+            "l2_flush_bytes": flush_buffer.numel() * flush_buffer.element_size(),
+            "flush_before_every_timed_launch": True,
+            "cache_policy": "cold-l2-per-sample",
+        },
+        "roofline": {
+            "memory_gbps": 1600,
+            "bf16_tflops": 500,
+        },
+        "kernel_source": ("csrc/musa/fused_add_rmsnorm.mu::fused_add_rmsnorm_kernel"),
+        "lease_device_fence": lease_device_fence,
+        "provenance": provenance(Path(__file__)),
+        "rows": output_rows,
+    }
+    emit_payload(payload, args.output)
+    return 0 if all(row["correctness_pass"] for row in output_rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_fused_gemv_moe_blocks.py
+++ b/benchmarks/kernel_tactics/benchmark_fused_gemv_moe_blocks.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paired A/B sweep of existing MUSA fused-MoE GEMV AOT blocks."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+
+# isort: off
+import torchada  # noqa: F401  # patch before torch ecosystem imports
+import torch
+# isort: on
+
+from _benchmark_utils import (
+    effective_gemv_block,
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+from vllm_musa import _custom_ops as musa_ops
+
+
+@dataclass(frozen=True)
+class Family:
+    name: str
+    experts: int
+    hidden_size: int
+    intermediate_size: int
+    topk: int
+    weight_dtype: torch.dtype
+    folded_shared_expert: bool = False
+
+
+FAMILIES = {
+    "dsv4_fp8": Family("dsv4_fp8", 256, 4096, 256, 6, torch.float8_e4m3fn),
+    "qwen_bf16": Family("qwen_bf16", 32, 2048, 128, 8, torch.bfloat16),
+    "qwen35_folded_bf16": Family(
+        "qwen35_folded_bf16", 33, 2048, 128, 9, torch.bfloat16, True
+    ),
+}
+
+
+def parse_block(value: str) -> tuple[int, int]:
+    try:
+        block_n, block_k = (int(part) for part in value.lower().split("x", 1))
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"invalid block {value!r}; expected NxK"
+        ) from exc
+    if block_n <= 0 or block_k <= 0:
+        raise argparse.ArgumentTypeError("block dimensions must be positive")
+    return block_n, block_k
+
+
+def parse_baseline_block(value: str) -> tuple[int, int]:
+    if value.lower() == "auto":
+        return (0, 0)
+    return parse_block(value)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--family", choices=sorted(FAMILIES), required=True)
+    parser.add_argument("--tokens", type=int, nargs="+", required=True)
+    parser.add_argument(
+        "--routes",
+        choices=("balanced", "hot", "unique_random"),
+        nargs="+",
+        default=("balanced",),
+    )
+    parser.add_argument(
+        "--stages", choices=("w1", "w2"), nargs="+", default=("w1", "w2")
+    )
+    parser.add_argument(
+        "--blocks",
+        type=parse_block,
+        nargs="+",
+        default=((4, 32), (8, 16), (16, 8), (32, 4), (32, 8)),
+    )
+    parser.add_argument(
+        "--baseline-block",
+        type=parse_baseline_block,
+        default=(0, 0),
+        help="paired baseline block, or 'auto'",
+    )
+    parser.add_argument("--dry-runs", type=int, default=4)
+    parser.add_argument("--repeats", type=int, default=24)
+    parser.add_argument("--inner-iters", type=int, default=1)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--seed", type=int, default=20260824)
+    parser.add_argument("--execution-mode", choices=("eager", "graph"), default="eager")
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def fp8_constant(shape: tuple[int, ...], *, device: torch.device) -> torch.Tensor:
+    # E4M3 byte 0x20 is a small finite positive value. Creating the payload as
+    # uint8 avoids a multi-gigabyte float32 staging allocation for DSV4 weights.
+    return torch.full(shape, 0x20, dtype=torch.uint8, device=device).view(
+        torch.float8_e4m3fn
+    )
+
+
+def make_weight(
+    shape: tuple[int, ...], dtype: torch.dtype, *, device: torch.device
+) -> torch.Tensor:
+    if dtype == torch.float8_e4m3fn:
+        return fp8_constant(shape, device=device)
+    return torch.randn(shape, dtype=dtype, device=device) * 0.01
+
+
+def make_route_ids(
+    tokens: int,
+    topk: int,
+    experts: int,
+    route: str,
+    folded_shared_expert: bool,
+    seed: int,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    routed_experts = experts - 1 if folded_shared_expert else experts
+    routed_topk = topk - 1 if folded_shared_expert else topk
+    offsets = torch.arange(routed_topk, dtype=torch.int64).reshape(1, -1)
+    if route == "balanced":
+        rows = torch.arange(tokens, dtype=torch.int64).reshape(-1, 1)
+        routed = (rows * routed_topk + offsets).remainder(routed_experts)
+    elif route == "hot":
+        routed = offsets.expand(tokens, -1)
+    else:
+        generator = torch.Generator().manual_seed(seed)
+        scores = torch.rand((tokens, routed_experts), generator=generator)
+        routed = scores.topk(routed_topk, dim=-1, sorted=False).indices
+    if folded_shared_expert:
+        shared = torch.full((tokens, 1), experts - 1, dtype=torch.int64)
+        routed = torch.cat((routed, shared), dim=1)
+    return routed.to(device=device, dtype=torch.int32)
+
+
+def route_evidence(topk_ids: torch.Tensor, experts: int) -> dict[str, object]:
+    ids = topk_ids.detach().cpu().to(torch.int64)
+    histogram = torch.bincount(ids.flatten(), minlength=experts).tolist()
+    encoded = json.dumps(ids.tolist(), separators=(",", ":")).encode()
+    nonzero = [index for index, count in enumerate(histogram) if count]
+    return {
+        "topk_ids_sha256": hashlib.sha256(encoded).hexdigest(),
+        "expert_load_histogram": histogram,
+        "nonzero_experts": nonzero,
+        "max_expert_load": max(histogram),
+        "min_nonzero_expert_load": min(histogram[index] for index in nonzero),
+    }
+
+
+def workload_theory(family: Family, tokens: int, stage: str) -> tuple[int, int]:
+    assignments = tokens * family.topk
+    hidden = family.hidden_size
+    intermediate = family.intermediate_size
+    weight_bytes = 1 if family.weight_dtype == torch.float8_e4m3fn else 2
+    if stage == "w1":
+        flops = assignments * 4 * hidden * intermediate
+        matrix_elements = 2 * hidden * intermediate
+        input_elements = hidden
+        output_elements = intermediate
+    else:
+        flops = assignments * 2 * hidden * intermediate
+        matrix_elements = hidden * intermediate
+        input_elements = intermediate
+        output_elements = hidden
+    algorithmic_bytes = assignments * (
+        matrix_elements * weight_bytes + input_elements * 2 + output_elements * 2
+    )
+    if family.weight_dtype == torch.float8_e4m3fn:
+        algorithmic_bytes += assignments * matrix_elements // (128 * 128) * 4
+    return flops, algorithmic_bytes
+
+
+def effective_block(
+    family: Family, tokens: int, stage: str, requested: tuple[int, int]
+) -> tuple[tuple[int, int], bool, str | None]:
+    """Return the block the checked-in C++ selector will actually launch."""
+    # This one-token DSV4 split-tile arm runs before the per-call diagnostic
+    # override.  Do not promote a requested block that the kernel ignored.
+    return effective_gemv_block(family.name, tokens, stage, requested)
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.tokens or min(args.tokens) <= 0:
+        raise ValueError("tokens must contain positive integers")
+    if min(args.dry_runs, args.repeats, args.inner_iters, args.l2_flush_mb) <= 0:
+        raise ValueError("timing arguments must be positive")
+    if args.inner_iters != 1:
+        raise ValueError(
+            "cold-L2 evidence requires --inner-iters 1; batching launches after "
+            "one flush measures warm-cache work"
+        )
+
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+    )
+    family = FAMILIES[args.family]
+    device = torch.device("musa")
+    torch.manual_seed(args.seed)
+    properties = torch.musa.get_device_properties(0)
+
+    w1 = make_weight(
+        (family.experts, 2 * family.intermediate_size, family.hidden_size),
+        family.weight_dtype,
+        device=device,
+    )
+    w2 = make_weight(
+        (family.experts, family.hidden_size, family.intermediate_size),
+        family.weight_dtype,
+        device=device,
+    )
+    if family.weight_dtype == torch.float8_e4m3fn:
+        w1_scale = torch.ones(
+            (
+                family.experts,
+                (2 * family.intermediate_size) // 128,
+                family.hidden_size // 128,
+            ),
+            dtype=torch.float32,
+            device=device,
+        )
+        w2_scale = torch.ones(
+            (
+                family.experts,
+                family.hidden_size // 128,
+                family.intermediate_size // 128,
+            ),
+            dtype=torch.float32,
+            device=device,
+        )
+    else:
+        w1_scale = None
+        w2_scale = None
+
+    flush_buffer = torch.empty(
+        args.l2_flush_mb * 1024 * 1024 // 4, dtype=torch.int32, device=device
+    )
+    rows = []
+    skipped = []
+    vector_length = 16 if family.weight_dtype == torch.float8_e4m3fn else 8
+
+    for tokens in args.tokens:
+        hidden = (
+            torch.randn(
+                (tokens, family.hidden_size), dtype=torch.bfloat16, device=device
+            )
+            * 0.01
+        )
+        intermediate = (
+            torch.randn(
+                (tokens * family.topk, family.intermediate_size),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            * 0.01
+        )
+
+        for route in args.routes:
+            topk_ids = make_route_ids(
+                tokens,
+                family.topk,
+                family.experts,
+                route,
+                family.folded_shared_expert,
+                args.seed + tokens,
+                device=device,
+            )
+            route_metadata = route_evidence(topk_ids, family.experts)
+            topk_weights = torch.full(
+                (tokens, family.topk),
+                1.0 / family.topk,
+                dtype=torch.float32,
+                device=device,
+            )
+
+            for stage in args.stages:
+                if stage == "w1":
+                    activation = hidden
+                    weight = w1
+                    weight_scale = w1_scale
+                    output = torch.empty(
+                        (tokens * family.topk, family.intermediate_size),
+                        dtype=torch.bfloat16,
+                        device=device,
+                    )
+                    kernel_topk = family.topk
+                    use_swigelu = True
+                    mul_routed_weight = False
+                    output_size = family.intermediate_size
+                    reduction_size = family.hidden_size
+                else:
+                    activation = intermediate
+                    weight = w2
+                    weight_scale = w2_scale
+                    output = torch.empty(
+                        (tokens, family.topk, family.hidden_size),
+                        dtype=torch.bfloat16,
+                        device=device,
+                    )
+                    kernel_topk = 1
+                    use_swigelu = False
+                    mul_routed_weight = True
+                    output_size = family.hidden_size
+                    reduction_size = family.intermediate_size
+
+                def launch(block: tuple[int, int]) -> None:
+                    block_n, block_k = block
+                    for _ in range(args.inner_iters):
+                        musa_ops.musa_fused_gemv_moe(
+                            activation,
+                            weight,
+                            output,
+                            None,
+                            weight_scale,
+                            topk_weights,
+                            topk_ids,
+                            mul_routed_weight,
+                            kernel_topk,
+                            False,
+                            use_swigelu,
+                            block_n=block_n,
+                            block_k=block_k,
+                        )
+
+                def capture_runner(block: tuple[int, int]):
+                    launch(block)
+                    torch.musa.synchronize()
+                    graph = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(graph):
+                        launch(block)
+                    return graph.replay
+
+                baseline_block = args.baseline_block
+                if baseline_block != (0, 0):
+                    baseline_n, baseline_k = baseline_block
+                    baseline_load_size = baseline_k * vector_length
+                    if output_size % baseline_n or reduction_size % baseline_load_size:
+                        raise ValueError(
+                            f"invalid baseline block {baseline_n}x{baseline_k} "
+                            f"for stage={stage}, output_size={output_size}, "
+                            f"reduction_size={reduction_size}, "
+                            f"vector_length={vector_length}"
+                        )
+                if args.execution_mode == "eager":
+                    launch(baseline_block)
+                    torch.musa.synchronize()
+                    baseline_output = output.clone()
+                else:
+                    baseline_output = None
+
+                for candidate_block in args.blocks:
+                    block_n, block_k = candidate_block
+                    load_size = block_k * vector_length
+                    if output_size % block_n or reduction_size % load_size:
+                        skipped.append(
+                            {
+                                "family": family.name,
+                                "tokens": tokens,
+                                "route": route,
+                                "stage": stage,
+                                "candidate_block": list(candidate_block),
+                                "reason": (
+                                    f"invalid for output_size={output_size}, "
+                                    f"reduction_size={reduction_size}, "
+                                    f"vector_length={vector_length}"
+                                ),
+                            }
+                        )
+                        continue
+                    if args.execution_mode == "graph":
+                        baseline_runner = capture_runner(baseline_block)
+                        candidate_runner = capture_runner(candidate_block)
+                        baseline_runner()
+                        torch.musa.synchronize()
+                        baseline_output = output.clone()
+                        candidate_runner()
+                        torch.musa.synchronize()
+                        candidate_output = output.clone()
+                    else:
+
+                        def baseline_runner() -> None:
+                            launch(baseline_block)
+
+                        def candidate_runner() -> None:
+                            launch(candidate_block)
+
+                        candidate_runner()
+                        torch.musa.synchronize()
+                        candidate_output = output.clone()
+                    assert baseline_output is not None
+                    torch.testing.assert_close(
+                        candidate_output.float(),
+                        baseline_output.float(),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    correctness = bool(torch.isfinite(candidate_output).all().item())
+                    output_absmax = float(candidate_output.float().abs().max().item())
+                    # A valid tiny/quantized GEMV result may have zero variance
+                    # (notably one-token FP8 rows).  Only classify an all-zero
+                    # result as poison; variance is not a correctness oracle.
+                    poison_output = output_absmax <= 1e-12
+                    correctness = correctness and not poison_output
+
+                    for dry in range(args.dry_runs):
+                        if dry % 2 == 0:
+                            baseline_runner()
+                        else:
+                            candidate_runner()
+                    torch.musa.synchronize()
+
+                    baseline_samples: list[float] = []
+                    candidate_samples: list[float] = []
+                    for repeat in range(args.repeats):
+                        order = (
+                            (baseline_block, candidate_block)
+                            if repeat % 2 == 0
+                            else (candidate_block, baseline_block)
+                        )
+                        measured: dict[tuple[int, int], float] = {}
+                        for block in order:
+                            flush_buffer.zero_()
+                            start = torch.musa.Event(enable_timing=True)
+                            end = torch.musa.Event(enable_timing=True)
+                            start.record()
+                            if block == baseline_block:
+                                baseline_runner()
+                            else:
+                                candidate_runner()
+                            end.record()
+                            end.synchronize()
+                            measured[block] = (
+                                float(start.elapsed_time(end)) / args.inner_iters
+                            )
+                        baseline_samples.append(measured[baseline_block])
+                        candidate_samples.append(measured[candidate_block])
+
+                    ratios = [
+                        candidate / baseline
+                        for baseline, candidate in zip(
+                            baseline_samples, candidate_samples
+                        )
+                    ]
+                    baseline_p50 = statistics.median(baseline_samples)
+                    candidate_p50 = statistics.median(candidate_samples)
+                    flops, algorithmic_bytes = workload_theory(family, tokens, stage)
+                    candidate_seconds = candidate_p50 / 1000.0
+                    effective, request_applied, override_reason = effective_block(
+                        family, tokens, stage, tuple(candidate_block)
+                    )
+                    baseline_effective, baseline_applied, baseline_override_reason = (
+                        effective_block(family, tokens, stage, tuple(baseline_block))
+                    )
+                    rows.append(
+                        {
+                            "family": family.name,
+                            "tokens": tokens,
+                            "route": route,
+                            "route_evidence": route_metadata,
+                            "stage": stage,
+                            "topk": family.topk,
+                            "activation_shape": list(activation.shape),
+                            "weight_shape": list(weight.shape),
+                            "baseline_block": list(baseline_block),
+                            "baseline_effective_block": list(baseline_effective),
+                            "baseline_block_applied": baseline_applied,
+                            "baseline_block_override_reason": baseline_override_reason,
+                            "candidate_block": list(candidate_block),
+                            "effective_block": list(effective),
+                            "requested_block_applied": request_applied,
+                            "block_override_reason": override_reason,
+                            "baseline_samples_ms": baseline_samples,
+                            "candidate_samples_ms": candidate_samples,
+                            "ratio_samples": ratios,
+                            "baseline_median_ms": baseline_p50,
+                            "candidate_median_ms": candidate_p50,
+                            "baseline_p90_ms": percentile(baseline_samples, 0.90),
+                            "baseline_p99_ms": percentile(baseline_samples, 0.99),
+                            "candidate_p90_ms": percentile(candidate_samples, 0.90),
+                            "candidate_p99_ms": percentile(candidate_samples, 0.99),
+                            "median_ratio": statistics.median(ratios),
+                            "geomean_ratio": math.exp(
+                                sum(math.log(value) for value in ratios) / len(ratios)
+                            ),
+                            "ratio_iqr": percentile(ratios, 0.75)
+                            - percentile(ratios, 0.25),
+                            "ratio_p95": percentile(ratios, 0.95),
+                            "ratio_p99": percentile(ratios, 0.99),
+                            "speedup_pct": (baseline_p50 / candidate_p50 - 1.0) * 100.0,
+                            "theory": {
+                                "flops": flops,
+                                "algorithmic_bytes": algorithmic_bytes,
+                                "candidate_tflops": flops / candidate_seconds / 1e12,
+                                "candidate_gbps": algorithmic_bytes
+                                / candidate_seconds
+                                / 1e9,
+                            },
+                            "output_absmax": output_absmax,
+                            "output_std": float(candidate_output.float().std().item()),
+                            "poison_output": poison_output,
+                            "correctness_pass": correctness,
+                        }
+                    )
+
+    payload = {
+        "schema": "musa-fused-gemv-moe-aot-paired-ab.v2",
+        "family": family.name,
+        "execution_mode": args.execution_mode,
+        "folded_shared_expert": family.folded_shared_expert,
+        "device_name": torch.musa.get_device_name(0),
+        "device_capability": [int(properties.major), int(properties.minor)],
+        "multiprocessor_count": int(properties.multi_processor_count),
+        "lease_device_fence": lease_device_fence,
+        "weight_dtype": str(family.weight_dtype),
+        "benchmark": {
+            "dry_runs": args.dry_runs,
+            "repeats": args.repeats,
+            "inner_iters": args.inner_iters,
+            "l2_flush_mb": args.l2_flush_mb,
+            "l2_flush_bytes": flush_buffer.numel() * flush_buffer.element_size(),
+            "flush_before_every_timed_launch": True,
+            "cache_policy": "cold-l2-per-sample",
+            "paired_alternating_order": True,
+        },
+        "roofline": {
+            "memory_gbps": 1600,
+            "bf16_tflops": 500,
+            "fp8_tflops": 1000,
+        },
+        "kernel_source": "csrc/musa/gemv.mu::musa_gemv_kernel",
+        "baseline_block": list(args.baseline_block),
+        "provenance": provenance(Path(__file__)),
+        "rows": rows,
+        "skipped": skipped,
+    }
+    emit_payload(payload, args.output)
+    return 0 if all(row["correctness_pass"] for row in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_jit_rmsnorm_threads.py
+++ b/benchmarks/kernel_tactics/benchmark_jit_rmsnorm_threads.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paired cold-cache requested-thread sweep for native-JIT RMSNorm kernels."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+SUPPORTED_THREADS = (32, 64, 96, 128, 192, 256, 320, 512, 640, 896, 1024)
+
+
+def parse_threads(value: str) -> int:
+    try:
+        threads = int(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"threads must be an integer: {value!r}"
+        ) from exc
+    if threads not in SUPPORTED_THREADS:
+        raise argparse.ArgumentTypeError(
+            f"threads must be one of {SUPPORTED_THREADS}, got {threads}"
+        )
+    return threads
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("plain", "gemma", "fused", "fused_gemma"),
+        required=True,
+    )
+    parser.add_argument("--rows", type=int, nargs="+", required=True)
+    parser.add_argument("--hidden-sizes", type=int, nargs="+", required=True)
+    parser.add_argument(
+        "--threads", type=parse_threads, nargs="+", default=SUPPORTED_THREADS
+    )
+    parser.add_argument("--weight-dtype", choices=("bf16", "fp32"), default="bf16")
+    parser.add_argument("--dry-runs", type=int, default=4)
+    parser.add_argument("--repeats", type=int, default=32)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def vec8_threads(hidden_size: int) -> int:
+    rounded = ((hidden_size // 8 + 31) // 32) * 32
+    return min(rounded, 1024)
+
+
+def production_threads(
+    mode: str,
+    rows: int,
+    hidden_size: int,
+    multiprocessor_count: int | None = None,
+) -> int | None:
+    if (
+        hidden_size == 5120
+        and multiprocessor_count == 48
+        and mode == "plain"
+        and rows == 512
+    ):
+        return 256
+    exact_h5120_mp_tactic = (
+        multiprocessor_count == 56
+        and rows == 512
+        and mode in {"plain", "gemma", "fused", "fused_gemma"}
+    ) or (
+        multiprocessor_count == 60
+        and (mode, rows)
+        in {
+            ("plain", 512),
+            ("gemma", 512),
+            ("gemma", 4096),
+            ("fused_gemma", 512),
+        }
+    )
+    if hidden_size == 5120 and exact_h5120_mp_tactic:
+        return 320
+    if mode in ("fused", "fused_gemma"):
+        return vec8_threads(hidden_size)
+    if rows <= 16 and hidden_size in (1024, 2048):
+        return None
+    if hidden_size <= 512:
+        return 64
+    if hidden_size <= 4096:
+        if rows <= 16:
+            return min(vec8_threads(hidden_size), 512)
+        if rows <= 256:
+            return min(vec8_threads(hidden_size), 256)
+        return 128
+    if hidden_size <= 8192:
+        return min(vec8_threads(hidden_size), 512)
+    return min(vec8_threads(hidden_size), 896)
+
+
+def _load_runtime() -> tuple[Any, Any, Any]:
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    from vllm_musa.jit_kernel.csrc import norm
+    from vllm_musa.tuning import prime_musa_kernel_hardware
+    # isort: on
+
+    return torch, norm, prime_musa_kernel_hardware
+
+
+def main() -> int:
+    args = parse_args()
+    if min(args.rows) <= 0 or min(args.hidden_sizes) <= 0:
+        raise ValueError("rows and hidden sizes must be positive")
+    if any(hidden_size % 8 for hidden_size in args.hidden_sizes):
+        raise ValueError("requested-thread sweep requires hidden sizes divisible by 8")
+    if max(args.hidden_sizes) > 32768:
+        raise ValueError("requested-thread sweep supports hidden sizes <=32768")
+    if min(args.dry_runs, args.repeats, args.l2_flush_mb) <= 0:
+        raise ValueError("timing arguments must be positive")
+    if args.mode in ("plain", "gemma") and args.weight_dtype != "bf16":
+        raise ValueError("plain RMSNorm requires activation-matching BF16 weight")
+
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+    )
+    torch, norm, prime_hardware = _load_runtime()
+    if not torch.musa.is_available() or torch.musa.device_count() != 1:
+        raise RuntimeError("JIT RMSNorm benchmark requires one visible MUSA GPU")
+    device = torch.device("musa")
+    properties = torch.musa.get_device_properties(0)
+    primed_hardware = prime_hardware(0)
+    if primed_hardware.multiprocessor_count != int(properties.multi_processor_count):
+        raise RuntimeError("primed hardware does not match runtime device")
+    torch.manual_seed(args.seed)
+    flush = torch.empty(
+        args.l2_flush_mb * 1024 * 1024 // 4,
+        dtype=torch.int32,
+        device=device,
+    )
+    rows_out: list[dict[str, Any]] = []
+
+    for hidden_size in args.hidden_sizes:
+        for rows in args.rows:
+            original_input = torch.randn(
+                (rows, hidden_size), dtype=torch.bfloat16, device=device
+            )
+            original_residual = torch.randn_like(original_input)
+            weight_dtype = (
+                torch.bfloat16 if args.weight_dtype == "bf16" else torch.float32
+            )
+            weight = torch.randn((hidden_size,), dtype=weight_dtype, device=device)
+            input_tensor = original_input.clone()
+            residual = original_residual.clone()
+            output = torch.empty_like(input_tensor)
+
+            def reset_mutable_inputs() -> None:
+                if args.mode in ("fused", "fused_gemma"):
+                    input_tensor.copy_(original_input)
+                    residual.copy_(original_residual)
+
+            def launch(threads: int) -> tuple[Any, ...]:
+                if args.mode in ("plain", "gemma"):
+                    op = norm.gemma_rmsnorm if args.mode == "gemma" else norm.rmsnorm
+                    op(
+                        input_tensor,
+                        weight,
+                        1e-6,
+                        out=output,
+                        block_threads=threads,
+                    )
+                    return (output,)
+                norm.fused_add_rmsnorm(
+                    input_tensor,
+                    residual,
+                    weight,
+                    1e-6,
+                    gemma=args.mode == "fused_gemma",
+                    block_threads=threads,
+                )
+                return (input_tensor, residual)
+
+            reset_mutable_inputs()
+            launch(0)
+            torch.musa.synchronize()
+            reset_mutable_inputs()
+            baseline_outputs = tuple(tensor.clone() for tensor in launch(0))
+            torch.musa.synchronize()
+
+            for candidate_threads in args.threads:
+                reset_mutable_inputs()
+                candidate_outputs = launch(candidate_threads)
+                torch.musa.synchronize()
+                for candidate, baseline in zip(candidate_outputs, baseline_outputs):
+                    torch.testing.assert_close(
+                        candidate.float(), baseline.float(), rtol=2e-2, atol=2e-2
+                    )
+                correctness = all(
+                    bool(torch.isfinite(tensor).all().item())
+                    and float(tensor.float().abs().max().item()) > 1e-12
+                    for tensor in candidate_outputs
+                )
+
+                for dry_run in range(args.dry_runs):
+                    reset_mutable_inputs()
+                    launch(0 if dry_run % 2 == 0 else candidate_threads)
+                torch.musa.synchronize()
+
+                baseline_samples: list[float] = []
+                candidate_samples: list[float] = []
+                for repeat in range(args.repeats):
+                    order = (
+                        (0, candidate_threads)
+                        if repeat % 2 == 0
+                        else (candidate_threads, 0)
+                    )
+                    measured: dict[int, float] = {}
+                    for threads in order:
+                        reset_mutable_inputs()
+                        flush.zero_()
+                        start = torch.musa.Event(enable_timing=True)
+                        end = torch.musa.Event(enable_timing=True)
+                        start.record()
+                        launch(threads)
+                        end.record()
+                        end.synchronize()
+                        measured[threads] = float(start.elapsed_time(end))
+                    baseline_samples.append(measured[0])
+                    candidate_samples.append(measured[candidate_threads])
+
+                ratios = [
+                    candidate / baseline
+                    for baseline, candidate in zip(baseline_samples, candidate_samples)
+                ]
+                baseline_median = statistics.median(baseline_samples)
+                candidate_median = statistics.median(candidate_samples)
+                rows_out.append(
+                    {
+                        "mode": args.mode,
+                        "rows": rows,
+                        "hidden_size": hidden_size,
+                        "activation_dtype": "torch.bfloat16",
+                        "weight_dtype": f"torch.{args.weight_dtype}",
+                        "baseline_threads": 0,
+                        "baseline_effective_threads": production_threads(
+                            args.mode,
+                            rows,
+                            hidden_size,
+                            primed_hardware.multiprocessor_count,
+                        ),
+                        "baseline_special_kernel": (
+                            production_threads(
+                                args.mode,
+                                rows,
+                                hidden_size,
+                                primed_hardware.multiprocessor_count,
+                            )
+                            is None
+                        ),
+                        "candidate_threads": candidate_threads,
+                        "requested_threads_applied": True,
+                        "baseline_samples_ms": baseline_samples,
+                        "candidate_samples_ms": candidate_samples,
+                        "baseline_median_ms": baseline_median,
+                        "candidate_median_ms": candidate_median,
+                        "median_ratio": statistics.median(ratios),
+                        "ratio_p95": percentile(ratios, 0.95),
+                        "ratio_p99": percentile(ratios, 0.99),
+                        "speedup_pct": (baseline_median / candidate_median - 1.0)
+                        * 100.0,
+                        "correctness_pass": correctness,
+                        "cache_policy": "cold-l2-per-sample",
+                    }
+                )
+
+    emit_payload(
+        {
+            "schema": "musa-jit-rmsnorm-threads-paired-ab.v1",
+            "mode": args.mode,
+            "device_name": torch.musa.get_device_name(0),
+            "device_capability": [int(properties.major), int(properties.minor)],
+            "multiprocessor_count": int(properties.multi_processor_count),
+            "primed_hardware": {
+                "device_capability": list(primed_hardware.device_capability),
+                "multiprocessor_count": primed_hardware.multiprocessor_count,
+            },
+            "lease_device_fence": lease_device_fence,
+            "benchmark": {
+                "dry_runs": args.dry_runs,
+                "repeats": args.repeats,
+                "inner_iters": 1,
+                "l2_flush_mb": args.l2_flush_mb,
+                "l2_flush_bytes": flush.numel() * flush.element_size(),
+                "flush_before_every_timed_launch": True,
+                "paired_alternating_order": True,
+            },
+            "kernel_source": "vllm_musa/jit_kernel/csrc/norm/rmsnorm.mu",
+            "provenance": provenance(Path(__file__)),
+            "rows": rows_out,
+            "skipped": [],
+        },
+        args.output,
+    )
+    return 0 if all(row["correctness_pass"] for row in rows_out) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_jit_topk_warps.py
+++ b/benchmarks/kernel_tactics/benchmark_jit_topk_warps.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Cold-L2 paired sweep for repo-owned native JIT top-k launch tactics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SHAPE_PATH = SCRIPT_DIR / "qwen_dsv4_fp8_quant_shapes.json"
+CAMPAIGN_PATH = SCRIPT_DIR / "mp_tactic_campaign.json"
+L2_FLUSH_BYTES = 8_000_000_000
+PRODUCTION_WARPS_PER_CTA = 4
+VALID_WARPS_PER_CTA = (1, 2, 4, 8)
+BENCHMARK_MODULE_NAME = "vllm_musa_topk_gating_benchmark_tactics"
+BENCHMARK_COMPILE_DEFINE = "-DVLLM_MUSA_TOPK_BENCHMARK_TACTICS=1"
+
+
+@dataclass(frozen=True)
+class Family:
+    name: str
+    scoring_func: str
+    input_experts: int
+    routed_experts: int
+    routed_topk: int
+    output_topk: int
+    num_fused_shared_experts: int
+    production_rows: tuple[int, ...]
+    routed_rows: tuple[int, ...]
+    campaign_family: str
+    kernel_name: str
+    production_reachable: bool
+    scope_note: str
+    renormalize: bool = True
+    has_correction_bias: bool = False
+
+
+def parse_warps_per_cta(value: str) -> int:
+    try:
+        warps = int(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"warps per CTA must be an integer: {value!r}"
+        ) from exc
+    if warps not in VALID_WARPS_PER_CTA:
+        raise argparse.ArgumentTypeError(
+            f"warps per CTA must be one of {VALID_WARPS_PER_CTA}"
+        )
+    return warps
+
+
+def launch_geometry(rows: int, warps_per_cta: int) -> dict[str, int]:
+    if rows <= 0:
+        raise ValueError("rows must be positive")
+    if warps_per_cta not in VALID_WARPS_PER_CTA:
+        raise ValueError(f"warps per CTA must be one of {VALID_WARPS_PER_CTA}")
+    return {
+        "warps_per_cta": warps_per_cta,
+        "threads_per_cta": warps_per_cta * 32,
+        "grid_ctas": math.ceil(rows / warps_per_cta),
+    }
+
+
+def _campaign_families(path: Path) -> set[str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    families: set[str] = set()
+    for cell in payload["cells"]:
+        args = cell.get("base_args", [])
+        for index, value in enumerate(args[:-1]):
+            if value == "--family":
+                families.add(str(args[index + 1]))
+    return families
+
+
+def _token_rows(routed_rows: Sequence[int], topk: int, label: str) -> tuple[int, ...]:
+    if topk <= 0 or any(row <= 0 or row % topk for row in routed_rows):
+        raise ValueError(
+            f"{label} routed rows must be positive multiples of topk={topk}"
+        )
+    return tuple(int(row) // topk for row in routed_rows)
+
+
+def load_production_families(
+    shape_path: Path = SHAPE_PATH,
+    campaign_path: Path = CAMPAIGN_PATH,
+) -> dict[str, Family]:
+    """Load row buckets from checked-in Qwen/DeepSeek campaign inputs."""
+    shapes = json.loads(shape_path.read_text(encoding="utf-8"))
+    routed_shapes = shapes["families"]["silu_routed_moe"]
+    campaign_families = _campaign_families(campaign_path)
+    required_campaign_families = {
+        "dsv4_fp8",
+        "qwen_bf16",
+        "qwen35_folded_bf16",
+    }
+    missing = required_campaign_families - campaign_families
+    if missing:
+        raise ValueError(f"campaign is missing top-k shape families: {sorted(missing)}")
+
+    qwen_routed_rows = tuple(routed_shapes["qwen_tp8_topk8"]["rows"])
+    dsv4_routed_rows = tuple(routed_shapes["deepseek_v4_tp8_topk6"]["rows"])
+    qwen_rows = _token_rows(qwen_routed_rows, 8, "Qwen")
+    dsv4_rows = _token_rows(dsv4_routed_rows, 6, "DeepSeek-V4")
+    return {
+        "qwen_softmax_e256_k8": Family(
+            name="qwen_softmax_e256_k8",
+            scoring_func="softmax",
+            input_experts=256,
+            routed_experts=256,
+            routed_topk=8,
+            output_topk=8,
+            num_fused_shared_experts=0,
+            production_rows=qwen_rows,
+            routed_rows=qwen_routed_rows,
+            campaign_family="qwen_bf16",
+            kernel_name="topk_softmax_no_bias_renorm_warp_kernel_fixed_k",
+            production_reachable=True,
+            scope_note="plain Qwen local softmax router",
+        ),
+        "qwen35_folded_softmax_e257_k9": Family(
+            name="qwen35_folded_softmax_e257_k9",
+            scoring_func="softmax",
+            input_experts=257,
+            routed_experts=256,
+            routed_topk=8,
+            output_topk=9,
+            num_fused_shared_experts=1,
+            production_rows=qwen_rows,
+            routed_rows=qwen_routed_rows,
+            campaign_family="qwen35_folded_bf16",
+            kernel_name=(
+                "topk_softmax_no_bias_renorm_warp_combined_shared1_kernel_fixed_k"
+            ),
+            production_reachable=True,
+            scope_note="Qwen3.5 folded routed-plus-shared local softmax router",
+        ),
+        "deepseek_v4_sigmoid_e256_k6_local_no_bias": Family(
+            name="deepseek_v4_sigmoid_e256_k6_local_no_bias",
+            scoring_func="sigmoid",
+            input_experts=256,
+            routed_experts=256,
+            routed_topk=6,
+            output_topk=6,
+            num_fused_shared_experts=0,
+            production_rows=dsv4_rows,
+            routed_rows=dsv4_routed_rows,
+            campaign_family="dsv4_fp8",
+            kernel_name="topk_sigmoid_no_bias_warp_kernel",
+            production_reachable=False,
+            scope_note=(
+                "DSV4 production E/topk/rows on the local no-bias JIT arm only; "
+                "the MATE grouped correction-bias router is excluded"
+            ),
+        ),
+        "deepseek_v4_sigmoid_e256_k6_correction_bias": Family(
+            name="deepseek_v4_sigmoid_e256_k6_correction_bias",
+            scoring_func="sigmoid",
+            input_experts=256,
+            routed_experts=256,
+            routed_topk=6,
+            output_topk=6,
+            num_fused_shared_experts=0,
+            production_rows=dsv4_rows,
+            routed_rows=dsv4_routed_rows,
+            campaign_family="dsv4_fp8",
+            kernel_name="topk_sigmoid_warp_kernel",
+            production_reachable=True,
+            scope_note="DSV4 local correction-bias sigmoid production router",
+            has_correction_bias=True,
+        ),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    families = load_production_families()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--families",
+        choices=tuple(families),
+        nargs="+",
+        default=list(families),
+    )
+    parser.add_argument(
+        "--rows",
+        type=int,
+        nargs="+",
+        help="Optional subset; every row must be a production bucket for each family.",
+    )
+    parser.add_argument(
+        "--warps-per-cta",
+        type=parse_warps_per_cta,
+        nargs="+",
+        default=list(VALID_WARPS_PER_CTA),
+    )
+    parser.add_argument("--dry-runs", type=int, default=4)
+    parser.add_argument("--repeats", type=int, default=32)
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--expected-multiprocessor-count", type=int, required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args(argv)
+
+
+def selected_rows(family: Family, requested: Sequence[int] | None) -> tuple[int, ...]:
+    if requested is None:
+        return family.production_rows
+    rows = tuple(dict.fromkeys(int(row) for row in requested))
+    invalid = sorted(set(rows) - set(family.production_rows))
+    if invalid:
+        raise ValueError(
+            f"{family.name} rows must be production buckets {family.production_rows}; "
+            f"got invalid {invalid}"
+        )
+    return rows
+
+
+def validate_timing_args(dry_runs: int, repeats: int) -> None:
+    if dry_runs <= 0:
+        raise ValueError("dry runs must be positive")
+    if repeats < 2 or repeats % 2:
+        raise ValueError(
+            "repeats must be an even integer of at least 2 for balanced AB/BA"
+        )
+
+
+def _load_runtime() -> tuple[Any, Any]:
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    from vllm_musa.jit_kernel.csrc.jit import load_musa_jit
+    # isort: on
+
+    module = load_musa_jit(
+        BENCHMARK_MODULE_NAME,
+        ("topk/topk_gating.mu",),
+        extra_musa_cflags=(BENCHMARK_COMPILE_DEFINE,),
+    )
+    return torch, module
+
+
+def _allocate_outputs(
+    torch: Any, family: Family, rows: int, device: Any
+) -> tuple[Any, Any]:
+    return (
+        torch.empty((rows, family.output_topk), dtype=torch.float32, device=device),
+        torch.empty((rows, family.output_topk), dtype=torch.int32, device=device),
+    )
+
+
+def _poison_outputs(outputs: tuple[Any, Any]) -> None:
+    weights, ids = outputs
+    weights.fill_(float("nan"))
+    ids.fill_(-1)
+
+
+def _launch(
+    module: Any,
+    family: Family,
+    gating: Any,
+    correction_bias: Any | None,
+    outputs: tuple[Any, Any],
+    warps_per_cta: int,
+) -> None:
+    weights, ids = outputs
+    unused = weights.reshape(-1)
+    if family.scoring_func == "softmax":
+        module.sgl_musa_topk_softmax(
+            weights,
+            ids,
+            gating,
+            family.renormalize,
+            0.0,
+            unused,
+            False,
+            unused,
+            family.num_fused_shared_experts,
+            False,
+            warps_per_cta,
+        )
+    else:
+        module.sgl_musa_topk_sigmoid(
+            weights,
+            ids,
+            gating,
+            family.renormalize,
+            correction_bias if correction_bias is not None else unused,
+            family.has_correction_bias,
+            unused,
+            0,
+            False,
+            warps_per_cta,
+        )
+
+
+def _reference(
+    torch: Any,
+    family: Family,
+    gating: Any,
+    correction_bias: Any | None,
+) -> tuple[Any, Any]:
+    routed_logits = gating[:, : family.routed_experts].float()
+    if family.scoring_func == "softmax":
+        scores = torch.softmax(routed_logits, dim=-1)
+    else:
+        scores = torch.sigmoid(routed_logits)
+    selection_scores = scores
+    if family.has_correction_bias:
+        if correction_bias is None:
+            raise RuntimeError("correction-bias family requires a bias tensor")
+        selection_scores = scores + correction_bias
+    # Native warp_argmax resolves equal scores to the lower expert id. BF16
+    # logits can tie, while torch.topk does not promise a stable tie order.
+    ids = torch.argsort(
+        selection_scores.detach().cpu(),
+        dim=-1,
+        descending=True,
+        stable=True,
+    )[:, : family.routed_topk].to(device=gating.device)
+    weights = scores.gather(1, ids)
+    if family.renormalize:
+        weights = weights / weights.sum(dim=-1, keepdim=True)
+    if family.num_fused_shared_experts:
+        shared = (
+            torch.sigmoid(gating[:, family.routed_experts :]).to(gating.dtype).float()
+        )
+        shared_ids = torch.full_like(ids[:, :1], family.routed_experts)
+        weights = torch.cat((weights, shared), dim=-1)
+        ids = torch.cat((ids, shared_ids), dim=-1)
+    return weights.float(), ids.to(torch.int32)
+
+
+def _correctness(
+    torch: Any,
+    family: Family,
+    outputs: tuple[Any, Any],
+    production: tuple[Any, Any],
+    reference: tuple[Any, Any],
+) -> dict[str, Any]:
+    weights, ids = outputs
+    production_weights, production_ids = production
+    reference_weights, reference_ids = reference
+    finite = bool(torch.isfinite(weights).all().item())
+    ids_in_range = bool(
+        (ids >= 0).all().item()
+        and (ids <= family.routed_experts).all().item()
+        and (
+            family.num_fused_shared_experts
+            or (ids < family.routed_experts).all().item()
+        )
+    )
+    nonzero = bool(weights.abs().max().item() > 1e-12)
+    nonconstant = bool((weights.max() - weights.min()).abs().item() > 1e-12)
+    poison_output = not (finite and ids_in_range and nonzero and nonconstant)
+    ids_equal_production = bool(torch.equal(ids, production_ids))
+    ids_equal_reference = bool(torch.equal(ids, reference_ids))
+    weights_equal_production = bool(torch.equal(weights, production_weights))
+    weights_close_reference = bool(
+        torch.allclose(weights, reference_weights, atol=3e-3, rtol=3e-3)
+    )
+    max_abs_diff = float((weights - production_weights).abs().max().item())
+    return {
+        "finite": finite,
+        "ids_in_range": ids_in_range,
+        "nonzero": nonzero,
+        "nonconstant": nonconstant,
+        "poison_output": poison_output,
+        "ids_equal_production": ids_equal_production,
+        "ids_equal_reference": ids_equal_reference,
+        "weights_equal_production": weights_equal_production,
+        "weights_close_reference": weights_close_reference,
+        "max_abs_diff_vs_production": max_abs_diff,
+        "correctness_pass": bool(
+            not poison_output
+            and ids_equal_production
+            and ids_equal_reference
+            and weights_equal_production
+            and weights_close_reference
+        ),
+    }
+
+
+def _timed_launch(
+    torch: Any,
+    flush: Any,
+    module: Any,
+    family: Family,
+    gating: Any,
+    correction_bias: Any | None,
+    outputs: tuple[Any, Any],
+    warps_per_cta: int,
+) -> float:
+    _poison_outputs(outputs)
+    flush.zero_()
+    torch.musa.synchronize()
+    start = torch.musa.Event(enable_timing=True)
+    end = torch.musa.Event(enable_timing=True)
+    start.record()
+    _launch(module, family, gating, correction_bias, outputs, warps_per_cta)
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end))
+
+
+def _effective_io_bytes(family: Family, rows: int, input_element_size: int) -> int:
+    input_bytes = rows * family.input_experts * input_element_size
+    output_bytes = rows * family.output_topk * (4 + 4)
+    return input_bytes + output_bytes
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    validate_timing_args(args.dry_runs, args.repeats)
+    families = load_production_families()
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+        args.expected_multiprocessor_count,
+    )
+    torch, module = _load_runtime()
+    if not torch.musa.is_available() or torch.musa.device_count() != 1:
+        raise RuntimeError("JIT top-k benchmark requires exactly one visible MUSA GPU")
+
+    device = torch.device("musa")
+    properties = torch.musa.get_device_properties(0)
+    flush = torch.empty(L2_FLUSH_BYTES // 4, dtype=torch.int32, device=device)
+    results: list[dict[str, Any]] = []
+
+    for family_index, family_name in enumerate(args.families):
+        family = families[family_name]
+        for rows in selected_rows(family, args.rows):
+            generator = torch.Generator(device="cpu").manual_seed(
+                args.seed + family_index * 100_000 + rows
+            )
+            gating = torch.randn(
+                (rows, family.input_experts),
+                generator=generator,
+                dtype=torch.float32,
+            ).to(dtype=torch.bfloat16, device=device)
+            correction_bias = None
+            if family.has_correction_bias:
+                correction_bias = (
+                    torch.rand(
+                        family.routed_experts,
+                        generator=generator,
+                        dtype=torch.float32,
+                    ).to(device=device)
+                    * 0.2
+                    - 0.1
+                )
+            production = _allocate_outputs(torch, family, rows, device)
+            candidate = _allocate_outputs(torch, family, rows, device)
+            reference = _reference(torch, family, gating, correction_bias)
+
+            _poison_outputs(production)
+            _launch(module, family, gating, correction_bias, production, 0)
+            torch.musa.synchronize()
+            production_reference = _correctness(
+                torch, family, production, production, reference
+            )
+
+            for warps_per_cta in dict.fromkeys(args.warps_per_cta):
+                _poison_outputs(candidate)
+                _launch(
+                    module,
+                    family,
+                    gating,
+                    correction_bias,
+                    candidate,
+                    warps_per_cta,
+                )
+                torch.musa.synchronize()
+                correctness = _correctness(
+                    torch, family, candidate, production, reference
+                )
+                correctness["production_reference_pass"] = production_reference[
+                    "correctness_pass"
+                ]
+                correctness["correctness_pass"] = bool(
+                    correctness["correctness_pass"]
+                    and production_reference["correctness_pass"]
+                )
+
+                for dry_run in range(args.dry_runs):
+                    tactic = warps_per_cta if dry_run % 2 else 0
+                    outputs = candidate if tactic else production
+                    _launch(
+                        module,
+                        family,
+                        gating,
+                        correction_bias,
+                        outputs,
+                        tactic,
+                    )
+                torch.musa.synchronize()
+
+                baseline_samples: list[float] = []
+                candidate_samples: list[float] = []
+                paired_ratios: list[float] = []
+                for repeat in range(args.repeats):
+                    order = (0, warps_per_cta)
+                    if repeat % 2:
+                        order = (warps_per_cta, 0)
+                    measured: dict[int, float] = {}
+                    for tactic in order:
+                        outputs = production if tactic == 0 else candidate
+                        measured[tactic] = _timed_launch(
+                            torch,
+                            flush,
+                            module,
+                            family,
+                            gating,
+                            correction_bias,
+                            outputs,
+                            tactic,
+                        )
+                    baseline_ms = measured[0]
+                    candidate_ms = measured[warps_per_cta]
+                    baseline_samples.append(baseline_ms)
+                    candidate_samples.append(candidate_ms)
+                    paired_ratios.append(candidate_ms / baseline_ms)
+
+                baseline_median = float(statistics.median(baseline_samples))
+                candidate_median = float(statistics.median(candidate_samples))
+                ratio_median = float(statistics.median(paired_ratios))
+                io_bytes = _effective_io_bytes(family, rows, gating.element_size())
+                results.append(
+                    {
+                        "family": family.name,
+                        "campaign_family": family.campaign_family,
+                        "scoring_func": family.scoring_func,
+                        "rows": rows,
+                        "input_experts": family.input_experts,
+                        "routed_experts": family.routed_experts,
+                        "routed_topk": family.routed_topk,
+                        "output_topk": family.output_topk,
+                        "num_fused_shared_experts": family.num_fused_shared_experts,
+                        "dtype": "torch.bfloat16",
+                        "kernel_name": family.kernel_name,
+                        "has_correction_bias": family.has_correction_bias,
+                        "production_reachable": family.production_reachable,
+                        "scope_note": family.scope_note,
+                        "tie_break": "lower-expert-id",
+                        "baseline_tactic": (
+                            "production"
+                            if family.production_reachable
+                            else "local-native-default"
+                        ),
+                        "baseline_resolved_warps_per_cta": PRODUCTION_WARPS_PER_CTA,
+                        "candidate_warps_per_cta": warps_per_cta,
+                        "baseline_launch": launch_geometry(
+                            rows, PRODUCTION_WARPS_PER_CTA
+                        ),
+                        "candidate_launch": launch_geometry(rows, warps_per_cta),
+                        "effective_io_bytes": io_bytes,
+                        "flops_model": None,
+                        "flops_model_note": (
+                            "transcendental and iterative top-k comparisons are not "
+                            "modeled as hardware FLOPs"
+                        ),
+                        "baseline_median_ms": baseline_median,
+                        "candidate_median_ms": candidate_median,
+                        "median_ratio": ratio_median,
+                        "ratio_p95": percentile(paired_ratios, 0.95),
+                        "ratio_p99": percentile(paired_ratios, 0.99),
+                        "speedup_pct": (1.0 / ratio_median - 1.0) * 100.0,
+                        "baseline_effective_gbps": io_bytes / baseline_median / 1e6,
+                        "candidate_effective_gbps": io_bytes / candidate_median / 1e6,
+                        "baseline_samples_ms": baseline_samples,
+                        "candidate_samples_ms": candidate_samples,
+                        "paired_ratios": paired_ratios,
+                        **correctness,
+                    }
+                )
+            del gating, production, candidate, reference, correction_bias
+            torch.musa.empty_cache()
+
+    payload = {
+        "schema": "vllm-musa-jit-topk-warp-tactic-paired-ab.v1",
+        "device_name": torch.musa.get_device_name(0),
+        "device_capability": [int(properties.major), int(properties.minor)],
+        "multiprocessor_count": int(properties.multi_processor_count),
+        "lease_device_fence": lease_device_fence,
+        "benchmark": {
+            "dry_runs": args.dry_runs,
+            "repeats": args.repeats,
+            "inner_iters": 1,
+            "l2_flush_bytes": flush.numel() * flush.element_size(),
+            "flush_before_every_timed_launch": True,
+            "cache_policy": "cold-l2-per-sample",
+            "paired_alternating_order": True,
+            "production_warps_per_cta": PRODUCTION_WARPS_PER_CTA,
+        },
+        "scope": {
+            "kernel_source": "vllm_musa/jit_kernel/csrc/topk/topk_gating.mu",
+            "benchmark_jit_module": BENCHMARK_MODULE_NAME,
+            "benchmark_compile_define": BENCHMARK_COMPILE_DEFINE,
+            "implementation": "vllm-musa local native JIT only",
+            "excluded": [
+                "MATE moe_fused_gate provider router",
+                "TileLang grouped_topk router",
+            ],
+            "shape_sources": [
+                str(SHAPE_PATH.relative_to(SCRIPT_DIR.parents[1])),
+                str(CAMPAIGN_PATH.relative_to(SCRIPT_DIR.parents[1])),
+            ],
+        },
+        "families": {
+            name: {
+                "campaign_family": family.campaign_family,
+                "production_rows": list(family.production_rows),
+                "routed_rows": list(family.routed_rows),
+                "input_experts": family.input_experts,
+                "routed_topk": family.routed_topk,
+                "output_topk": family.output_topk,
+                "production_reachable": family.production_reachable,
+                "scope_note": family.scope_note,
+            }
+            for name, family in families.items()
+            if name in args.families
+        },
+        "provenance": provenance(Path(__file__)),
+        "rows": results,
+        "skipped": [],
+    }
+    emit_payload(payload, args.output)
+    return 0 if all(row["correctness_pass"] for row in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_mate_grouped_gemm_mp.py
+++ b/benchmarks/kernel_tactics/benchmark_mate_grouped_gemm_mp.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Measure MATE grouped-GEMM sensitivity to its runtime MP-count hint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+
+# isort: off
+import torchada  # noqa: F401  # patch before torch ecosystem imports
+import torch
+# isort: on
+
+from mate.gemm import ragged_m_moe_gemm_16bit
+from mate.testing.utils import bench_gpu_time_with_musa_event
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--experts", type=int, default=8)
+    parser.add_argument("--tokens-per-expert", type=int, default=128)
+    parser.add_argument("--n", type=int, default=1024)
+    parser.add_argument("--k", type=int, default=2048)
+    parser.add_argument("--mp-counts", type=int, nargs="+", default=(48, 52, 56, 60))
+    parser.add_argument("--dry-runs", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--seed", type=int, default=20260824)
+    return parser.parse_args()
+
+
+def percentile(samples: list[float], fraction: float) -> float:
+    ordered = sorted(samples)
+    index = min(len(ordered) - 1, round((len(ordered) - 1) * fraction))
+    return ordered[index]
+
+
+def main() -> int:
+    args = parse_args()
+    if min(args.experts, args.tokens_per_expert, args.n, args.k) <= 0:
+        raise ValueError("shape dimensions must be positive")
+    if not args.mp_counts or min(args.mp_counts) <= 0:
+        raise ValueError("mp-counts must contain positive integers")
+
+    device = torch.device("musa")
+    properties = torch.musa.get_device_properties(0)
+    physical_mps = int(properties.multi_processor_count)
+    if max(args.mp_counts) > physical_mps:
+        raise ValueError(
+            f"requested MP count exceeds physical count: {args.mp_counts} > {physical_mps}"
+        )
+
+    generator = torch.Generator(device=device)
+    generator.manual_seed(args.seed)
+    total_tokens = args.experts * args.tokens_per_expert
+    input_a = torch.randn(
+        (total_tokens, args.k),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    input_b = torch.randn(
+        (args.experts, args.n, args.k),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    expert_ids = torch.arange(args.experts, dtype=torch.int32, device=device)
+    expert_ids = expert_ids.repeat_interleave(args.tokens_per_expert)
+    output = torch.empty((total_tokens, args.n), dtype=torch.bfloat16, device=device)
+
+    def run(num_mps: int) -> torch.Tensor:
+        return ragged_m_moe_gemm_16bit(
+            input_a,
+            input_b,
+            expert_ids,
+            output,
+            gemm_mode="per_token",
+            num_mp=num_mps,
+            alignment_m=args.tokens_per_expert,
+            backend="mutlass",
+        )
+
+    reference = run(physical_mps).clone()
+    torch.musa.synchronize()
+    rows = []
+    for num_mps in args.mp_counts:
+        candidate = run(num_mps).clone()
+        torch.musa.synchronize()
+        difference = (candidate.float() - reference.float()).abs()
+        samples = [
+            float(value)
+            for value in bench_gpu_time_with_musa_event(
+                lambda: run(num_mps),
+                dry_run_iters=args.dry_runs,
+                repeat_iters=args.repeats,
+                l2_flush=True,
+                l2_flush_size_mb=args.l2_flush_mb,
+            )
+        ]
+        rows.append(
+            {
+                "num_mps": num_mps,
+                "samples_ms": samples,
+                "median_ms": statistics.median(samples),
+                "p95_ms": percentile(samples, 0.95),
+                "iqr_ms": percentile(samples, 0.75) - percentile(samples, 0.25),
+                "max_abs_diff": float(difference.max().item()),
+                "correctness_pass": bool(torch.equal(candidate, reference)),
+            }
+        )
+
+    payload = {
+        "schema": "musa-mate-grouped-gemm-mp-sensitivity.v1",
+        "device_name": torch.musa.get_device_name(0),
+        "device_capability": [int(properties.major), int(properties.minor)],
+        "physical_multiprocessor_count": physical_mps,
+        "shape": {
+            "experts": args.experts,
+            "tokens_per_expert": args.tokens_per_expert,
+            "total_tokens": total_tokens,
+            "n": args.n,
+            "k": args.k,
+            "dtype": "bfloat16",
+        },
+        "benchmark": {
+            "dry_runs": args.dry_runs,
+            "repeats": args.repeats,
+            "l2_flush": True,
+            "l2_flush_mb": args.l2_flush_mb,
+        },
+        "rows": rows,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if all(row["correctness_pass"] for row in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_reshape_cache_nhd_blocks.py
+++ b/benchmarks/kernel_tactics/benchmark_reshape_cache_nhd_blocks.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paired cold-L2 BLOCK_X sweep for the native NHD cache-write kernel."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+PRODUCTION_DEFAULT_BLOCK_X = 512
+SUPPORTED_BLOCK_X = (128, 256, 512, 1024)
+CACHE_BLOCK_SIZE = 64
+PRODUCTION_TOKEN_BUCKETS = (
+    1,
+    2,
+    3,
+    4,
+    6,
+    8,
+    12,
+    16,
+    32,
+    48,
+    64,
+    128,
+    192,
+    256,
+    2048,
+    4096,
+)
+TOKEN_BUCKET_SOURCES = (
+    "benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json::row_shapes",
+    "git:1fe15be47::benchmarks/op_perf/bench_reshape_and_cache_flash.py",
+)
+PRODUCTION_CONSUMERS = (
+    "vllm_musa/v1/attention/backends/fa_utils.py::reshape_and_cache_flash",
+    "vllm_musa/v1/attention/backends/flash_attn.py::do_kv_cache_update",
+    "vllm_musa/v1/attention/backends/tree_attn.py::do_kv_cache_update",
+)
+
+
+@dataclass(frozen=True)
+class CacheShape:
+    num_kv_heads: int
+    head_size: int
+    source: str
+
+    @property
+    def vecs_per_token(self) -> int:
+        return self.num_kv_heads * self.head_size // 8
+
+
+# These are current production envelopes from the Qwen2/Qwen3 FlashAttention
+# consumers. Keep the cache dimensions separate from query-head count: this op
+# receives K/V after they have been viewed as [tokens, num_kv_heads, head_size].
+PRODUCTION_SHAPES = {
+    "qwen2-kv2-d64": CacheShape(
+        2,
+        64,
+        "vllm_musa/v1/attention/backends/flash_attn.py::"
+        "fused_rope_kvcache_supported",
+    ),
+    "qwen3-kv8-d128": CacheShape(
+        8,
+        128,
+        "vllm_musa/v1/attention/backends/flash_attn.py::"
+        "qwen3_qk_rope_kvcache_supported",
+    ),
+    "qwen3-kv1-d256": CacheShape(
+        1,
+        256,
+        "vllm_musa/v1/attention/backends/flash_attn.py::"
+        "qwen3_qk_rope_kvcache_supported",
+    ),
+    "qwen3-kv2-d256": CacheShape(
+        2,
+        256,
+        "vllm_musa/v1/attention/backends/flash_attn.py::"
+        "qwen3_qk_rope_kvcache_supported",
+    ),
+}
+
+
+def parse_block_x(value: str) -> int:
+    try:
+        block_x = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("BLOCK_X must be an integer") from exc
+    if block_x not in SUPPORTED_BLOCK_X:
+        raise argparse.ArgumentTypeError(
+            f"BLOCK_X must be one of {SUPPORTED_BLOCK_X}, got {block_x}"
+        )
+    return block_x
+
+
+def parse_production_tokens(value: str) -> int:
+    try:
+        tokens = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("tokens must be an integer") from exc
+    if tokens not in PRODUCTION_TOKEN_BUCKETS:
+        raise argparse.ArgumentTypeError(
+            "tokens must be a checked production bucket in "
+            f"{PRODUCTION_TOKEN_BUCKETS}, got {tokens}"
+        )
+    return tokens
+
+
+def production_tokens_per_block(shape: CacheShape) -> int:
+    if shape.vecs_per_token <= 64:
+        return 8
+    if shape.vecs_per_token <= 128:
+        return 4
+    if shape.vecs_per_token <= 256:
+        return 2
+    return 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shapes",
+        choices=tuple(PRODUCTION_SHAPES),
+        nargs="+",
+        required=True,
+    )
+    parser.add_argument(
+        "--tokens",
+        type=parse_production_tokens,
+        nargs="+",
+        required=True,
+    )
+    parser.add_argument(
+        "--blocks",
+        type=parse_block_x,
+        nargs="+",
+        default=list(SUPPORTED_BLOCK_X),
+    )
+    parser.add_argument("--dtype", choices=("bf16", "fp16"), default="bf16")
+    parser.add_argument("--dry-runs", type=int, default=4)
+    parser.add_argument("--repeats", type=int, default=32)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--expected-physical-device", type=int, required=True)
+    parser.add_argument("--expected-device-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def _load_runtime() -> tuple[Any, Any]:
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    from vllm_musa import _custom_ops as musa_ops
+    # isort: on
+
+    return torch, musa_ops
+
+
+def _launch(
+    musa_ops: Any,
+    key: Any,
+    value: Any,
+    key_cache: Any,
+    value_cache: Any,
+    slot_mapping: Any,
+    block_x: int,
+) -> None:
+    musa_ops.musa_reshape_and_cache_flash_nhd(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        block_x=block_x,
+    )
+
+
+def _reference_cache_write(
+    torch: Any,
+    key: Any,
+    value: Any,
+    key_cache: Any,
+    value_cache: Any,
+    slot_mapping: Any,
+) -> None:
+    valid = slot_mapping >= 0
+    valid_slots = slot_mapping[valid]
+    block_indices = torch.div(valid_slots, CACHE_BLOCK_SIZE, rounding_mode="floor")
+    block_offsets = torch.remainder(valid_slots, CACHE_BLOCK_SIZE)
+    key_cache[block_indices, block_offsets] = key[valid]
+    value_cache[block_indices, block_offsets] = value[valid]
+
+
+def _check_correctness(
+    torch: Any,
+    musa_ops: Any,
+    key: Any,
+    value: Any,
+    initial_key_cache: Any,
+    initial_value_cache: Any,
+    slot_mapping: Any,
+    block_x: int,
+) -> dict[str, bool]:
+    correctness_slots = slot_mapping.clone()
+    if correctness_slots.numel() > 1:
+        correctness_slots[-1] = -1
+    expected_key = initial_key_cache.clone()
+    expected_value = initial_value_cache.clone()
+    _reference_cache_write(
+        torch,
+        key,
+        value,
+        expected_key,
+        expected_value,
+        correctness_slots,
+    )
+
+    actual_key = initial_key_cache.clone()
+    actual_value = initial_value_cache.clone()
+    _launch(
+        musa_ops,
+        key,
+        value,
+        actual_key,
+        actual_value,
+        correctness_slots,
+        block_x,
+    )
+    torch.musa.synchronize()
+    key_equal = bool(torch.equal(expected_key, actual_key))
+    value_equal = bool(torch.equal(expected_value, actual_value))
+    finite = bool(
+        torch.isfinite(actual_key).all().item()
+        and torch.isfinite(actual_value).all().item()
+    )
+    changed = bool(
+        not torch.equal(initial_key_cache, actual_key)
+        and not torch.equal(initial_value_cache, actual_value)
+    )
+    negative_key = initial_key_cache.clone()
+    negative_value = initial_value_cache.clone()
+    negative_slots = torch.full_like(slot_mapping, -1)
+    _launch(
+        musa_ops,
+        key,
+        value,
+        negative_key,
+        negative_value,
+        negative_slots,
+        block_x,
+    )
+    torch.musa.synchronize()
+    negative_slot_unchanged = bool(
+        torch.equal(initial_key_cache, negative_key)
+        and torch.equal(initial_value_cache, negative_value)
+    )
+    return {
+        "passed": (
+            key_equal and value_equal and finite and changed and negative_slot_unchanged
+        ),
+        "key_bit_equal": key_equal,
+        "value_bit_equal": value_equal,
+        "finite": finite,
+        "changed_from_poison": changed,
+        "negative_slot_unchanged": negative_slot_unchanged,
+    }
+
+
+def _measure_ms(
+    torch: Any,
+    flush: Any,
+    launch: Any,
+) -> float:
+    flush.zero_()
+    start = torch.musa.Event(enable_timing=True)
+    end = torch.musa.Event(enable_timing=True)
+    start.record()
+    launch()
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end))
+
+
+def _benchmark_pair(
+    torch: Any,
+    flush: Any,
+    launch_baseline: Any,
+    launch_candidate: Any,
+    dry_runs: int,
+    repeats: int,
+) -> dict[str, Any]:
+    for dry_run in range(dry_runs):
+        (launch_candidate if dry_run % 2 else launch_baseline)()
+    torch.musa.synchronize()
+
+    baseline_samples: list[float] = []
+    candidate_samples: list[float] = []
+    paired_ratios: list[float] = []
+    for repeat in range(repeats):
+        order = ("baseline", "candidate")
+        if repeat % 2:
+            order = tuple(reversed(order))
+        measured: dict[str, float] = {}
+        for variant in order:
+            launch = launch_baseline if variant == "baseline" else launch_candidate
+            measured[variant] = _measure_ms(torch, flush, launch)
+        baseline_ms = measured["baseline"]
+        candidate_ms = measured["candidate"]
+        if baseline_ms <= 0 or candidate_ms <= 0:
+            raise RuntimeError(
+                "MUSA event timing must be positive, got "
+                f"baseline={baseline_ms}, candidate={candidate_ms}"
+            )
+        baseline_samples.append(baseline_ms)
+        candidate_samples.append(candidate_ms)
+        paired_ratios.append(candidate_ms / baseline_ms)
+
+    return {
+        "baseline_samples_ms": baseline_samples,
+        "candidate_samples_ms": candidate_samples,
+        "paired_ratios": paired_ratios,
+        "baseline_median_ms": statistics.median(baseline_samples),
+        "candidate_median_ms": statistics.median(candidate_samples),
+        "median_ratio": statistics.median(paired_ratios),
+        "ratio_p95": percentile(paired_ratios, 0.95),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    if min(args.dry_runs, args.repeats, args.l2_flush_mb) <= 0:
+        raise ValueError("timing arguments must be positive")
+    if len(set(args.shapes)) != len(args.shapes):
+        raise ValueError("shapes must not contain duplicates")
+    if len(set(args.tokens)) != len(args.tokens):
+        raise ValueError("tokens must not contain duplicates")
+    if len(set(args.blocks)) != len(args.blocks):
+        raise ValueError("blocks must not contain duplicates")
+    tokens_per_block_override = os.environ.get(
+        "VLLM_MUSA_RESHAPE_CACHE_TOKENS_PER_BLOCK"
+    )
+    if tokens_per_block_override is not None:
+        raise RuntimeError(
+            "unset VLLM_MUSA_RESHAPE_CACHE_TOKENS_PER_BLOCK for an unbiased "
+            "production-selector comparison"
+        )
+
+    lease_device_fence = verify_lease_device_fence(
+        args.expected_physical_device,
+        args.expected_device_uuid,
+    )
+    torch, musa_ops = _load_runtime()
+    if not torch.musa.is_available() or torch.musa.device_count() != 1:
+        raise RuntimeError("NHD cache benchmark requires exactly one visible GPU")
+
+    device = torch.device("musa")
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+    properties = torch.musa.get_device_properties(0)
+    flush = torch.empty(
+        args.l2_flush_mb * 1024 * 1024,
+        dtype=torch.uint8,
+        device=device,
+    )
+    rows: list[dict[str, Any]] = []
+
+    for shape_index, shape_name in enumerate(args.shapes):
+        shape = PRODUCTION_SHAPES[shape_name]
+        for tokens in args.tokens:
+            torch.manual_seed(args.seed + shape_index * 10000 + tokens)
+            key = torch.randn(
+                (tokens, shape.num_kv_heads, shape.head_size),
+                dtype=dtype,
+                device=device,
+            )
+            value = torch.randn_like(key)
+            slot_offset = 17
+            num_blocks = (
+                slot_offset + tokens + CACHE_BLOCK_SIZE - 1
+            ) // CACHE_BLOCK_SIZE
+            initial_key_cache = torch.randn(
+                (num_blocks, CACHE_BLOCK_SIZE, shape.num_kv_heads, shape.head_size),
+                dtype=dtype,
+                device=device,
+            )
+            initial_value_cache = torch.randn_like(initial_key_cache)
+            slot_mapping = (
+                torch.arange(tokens, dtype=torch.int64, device=device) + slot_offset
+            )
+
+            baseline_key_cache = initial_key_cache.clone()
+            baseline_value_cache = initial_value_cache.clone()
+            baseline_correctness = _check_correctness(
+                torch,
+                musa_ops,
+                key,
+                value,
+                initial_key_cache,
+                initial_value_cache,
+                slot_mapping,
+                0,
+            )
+
+            for candidate_block_x in args.blocks:
+                candidate_key_cache = initial_key_cache.clone()
+                candidate_value_cache = initial_value_cache.clone()
+                candidate_correctness = _check_correctness(
+                    torch,
+                    musa_ops,
+                    key,
+                    value,
+                    initial_key_cache,
+                    initial_value_cache,
+                    slot_mapping,
+                    candidate_block_x,
+                )
+
+                def launch_baseline() -> None:
+                    _launch(
+                        musa_ops,
+                        key,
+                        value,
+                        baseline_key_cache,
+                        baseline_value_cache,
+                        slot_mapping,
+                        0,
+                    )
+
+                def launch_candidate() -> None:
+                    _launch(
+                        musa_ops,
+                        key,
+                        value,
+                        candidate_key_cache,
+                        candidate_value_cache,
+                        slot_mapping,
+                        candidate_block_x,
+                    )
+
+                timing = _benchmark_pair(
+                    torch,
+                    flush,
+                    launch_baseline,
+                    launch_candidate,
+                    args.dry_runs,
+                    args.repeats,
+                )
+                io_bytes = 4 * tokens * shape.num_kv_heads * shape.head_size * 2
+                baseline_seconds = timing["baseline_median_ms"] / 1000.0
+                candidate_seconds = timing["candidate_median_ms"] / 1000.0
+                rows.append(
+                    {
+                        "shape": shape_name,
+                        "shape_source": shape.source,
+                        "tokens": tokens,
+                        "num_kv_heads": shape.num_kv_heads,
+                        "head_size": shape.head_size,
+                        "cache_block_size": CACHE_BLOCK_SIZE,
+                        "vecs_per_token": shape.vecs_per_token,
+                        "tokens_per_block": production_tokens_per_block(shape),
+                        "baseline_block_x": PRODUCTION_DEFAULT_BLOCK_X,
+                        "candidate_block_x": candidate_block_x,
+                        "baseline_correctness": baseline_correctness,
+                        "candidate_correctness": candidate_correctness,
+                        "io_bytes": io_bytes,
+                        "baseline_gbps": io_bytes / baseline_seconds / 1e9,
+                        "candidate_gbps": io_bytes / candidate_seconds / 1e9,
+                        "speedup_pct": (
+                            timing["baseline_median_ms"] / timing["candidate_median_ms"]
+                            - 1.0
+                        )
+                        * 100.0,
+                        **timing,
+                    }
+                )
+
+    payload = {
+        "schema": "vllm-musa-reshape-cache-nhd-block-x.v1",
+        "benchmark": "reshape-cache-nhd-block-x",
+        "kernel_name": "reshape_and_cache_flash_nhd_kernel",
+        "kernel_source": "csrc/musa/cache_kernels.mu",
+        "production_consumers": list(PRODUCTION_CONSUMERS),
+        "consumer_scope": (
+            "generic NHD fallback and prefill cache writes; successful fused "
+            "Qwen2/Qwen3 cache-out paths can bypass this standalone op"
+        ),
+        "production_default_block_x": PRODUCTION_DEFAULT_BLOCK_X,
+        "supported_candidate_block_x": list(SUPPORTED_BLOCK_X),
+        "token_bucket_sources": list(TOKEN_BUCKET_SOURCES),
+        "device_name": torch.musa.get_device_name(0),
+        "device_capability": list(torch.musa.get_device_capability(0)),
+        "multiprocessor_count": int(properties.multi_processor_count),
+        "lease_device_fence": lease_device_fence,
+        "timing": {
+            "dry_runs": args.dry_runs,
+            "repeats": args.repeats,
+            "inner_iters": 1,
+            "l2_flush_mb": args.l2_flush_mb,
+            "paired_alternating_order": True,
+        },
+        "provenance": provenance(Path(__file__)),
+        "rows": rows,
+    }
+    emit_payload(payload, args.output)
+    return (
+        0
+        if all(
+            row["baseline_correctness"]["passed"]
+            and row["candidate_correctness"]["passed"]
+            for row in rows
+        )
+        else 1
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/benchmark_rmsnorm_inductor.py
+++ b/benchmarks/kernel_tactics/benchmark_rmsnorm_inductor.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Cold-L2 paired A/B for native Inductor versus an exploratory RMSNorm HOP."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+from pathlib import Path
+from typing import Any, Callable
+
+from _benchmark_utils import (
+    emit_payload,
+    percentile,
+    provenance,
+    verify_lease_device_fence,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, default=512)
+    parser.add_argument("--hidden-size", type=int, default=5120)
+    parser.add_argument("--num-warps", type=int, nargs="+", default=[1, 2, 4, 8])
+    parser.add_argument("--chain", choices=("op", "scale"), default="op")
+    parser.add_argument("--dry-runs", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=64)
+    parser.add_argument("--l2-flush-mb", type=int, default=8192)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--expected-physical-device", type=int)
+    parser.add_argument("--expected-device-uuid")
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def _load_runtime() -> tuple[Any, Any, Any, Any]:
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    import torch.nn.functional as functional
+    # isort: on
+
+    from _rmsnorm_inductor_candidate import rms_norm_triton
+
+    return torch, functional, rms_norm_triton, torch._inductor.config
+
+
+def _compile_functions(
+    torch: Any,
+    functional: Any,
+    rms_norm_triton: Any,
+    *,
+    hidden_size: int,
+    chain: str,
+    candidates: list[int],
+) -> tuple[Callable[..., Any], dict[int, Callable[..., Any]]]:
+    def finish(output: Any, post_scale: Any) -> Any:
+        return output if chain == "op" else output * post_scale
+
+    def native(input_tensor: Any, weight: Any, post_scale: Any) -> Any:
+        output = functional.rms_norm(
+            input_tensor,
+            (hidden_size,),
+            weight,
+            eps=1e-6,
+        )
+        return finish(output, post_scale)
+
+    native_compiled = torch.compile(native, fullgraph=True, dynamic=False)
+    candidate_compiled: dict[int, Callable[..., Any]] = {}
+    for num_warps in candidates:
+
+        def candidate(
+            input_tensor: Any,
+            weight: Any,
+            post_scale: Any,
+            *,
+            _num_warps: int = num_warps,
+        ) -> Any:
+            output = rms_norm_triton(
+                input_tensor,
+                weight,
+                1e-6,
+                num_warps=_num_warps,
+            )
+            return finish(output, post_scale)
+
+        candidate_compiled[num_warps] = torch.compile(
+            candidate,
+            fullgraph=True,
+            dynamic=False,
+        )
+    return native_compiled, candidate_compiled
+
+
+def main() -> int:
+    args = parse_args()
+    if args.rows <= 0 or args.hidden_size <= 0:
+        raise ValueError("rows and hidden-size must be positive")
+    if args.repeats <= 0 or args.dry_runs < 0:
+        raise ValueError("repeats must be positive and dry-runs non-negative")
+    if any(item not in (1, 2, 4, 8) for item in args.num_warps):
+        raise ValueError("num-warps candidates must be chosen from 1, 2, 4, 8")
+
+    lease_device_fence = verify_lease_device_fence(
+        expected_physical_device=args.expected_physical_device,
+        expected_device_uuid=args.expected_device_uuid,
+    )
+    torch, functional, rms_norm_triton, inductor_config = _load_runtime()
+    torch.manual_seed(args.seed)
+    torch.musa.set_device(0)
+    inductor_config.force_disable_caches = True
+
+    from vllm_musa.tuning import prime_musa_kernel_hardware
+
+    hardware = prime_musa_kernel_hardware(0)
+    properties = torch.musa.get_device_properties(0)
+    input_tensor = torch.randn(
+        (args.rows, args.hidden_size),
+        device="musa",
+        dtype=torch.bfloat16,
+    )
+    weight = torch.randn(
+        (args.hidden_size,),
+        device="musa",
+        dtype=torch.bfloat16,
+    )
+    post_scale = torch.randn_like(input_tensor)
+    flush_elements = max(1, args.l2_flush_mb * 1024 * 1024 // 4)
+    flush = torch.empty(flush_elements, device="musa", dtype=torch.float32)
+
+    native, candidates = _compile_functions(
+        torch,
+        functional,
+        rms_norm_triton,
+        hidden_size=args.hidden_size,
+        chain=args.chain,
+        candidates=args.num_warps,
+    )
+    expected = native(input_tensor, weight, post_scale)
+    torch.musa.synchronize()
+
+    rows_out = []
+    for num_warps, candidate in candidates.items():
+        actual = candidate(input_tensor, weight, post_scale)
+        torch.musa.synchronize()
+        torch.testing.assert_close(
+            actual.float(), expected.float(), rtol=2e-2, atol=2e-2
+        )
+        correctness = bool(torch.isfinite(actual).all().item())
+
+        for dry_run in range(args.dry_runs):
+            (native if dry_run % 2 == 0 else candidate)(
+                input_tensor, weight, post_scale
+            )
+        torch.musa.synchronize()
+
+        baseline_samples: list[float] = []
+        candidate_samples: list[float] = []
+        for repeat in range(args.repeats):
+            order = (
+                (("baseline", native), ("candidate", candidate))
+                if repeat % 2 == 0
+                else (("candidate", candidate), ("baseline", native))
+            )
+            measured: dict[str, float] = {}
+            for name, launch in order:
+                flush.zero_()
+                start = torch.musa.Event(enable_timing=True)
+                end = torch.musa.Event(enable_timing=True)
+                start.record()
+                launch(input_tensor, weight, post_scale)
+                end.record()
+                end.synchronize()
+                measured[name] = float(start.elapsed_time(end))
+            baseline_samples.append(measured["baseline"])
+            candidate_samples.append(measured["candidate"])
+
+        ratios = [
+            candidate_ms / baseline_ms
+            for baseline_ms, candidate_ms in zip(
+                baseline_samples, candidate_samples, strict=True
+            )
+        ]
+        baseline_median = statistics.median(baseline_samples)
+        candidate_median = statistics.median(candidate_samples)
+        rows_out.append(
+            {
+                "rows": args.rows,
+                "hidden_size": args.hidden_size,
+                "chain": args.chain,
+                "candidate_num_warps": num_warps,
+                "baseline": "torch.compile(F.rms_norm)",
+                "candidate": "torch.compile(benchmark-local wrap_triton RMSNorm)",
+                "baseline_samples_ms": baseline_samples,
+                "candidate_samples_ms": candidate_samples,
+                "baseline_median_ms": baseline_median,
+                "candidate_median_ms": candidate_median,
+                "median_ratio": statistics.median(ratios),
+                "ratio_p95": percentile(ratios, 0.95),
+                "ratio_p99": percentile(ratios, 0.99),
+                "speedup_pct": (baseline_median / candidate_median - 1.0) * 100.0,
+                "correctness_pass": correctness,
+                "cache_policy": "cold-l2-per-sample",
+            }
+        )
+
+    emit_payload(
+        {
+            "schema": "musa-rmsnorm-inductor-paired-ab.v2",
+            "candidate_kind": "exploratory-rejected",
+            "device_name": torch.musa.get_device_name(0),
+            "device_capability": [int(properties.major), int(properties.minor)],
+            "multiprocessor_count": int(properties.multi_processor_count),
+            "primed_hardware": {
+                "device_capability": list(hardware.device_capability),
+                "multiprocessor_count": hardware.multiprocessor_count,
+            },
+            "lease_device_fence": lease_device_fence,
+            "benchmark": {
+                "dry_runs": args.dry_runs,
+                "repeats": args.repeats,
+                "l2_flush_mb": args.l2_flush_mb,
+                "l2_flush_bytes": flush.numel() * flush.element_size(),
+                "flush_before_every_timed_launch": True,
+                "paired_alternating_order": True,
+                "inductor_cache_disabled": True,
+            },
+            "kernel_source": (
+                "benchmarks/kernel_tactics/_rmsnorm_inductor_candidate.py"
+            ),
+            "provenance": provenance(Path(__file__)),
+            "rows": rows_out,
+        },
+        args.output,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/full_kernel_sweep.json
+++ b/benchmarks/kernel_tactics/full_kernel_sweep.json
@@ -1,0 +1,1329 @@
+{
+  "allowed_dispositions": [
+    "pending",
+    "no-tunable-seam",
+    "external-provider-excluded",
+    "non-production"
+  ],
+  "families": [
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-deepseek-v4-c4-indexer-compress-cache",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_c4_indexer_compress_cache"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/patches/series/0093-MUSA-dispatch-DeepSeek-V4-C4-indexer-compression-to-.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "aot-native-deepseek-v4-combine-topk-swa-indices",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_combine_topk_swa_indices"
+      ],
+      "notes": "Registered local wrapper has no caller in the v0.28 patch series.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "aot-native-deepseek-v4-compute-global-topk-indices-and-lens",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_compute_global_topk_indices_and_lens"
+      ],
+      "notes": "Registered local wrapper has no caller in the v0.28 patch series.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "aot-native-deepseek-v4-dequantize-and-gather-k-cache",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_dequantize_and_gather_k_cache"
+      ],
+      "notes": "Registered local wrapper has no caller in the v0.28 patch series.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-deepseek-v4-fused-inv-rope-fp8-quant",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_fused_inv_rope_fp8_quant"
+      ],
+      "notes": "The fused inverse-rope/FP8 path has fixed launch geometry and no benchmark-safe per-call tile argument.",
+      "production_consumers": [
+        "vllm_musa/patches/series/0014-MUSA-vllm.models.deepseek_v4.attention.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "aot-native-deepseek-v4-fused-q-kv-rmsnorm",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_fused_q_kv_rmsnorm"
+      ],
+      "notes": "Current DSV4 path uses qnorm/rope/KV insert instead.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-deepseek-v4-indexer-rerank-prefill",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_indexer_rerank_prefill"
+      ],
+      "notes": "Prefill rerank launch is fixed by the semantic indexer shape.",
+      "production_consumers": [
+        "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-deepseek-v4-indexer-topk-decode",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_indexer_topk_decode"
+      ],
+      "notes": "Decode top-k launch is fixed by the indexer contract.",
+      "production_consumers": [
+        "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-deepseek-v4-indexer-topk-prefill",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_indexer_topk_prefill"
+      ],
+      "notes": "Prefill top-k launch is fixed by the indexer contract.",
+      "production_consumers": [
+        "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-deepseek-v4-mhc-pre",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_mhc_pre"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/deepseek_v4_mhc.py",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-deepseek-v4-qnorm-rope-kv-insert",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_qnorm_rope_kv_insert"
+      ],
+      "notes": "QNorm/rope/KV insertion is a fixed one-token path; changing its launch shape requires a new correctness and graph-capture design.",
+      "production_consumers": [
+        "vllm_musa/patches/series/0014-MUSA-vllm.models.deepseek_v4.attention.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "external-provider-excluded",
+      "id": "aot-native-deepseek-v4-sparse-flashmla-decode",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_sparse_flashmla_decode"
+      ],
+      "notes": "Production sparse FlashMLA is provided by MATE and excluded.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "aot-native-deepseek-v4-store-sparse-kv",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_store_sparse_kv"
+      ],
+      "notes": "Current DSV4 path uses fused qnorm/rope/KV insert instead.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "aot-native-deepseek-v4-topk-softplus-sqrt",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:deepseek_v4_topk_softplus_sqrt"
+      ],
+      "notes": "No v0.28 production caller was found.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py",
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-fused-add-rms-norm-per-token-group-fp8-quant",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:fused_add_rms_norm_per_token_group_fp8_quant"
+      ],
+      "notes": "The production kernel is fixed to H=4096, group size 128, and kThreads=512. The catalog's former block_threads/vector_width labels were hypotheses, not a real ABI or benchmark seam.",
+      "production_consumers": [
+        "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json",
+        "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json"
+      ],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-glm52-indexer-topk-decode",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:glm52_indexer_topk_decode"
+      ],
+      "notes": "GLM52 decode top-k launch is fixed by the semantic contract.",
+      "production_consumers": [
+        "vllm_musa/patches/series/0085-MUSA-vllm.v1.attention.backends.mla.indexer.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-glm52-indexer-topk-prefill",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:glm52_indexer_topk_prefill"
+      ],
+      "notes": "GLM52 prefill top-k launch is fixed by the semantic contract.",
+      "production_consumers": [
+        "vllm_musa/patches/series/0085-MUSA-vllm.v1.attention.backends.mla.indexer.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "external-provider-excluded",
+      "id": "aot-native-min-p-sampling-from-probs",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:min_p_sampling_from_probs"
+      ],
+      "notes": "",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-musa-chunked-min-p-sampling-from-probs",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:musa_chunked_min_p_sampling_from_probs"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/_custom_ops.py",
+        "vllm_musa/v1/sample/topk_topp_sampler.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_fused_add_rmsnorm_paired_ab.py",
+      "disposition": "pending",
+      "id": "aot-native-musa-fused-add-rms-norm",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:musa_fused_add_rms_norm"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/_custom_ops.py",
+        "vllm_musa/kernels/musa_ops.py",
+        "vllm_musa/model_executor/layers/layernorm.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": [
+        "block_x"
+      ]
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_dense_fp8_gemv_blocks.py",
+      "disposition": "pending",
+      "id": "aot-native-musa-fused-gemv",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:musa_fused_gemv"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        "vllm_musa/deepseek_v4_jit/fp8_einsum.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": [
+        "block_n",
+        "block_k"
+      ]
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_fused_gemv_moe_blocks.py",
+      "disposition": "pending",
+      "id": "aot-native-musa-fused-gemv-moe",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:musa_fused_gemv_moe"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/model_executor/layers/fused_moe/fused_moe.py",
+        "vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": [
+        "w1_block_n",
+        "w1_block_k",
+        "w2_block_n",
+        "w2_block_k"
+      ]
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_reshape_cache_nhd_blocks.py",
+      "disposition": "pending",
+      "id": "aot-native-musa-reshape-and-cache-flash-nhd",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:musa_reshape_and_cache_flash_nhd"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/v1/attention/backends/fa_utils.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/benchmark_reshape_cache_nhd_blocks.py::NHD_SHAPES"
+      ],
+      "tunable_parameters": [
+        "block_x"
+      ]
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-musa-rubymine-top-k-renorm-probs",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:musa_rubymine_top_k_renorm_probs"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/_custom_ops.py",
+        "vllm_musa/v1/sample/topk_topp_sampler.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-musa-top-k-top-p-sampling-from-probs",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:musa_top_k_top_p_sampling_from_probs"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/_custom_ops.py",
+        "vllm_musa/v1/sample/topk_topp_sampler.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py",
+      "disposition": "pending",
+      "id": "aot-native-per-token-group-quant-8bit-vec",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:per_token_group_quant_8bit_vec"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": [
+        "groups_per_block"
+      ]
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py",
+      "disposition": "pending",
+      "id": "aot-native-silu-and-mul-clamp-per-token-group-fp8-quant",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:silu_and_mul_clamp_per_token_group_fp8_quant"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": [
+        "groups_per_block"
+      ]
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py",
+      "disposition": "pending",
+      "id": "aot-native-silu-and-mul-per-token-group-fp8-quant",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:silu_and_mul_per_token_group_fp8_quant"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        "vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": [
+        "groups_per_block"
+      ]
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-sparse-indexer-fill-all",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:sparse_indexer_fill_all"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-sparse-indexer-topk",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:sparse_indexer_topk"
+      ],
+      "notes": "Sparse-indexer top-k geometry is fixed by the index format.",
+      "production_consumers": [
+        "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "aot-native-sparse-indexer-topk-decode",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:sparse_indexer_topk_decode"
+      ],
+      "notes": "Sparse-indexer decode geometry is fixed by the index format.",
+      "production_consumers": [
+        "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+        "vllm_musa/_custom_ops.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "external-provider-excluded",
+      "id": "aot-native-top-k-renorm-probs",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:top_k_renorm_probs"
+      ],
+      "notes": "",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "external-provider-excluded",
+      "id": "aot-native-top-p-renorm-probs",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:top_p_renorm_probs"
+      ],
+      "notes": "",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "aot-native"
+      ],
+      "benchmark": null,
+      "disposition": "external-provider-excluded",
+      "id": "aot-native-top-p-sampling-from-probs",
+      "members": [
+        "aot-native:csrc/musa/torch_bindings.cpp:top_p_sampling_from_probs"
+      ],
+      "notes": "",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-native-ffi"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-native-custom-allreduce",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu:vllm_musa_custom_ar_launch_all_gather",
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu:vllm_musa_custom_ar_launch_graph_registered",
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu:vllm_musa_custom_ar_launch_registered",
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu:vllm_musa_custom_ar_launch_unregistered",
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu:vllm_musa_custom_ar_meta_size",
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu:vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered",
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu:vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered",
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu:vllm_musa_fused_ar_rmsnorm_launch_unregistered"
+      ],
+      "notes": "Peer count and payload size select the collective path, but the vLLM-MUSA wrapper exposes no active-MP block/thread override.",
+      "production_consumers": [
+        "vllm_musa/distributed/device_communicators/custom_all_reduce.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-native",
+        "jit-native-ffi"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_jit_rmsnorm_threads.py",
+      "disposition": "pending",
+      "id": "jit-native-fused-add-rmsnorm",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/norm/rmsnorm.mu:sgl_musa_fused_add_rmsnorm",
+        "jit-native:vllm_musa/jit_kernel/csrc/norm.py:musa_csrc_fused_add_rmsnorm"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/model_executor/layers/layernorm.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json"
+      ],
+      "tunable_parameters": [
+        "block_threads"
+      ]
+    },
+    {
+      "backend_classes": [
+        "jit-native",
+        "jit-native-ffi"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-native-fused-qk-rmsnorm-mrope",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/norm/qk_mrope.mu:sgl_musa_fused_qk_rmsnorm_mrope",
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/norm/qk_mrope.mu:sgl_musa_fused_qk_rmsnorm_mrope_cache",
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/norm/qk_mrope.mu:sgl_musa_fused_qk_rmsnorm_mrope_cache_out",
+        "jit-native:vllm_musa/jit_kernel/csrc/norm.py:musa_csrc_fused_qk_rmsnorm_mrope",
+        "jit-native:vllm_musa/jit_kernel/csrc/norm.py:musa_csrc_fused_qk_rmsnorm_mrope_cache_out"
+      ],
+      "notes": "The production FFI wrapper compiles one fixed launch contract.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/csrc/fused_qk_rmsnorm_mrope.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-native",
+        "jit-native-ffi"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-native-moe-act-and-mul",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/moe/act_and_mul.mu:sgl_musa_moe_act_and_mul",
+        "jit-native:vllm_musa/jit_kernel/csrc/moe.py:musa_fast_silu_and_mul"
+      ],
+      "notes": "The activation fusion has no per-call MP launch selector.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/csrc/moe/moe_act_and_mul.py",
+        "vllm_musa/model_executor/layers/fused_moe/fused_moe.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-native",
+        "jit-native-ffi"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-native-moe-sum",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/moe/moe_sum_reduce.mu:sgl_musa_moe_sum_reduce",
+        "jit-native:vllm_musa/jit_kernel/csrc/moe.py:musa_fast_moe_sum"
+      ],
+      "notes": "The MoE sum launch geometry is fixed by the current FFI wrapper.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/csrc/moe/moe_sum.py",
+        "vllm_musa/model_executor/layers/fused_moe/fused_moe.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-native",
+        "jit-native-ffi"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-native-per-token-group-quant",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/quant/per_token_group_quant_8bit_v2.mu:sgl_per_token_group_quant_8bit_v2",
+        "jit-native:vllm_musa/jit_kernel/csrc/quant.py:musa_csrc_per_token_group_quant_8bit"
+      ],
+      "notes": "The JIT quant wrapper exposes no groups-per-block MP seam.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/csrc/quantization/quant_per_token_group.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-native",
+        "jit-native-ffi"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_jit_rmsnorm_threads.py",
+      "disposition": "pending",
+      "id": "jit-native-rmsnorm",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/norm/rmsnorm.mu:sgl_musa_rmsnorm",
+        "jit-native:vllm_musa/jit_kernel/csrc/norm.py:musa_csrc_rmsnorm"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/model_executor/layers/layernorm.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json"
+      ],
+      "tunable_parameters": [
+        "block_threads"
+      ]
+    },
+    {
+      "backend_classes": [
+        "jit-native",
+        "jit-native-ffi"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-native-rotary-embedding",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/rope/rotary_embedding.mu:sgl_rotary_embedding",
+        "jit-native:vllm_musa/jit_kernel/csrc/rope.py:musa_rotary_embedding"
+      ],
+      "notes": "Rotary launch geometry is fixed by the current production ABI.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/csrc/rotary_embedding.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-native",
+        "jit-native-ffi"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_jit_topk_warps.py",
+      "disposition": "pending",
+      "id": "jit-native-topk-sigmoid",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/topk/topk_gating.mu:sgl_musa_topk_sigmoid",
+        "jit-native:vllm_musa/jit_kernel/csrc/topk.py:musa_topk_sigmoid"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": [
+        "warps_per_cta"
+      ]
+    },
+    {
+      "backend_classes": [
+        "jit-native",
+        "jit-native-ffi"
+      ],
+      "benchmark": "benchmarks/kernel_tactics/benchmark_jit_topk_warps.py",
+      "disposition": "pending",
+      "id": "jit-native-topk-softmax",
+      "members": [
+        "jit-native-ffi:vllm_musa/jit_kernel/csrc/topk/topk_gating.mu:sgl_musa_topk_softmax",
+        "jit-native:vllm_musa/jit_kernel/csrc/topk.py:musa_topk_softmax"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": [
+        "warps_per_cta"
+      ]
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-causal-conv1d-decode-width4-batched-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/causal_conv1d.py:_causal_conv1d_decode_width4_batched_kernel"
+      ],
+      "notes": "Width-4 batched decode uses a fixed TileLang schedule.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+        "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-causal-conv1d-fwd-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/causal_conv1d.py:_causal_conv1d_fwd_kernel"
+      ],
+      "notes": "Forward causal-conv uses a fixed TileLang schedule.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+        "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-causal-conv1d-fwd-width4-vec-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/causal_conv1d.py:_causal_conv1d_fwd_width4_vec_kernel"
+      ],
+      "notes": "Width-4 vector forward uses a fixed TileLang schedule.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+        "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-causal-conv1d-prefill-width4",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/causal_conv1d.py:_causal_conv1d_prefill_width4_body_kernel",
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/causal_conv1d.py:_causal_conv1d_prefill_width4_kernel"
+      ],
+      "notes": "Width-4 prefill uses a fixed TileLang schedule.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+        "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-deepgemm-contig-assign-compact",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_bf16_assign_compact_kernel",
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_fp8_assign_compact_kernel"
+      ],
+      "notes": "Compact assignment uses a fixed shape-derived config.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+        "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-deepgemm-contig-clear-fill",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_clear_i32_kernel",
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_fill_i32_kernel"
+      ],
+      "notes": "Clear/fill preprocessing uses a fixed shape-derived config.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+        "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-deepgemm-contig-count-prefix",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_count_prefix_topk_single_block_kernel",
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_count_topk_block_hist_kernel",
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_count_topk_single_block_kernel",
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_prefix_counts_kernel"
+      ],
+      "notes": "Count/prefix preprocessing uses a fixed shape-derived config.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+        "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-deepgemm-contig-scan-tree",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_prefix_counts_scan_kernel",
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py:_prefix_counts_tree_kernel"
+      ],
+      "notes": "Tree scan preprocessing uses a fixed shape-derived config.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+        "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+      ],
+      "shape_sources": [
+        "benchmarks/kernel_tactics/mp_tactic_campaign.json"
+      ],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "pending",
+      "id": "jit-tilelang-dsv4-mhc-pre-big-fuse",
+      "members": [
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:mhc_pre_big_fuse_decode_split_kernel",
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:mhc_pre_big_fuse_kernel"
+      ],
+      "notes": "",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "pending",
+      "id": "jit-tilelang-dsv4-mhc-weighted-rmsnorm",
+      "members": [
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:mhc_weighted_rmsnorm_kernel",
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:mhc_weighted_rmsnorm_mudnn_like_kernel"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/tuning.py",
+        "vllm_musa/deepseek_v4_jit/tilelang_kernels.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": [
+        "threads"
+      ]
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-fused-zba-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/gdn_fused_proj.py:_fused_zba_kernel"
+      ],
+      "notes": "The GDN projection fusion has one fixed TileLang schedule.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/gdn_fused_proj.py",
+        "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-grouped-topk",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/grouped_topk.py:_grouped_topk_parallel_kernel",
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/grouped_topk.py:_grouped_topk_serial_kernel"
+      ],
+      "notes": "Only a semantic serial/parallel crossover exists; geometry is fixed at 32 threads.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "jit-tilelang-kv-rope-pack-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:kv_rope_pack_kernel"
+      ],
+      "notes": "Only an orphan TileLang helper calls this factory; production uses AOT.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-mhc-fused-post-prenorm-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:mhc_fused_post_prenorm_kernel"
+      ],
+      "notes": "The factory accepts compile-time threads/tile/split parameters, but the production caller hardcodes them and exposes no per-call active-MP selector.",
+      "production_consumers": [
+        "vllm_musa/deepseek_v4_mhc.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "pending",
+      "id": "jit-tilelang-mhc-post-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:mhc_post_kernel"
+      ],
+      "notes": "",
+      "production_consumers": [
+        "vllm_musa/deepseek_v4_mhc.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "jit-tilelang-mhc-pre-split-sinkhorn-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:mhc_pre_split_sinkhorn_kernel"
+      ],
+      "notes": "The current auto selector never selects this fallback provider.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "jit-tilelang-mhc-prenorm-splitk-x-tme-cast-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:mhc_prenorm_splitk_x_tme_cast_kernel"
+      ],
+      "notes": "The current auto selector always selects DeepGEMM for this stage.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-musa-sparse-attention-fwd-kernel-v1",
+      "members": [
+        "jit-tilelang:vllm_musa/v1/attention/ops/sparse_mla_tilelang.py:musa_sparse_attention_fwd_kernel_v1"
+      ],
+      "notes": "Sparse MLA forward exposes no per-call MP schedule override.",
+      "production_consumers": [
+        "vllm_musa/v1/attention/ops/sparse_mla_tilelang.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "non-production",
+      "id": "jit-tilelang-qnorm-rope-kernel",
+      "members": [
+        "jit-tilelang:vllm_musa/deepseek_v4_jit/tilelang_kernels.py:qnorm_rope_kernel"
+      ],
+      "notes": "Only an orphan TileLang helper calls this factory; production uses AOT.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-tilelang"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-tilelang-rmsnorm-gated",
+      "members": [
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/layernorm_gated.py:_rms_norm_gated_kernel",
+        "jit-tilelang:vllm_musa/jit_kernel/tilelang/layernorm_gated.py:_rms_norm_gated_kernel_cta"
+      ],
+      "notes": "Gated RMSNorm uses a fixed TileLang schedule.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/tilelang/layernorm_gated.py",
+        "vllm_musa/model_executor/layers/layernorm.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-triton"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-triton-build-qwen-single-request-fa3-metadata-kernel",
+      "members": [
+        "jit-triton:vllm_musa/jit_kernel/fa3_metadata.py:_build_qwen_single_request_fa3_metadata_kernel"
+      ],
+      "notes": "",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-triton"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-triton-eagle-prepare-next-token-padded-kernel",
+      "members": [
+        "jit-triton:vllm_musa/v1/spec_decode/utils.py:eagle_prepare_next_token_padded_kernel"
+      ],
+      "notes": "Block size is the semantic next-power-of-two token capacity.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-triton"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-triton-extend-topk-with-shared-kernel",
+      "members": [
+        "jit-triton:vllm_musa/jit_kernel/extend_topk_shared.py:_extend_topk_with_shared_kernel"
+      ],
+      "notes": "Block size is fixed by the top-k semantic capacity.",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-triton"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-triton-fused-gdn-gating-kernel",
+      "members": [
+        "jit-triton:vllm_musa/jit_kernel/fused_gdn_gating.py:_fused_gdn_gating_kernel"
+      ],
+      "notes": "The Triton GDN gate has no active-MP launch selector.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/fused_gdn_gating.py",
+        "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-triton"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-triton-gated-qk-norm-rope-token-kernel",
+      "members": [
+        "jit-triton:vllm_musa/kernels/gated_qkv.py:_gated_qk_norm_rope_token_kernel"
+      ],
+      "notes": "The token kernel uses a fixed Triton schedule per shape.",
+      "production_consumers": [
+        "vllm_musa/kernels/gated_qkv.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-triton"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-triton-post-reorder-triton-kernel",
+      "members": [
+        "jit-triton:vllm_musa/jit_kernel/post_reorder.py:post_reorder_triton_kernel"
+      ],
+      "notes": "Post-reorder uses a fixed Triton schedule per shape.",
+      "production_consumers": [
+        "vllm_musa/jit_kernel/post_reorder.py",
+        "vllm_musa/model_executor/layers/fused_moe/fused_moe.py"
+      ],
+      "shape_sources": [],
+      "tunable_parameters": []
+    },
+    {
+      "backend_classes": [
+        "jit-triton"
+      ],
+      "benchmark": null,
+      "disposition": "no-tunable-seam",
+      "id": "jit-triton-qwen2-rope-kv-cache-kernel",
+      "members": [
+        "jit-triton:vllm_musa/kernels/qwen2_rope_kv.py:_qwen2_rope_kv_cache_kernel"
+      ],
+      "notes": "",
+      "production_consumers": [],
+      "shape_sources": [],
+      "tunable_parameters": []
+    }
+  ],
+  "schema": "vllm-musa-public-kernel-catalog.v1",
+  "scope": {
+    "callable_entrypoint_count": 101,
+    "external_provider_wrappers": "excluded",
+    "owned_implementations_only": true,
+    "physical_implementation_count": 152,
+    "physical_implementation_counts": {
+      "aot-native-physical": 36,
+      "jit-native-physical": 77,
+      "jit-tilelang-physical": 32,
+      "jit-triton-physical": 7
+    },
+    "physical_kernel_note": "Callable entries and physical definitions are separate denominators; physical_coverage() maps every definition.",
+    "repository": "vllm-musa",
+    "runtime_hardware_key": "multi_processor_count"
+  }
+}

--- a/benchmarks/kernel_tactics/inventory_vllm_musa_kernels.py
+++ b/benchmarks/kernel_tactics/inventory_vllm_musa_kernels.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Discover the vLLM-MUSA-owned AOT/JIT kernel coverage denominator.
+
+The discovery layer is intentionally source-only and stdlib-only. It does not
+decide whether a kernel is production reachable or tunable; the source-only
+classifications live in ``full_kernel_sweep.json``. Hardware qualification
+results are deliberately kept in local generated evidence. Keeping discovery
+separate lets a completeness test fail whenever a new kernel is added without
+an explicit campaign disposition.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+SCHEMA = "vllm-musa-owned-kernel-inventory.v1"
+AOT_BINDINGS = Path("csrc/musa/torch_bindings.cpp")
+JIT_CSRC_ROOT = Path("vllm_musa/jit_kernel/csrc")
+TILELANG_ROOTS = (
+    Path("vllm_musa/deepseek_v4_jit"),
+    Path("vllm_musa/jit_kernel/tilelang"),
+)
+TILELANG_FILES = (Path("vllm_musa/v1/attention/ops/sparse_mla_tilelang.py"),)
+REGISTER_CALLS = frozenset(
+    {
+        "_register",
+        "direct_register_custom_op",
+        "register_custom_op",
+    }
+)
+
+
+@dataclass(frozen=True, order=True)
+class KernelEntry:
+    id: str
+    backend: str
+    source: str
+    symbol: str
+    discovery: str
+
+
+def _source_files(root: Path, pattern: str = "*.py") -> Iterable[Path]:
+    if not root.exists():
+        return ()
+    return sorted(path for path in root.rglob(pattern) if path.is_file())
+
+
+def _call_name(call: ast.Call) -> str | None:
+    function = call.func
+    if isinstance(function, ast.Name):
+        return function.id
+    if isinstance(function, ast.Attribute):
+        return function.attr
+    return None
+
+
+def _decorator_name(decorator: ast.expr) -> str:
+    if isinstance(decorator, ast.Call):
+        return _decorator_name(decorator.func)
+    if isinstance(decorator, ast.Attribute):
+        prefix = _decorator_name(decorator.value)
+        return f"{prefix}.{decorator.attr}" if prefix else decorator.attr
+    if isinstance(decorator, ast.Name):
+        return decorator.id
+    return ""
+
+
+def _entry(
+    backend: str,
+    source: Path,
+    symbol: str,
+    discovery: str,
+) -> KernelEntry:
+    normalized_source = source.as_posix()
+    return KernelEntry(
+        id=f"{backend}:{normalized_source}:{symbol}",
+        backend=backend,
+        source=normalized_source,
+        symbol=symbol,
+        discovery=discovery,
+    )
+
+
+def discover_aot(root: Path) -> list[KernelEntry]:
+    source = root / AOT_BINDINGS
+    text = source.read_text(encoding="utf-8")
+    symbols = sorted(set(re.findall(r'\b\w+\.def\(\s*"([A-Za-z0-9_]+)\(', text)))
+    return [
+        _entry("aot-native", AOT_BINDINGS, symbol, "torch-library-binding")
+        for symbol in symbols
+    ]
+
+
+def discover_jit_native(root: Path) -> list[KernelEntry]:
+    entries: list[KernelEntry] = []
+    for source in _source_files(root / JIT_CSRC_ROOT):
+        relative = source.relative_to(root)
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        symbols: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or _call_name(node) not in REGISTER_CALLS:
+                continue
+            candidates = list(node.args[:1])
+            candidates.extend(
+                keyword.value for keyword in node.keywords if keyword.arg == "op_name"
+            )
+            for candidate in candidates:
+                if isinstance(candidate, ast.Constant) and isinstance(
+                    candidate.value, str
+                ):
+                    symbols.add(candidate.value)
+        entries.extend(
+            _entry("jit-native", relative, symbol, "custom-op-registration")
+            for symbol in sorted(symbols)
+        )
+    return entries
+
+
+def discover_jit_native_ffi(root: Path) -> list[KernelEntry]:
+    entries: list[KernelEntry] = []
+    pattern = re.compile(r"TVM_FFI_DLL_EXPORT_TYPED_FUNC\(\s*([A-Za-z0-9_]+)")
+    for source in _source_files(root / JIT_CSRC_ROOT, "*.mu"):
+        relative = source.relative_to(root)
+        symbols = sorted(set(pattern.findall(source.read_text(encoding="utf-8"))))
+        entries.extend(
+            _entry("jit-native-ffi", relative, symbol, "tvm-ffi-export")
+            for symbol in symbols
+        )
+    return entries
+
+
+def discover_triton(root: Path) -> list[KernelEntry]:
+    entries: list[KernelEntry] = []
+    for source in _source_files(root / "vllm_musa"):
+        relative = source.relative_to(root)
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for node in tree.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            decorators = {_decorator_name(item) for item in node.decorator_list}
+            if not any(name.endswith("triton.jit") for name in decorators):
+                continue
+            entries.append(_entry("jit-triton", relative, node.name, "triton-jit"))
+    return entries
+
+
+def _tilelang_files(root: Path) -> list[Path]:
+    sources: set[Path] = set()
+    for relative_root in TILELANG_ROOTS:
+        sources.update(_source_files(root / relative_root))
+    for relative in TILELANG_FILES:
+        source = root / relative
+        if source.is_file():
+            sources.add(source)
+    return sorted(sources)
+
+
+def discover_tilelang(root: Path) -> list[KernelEntry]:
+    entries: list[KernelEntry] = []
+    for source in _tilelang_files(root):
+        relative = source.relative_to(root)
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for node in tree.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            decorators = {_decorator_name(item) for item in node.decorator_list}
+            if node.name == "_prefix_counts_no_pad_kernel":
+                continue
+            if not node.name.endswith("kernel") and not any(
+                name.endswith("tilelang.jit") for name in decorators
+            ):
+                continue
+            entries.append(
+                _entry("jit-tilelang", relative, node.name, "tilelang-callable-factory")
+            )
+    return entries
+
+
+def discover(root: Path) -> list[KernelEntry]:
+    entries = [
+        *discover_aot(root),
+        *discover_jit_native(root),
+        *discover_jit_native_ffi(root),
+        *discover_triton(root),
+        *discover_tilelang(root),
+    ]
+    by_id = {entry.id: entry for entry in entries}
+    if len(by_id) != len(entries):
+        duplicates = sorted(
+            entry.id
+            for entry in entries
+            if sum(item.id == entry.id for item in entries) > 1
+        )
+        raise RuntimeError(f"duplicate discovered kernel ids: {duplicates}")
+    return sorted(entries)
+
+
+def payload(root: Path) -> dict[str, object]:
+    entries = discover(root)
+    counts: dict[str, int] = {}
+    for entry in entries:
+        counts[entry.backend] = counts.get(entry.backend, 0) + 1
+    return {
+        "schema": SCHEMA,
+        "root": str(root.resolve()),
+        "counts": counts,
+        "entries": [asdict(entry) for entry in entries],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+    )
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    document = json.dumps(payload(args.root), indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(document, end="")
+    else:
+        args.output.write_text(document, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/inventory_vllm_musa_physical_kernels.py
+++ b/benchmarks/kernel_tactics/inventory_vllm_musa_physical_kernels.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Discover physical kernel definitions owned by the vLLM-MUSA repository."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+SCHEMA = "vllm-musa-owned-physical-kernel-inventory.v1"
+NATIVE_ROOTS = (
+    ("aot-native-physical", Path("csrc/musa"), ("*.mu", "*.cu")),
+    ("jit-native-physical", Path("vllm_musa/jit_kernel/csrc"), ("*.mu",)),
+)
+TILELANG_ROOTS = (
+    Path("vllm_musa/deepseek_v4_jit"),
+    Path("vllm_musa/jit_kernel/tilelang"),
+)
+TILELANG_FILES = (Path("vllm_musa/v1/attention/ops/sparse_mla_tilelang.py"),)
+
+
+@dataclass(frozen=True, order=True)
+class PhysicalKernelEntry:
+    id: str
+    backend: str
+    source: str
+    symbol: str
+    line: int
+    owner: str | None
+    discovery: str
+
+
+def _source_files(root: Path, patterns: tuple[str, ...]) -> Iterable[Path]:
+    if not root.exists():
+        return ()
+    paths: set[Path] = set()
+    for pattern in patterns:
+        paths.update(path for path in root.rglob(pattern) if path.is_file())
+    return sorted(paths)
+
+
+def _entry(
+    backend: str,
+    source: Path,
+    symbol: str,
+    line: int,
+    owner: str | None,
+    discovery: str,
+) -> PhysicalKernelEntry:
+    normalized_source = source.as_posix()
+    return PhysicalKernelEntry(
+        id=f"{backend}:{normalized_source}:{symbol}@{line}",
+        backend=backend,
+        source=normalized_source,
+        symbol=symbol,
+        line=line,
+        owner=owner,
+        discovery=discovery,
+    )
+
+
+def _native_global_symbols(text: str) -> list[tuple[str, int]]:
+    symbols: list[tuple[str, int]] = []
+    for match in re.finditer(r"\b__global__\b(?P<tail>.*?)(?:\{|;)", text, re.S):
+        signature = re.sub(r"__launch_bounds__\s*\([^)]*\)", " ", match.group("tail"))
+        names = re.findall(r"\b([A-Za-z_]\w*)\s*\(", signature)
+        if names:
+            line = text.count("\n", 0, match.start()) + 1
+            symbols.append((names[0], line))
+    return sorted(symbols)
+
+
+def discover_native(root: Path) -> list[PhysicalKernelEntry]:
+    entries: list[PhysicalKernelEntry] = []
+    for backend, relative_root, patterns in NATIVE_ROOTS:
+        for source in _source_files(root / relative_root, patterns):
+            relative = source.relative_to(root)
+            entries.extend(
+                _entry(backend, relative, symbol, line, None, "native-__global__")
+                for symbol, line in _native_global_symbols(
+                    source.read_text(encoding="utf-8")
+                )
+            )
+    return entries
+
+
+def _decorator_name(decorator: ast.expr) -> str:
+    if isinstance(decorator, ast.Call):
+        return _decorator_name(decorator.func)
+    if isinstance(decorator, ast.Attribute):
+        prefix = _decorator_name(decorator.value)
+        return f"{prefix}.{decorator.attr}" if prefix else decorator.attr
+    if isinstance(decorator, ast.Name):
+        return decorator.id
+    return ""
+
+
+def _tilelang_files(root: Path) -> list[Path]:
+    sources: set[Path] = set()
+    for relative_root in TILELANG_ROOTS:
+        sources.update(_source_files(root / relative_root, ("*.py",)))
+    for relative in TILELANG_FILES:
+        source = root / relative
+        if source.is_file():
+            sources.add(source)
+    return sorted(sources)
+
+
+def discover_tilelang(root: Path) -> list[PhysicalKernelEntry]:
+    entries: list[PhysicalKernelEntry] = []
+    for source in _tilelang_files(root):
+        relative = source.relative_to(root)
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for owner in tree.body:
+            if not isinstance(owner, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for node in ast.walk(owner):
+                if node is owner or not isinstance(
+                    node, (ast.FunctionDef, ast.AsyncFunctionDef)
+                ):
+                    continue
+                decorators = {_decorator_name(item) for item in node.decorator_list}
+                if not any(name.endswith("T.prim_func") for name in decorators):
+                    continue
+                entries.append(
+                    _entry(
+                        "jit-tilelang-physical",
+                        relative,
+                        node.name,
+                        node.lineno,
+                        owner.name,
+                        "tilelang-T.prim_func",
+                    )
+                )
+    return entries
+
+
+def discover_triton(root: Path) -> list[PhysicalKernelEntry]:
+    entries: list[PhysicalKernelEntry] = []
+    for source in _source_files(root / "vllm_musa", ("*.py",)):
+        relative = source.relative_to(root)
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for node in tree.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            decorators = {_decorator_name(item) for item in node.decorator_list}
+            if any(name.endswith("triton.jit") for name in decorators):
+                entries.append(
+                    _entry(
+                        "jit-triton-physical",
+                        relative,
+                        node.name,
+                        node.lineno,
+                        node.name,
+                        "triton-jit",
+                    )
+                )
+    return entries
+
+
+def discover(root: Path) -> list[PhysicalKernelEntry]:
+    entries = [
+        *discover_native(root),
+        *discover_tilelang(root),
+        *discover_triton(root),
+    ]
+    by_id = {entry.id: entry for entry in entries}
+    if len(by_id) != len(entries):
+        raise RuntimeError("duplicate physical kernel inventory ids")
+    return sorted(entries)
+
+
+def payload(root: Path) -> dict[str, object]:
+    entries = discover(root)
+    counts: dict[str, int] = {}
+    for entry in entries:
+        counts[entry.backend] = counts.get(entry.backend, 0) + 1
+    return {
+        "schema": SCHEMA,
+        "root": str(root.resolve()),
+        "counts": counts,
+        "entries": [asdict(entry) for entry in entries],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", type=Path, default=Path(__file__).resolve().parents[2]
+    )
+    args = parser.parse_args()
+    print(json.dumps(payload(args.root), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/kernel_sweep_catalog.py
+++ b/benchmarks/kernel_tactics/kernel_sweep_catalog.py
@@ -1,0 +1,1043 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Group discovered kernel entrypoints into a public source-only catalog.
+
+Qualification overlays (device bins, timings, receipts, and promotion
+decisions) are local generated evidence and must not be embedded here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+INVENTORY_PATH = SCRIPT_DIR / "inventory_vllm_musa_kernels.py"
+SPEC = importlib.util.spec_from_file_location(
+    "inventory_vllm_musa_kernels", INVENTORY_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+INVENTORY = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = INVENTORY
+SPEC.loader.exec_module(INVENTORY)
+
+PHYSICAL_INVENTORY_PATH = SCRIPT_DIR / "inventory_vllm_musa_physical_kernels.py"
+PHYSICAL_SPEC = importlib.util.spec_from_file_location(
+    "inventory_vllm_musa_physical_kernels", PHYSICAL_INVENTORY_PATH
+)
+assert PHYSICAL_SPEC is not None and PHYSICAL_SPEC.loader is not None
+PHYSICAL_INVENTORY = importlib.util.module_from_spec(PHYSICAL_SPEC)
+sys.modules[PHYSICAL_SPEC.name] = PHYSICAL_INVENTORY
+PHYSICAL_SPEC.loader.exec_module(PHYSICAL_INVENTORY)
+
+SCHEMA = "vllm-musa-public-kernel-catalog.v1"
+
+_FAMILY_METADATA: dict[str, dict[str, object]] = {
+    "aot-native-deepseek-v4-c4-indexer-compress-cache": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/patches/series/0093-MUSA-dispatch-DeepSeek-V4-C4-indexer-compression-to-.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-deepseek-v4-combine-topk-swa-indices": {
+        "disposition": "non-production",
+        "notes": "Registered local wrapper has no caller in the v0.28 patch series.",
+    },
+    "aot-native-deepseek-v4-compute-global-topk-indices-and-lens": {
+        "disposition": "non-production",
+        "notes": "Registered local wrapper has no caller in the v0.28 patch series.",
+    },
+    "aot-native-deepseek-v4-dequantize-and-gather-k-cache": {
+        "disposition": "non-production",
+        "notes": "Registered local wrapper has no caller in the v0.28 patch series.",
+    },
+    "aot-native-deepseek-v4-fused-inv-rope-fp8-quant": {
+        "disposition": "no-tunable-seam",
+        "notes": "The fused inverse-rope/FP8 path has fixed launch geometry and no benchmark-safe per-call tile argument.",
+        "production_consumers": [
+            "vllm_musa/patches/series/0014-MUSA-vllm.models.deepseek_v4.attention.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-deepseek-v4-fused-q-kv-rmsnorm": {
+        "disposition": "non-production",
+        "notes": "Current DSV4 path uses qnorm/rope/KV insert instead.",
+    },
+    "aot-native-deepseek-v4-indexer-rerank-prefill": {
+        "disposition": "no-tunable-seam",
+        "notes": "Prefill rerank launch is fixed by the semantic indexer shape.",
+        "production_consumers": [
+            "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-deepseek-v4-indexer-topk-decode": {
+        "disposition": "no-tunable-seam",
+        "notes": "Decode top-k launch is fixed by the indexer contract.",
+        "production_consumers": [
+            "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-deepseek-v4-indexer-topk-prefill": {
+        "disposition": "no-tunable-seam",
+        "notes": "Prefill top-k launch is fixed by the indexer contract.",
+        "production_consumers": [
+            "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-deepseek-v4-mhc-pre": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/deepseek_v4_mhc.py",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-deepseek-v4-qnorm-rope-kv-insert": {
+        "disposition": "no-tunable-seam",
+        "notes": "QNorm/rope/KV insertion is a fixed one-token path; changing its launch shape requires a new correctness and graph-capture design.",
+        "production_consumers": [
+            "vllm_musa/patches/series/0014-MUSA-vllm.models.deepseek_v4.attention.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-deepseek-v4-sparse-flashmla-decode": {
+        "disposition": "external-provider-excluded",
+        "notes": "Production sparse FlashMLA is provided by MATE and excluded.",
+    },
+    "aot-native-deepseek-v4-store-sparse-kv": {
+        "disposition": "non-production",
+        "notes": "Current DSV4 path uses fused qnorm/rope/KV insert instead.",
+    },
+    "aot-native-deepseek-v4-topk-softplus-sqrt": {
+        "disposition": "non-production",
+        "notes": "No v0.28 production caller was found.",
+    },
+    "aot-native-fused-add-rms-norm-per-token-group-fp8-quant": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py",
+        "disposition": "no-tunable-seam",
+        "notes": "The production kernel is fixed to H=4096, group size 128, and kThreads=512. The catalog's former block_threads/vector_width labels were hypotheses, not a real ABI or benchmark seam.",
+        "production_consumers": [
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+        ],
+        "shape_sources": [
+            "benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json",
+            "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+        ],
+    },
+    "aot-native-glm52-indexer-topk-decode": {
+        "disposition": "no-tunable-seam",
+        "notes": "GLM52 decode top-k launch is fixed by the semantic contract.",
+        "production_consumers": [
+            "vllm_musa/patches/series/0085-MUSA-vllm.v1.attention.backends.mla.indexer.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-glm52-indexer-topk-prefill": {
+        "disposition": "no-tunable-seam",
+        "notes": "GLM52 prefill top-k launch is fixed by the semantic contract.",
+        "production_consumers": [
+            "vllm_musa/patches/series/0085-MUSA-vllm.v1.attention.backends.mla.indexer.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-min-p-sampling-from-probs": {
+        "disposition": "external-provider-excluded"
+    },
+    "aot-native-musa-chunked-min-p-sampling-from-probs": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/_custom_ops.py",
+            "vllm_musa/v1/sample/topk_topp_sampler.py",
+        ],
+    },
+    "aot-native-musa-fused-add-rms-norm": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_fused_add_rmsnorm_paired_ab.py",
+        "production_consumers": [
+            "vllm_musa/_custom_ops.py",
+            "vllm_musa/kernels/musa_ops.py",
+            "vllm_musa/model_executor/layers/layernorm.py",
+        ],
+        "tunable_parameters": ["block_x"],
+    },
+    "aot-native-musa-fused-gemv": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_dense_fp8_gemv_blocks.py",
+        "production_consumers": [
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+            "vllm_musa/deepseek_v4_jit/fp8_einsum.py",
+        ],
+        "shape_sources": ["benchmarks/kernel_tactics/mp_tactic_campaign.json"],
+        "tunable_parameters": ["block_n", "block_k"],
+    },
+    "aot-native-musa-fused-gemv-moe": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_fused_gemv_moe_blocks.py",
+        "production_consumers": [
+            "vllm_musa/model_executor/layers/fused_moe/fused_moe.py",
+            "vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py",
+        ],
+        "shape_sources": ["benchmarks/kernel_tactics/mp_tactic_campaign.json"],
+        "tunable_parameters": ["w1_block_n", "w1_block_k", "w2_block_n", "w2_block_k"],
+    },
+    "aot-native-musa-reshape-and-cache-flash-nhd": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_reshape_cache_nhd_blocks.py",
+        "production_consumers": ["vllm_musa/v1/attention/backends/fa_utils.py"],
+        "shape_sources": [
+            "benchmarks/kernel_tactics/benchmark_reshape_cache_nhd_blocks.py::NHD_SHAPES"
+        ],
+        "tunable_parameters": ["block_x"],
+    },
+    "aot-native-musa-rubymine-top-k-renorm-probs": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/_custom_ops.py",
+            "vllm_musa/v1/sample/topk_topp_sampler.py",
+        ],
+    },
+    "aot-native-musa-top-k-top-p-sampling-from-probs": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/_custom_ops.py",
+            "vllm_musa/v1/sample/topk_topp_sampler.py",
+        ],
+    },
+    "aot-native-per-token-group-quant-8bit-vec": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py",
+        "production_consumers": [
+            "vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py"
+        ],
+        "shape_sources": [
+            "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+            "benchmarks/kernel_tactics/mp_tactic_campaign.json",
+        ],
+        "tunable_parameters": ["groups_per_block"],
+    },
+    "aot-native-silu-and-mul-clamp-per-token-group-fp8-quant": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py",
+        "production_consumers": [
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+        ],
+        "shape_sources": [
+            "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+            "benchmarks/kernel_tactics/mp_tactic_campaign.json",
+        ],
+        "tunable_parameters": ["groups_per_block"],
+    },
+    "aot-native-silu-and-mul-per-token-group-fp8-quant": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py",
+        "production_consumers": [
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+            "vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py",
+        ],
+        "shape_sources": [
+            "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+            "benchmarks/kernel_tactics/mp_tactic_campaign.json",
+        ],
+        "tunable_parameters": ["groups_per_block"],
+    },
+    "aot-native-sparse-indexer-fill-all": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-sparse-indexer-topk": {
+        "disposition": "no-tunable-seam",
+        "notes": "Sparse-indexer top-k geometry is fixed by the index format.",
+        "production_consumers": [
+            "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-sparse-indexer-topk-decode": {
+        "disposition": "no-tunable-seam",
+        "notes": "Sparse-indexer decode geometry is fixed by the index format.",
+        "production_consumers": [
+            "vllm_musa/patches/series/0013-MUSA-vllm.model_executor.layers.sparse_attn_indexer.patch",
+            "vllm_musa/_custom_ops.py",
+        ],
+    },
+    "aot-native-top-k-renorm-probs": {"disposition": "external-provider-excluded"},
+    "aot-native-top-p-renorm-probs": {"disposition": "external-provider-excluded"},
+    "aot-native-top-p-sampling-from-probs": {
+        "disposition": "external-provider-excluded"
+    },
+    "jit-native-custom-allreduce": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/distributed/device_communicators/custom_all_reduce.py"
+        ],
+    },
+    "jit-native-fused-add-rmsnorm": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_jit_rmsnorm_threads.py",
+        "production_consumers": ["vllm_musa/model_executor/layers/layernorm.py"],
+        "shape_sources": ["benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json"],
+        "tunable_parameters": ["block_threads"],
+    },
+    "jit-native-fused-qk-rmsnorm-mrope": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": ["vllm_musa/jit_kernel/csrc/fused_qk_rmsnorm_mrope.py"],
+    },
+    "jit-native-moe-act-and-mul": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/csrc/moe/moe_act_and_mul.py",
+            "vllm_musa/model_executor/layers/fused_moe/fused_moe.py",
+        ],
+    },
+    "jit-native-moe-sum": {
+        "disposition": "no-tunable-seam",
+        "notes": "The MoE sum launch geometry is fixed by the current FFI wrapper.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/csrc/moe/moe_sum.py",
+            "vllm_musa/model_executor/layers/fused_moe/fused_moe.py",
+        ],
+    },
+    "jit-native-per-token-group-quant": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/csrc/quantization/quant_per_token_group.py"
+        ],
+    },
+    "jit-native-rmsnorm": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_jit_rmsnorm_threads.py",
+        "production_consumers": ["vllm_musa/model_executor/layers/layernorm.py"],
+        "shape_sources": ["benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json"],
+        "tunable_parameters": ["block_threads"],
+    },
+    "jit-native-rotary-embedding": {
+        "disposition": "no-tunable-seam",
+        "notes": "Rotary launch geometry is fixed by the current production ABI.",
+        "production_consumers": ["vllm_musa/jit_kernel/csrc/rotary_embedding.py"],
+    },
+    "jit-native-topk-sigmoid": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_jit_topk_warps.py",
+        "production_consumers": [
+            "vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py"
+        ],
+        "shape_sources": [
+            "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+            "benchmarks/kernel_tactics/mp_tactic_campaign.json",
+        ],
+        "tunable_parameters": ["warps_per_cta"],
+    },
+    "jit-native-topk-softmax": {
+        "benchmark": "benchmarks/kernel_tactics/benchmark_jit_topk_warps.py",
+        "production_consumers": [
+            "vllm_musa/model_executor/layers/fused_moe/router/grouped_topk_router.py"
+        ],
+        "shape_sources": [
+            "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+            "benchmarks/kernel_tactics/mp_tactic_campaign.json",
+        ],
+        "tunable_parameters": ["warps_per_cta"],
+    },
+    "jit-tilelang-causal-conv1d-decode-width4-batched-kernel": {
+        "disposition": "no-tunable-seam",
+        "notes": "Width-4 batched decode uses a fixed TileLang schedule.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+    },
+    "jit-tilelang-causal-conv1d-fwd-kernel": {
+        "disposition": "no-tunable-seam",
+        "notes": "Forward causal-conv uses a fixed TileLang schedule.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+    },
+    "jit-tilelang-causal-conv1d-fwd-width4-vec-kernel": {
+        "disposition": "no-tunable-seam",
+        "notes": "Width-4 vector forward uses a fixed TileLang schedule.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+    },
+    "jit-tilelang-causal-conv1d-prefill-width4": {
+        "disposition": "no-tunable-seam",
+        "notes": "Width-4 prefill uses a fixed TileLang schedule.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+    },
+    "jit-tilelang-deepgemm-contig-assign-compact": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "shape_sources": ["benchmarks/kernel_tactics/mp_tactic_campaign.json"],
+    },
+    "jit-tilelang-deepgemm-contig-clear-fill": {
+        "disposition": "no-tunable-seam",
+        "notes": "Clear/fill preprocessing uses a fixed shape-derived config.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "shape_sources": ["benchmarks/kernel_tactics/mp_tactic_campaign.json"],
+    },
+    "jit-tilelang-deepgemm-contig-count-prefix": {
+        "disposition": "no-tunable-seam",
+        "notes": "Count/prefix preprocessing uses a fixed shape-derived config.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "shape_sources": ["benchmarks/kernel_tactics/mp_tactic_campaign.json"],
+    },
+    "jit-tilelang-deepgemm-contig-scan-tree": {
+        "disposition": "no-tunable-seam",
+        "notes": "Tree scan preprocessing uses a fixed shape-derived config.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "shape_sources": ["benchmarks/kernel_tactics/mp_tactic_campaign.json"],
+    },
+    "jit-tilelang-dsv4-mhc-weighted-rmsnorm": {
+        "production_consumers": [
+            "vllm_musa/tuning.py",
+            "vllm_musa/deepseek_v4_jit/tilelang_kernels.py",
+        ],
+        "tunable_parameters": ["threads"],
+    },
+    "jit-tilelang-fused-zba-kernel": {
+        "disposition": "no-tunable-seam",
+        "notes": "The GDN projection fusion has one fixed TileLang schedule.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/gdn_fused_proj.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+    },
+    "jit-tilelang-grouped-topk": {
+        "disposition": "no-tunable-seam",
+        "notes": "Only a semantic serial/parallel crossover exists; geometry is fixed at 32 threads.",
+    },
+    "jit-tilelang-kv-rope-pack-kernel": {
+        "disposition": "non-production",
+        "notes": "Only an orphan TileLang helper calls this factory; production uses AOT.",
+    },
+    "jit-tilelang-mhc-fused-post-prenorm-kernel": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": ["vllm_musa/deepseek_v4_mhc.py"],
+    },
+    "jit-tilelang-mhc-post-kernel": {
+        "production_consumers": ["vllm_musa/deepseek_v4_mhc.py"]
+    },
+    "jit-tilelang-mhc-pre-split-sinkhorn-kernel": {
+        "disposition": "non-production",
+        "notes": "The current auto selector never selects this fallback provider.",
+    },
+    "jit-tilelang-mhc-prenorm-splitk-x-tme-cast-kernel": {
+        "disposition": "non-production",
+        "notes": "The current auto selector always selects DeepGEMM for this stage.",
+    },
+    "jit-tilelang-musa-sparse-attention-fwd-kernel-v1": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": ["vllm_musa/v1/attention/ops/sparse_mla_tilelang.py"],
+    },
+    "jit-tilelang-qnorm-rope-kernel": {
+        "disposition": "non-production",
+        "notes": "Only an orphan TileLang helper calls this factory; production uses AOT.",
+    },
+    "jit-tilelang-rmsnorm-gated": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/layernorm_gated.py",
+            "vllm_musa/model_executor/layers/layernorm.py",
+        ],
+    },
+    "jit-triton-build-qwen-single-request-fa3-metadata-kernel": {
+        "disposition": "no-tunable-seam"
+    },
+    "jit-triton-eagle-prepare-next-token-padded-kernel": {
+        "disposition": "no-tunable-seam",
+        "notes": "Block size is the semantic next-power-of-two token capacity.",
+    },
+    "jit-triton-extend-topk-with-shared-kernel": {
+        "disposition": "no-tunable-seam",
+        "notes": "Block size is fixed by the top-k semantic capacity.",
+    },
+    "jit-triton-fused-gdn-gating-kernel": {
+        "disposition": "no-tunable-seam",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/fused_gdn_gating.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+    },
+    "jit-triton-gated-qk-norm-rope-token-kernel": {
+        "disposition": "no-tunable-seam",
+        "notes": "The token kernel uses a fixed Triton schedule per shape.",
+        "production_consumers": ["vllm_musa/kernels/gated_qkv.py"],
+    },
+    "jit-triton-post-reorder-triton-kernel": {
+        "disposition": "no-tunable-seam",
+        "notes": "Post-reorder uses a fixed Triton schedule per shape.",
+        "production_consumers": [
+            "vllm_musa/jit_kernel/post_reorder.py",
+            "vllm_musa/model_executor/layers/fused_moe/fused_moe.py",
+        ],
+    },
+    "jit-triton-qwen2-rope-kv-cache-kernel": {"disposition": "no-tunable-seam"},
+}
+
+# Keep the checked-in catalog a source inventory.  Qualification overlays are
+# intentionally not valid metadata here; they belong in local generated
+# evidence and ticket attachments.
+_PUBLIC_METADATA_KEYS = frozenset(
+    {
+        "benchmark",
+        "notes",
+        "production_consumers",
+        "shape_sources",
+        "tunable_parameters",
+        "disposition",
+    }
+)
+
+# These owned production kernels have compile-time or shape-derived launch
+# geometry, but no benchmark-safe per-call MP override in the current ABI.  A
+# future campaign may add seams for them; until then they are explicitly
+# classified instead of sitting in ``pending`` as if a runnable sweep existed.
+_FIXED_GEOMETRY_FAMILIES: dict[str, dict[str, object]] = {
+    "jit-tilelang-mhc-fused-post-prenorm-kernel": {
+        "production_consumers": [
+            "vllm_musa/deepseek_v4_mhc.py",
+        ],
+        "notes": (
+            "The factory accepts compile-time threads/tile/split parameters, "
+            "but the production caller hardcodes them and exposes no per-call "
+            "active-MP selector."
+        ),
+    },
+    "jit-native-custom-allreduce": {
+        "production_consumers": [
+            "vllm_musa/distributed/device_communicators/custom_all_reduce.py",
+        ],
+        "notes": (
+            "Peer count and payload size select the collective path, but the "
+            "vLLM-MUSA wrapper exposes no active-MP block/thread override."
+        ),
+    },
+    "jit-native-fused-qk-rmsnorm-mrope": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/csrc/fused_qk_rmsnorm_mrope.py",
+        ],
+        "notes": "The production FFI wrapper compiles one fixed launch contract.",
+    },
+    "jit-native-moe-act-and-mul": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/csrc/moe/moe_act_and_mul.py",
+            "vllm_musa/model_executor/layers/fused_moe/fused_moe.py",
+        ],
+        "notes": "The activation fusion has no per-call MP launch selector.",
+    },
+    "jit-native-moe-sum": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/csrc/moe/moe_sum.py",
+            "vllm_musa/model_executor/layers/fused_moe/fused_moe.py",
+        ],
+        "notes": "The MoE sum launch geometry is fixed by the current FFI wrapper.",
+    },
+    "jit-native-per-token-group-quant": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/csrc/quantization/quant_per_token_group.py",
+        ],
+        "notes": "The JIT quant wrapper exposes no groups-per-block MP seam.",
+    },
+    "jit-native-rotary-embedding": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/csrc/rotary_embedding.py",
+        ],
+        "notes": "Rotary launch geometry is fixed by the current production ABI.",
+    },
+    "jit-tilelang-causal-conv1d-channels-first-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+        "notes": "Channels-first causal-conv uses a fixed TileLang schedule.",
+    },
+    "jit-tilelang-causal-conv1d-decode-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+        "notes": "Decode causal-conv uses a fixed TileLang schedule.",
+    },
+    "jit-tilelang-causal-conv1d-fwd-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+        "notes": "Forward causal-conv uses a fixed TileLang schedule.",
+    },
+    "jit-tilelang-causal-conv1d-update-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+        "notes": "State-update causal-conv uses a fixed TileLang schedule.",
+    },
+    "jit-tilelang-causal-conv1d-decode-width4-batched-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+        "notes": "Width-4 batched decode uses a fixed TileLang schedule.",
+    },
+    "jit-tilelang-causal-conv1d-fwd-width4-vec-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+        "notes": "Width-4 vector forward uses a fixed TileLang schedule.",
+    },
+    "jit-tilelang-causal-conv1d-prefill-width4": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/causal_conv1d.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+        "notes": "Width-4 prefill uses a fixed TileLang schedule.",
+    },
+    "jit-tilelang-deep-gemm-contig-preprocess-full-tile-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "notes": "Full-tile preprocessing uses a fixed shape-derived config.",
+    },
+    "jit-tilelang-deep-gemm-contig-preprocess-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "notes": "General preprocessing uses a fixed shape-derived config.",
+    },
+    "jit-tilelang-deep-gemm-contig-preprocess-noidx-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "notes": "No-index preprocessing uses a fixed shape-derived config.",
+    },
+    "jit-tilelang-deep-gemm-contig-preprocess-padded-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "notes": "Padded preprocessing uses a fixed shape-derived config.",
+    },
+    "jit-tilelang-deepgemm-contig-assign-compact": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "notes": "Compact assignment uses a fixed shape-derived config.",
+    },
+    "jit-tilelang-deepgemm-contig-clear-fill": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "notes": "Clear/fill preprocessing uses a fixed shape-derived config.",
+    },
+    "jit-tilelang-deepgemm-contig-count-prefix": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "notes": "Count/prefix preprocessing uses a fixed shape-derived config.",
+    },
+    "jit-tilelang-deepgemm-contig-scan-tree": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/deep_gemm_contig_preprocess.py",
+            "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py",
+        ],
+        "notes": "Tree scan preprocessing uses a fixed shape-derived config.",
+    },
+    "jit-tilelang-fused-zba-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/gdn_fused_proj.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+        "notes": "The GDN projection fusion has one fixed TileLang schedule.",
+    },
+    "jit-tilelang-musa-sparse-attention-fwd-kernel-v1": {
+        "production_consumers": [
+            "vllm_musa/v1/attention/ops/sparse_mla_tilelang.py",
+        ],
+        "notes": "Sparse MLA forward exposes no per-call MP schedule override.",
+    },
+    "jit-tilelang-rmsnorm-gated": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/tilelang/layernorm_gated.py",
+            "vllm_musa/model_executor/layers/layernorm.py",
+        ],
+        "notes": "Gated RMSNorm uses a fixed TileLang schedule.",
+    },
+    "jit-triton-fused-gdn-gating-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/fused_gdn_gating.py",
+            "vllm_musa/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py",
+        ],
+        "notes": "The Triton GDN gate has no active-MP launch selector.",
+    },
+    "jit-triton-gated-qk-norm-rope-token-kernel": {
+        "production_consumers": [
+            "vllm_musa/kernels/gated_qkv.py",
+        ],
+        "notes": "The token kernel uses a fixed Triton schedule per shape.",
+    },
+    "jit-triton-post-reorder-triton-kernel": {
+        "production_consumers": [
+            "vllm_musa/jit_kernel/post_reorder.py",
+            "vllm_musa/model_executor/layers/fused_moe/fused_moe.py",
+        ],
+        "notes": "Post-reorder uses a fixed Triton schedule per shape.",
+    },
+}
+
+
+def _keys(backend: str, *symbols: str) -> dict[str, str]:
+    return {f"{backend}:{symbol}": "" for symbol in symbols}
+
+
+_SHARED_FAMILY_GROUPS: dict[str, tuple[str, ...]] = {
+    "jit-native-custom-allreduce": (
+        "jit-native-ffi:vllm_musa_custom_ar_launch_all_gather",
+        "jit-native-ffi:vllm_musa_custom_ar_launch_graph_registered",
+        "jit-native-ffi:vllm_musa_custom_ar_launch_registered",
+        "jit-native-ffi:vllm_musa_custom_ar_launch_unregistered",
+        "jit-native-ffi:vllm_musa_custom_ar_meta_size",
+        "jit-native-ffi:vllm_musa_fused_ar_residual_rmsnorm_launch_unregistered",
+        "jit-native-ffi:vllm_musa_fused_ar_residual_rmsnorm_no_raw_launch_unregistered",
+        "jit-native-ffi:vllm_musa_fused_ar_rmsnorm_launch_unregistered",
+    ),
+    "jit-native-moe-act-and-mul": (
+        "jit-native:musa_fast_silu_and_mul",
+        "jit-native-ffi:sgl_musa_moe_act_and_mul",
+    ),
+    "jit-native-moe-sum": (
+        "jit-native:musa_fast_moe_sum",
+        "jit-native-ffi:sgl_musa_moe_sum_reduce",
+    ),
+    "jit-native-fused-add-rmsnorm": (
+        "jit-native:musa_csrc_fused_add_rmsnorm",
+        "jit-native-ffi:sgl_musa_fused_add_rmsnorm",
+    ),
+    "jit-native-rmsnorm": (
+        "jit-native:musa_csrc_rmsnorm",
+        "jit-native-ffi:sgl_musa_rmsnorm",
+    ),
+    "jit-native-fused-qk-rmsnorm-mrope": (
+        "jit-native:musa_csrc_fused_qk_rmsnorm_mrope",
+        "jit-native:musa_csrc_fused_qk_rmsnorm_mrope_cache_out",
+        "jit-native-ffi:sgl_musa_fused_qk_rmsnorm_mrope",
+        "jit-native-ffi:sgl_musa_fused_qk_rmsnorm_mrope_cache",
+        "jit-native-ffi:sgl_musa_fused_qk_rmsnorm_mrope_cache_out",
+    ),
+    "jit-native-per-token-group-quant": (
+        "jit-native:musa_csrc_per_token_group_quant_8bit",
+        "jit-native-ffi:sgl_per_token_group_quant_8bit_v2",
+    ),
+    "jit-native-rotary-embedding": (
+        "jit-native:musa_rotary_embedding",
+        "jit-native-ffi:sgl_rotary_embedding",
+    ),
+    "jit-native-topk-sigmoid": (
+        "jit-native:musa_topk_sigmoid",
+        "jit-native-ffi:sgl_musa_topk_sigmoid",
+    ),
+    "jit-native-topk-softmax": (
+        "jit-native:musa_topk_softmax",
+        "jit-native-ffi:sgl_musa_topk_softmax",
+    ),
+    "jit-tilelang-dsv4-mhc-pre-big-fuse": (
+        "jit-tilelang:mhc_pre_big_fuse_decode_split_kernel",
+        "jit-tilelang:mhc_pre_big_fuse_kernel",
+    ),
+    "jit-tilelang-dsv4-mhc-weighted-rmsnorm": (
+        "jit-tilelang:mhc_weighted_rmsnorm_kernel",
+        "jit-tilelang:mhc_weighted_rmsnorm_mudnn_like_kernel",
+    ),
+    "jit-tilelang-causal-conv1d-prefill-width4": (
+        "jit-tilelang:_causal_conv1d_prefill_width4_body_kernel",
+        "jit-tilelang:_causal_conv1d_prefill_width4_kernel",
+    ),
+    "jit-tilelang-deepgemm-contig-assign-compact": (
+        "jit-tilelang:_bf16_assign_compact_kernel",
+        "jit-tilelang:_fp8_assign_compact_kernel",
+    ),
+    "jit-tilelang-deepgemm-contig-clear-fill": (
+        "jit-tilelang:_clear_i32_kernel",
+        "jit-tilelang:_fill_i32_kernel",
+    ),
+    "jit-tilelang-deepgemm-contig-count-prefix": (
+        "jit-tilelang:_count_prefix_topk_single_block_kernel",
+        "jit-tilelang:_count_topk_block_hist_kernel",
+        "jit-tilelang:_count_topk_single_block_kernel",
+        "jit-tilelang:_prefix_counts_kernel",
+    ),
+    "jit-tilelang-deepgemm-contig-scan-tree": (
+        "jit-tilelang:_prefix_counts_scan_kernel",
+        "jit-tilelang:_prefix_counts_tree_kernel",
+    ),
+    "jit-tilelang-grouped-topk": (
+        "jit-tilelang:_grouped_topk_parallel_kernel",
+        "jit-tilelang:_grouped_topk_serial_kernel",
+    ),
+    "jit-tilelang-rmsnorm-gated": (
+        "jit-tilelang:_rms_norm_gated_kernel",
+        "jit-tilelang:_rms_norm_gated_kernel_cta",
+    ),
+}
+
+_MEMBER_TO_SHARED_FAMILY = {
+    member: family
+    for family, members in _SHARED_FAMILY_GROUPS.items()
+    for member in members
+}
+
+_AOT_PHYSICAL_SOURCE_FAMILIES: dict[str, tuple[str, ...]] = {
+    "csrc/musa/attention/deepseek_v4_c4_indexer_compressor.mu": (
+        "aot-native-deepseek-v4-c4-indexer-compress-cache",
+    ),
+    "csrc/musa/attention/deepseek_v4_cache_store.mu": (
+        "aot-native-deepseek-v4-qnorm-rope-kv-insert",
+        "aot-native-deepseek-v4-store-sparse-kv",
+    ),
+    "csrc/musa/attention/deepseek_v4_cache_utils.mu": (
+        "aot-native-deepseek-v4-combine-topk-swa-indices",
+        "aot-native-deepseek-v4-compute-global-topk-indices-and-lens",
+        "aot-native-deepseek-v4-dequantize-and-gather-k-cache",
+    ),
+    "csrc/musa/attention/deepseek_v4_fused_qkv_rmsnorm.mu": (
+        "aot-native-deepseek-v4-fused-q-kv-rmsnorm",
+    ),
+    "csrc/musa/attention/deepseek_v4_indexer_topk.mu": (
+        "aot-native-deepseek-v4-indexer-rerank-prefill",
+        "aot-native-deepseek-v4-indexer-topk-decode",
+        "aot-native-deepseek-v4-indexer-topk-prefill",
+    ),
+    "csrc/musa/attention/deepseek_v4_inv_rope_fp8_quant.mu": (
+        "aot-native-deepseek-v4-fused-inv-rope-fp8-quant",
+    ),
+    "csrc/musa/attention/deepseek_v4_sparse_flashmla.mu": (
+        "aot-native-deepseek-v4-sparse-flashmla-decode",
+    ),
+    "csrc/musa/attention/glm52_indexer_topk.mu": (
+        "aot-native-glm52-indexer-topk-decode",
+        "aot-native-glm52-indexer-topk-prefill",
+        "aot-native-sparse-indexer-fill-all",
+        "aot-native-sparse-indexer-topk",
+        "aot-native-sparse-indexer-topk-decode",
+    ),
+    "csrc/musa/cache_kernels.mu": ("aot-native-musa-reshape-and-cache-flash-nhd",),
+    "csrc/musa/fused_add_rmsnorm.mu": ("aot-native-musa-fused-add-rms-norm",),
+    "csrc/musa/gemv.mu": (
+        "aot-native-musa-fused-gemv",
+        "aot-native-musa-fused-gemv-moe",
+    ),
+    "csrc/musa/mhc/deepseek_v4_mhc_pre.mu": ("aot-native-deepseek-v4-mhc-pre",),
+    "csrc/musa/min_p_sampler.mu": (
+        "aot-native-musa-chunked-min-p-sampling-from-probs",
+    ),
+    "csrc/musa/moe/deepseek_v4_topk_softplus_sqrt.mu": (
+        "aot-native-deepseek-v4-topk-softplus-sqrt",
+    ),
+    "csrc/musa/quantization/fused_add_rms_norm_per_token_group_fp8_quant.cu": (
+        "aot-native-fused-add-rms-norm-per-token-group-fp8-quant",
+    ),
+    "csrc/musa/quantization/per_token_group_quant_8bit_vec.cu": (
+        "aot-native-per-token-group-quant-8bit-vec",
+    ),
+    "csrc/musa/quantization/silu_and_mul_per_token_group_fp8_quant.cu": (
+        "aot-native-silu-and-mul-clamp-per-token-group-fp8-quant",
+        "aot-native-silu-and-mul-per-token-group-fp8-quant",
+    ),
+    "csrc/musa/sampler.mu": ("aot-native-musa-top-k-top-p-sampling-from-probs",),
+    "csrc/musa/top_k_renorm.mu": ("aot-native-musa-rubymine-top-k-renorm-probs",),
+}
+
+_JIT_PHYSICAL_SOURCE_FAMILIES: dict[str, tuple[str, ...]] = {
+    "vllm_musa/jit_kernel/csrc/distributed/custom_all_reduce.mu": (
+        "jit-native-custom-allreduce",
+    ),
+    "vllm_musa/jit_kernel/csrc/moe/act_and_mul.mu": ("jit-native-moe-act-and-mul",),
+    "vllm_musa/jit_kernel/csrc/moe/moe_sum_reduce.mu": ("jit-native-moe-sum",),
+    "vllm_musa/jit_kernel/csrc/norm/qk_mrope.mu": (
+        "jit-native-fused-qk-rmsnorm-mrope",
+    ),
+    "vllm_musa/jit_kernel/csrc/quant/per_token_group_quant_8bit_v2.mu": (
+        "jit-native-per-token-group-quant",
+    ),
+    "vllm_musa/jit_kernel/csrc/rope/rotary_embedding.mu": (
+        "jit-native-rotary-embedding",
+    ),
+}
+
+
+def _slug(value: str) -> str:
+    value = re.sub(r"^_+", "", value)
+    value = re.sub(r"[^a-zA-Z0-9]+", "-", value)
+    return value.strip("-").lower()
+
+
+def family_id_for_symbol(backend: str, symbol: str) -> str:
+    short_id = f"{backend}:{symbol}"
+    shared = _MEMBER_TO_SHARED_FAMILY.get(short_id)
+    if shared is not None:
+        return shared
+    return f"{backend}-{_slug(symbol)}"
+
+
+def family_id(entry: INVENTORY.KernelEntry) -> str:
+    return family_id_for_symbol(entry.backend, entry.symbol)
+
+
+def physical_coverage(root: Path) -> dict[str, tuple[str, ...]]:
+    """Map every physical kernel definition to reviewed callable families."""
+    callable_families = set(grouped_families(root))
+    coverage: dict[str, tuple[str, ...]] = {}
+    for entry in PHYSICAL_INVENTORY.discover(root):
+        families: tuple[str, ...]
+        if entry.backend == "aot-native-physical":
+            families = _AOT_PHYSICAL_SOURCE_FAMILIES.get(entry.source, ())
+        elif entry.backend == "jit-native-physical":
+            if entry.source == "vllm_musa/jit_kernel/csrc/norm/rmsnorm.mu":
+                families = (
+                    "jit-native-fused-add-rmsnorm"
+                    if entry.symbol.startswith("fused_add_")
+                    else "jit-native-rmsnorm",
+                )
+            elif entry.source == "vllm_musa/jit_kernel/csrc/topk/topk_gating.mu":
+                if entry.symbol == "topk_block_kernel":
+                    families = (
+                        "jit-native-topk-sigmoid",
+                        "jit-native-topk-softmax",
+                    )
+                elif "sigmoid" in entry.symbol:
+                    families = ("jit-native-topk-sigmoid",)
+                else:
+                    families = ("jit-native-topk-softmax",)
+            else:
+                families = _JIT_PHYSICAL_SOURCE_FAMILIES.get(entry.source, ())
+        elif entry.backend == "jit-tilelang-physical":
+            assert entry.owner is not None
+            if entry.owner == "_prefix_counts_no_pad_kernel":
+                families = ("jit-tilelang-deepgemm-contig-count-prefix",)
+            else:
+                families = (family_id_for_symbol("jit-tilelang", entry.owner),)
+        elif entry.backend == "jit-triton-physical":
+            assert entry.owner is not None
+            families = (family_id_for_symbol("jit-triton", entry.owner),)
+        else:
+            families = ()
+        if not families:
+            raise RuntimeError(f"physical kernel has no family coverage: {entry}")
+        unknown = set(families) - callable_families
+        if unknown:
+            raise RuntimeError(
+                f"physical kernel maps to unknown families {sorted(unknown)}: {entry}"
+            )
+        coverage[entry.id] = families
+    return coverage
+
+
+def grouped_families(root: Path) -> dict[str, list[INVENTORY.KernelEntry]]:
+    grouped: dict[str, list[INVENTORY.KernelEntry]] = defaultdict(list)
+    for entry in INVENTORY.discover(root):
+        grouped[family_id(entry)].append(entry)
+    return {family: sorted(entries) for family, entries in sorted(grouped.items())}
+
+
+def skeleton(root: Path) -> dict[str, object]:
+    families = grouped_families(root)
+    family_documents = []
+    for family, entries in families.items():
+        document = {
+            "id": family,
+            "members": [entry.id for entry in entries],
+            "backend_classes": sorted({entry.backend for entry in entries}),
+            "disposition": "pending",
+            "production_consumers": [],
+            "shape_sources": [],
+            "tunable_parameters": [],
+            "benchmark": None,
+            "notes": "",
+        }
+        metadata = _FAMILY_METADATA.get(family, {})
+        unexpected = set(metadata) - _PUBLIC_METADATA_KEYS
+        if unexpected:
+            raise ValueError(
+                f"non-public catalog metadata for {family}: " f"{sorted(unexpected)}"
+            )
+        document.update(metadata)
+        fixed_geometry = _FIXED_GEOMETRY_FAMILIES.get(family)
+        if fixed_geometry is not None:
+            document.update(
+                {
+                    "disposition": "no-tunable-seam",
+                    "tunable_parameters": [],
+                    **fixed_geometry,
+                }
+            )
+        family_documents.append(document)
+    physical_payload = PHYSICAL_INVENTORY.payload(root)
+    return {
+        "schema": SCHEMA,
+        "scope": {
+            "repository": "vllm-musa",
+            "owned_implementations_only": True,
+            "external_provider_wrappers": "excluded",
+            "runtime_hardware_key": "multi_processor_count",
+            "callable_entrypoint_count": len(INVENTORY.discover(root)),
+            "physical_implementation_counts": physical_payload["counts"],
+            "physical_implementation_count": len(physical_payload["entries"]),
+            "physical_kernel_note": (
+                "Callable entries and physical definitions are separate "
+                "denominators; physical_coverage() maps every definition."
+            ),
+        },
+        "allowed_dispositions": [
+            "pending",
+            "no-tunable-seam",
+            "external-provider-excluded",
+            "non-production",
+        ],
+        "families": family_documents,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", type=Path, default=Path(__file__).resolve().parents[2]
+    )
+    parser.add_argument("--skeleton", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    document = skeleton(args.root)
+    print(json.dumps(document, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/mp_tactic_campaign.json
+++ b/benchmarks/kernel_tactics/mp_tactic_campaign.json
@@ -1,0 +1,249 @@
+{
+  "schema": "vllm-musa-mp-tactic-campaign.v2",
+  "purpose": "Public benchmark recipes; device and qualification provenance is supplied at run time and kept in local generated evidence.",
+  "methodology": {
+    "isolated_device_required_for_promotion": true,
+    "cache_policy": "cold-l2-per-sample",
+    "l2_flush_mb": 8000,
+    "inner_iters": 1,
+    "order": "paired alternating AB/BA",
+    "promotion_gate": {
+      "correctness_required": true,
+      "poison_output_forbidden": true,
+      "median_ratio_max": 0.98,
+      "ratio_p95_max": 1.02,
+      "winner_must_match_across_seeds": true,
+      "winner_must_pass_every_route": true
+    }
+  },
+  "cells": [
+    {
+      "id": "qwen35-folded-bf16-moe-blocks",
+      "enabled": true,
+      "priority": 1,
+      "script": "benchmarks/kernel_tactics/benchmark_fused_gemv_moe_blocks.py",
+      "base_args": [
+        "--family", "qwen35_folded_bf16",
+        "--stages", "w1", "w2",
+        "--blocks", "4x32", "8x16", "16x8", "32x4", "32x8",
+        "--inner-iters", "1",
+        "--l2-flush-mb", "8000"
+      ],
+      "modes": {
+        "quick": [
+          "--tokens", "1", "4", "16",
+          "--routes", "balanced", "hot", "unique_random",
+          "--dry-runs", "3", "--repeats", "8"
+        ],
+        "full": [
+          "--tokens", "1", "2", "4", "8", "16", "32", "64",
+          "--routes", "balanced", "hot", "unique_random",
+          "--dry-runs", "5", "--repeats", "24"
+        ]
+      },
+      "variants": [
+        {"id": "seed7", "args": ["--seed", "7"]},
+        {"id": "seed17", "args": ["--seed", "17"]},
+        {"id": "seed20260826", "args": ["--seed", "20260826"]}
+      ],
+      "production_consumer": "vllm_musa/model_executor/layers/fused_moe/fused_moe.py"
+    },
+    {
+      "id": "qwen-unfolded-bf16-moe-blocks",
+      "enabled": true,
+      "priority": 2,
+      "script": "benchmarks/kernel_tactics/benchmark_fused_gemv_moe_blocks.py",
+      "base_args": [
+        "--family", "qwen_bf16",
+        "--stages", "w1", "w2",
+        "--blocks", "4x32", "8x16", "16x8", "32x4", "32x8",
+        "--inner-iters", "1", "--l2-flush-mb", "8000"
+      ],
+      "modes": {
+        "quick": [
+          "--tokens", "1", "4", "16",
+          "--routes", "balanced", "hot", "unique_random",
+          "--dry-runs", "3", "--repeats", "8"
+        ],
+        "full": [
+          "--tokens", "1", "2", "4", "8", "16", "32", "64",
+          "--routes", "balanced", "hot", "unique_random",
+          "--dry-runs", "5", "--repeats", "24"
+        ]
+      },
+      "variants": [
+        {"id": "seed7", "args": ["--seed", "7"]},
+        {"id": "seed17", "args": ["--seed", "17"]},
+        {"id": "seed20260826", "args": ["--seed", "20260826"]}
+      ],
+      "production_consumer": "vllm_musa/model_executor/layers/fused_moe/fused_moe.py"
+    },
+    {
+      "id": "dsv4-fp8-moe-blocks",
+      "enabled": true,
+      "priority": 2,
+      "script": "benchmarks/kernel_tactics/benchmark_fused_gemv_moe_blocks.py",
+      "base_args": [
+        "--family", "dsv4_fp8",
+        "--stages", "w1", "w2",
+        "--blocks", "4x32", "8x16", "16x8", "32x4", "32x8",
+        "--inner-iters", "1", "--l2-flush-mb", "8000"
+      ],
+      "modes": {
+        "quick": [
+          "--tokens", "1", "4", "16",
+          "--routes", "balanced", "hot", "unique_random",
+          "--dry-runs", "3", "--repeats", "8"
+        ],
+        "full": [
+          "--tokens", "1", "2", "4", "8", "16", "32", "64",
+          "--routes", "balanced", "hot", "unique_random",
+          "--dry-runs", "5", "--repeats", "24"
+        ]
+      },
+      "variants": [
+        {"id": "seed7", "args": ["--seed", "7"]},
+        {"id": "seed17", "args": ["--seed", "17"]},
+        {"id": "seed20260826", "args": ["--seed", "20260826"]}
+      ],
+      "production_consumer": "vllm_musa/model_executor/layers/fused_moe/fused_moe.py"
+    },
+    {
+      "id": "dsv4-fused-add-rmsnorm-aot",
+      "enabled": true,
+      "priority": 3,
+      "script": "benchmarks/kernel_tactics/benchmark_fused_add_rmsnorm_paired_ab.py",
+      "base_args": [
+        "--hidden-size", "4096",
+        "--pairs", "0", "128",
+        "--pairs", "0", "256",
+        "--pairs", "0", "512",
+        "--pairs", "0", "1024",
+        "--inner-iters", "1", "--l2-flush-mb", "8000"
+      ],
+      "modes": {
+        "quick": [
+          "--rows", "1", "5", "16", "64", "80", "320",
+          "--dry-runs", "3", "--repeats", "8"
+        ],
+        "full": [
+          "--rows", "1", "2", "4", "5", "8", "16", "20", "32", "64", "80", "320", "2048", "4096", "4100", "8195",
+          "--dry-runs", "5", "--repeats", "24"
+        ]
+      },
+      "variants": [
+        {"id": "seed20260824", "args": ["--seed", "20260824"]}
+      ],
+      "production_consumer": "vllm_musa/model_executor/layers/layernorm.py"
+    },
+    {
+      "id": "qwen-fused-add-rmsnorm-aot",
+      "enabled": true,
+      "priority": 4,
+      "script": "benchmarks/kernel_tactics/benchmark_fused_add_rmsnorm_paired_ab.py",
+      "base_args": [
+        "--pairs", "0", "128",
+        "--pairs", "0", "256",
+        "--pairs", "0", "512",
+        "--pairs", "0", "1024",
+        "--inner-iters", "1", "--l2-flush-mb", "8000"
+      ],
+      "modes": {
+        "quick": [
+          "--rows", "1", "16", "32", "64", "128", "256",
+          "--dry-runs", "3", "--repeats", "8"
+        ],
+        "full": [
+          "--rows", "1", "2", "3", "4", "8", "12", "16", "32", "48", "64", "128", "192", "256", "320",
+          "--dry-runs", "5", "--repeats", "24"
+        ]
+      },
+      "variants": [
+        {"id": "h1024", "args": ["--hidden-size", "1024"]},
+        {"id": "h1536", "args": ["--hidden-size", "1536"]},
+        {"id": "h2048", "args": ["--hidden-size", "2048"]},
+        {"id": "h3584", "args": ["--hidden-size", "3584"]},
+        {"id": "h4096", "args": ["--hidden-size", "4096"]},
+        {"id": "h5120", "args": ["--hidden-size", "5120"]},
+        {"id": "h8192", "args": ["--hidden-size", "8192"]}
+      ],
+      "production_consumer": "vllm_musa/kernels/musa_ops.py"
+    },
+    {
+      "id": "dsv4-mhc-jit-fuse",
+      "enabled": true,
+      "priority": 2,
+      "script": "benchmarks/kernel_tactics/benchmark_dsv4_mhc_jit.py",
+      "base_args": [
+        "--hidden-size", "4096",
+        "--production-path", "fused_post_prenorm",
+        "--l2-flush-mb", "8000"
+      ],
+      "modes": {
+        "quick": [
+          "--tokens", "1", "4", "8", "16",
+          "--threads", "128", "256",
+          "--hidden-blocks", "512",
+          "--pass-configs", "safe", "burst",
+          "--warmup", "2", "--repeats", "8"
+        ],
+        "full": [
+          "--tokens", "1", "2", "4", "8", "16",
+          "--threads", "128", "256",
+          "--hidden-blocks", "512", "1024",
+          "--pass-configs", "safe", "burst", "aggressive_index32",
+          "--warmup", "3", "--repeats", "24"
+        ]
+      },
+      "variants": [
+        {"id": "seed20260827", "args": ["--seed", "20260827"]}
+      ],
+      "production_consumer": "vllm_musa/deepseek_v4_mhc.py"
+    },
+    {
+      "id": "dsv4-mhc-jit-standalone",
+      "enabled": true,
+      "priority": 3,
+      "script": "benchmarks/kernel_tactics/benchmark_dsv4_mhc_jit.py",
+      "base_args": [
+        "--hidden-size", "4096",
+        "--production-path", "standalone",
+        "--l2-flush-mb", "8000"
+      ],
+      "modes": {
+        "quick": [
+          "--tokens", "1", "32", "64", "128", "256",
+          "--threads", "128", "256",
+          "--hidden-blocks", "512", "1024",
+          "--pass-configs", "safe", "burst", "aggressive_index32",
+          "--warmup", "2", "--repeats", "8"
+        ],
+        "full": [
+          "--tokens", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512",
+          "--threads", "128", "256",
+          "--hidden-blocks", "512", "1024",
+          "--pass-configs", "safe", "burst", "aggressive_index32",
+          "--warmup", "3", "--repeats", "24"
+        ]
+      },
+      "variants": [
+        {"id": "seed20260827", "args": ["--seed", "20260827"]}
+      ],
+      "production_consumer": "vllm_musa/deepseek_v4_mhc.py::mhc_pre_musa"
+    },
+    {
+      "id": "dsv4-dense-fp8-gemv",
+      "enabled": false,
+      "priority": 5,
+      "blocked_reason": "Current production op has exact shape selectors but no safe per-call benchmark block argument; the removed global environment seam must not be restored.",
+      "production_consumer": "csrc/musa/gemv.mu::SelectDeepSeekV4Fp8OProjTile"
+    },
+    {
+      "id": "qwen-gemma-jit-rmsnorm",
+      "enabled": false,
+      "priority": 5,
+      "blocked_reason": "The JIT kernel has row/hidden thread heuristics but no benchmark-only requested-thread contract yet.",
+      "production_consumer": "vllm_musa/jit_kernel/csrc/norm/rmsnorm.mu"
+    }
+  ]
+}

--- a/benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json
+++ b/benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json
@@ -1,0 +1,49 @@
+{
+  "schema": "vllm-musa-fp8-quant-production-shapes.v1",
+  "notes": [
+    "rows for routed SwiGLU are post-routing rows: model tokens multiplied by routed top-k",
+    "hidden_size is the quantized output width after SwiGLU, not the model hidden size",
+    "DeepSeek-V4 TP8 uses moe_intermediate_size=2048 / TP8 = 256",
+    "Qwen TP8 campaign W1 N=256 represents 2 * intermediate, so SwiGLU output width is 128"
+  ],
+  "sources": [
+    "benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json",
+    "tests/test_patches.py::DeepSeek-V4 moe_intermediate_size=2048",
+    "vllm_musa/model_executor/layers/quantization/utils/fp8_utils.py::M2.5 hidden=1536 gate"
+  ],
+  "families": {
+    "activation_quant": {
+      "deepseek_v4_tp8": {
+        "rows": [1, 2, 4, 5, 8, 16, 20, 32, 64, 80, 128, 256, 320],
+        "hidden_sizes": [4096]
+      },
+      "qwen_tp8": {
+        "rows": [1, 2, 4, 8, 12, 16, 32, 36, 64],
+        "hidden_sizes": [2048]
+      }
+    },
+    "silu_clamp_shared_mlp": {
+      "deepseek_v4_tp8": {
+        "rows": [1, 2, 4, 5, 8, 16, 20, 32, 64, 80, 128, 256, 320],
+        "hidden_sizes": [256],
+        "swiglu_limit": 10.0
+      }
+    },
+    "silu_routed_moe": {
+      "deepseek_v4_tp8_topk6": {
+        "rows": [6, 12, 24, 30, 48, 96, 120, 192, 384, 480, 768, 1536, 1920],
+        "hidden_sizes": [256]
+      },
+      "qwen_tp8_topk8": {
+        "rows": [8, 16, 32, 64, 96, 128, 256, 288, 512],
+        "hidden_sizes": [128]
+      }
+    },
+    "silu_dense_fallback": {
+      "m2_5_local_after_sphere_gate": {
+        "rows": [320, 512, 2048, 4096],
+        "hidden_sizes": [1536]
+      }
+    }
+  }
+}

--- a/benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json
+++ b/benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json
@@ -1,0 +1,59 @@
+{
+  "schema": "musa-qwen-dsv4-rmsnorm-shapes.v2",
+  "sources": [
+    "model configuration inventory",
+    "official Qwen Hugging Face config.json for Qwen2.5 text, VL, and Omni checkpoints"
+  ],
+  "row_shapes": {
+    "graph_ladder": [1, 2, 4, 8, 16, 32, 64],
+    "qwen_mtp1": [2, 8, 32, 128],
+    "qwen_mtp2": [3, 12, 48, 192],
+    "qwen_mtp3": [4, 16, 64, 256],
+    "deepseek_v4_mtp4": [5, 20, 80, 320],
+    "prefill_and_bounds": [2048, 4096, 4100, 8195]
+  },
+  "qwen_aot_hidden_sizes": {
+    "1024": ["Qwen3-0.6B"],
+    "1536": ["Qwen2-VL-2B-Instruct"],
+    "2048": [
+      "Qwen3-30B-A3B",
+      "Qwen3-VL-30B-A3B"
+    ],
+    "3584": [
+      "Qwen2.5-7B-Instruct",
+      "Qwen2.5-VL-7B-Instruct",
+      "Qwen2.5-Omni-7B"
+    ],
+    "4096": [
+      "Qwen3-8B",
+      "Qwen3-235B-A22B",
+      "Qwen3-VL-8B"
+    ],
+    "8192": ["Qwen2.5-VL-72B-Instruct"]
+  },
+  "qwen_split_provider_hidden_sizes": {
+    "5120": {
+      "models": ["Qwen3-32B"],
+      "aot_rows": "rows < 64",
+      "jit_rows": "rows >= 64"
+    }
+  },
+  "qwen_gemma_jit_exclusions": {
+    "2048": ["Qwen3.5-35B-A3B", "Qwen3.5-Flash", "Qwen3.6-35B-A3B"],
+    "2560": ["Qwen3.6-80B-A3B"],
+    "3072": ["Qwen3.5-122B-A10B"],
+    "4096": [
+      "Qwen3.5-9B",
+      "Qwen3.5-397B",
+      "Qwen3.5-397B-A17B",
+      "Qwen3.6-397B-A17B"
+    ],
+    "5120": ["Qwen3.5-27B", "Qwen3.6-27B"],
+    "note": "Qwen3.5 and Qwen3.6 use GemmaRMSNorm and route eligible residual calls to the JIT gemma=True kernel, not this C-extension AOT kernel."
+  },
+  "deepseek_v4_flash": {
+    "models": ["DeepSeek-V4-Flash-Base"],
+    "hidden_size": 4096,
+    "row_shapes": [1, 5, 20, 80, 320]
+  }
+}

--- a/benchmarks/kernel_tactics/report_wave_quantization.py
+++ b/benchmarks/kernel_tactics/report_wave_quantization.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Report MP-count wave discontinuities before running silicon benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+
+from vllm_musa.tuning import estimate_wave_quantization
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--multiprocessor-counts",
+        type=int,
+        nargs="+",
+        default=(48, 52, 56, 60, 64),
+        help="Exact runtime multi_processor_count values to compare.",
+    )
+    parser.add_argument(
+        "--tiles",
+        type=int,
+        nargs="+",
+        required=True,
+        help="Total logical tile counts emitted by candidate launch shapes.",
+    )
+    parser.add_argument("--blocks-per-multiprocessor", type=int, default=1)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    rows = []
+    for total_tiles in args.tiles:
+        for multiprocessor_count in args.multiprocessor_counts:
+            estimate = estimate_wave_quantization(
+                total_tiles,
+                multiprocessor_count,
+                blocks_per_multiprocessor=args.blocks_per_multiprocessor,
+            )
+            rows.append(
+                {
+                    "multiprocessor_count": multiprocessor_count,
+                    "blocks_per_multiprocessor": args.blocks_per_multiprocessor,
+                    **asdict(estimate),
+                }
+            )
+    print(json.dumps({"schema": "musa-wave-quantization.v1", "rows": rows}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/run_mate_benchmark_with_events.py
+++ b/benchmarks/kernel_tactics/run_mate_benchmark_with_events.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Run a MATE benchmark script with MUSA-event timing instead of Kineto."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import statistics
+import sys
+from pathlib import Path
+
+# isort: off
+import torchada  # noqa: F401  # patch before torch ecosystem imports
+from mate.testing.utils import bench_gpu_time_with_musa_event
+# isort: on
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", type=Path, required=True)
+    parser.add_argument("--dry-runs", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--l2-flush-mb", type=int, default=8000)
+    return parser.parse_known_args()
+
+
+def main() -> int:
+    args, target_args = parse_args()
+    target = args.target.resolve()
+    if not target.is_file():
+        raise FileNotFoundError(target)
+    if min(args.dry_runs, args.repeats, args.l2_flush_mb) <= 0:
+        raise ValueError("timing parameters must be positive")
+
+    sys.path.insert(0, str(target.parent))
+    module_name = f"musa_event_benchmark_{target.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, target)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load benchmark: {target}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    def bench_with_events(fn, **_ignored) -> float:
+        samples_ms = [
+            float(value)
+            for value in bench_gpu_time_with_musa_event(
+                fn,
+                dry_run_iters=args.dry_runs,
+                repeat_iters=args.repeats,
+                l2_flush=True,
+                l2_flush_size_mb=args.l2_flush_mb,
+            )
+        ]
+        print(
+            "MUSA_EVENT_SAMPLES "
+            + json.dumps(
+                {
+                    "samples_ms": samples_ms,
+                    "median_ms": statistics.median(samples_ms),
+                    "dry_runs": args.dry_runs,
+                    "repeats": args.repeats,
+                    "l2_flush_mb": args.l2_flush_mb,
+                },
+                sort_keys=True,
+            )
+        )
+        return statistics.median(samples_ms) / 1000.0
+
+    if not hasattr(module, "bench_kineto"):
+        raise AttributeError(f"target has no bench_kineto binding: {target}")
+    module.bench_kineto = bench_with_events
+    sys.argv = [str(target), *target_args]
+    module.main()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/run_mp_tactic_campaign.py
+++ b/benchmarks/kernel_tactics/run_mp_tactic_campaign.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Run a reviewed MP tactic campaign on one lease-scoped MUSA device."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import source_identity
+
+DEFAULT_CAMPAIGN = Path(__file__).with_name("mp_tactic_campaign.json")
+SUPPORTED_CAMPAIGN_SCHEMAS = frozenset(
+    {
+        "vllm-musa-mp-tactic-campaign.v1",
+        "vllm-musa-mp-tactic-campaign.v2",
+    }
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--campaign", type=Path, default=DEFAULT_CAMPAIGN)
+    parser.add_argument("--mode", choices=("quick", "full"), default="quick")
+    parser.add_argument("--cell", action="append", default=[])
+    parser.add_argument("--expected-mp", type=int)
+    parser.add_argument(
+        "--allowed-mp",
+        type=int,
+        action="append",
+        help=(
+            "optional local qualification allow-list; keep fleet-specific "
+            "values out of the checked-in campaign recipe"
+        ),
+    )
+    parser.add_argument("--expected-physical-device", type=int)
+    parser.add_argument("--expected-device-uuid")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("--allow-dirty", action="store_true")
+    parser.add_argument(
+        "--lease-isolated",
+        action="store_true",
+        help="attest that the SOL lease was isolated; omitted runs are exploratory",
+    )
+    parser.add_argument("--continue-on-error", action="store_true")
+    return parser.parse_args()
+
+
+def load_campaign(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text())
+    if payload.get("schema") not in SUPPORTED_CAMPAIGN_SCHEMAS:
+        raise ValueError(f"unsupported campaign schema in {path}")
+    cells = payload.get("cells")
+    if not isinstance(cells, list) or not cells:
+        raise ValueError("campaign must contain non-empty cells")
+    ids = [cell.get("id") for cell in cells]
+    if any(not isinstance(cell_id, str) or not cell_id for cell_id in ids):
+        raise ValueError("every campaign cell must have a non-empty id")
+    if len(ids) != len(set(ids)):
+        raise ValueError("campaign cell ids must be unique")
+    return payload
+
+
+def probe_device() -> dict[str, Any]:
+    # Import order is part of the MUSA compatibility contract.
+    # isort: off
+    import torchada  # noqa: F401
+    import torch
+    # isort: on
+
+    if not hasattr(torch, "musa") or not torch.musa.is_available():
+        raise RuntimeError("MUSA device is not available")
+    device_count = int(torch.musa.device_count())
+    if device_count != 1:
+        raise RuntimeError(
+            "campaign requires exactly one lease-scoped visible MUSA device, "
+            f"got {device_count}"
+        )
+    properties = torch.musa.get_device_properties(0)
+    return {
+        "device_count": device_count,
+        "device_name": torch.musa.get_device_name(0),
+        "device_capability": [int(properties.major), int(properties.minor)],
+        "multiprocessor_count": int(properties.multi_processor_count),
+    }
+
+
+def verify_visible_device_contract() -> dict[str, str]:
+    """Require explicit, identical MUSA/CUDA visibility for reported runs."""
+    musa_visible = os.environ.get("MUSA_VISIBLE_DEVICES")
+    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if not musa_visible or cuda_visible != musa_visible:
+        raise RuntimeError(
+            "MUSA_VISIBLE_DEVICES and CUDA_VISIBLE_DEVICES must both be set to "
+            "the same value for a campaign run"
+        )
+    return {
+        "MUSA_VISIBLE_DEVICES": musa_visible,
+        "CUDA_VISIBLE_DEVICES": cuda_visible,
+    }
+
+
+def add_device_fence_args(
+    command: list[str],
+    expected_physical_device: int | None,
+    expected_device_uuid: str | None,
+) -> list[str]:
+    """Attach the lease-device fence required by every enabled benchmark."""
+    if expected_physical_device is None or not expected_device_uuid:
+        raise ValueError(
+            "campaign runs require --expected-physical-device and "
+            "--expected-device-uuid from the active SOL lease"
+        )
+    return [
+        *command,
+        "--expected-physical-device",
+        str(expected_physical_device),
+        "--expected-device-uuid",
+        expected_device_uuid,
+    ]
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def selected_cells(
+    campaign: dict[str, Any], requested: list[str]
+) -> list[dict[str, Any]]:
+    cells = campaign["cells"]
+    if not requested:
+        return [cell for cell in cells if cell.get("enabled")]
+    by_id = {cell["id"]: cell for cell in cells}
+    unknown = sorted(set(requested) - set(by_id))
+    if unknown:
+        raise ValueError(f"unknown campaign cells: {', '.join(unknown)}")
+    disabled = [cell_id for cell_id in requested if not by_id[cell_id].get("enabled")]
+    if disabled:
+        reasons = "; ".join(
+            f"{cell_id}: {by_id[cell_id].get('blocked_reason', 'disabled')}"
+            for cell_id in disabled
+        )
+        raise ValueError(f"requested disabled campaign cells: {reasons}")
+    return [by_id[cell_id] for cell_id in requested]
+
+
+def main() -> int:
+    args = parse_args()
+    campaign_path = args.campaign.resolve()
+    campaign = load_campaign(campaign_path)
+    cells = selected_cells(campaign, args.cell)
+    if args.list:
+        for cell in campaign["cells"]:
+            state = "enabled" if cell.get("enabled") else "blocked"
+            print(f"{cell['id']}\t{state}\tpriority={cell.get('priority')}")
+        return 0
+    if args.expected_mp is None or args.output_dir is None:
+        raise ValueError("--expected-mp and --output-dir are required unless --list")
+    if args.expected_physical_device is None or not args.expected_device_uuid:
+        raise ValueError(
+            "--expected-physical-device and --expected-device-uuid are required "
+            "for a reported campaign run"
+        )
+    allowed_mps = args.allowed_mp or campaign.get("allowed_multiprocessor_counts")
+    if allowed_mps is None:
+        # Keep already-generated v1 evidence replayable.  New public recipes
+        # intentionally omit this fleet-specific field.
+        allowed_mps = campaign.get("hardware", {}).get("runtime_multiprocessor_counts")
+    if allowed_mps is not None and args.expected_mp not in allowed_mps:
+        raise ValueError(
+            f"expected MP {args.expected_mp} is outside campaign bins {allowed_mps}"
+        )
+
+    visible_devices = verify_visible_device_contract()
+    repo = Path(__file__).resolve().parents[2]
+    source = source_identity(Path(__file__))
+    if source["dirty"] and not args.allow_dirty:
+        raise RuntimeError(
+            "refusing reported campaign on dirty source; commit the harness or "
+            "pass --allow-dirty for explicitly exploratory output"
+        )
+    device = probe_device()
+    if device["multiprocessor_count"] != args.expected_mp:
+        raise RuntimeError(
+            f"runtime MP mismatch: expected {args.expected_mp}, "
+            f"observed {device['multiprocessor_count']}"
+        )
+
+    output_dir = args.output_dir.resolve()
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise FileExistsError(f"output directory is not empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(campaign_path, output_dir / "campaign.json")
+    campaign_sha256 = hashlib.sha256(campaign_path.read_bytes()).hexdigest()
+    manifest: dict[str, Any] = {
+        "schema": "vllm-musa-mp-tactic-run.v1",
+        "started_at_utc": datetime.now(timezone.utc).isoformat(),
+        "mode": args.mode,
+        "campaign_sha256": campaign_sha256,
+        "source": source,
+        "device": device,
+        "expected_mp": args.expected_mp,
+        "visible_devices": visible_devices,
+        "lease_isolated": bool(args.lease_isolated),
+        "exploratory": bool(source["dirty"] or not args.lease_isolated),
+        "runs": [],
+    }
+    manifest_path = output_dir / "run-manifest.json"
+    write_json(manifest_path, manifest)
+
+    failures = 0
+    for cell in cells:
+        mode_args = cell["modes"][args.mode]
+        variants = cell.get("variants") or [{"id": "default", "args": []}]
+        for variant in variants:
+            run_id = f"{cell['id']}__{variant['id']}"
+            result_path = output_dir / f"{run_id}.json"
+            log_path = output_dir / f"{run_id}.log"
+            receipt_path = output_dir / f"{run_id}.receipt.json"
+            command = [
+                sys.executable,
+                str(repo / cell["script"]),
+                *cell.get("base_args", []),
+                *mode_args,
+                *variant.get("args", []),
+                "--output",
+                str(result_path),
+            ]
+            command = add_device_fence_args(
+                command,
+                args.expected_physical_device,
+                args.expected_device_uuid,
+            )
+            started = datetime.now(timezone.utc)
+            env = os.environ.copy()
+            env["PYTHONUNBUFFERED"] = "1"
+            with log_path.open("w") as log:
+                completed = subprocess.run(
+                    command,
+                    cwd=repo,
+                    env=env,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                )
+            ended = datetime.now(timezone.utc)
+            error = None
+            output_sha256 = None
+            if completed.returncode == 0:
+                try:
+                    result = json.loads(result_path.read_text())
+                    observed_mp = result.get("multiprocessor_count")
+                    if observed_mp != args.expected_mp:
+                        raise ValueError(
+                            f"result MP mismatch: expected {args.expected_mp}, "
+                            f"got {observed_mp}"
+                        )
+                    output_sha256 = hashlib.sha256(result_path.read_bytes()).hexdigest()
+                except (OSError, ValueError, json.JSONDecodeError) as exc:
+                    error = str(exc)
+            else:
+                error = f"benchmark exited {completed.returncode}"
+            if error is not None:
+                failures += 1
+            receipt = {
+                "schema": "vllm-musa-mp-tactic-cell-receipt.v1",
+                "run_id": run_id,
+                "cell": cell["id"],
+                "variant": variant["id"],
+                "command": command,
+                "started_at_utc": started.isoformat(),
+                "ended_at_utc": ended.isoformat(),
+                "duration_seconds": (ended - started).total_seconds(),
+                "returncode": completed.returncode,
+                "result": str(result_path),
+                "result_sha256": output_sha256,
+                "log": str(log_path),
+                "error": error,
+            }
+            write_json(receipt_path, receipt)
+            manifest["runs"].append(receipt)
+            write_json(manifest_path, manifest)
+            if error is not None and not args.continue_on_error:
+                manifest["ended_at_utc"] = datetime.now(timezone.utc).isoformat()
+                manifest["status"] = "failed"
+                write_json(manifest_path, manifest)
+                return 1
+
+    manifest["ended_at_utc"] = datetime.now(timezone.utc).isoformat()
+    manifest["status"] = "passed" if failures == 0 else "partial"
+    manifest["failure_count"] = failures
+    write_json(manifest_path, manifest)
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernel_tactics/summarize_mp_tactic_campaign.py
+++ b/benchmarks/kernel_tactics/summarize_mp_tactic_campaign.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Reduce MP tactic run bundles into conservative promotion candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from _benchmark_utils import effective_gemv_block
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dirs", type=Path, nargs="+")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--markdown", type=Path)
+    parser.add_argument("--prediction-input", type=Path)
+    parser.add_argument(
+        "--minimum-host-replicates",
+        type=int,
+        default=1,
+        help="local qualification requirement; not stored in the public recipe",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def result_path(run_dir: Path, receipt: dict[str, Any]) -> Path:
+    recorded = Path(receipt["result"])
+    if recorded.is_file():
+        return recorded
+    local = run_dir / recorded.name
+    if not local.is_file():
+        raise FileNotFoundError(f"result missing for {receipt['run_id']}: {local}")
+    return local
+
+
+def row_key(schema: str, row: dict[str, Any]) -> tuple[Any, ...]:
+    if schema == "musa-fused-gemv-moe-aot-paired-ab.v2":
+        return (
+            row["family"],
+            int(row["tokens"]),
+            row["route"],
+            row["stage"],
+        )
+    if schema == "musa-fused-add-rmsnorm-aot-paired-ab.v2":
+        return (int(row["hidden_size"]), int(row["rows"]))
+    if schema == "musa-dsv4-mhc-jit-aot-paired-ab.v1":
+        return (
+            row.get("production_path", "standalone"),
+            int(row["tokens"]),
+            int(row["split_k"]),
+        )
+    raise ValueError(f"unsupported result schema: {schema}")
+
+
+def tactic(schema: str, row: dict[str, Any]) -> str:
+    if schema == "musa-fused-gemv-moe-aot-paired-ab.v2":
+        requested = tuple(row["candidate_block"])
+        effective, _applied, _reason = effective_gemv_block(
+            row["family"], int(row["tokens"]), row["stage"], requested
+        )
+        return "x".join(str(value) for value in row.get("effective_block", effective))
+    if schema == "musa-fused-add-rmsnorm-aot-paired-ab.v2":
+        return str(row["candidate_block_x"])
+    if schema == "musa-dsv4-mhc-jit-aot-paired-ab.v1":
+        return "x".join(
+            str(row[field]) for field in ("threads", "hidden_block", "pass_config")
+        )
+    raise ValueError(f"unsupported result schema: {schema}")
+
+
+def key_dict(schema: str, key: tuple[Any, ...]) -> dict[str, Any]:
+    if schema == "musa-fused-gemv-moe-aot-paired-ab.v2":
+        family, tokens, route, stage = key
+        return {
+            "family": family,
+            "tokens": tokens,
+            "route": route,
+            "stage": stage,
+        }
+    if schema == "musa-fused-add-rmsnorm-aot-paired-ab.v2":
+        hidden_size, rows = key
+        return {"hidden_size": hidden_size, "rows": rows}
+    if schema == "musa-dsv4-mhc-jit-aot-paired-ab.v1":
+        production_path, tokens, split_k = key
+        return {
+            "production_path": production_path,
+            "tokens": tokens,
+            "split_k": split_k,
+        }
+    raise ValueError(f"unsupported result schema: {schema}")
+
+
+def mp_only_key(schema: str, key: tuple[Any, ...]) -> tuple[Any, ...]:
+    if schema == "musa-fused-gemv-moe-aot-paired-ab.v2":
+        family, tokens, _route, stage = key
+        return (family, tokens, stage)
+    return key
+
+
+def promotion_pass(row: dict[str, Any], gate: dict[str, Any]) -> bool:
+    requested_applied = row.get("requested_block_applied", True)
+    if (
+        requested_applied
+        and row.get("schema") == "musa-fused-gemv-moe-aot-paired-ab.v2"
+    ):
+        requested = tuple(row["candidate_block"])
+        _effective, requested_applied, _reason = effective_gemv_block(
+            row["family"], int(row["tokens"]), row["stage"], requested
+        )
+    return bool(
+        row.get("correctness_pass")
+        and not row.get("poison_output", False)
+        and requested_applied
+        and row.get("is_production_split", True)
+        and float(row["median_ratio"]) <= float(gate["median_ratio_max"])
+        and float(row["ratio_p95"]) <= float(gate["ratio_p95_max"])
+    )
+
+
+def amdahl_prediction(
+    ratio: float, time_share: float | None, hit_rate: float | None
+) -> float | None:
+    if time_share is None or hit_rate is None:
+        return None
+    affected = time_share * hit_rate
+    new_total = 1.0 - affected + affected * ratio
+    return (1.0 / new_total - 1.0) * 100.0
+
+
+def main() -> int:
+    args = parse_args()
+    predictions = (
+        load_json(args.prediction_input) if args.prediction_input is not None else {}
+    )
+    observations: list[dict[str, Any]] = []
+    campaign_sha256: str | None = None
+    campaign: dict[str, Any] | None = None
+
+    for run_dir_argument in args.run_dirs:
+        run_dir = run_dir_argument.resolve()
+        manifest = load_json(run_dir / "run-manifest.json")
+        if manifest.get("schema") != "vllm-musa-mp-tactic-run.v1":
+            raise ValueError(f"unsupported run manifest: {run_dir}")
+        current_sha = manifest["campaign_sha256"]
+        if campaign_sha256 is None:
+            campaign_sha256 = current_sha
+            campaign = load_json(run_dir / "campaign.json")
+        elif current_sha != campaign_sha256:
+            raise ValueError("cannot combine different campaign definitions")
+        mp = int(manifest["expected_mp"])
+        evidence_eligible = bool(manifest.get("lease_isolated", False)) and not bool(
+            manifest.get("exploratory", True)
+        )
+        for receipt in manifest["runs"]:
+            if receipt.get("error") is not None or receipt.get("returncode") != 0:
+                continue
+            result = load_json(result_path(run_dir, receipt))
+            schema = result["schema"]
+            grouped: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+            for row in result["rows"]:
+                grouped[row_key(schema, row)].append(row)
+            for key, rows in grouped.items():
+                winner = min(rows, key=lambda item: float(item["median_ratio"]))
+                observations.append(
+                    {
+                        "mp": mp,
+                        "cell": receipt["cell"],
+                        "variant": receipt["variant"],
+                        "schema": schema,
+                        "family": row.get("family"),
+                        "tokens": row.get("tokens"),
+                        "stage": row.get("stage"),
+                        "candidate_block": row.get("candidate_block"),
+                        "key": key,
+                        "key_fields": key_dict(schema, key),
+                        "tactic": tactic(schema, winner),
+                        "median_ratio": float(winner["median_ratio"]),
+                        "ratio_p95": float(winner["ratio_p95"]),
+                        "speedup_pct": float(winner["speedup_pct"]),
+                        "correctness_pass": bool(winner["correctness_pass"]),
+                        "poison_output": bool(winner.get("poison_output", False)),
+                        "hostname": result.get("provenance", {}).get("hostname"),
+                        "evidence_eligible": evidence_eligible,
+                        "result": str(result_path(run_dir, receipt)),
+                    }
+                )
+
+    assert campaign is not None and campaign_sha256 is not None
+    gate = campaign["methodology"]["promotion_gate"]
+    legacy_minimum_hosts = campaign.get("hardware", {}).get(
+        "minimum_host_replicates", {}
+    )
+    if args.minimum_host_replicates < 1:
+        raise ValueError("--minimum-host-replicates must be positive")
+    by_key: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+    for observation in observations:
+        by_key[
+            (
+                observation["mp"],
+                observation["cell"],
+                observation["schema"],
+                observation["key"],
+            )
+        ].append(observation)
+
+    route_candidates: list[dict[str, Any]] = []
+    for (mp, cell, schema, key), legs in sorted(by_key.items(), key=str):
+        tactics = sorted({leg["tactic"] for leg in legs})
+        hosts = sorted({leg["hostname"] for leg in legs if leg["hostname"]})
+        # Historical v1 bundles may carry a per-bin host requirement.  New
+        # public recipes deliberately do not: fleet-specific replication is a
+        # local run policy supplied on the command line.
+        required_hosts = int(
+            legacy_minimum_hosts.get(str(mp), args.minimum_host_replicates)
+        )
+        stable = len(tactics) == 1
+        all_pass = all(promotion_pass(leg, gate) for leg in legs)
+        enough_hosts = len(hosts) >= required_hosts
+        every_leg_eligible = all(leg["evidence_eligible"] for leg in legs)
+        worst_median_ratio = max(leg["median_ratio"] for leg in legs)
+        worst_p95_ratio = max(leg["ratio_p95"] for leg in legs)
+        prediction = predictions.get(cell, {})
+        time_share = prediction.get("op_time_share")
+        hit_rate = prediction.get("production_hit_rate")
+        route_candidates.append(
+            {
+                "mp": mp,
+                "cell": cell,
+                "schema": schema,
+                "key": key_dict(schema, key),
+                "winner": tactics[0] if stable else None,
+                "observed_winners": tactics,
+                "variants": sorted({leg["variant"] for leg in legs}),
+                "hosts": hosts,
+                "required_hosts": required_hosts,
+                "worst_median_ratio": worst_median_ratio,
+                "worst_p95_ratio": worst_p95_ratio,
+                "stable_across_runs": stable,
+                "all_legs_pass": all_pass,
+                "host_replication_pass": enough_hosts,
+                "evidence_eligible": every_leg_eligible,
+                "route_candidate_pass": (
+                    stable and all_pass and enough_hosts and every_leg_eligible
+                ),
+                "prediction": {
+                    "op_time_share": time_share,
+                    "production_hit_rate": hit_rate,
+                    "predicted_e2e_speedup_pct": amdahl_prediction(
+                        worst_median_ratio, time_share, hit_rate
+                    ),
+                    "status": (
+                        "estimated"
+                        if time_share is not None and hit_rate is not None
+                        else "needs-current-profile"
+                    ),
+                },
+            }
+        )
+
+    mp_groups: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+    for candidate in route_candidates:
+        key = tuple(candidate["key"].values())
+        mp_groups[
+            (
+                candidate["mp"],
+                candidate["cell"],
+                candidate["schema"],
+                mp_only_key(candidate["schema"], key),
+            )
+        ].append(candidate)
+
+    mp_only_candidates: list[dict[str, Any]] = []
+    for (mp, cell, schema, key), route_legs in sorted(mp_groups.items(), key=str):
+        winners = sorted(
+            {leg["winner"] for leg in route_legs if leg["winner"] is not None}
+        )
+        every_route_pass = all(leg["route_candidate_pass"] for leg in route_legs)
+        same_winner = len(winners) == 1 and all(
+            leg["winner"] == winners[0] for leg in route_legs
+        )
+        mp_only_candidates.append(
+            {
+                "mp": mp,
+                "cell": cell,
+                "schema": schema,
+                "key": list(key),
+                "winner": winners[0] if same_winner else None,
+                "route_count": len(route_legs),
+                "same_winner_across_routes": same_winner,
+                "every_route_pass": every_route_pass,
+                "promotion_ready": same_winner and every_route_pass,
+            }
+        )
+
+    payload = {
+        "schema": "vllm-musa-mp-tactic-summary.v1",
+        "campaign_sha256": campaign_sha256,
+        "gate": gate,
+        "observation_count": len(observations),
+        "route_candidates": route_candidates,
+        "mp_only_candidates": mp_only_candidates,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    if args.markdown is not None:
+        lines = [
+            "# MP tactic campaign summary",
+            "",
+            f"Observations: {len(observations)}",
+            "",
+            "| MP | Cell | Key | Winner | Ready |",
+            "|---:|---|---|---|---|",
+        ]
+        for candidate in mp_only_candidates:
+            lines.append(
+                "| {mp} | {cell} | `{key}` | {winner} | {ready} |".format(
+                    mp=candidate["mp"],
+                    cell=candidate["cell"],
+                    key=json.dumps(candidate["key"], separators=(",", ":")),
+                    winner=candidate["winner"] or "route/run dependent",
+                    ready="yes" if candidate["promotion_ready"] else "no",
+                )
+            )
+        lines.extend(
+            [
+                "",
+                "`Ready=no` is expected until all required seeds and host replicas pass.",
+            ]
+        )
+        args.markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.write_text("\n".join(lines) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/serving/benchmark_qwen35_graph_bucket_replay.py
+++ b/benchmarks/serving/benchmark_qwen35_graph_bucket_replay.py
@@ -1,0 +1,239 @@
+"""Replay mixed decode buckets through one compiled Qwen3.5 engine.
+
+This is a graph-contamination gate, not an HTTP latency benchmark. It keeps one
+engine alive while replaying small and fallback buckets in an adversarial order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import statistics
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from benchmark_qwen35_mp_ab import (
+    DISPATCH_ENV,
+    inspect_compile_state,
+    make_prompt_ids,
+)
+
+
+def _parse_sequence(value: str) -> list[int]:
+    sequence = [int(item) for item in value.split(",") if item.strip()]
+    if not sequence or any(batch < 1 for batch in sequence):
+        raise argparse.ArgumentTypeError(
+            "batch sequence must contain positive integers"
+        )
+    return sequence
+
+
+def _run_batch(
+    *,
+    llm: Any,
+    prompts: list[Any],
+    sampling_params: Any,
+    batch_size: int,
+    expected_output_tokens: int,
+) -> dict[str, Any]:
+    import torch
+
+    batch = prompts[:batch_size]
+    torch.musa.synchronize()
+    started = time.perf_counter()
+    outputs = llm.generate(batch, sampling_params, use_tqdm=False)
+    torch.musa.synchronize()
+    elapsed_s = time.perf_counter() - started
+
+    token_counts = [len(output.outputs[0].token_ids) for output in outputs]
+    texts = [output.outputs[0].text for output in outputs]
+    semantic_pass = all("beijing" in text.lower() for text in texts)
+    exact_output_tokens = all(count == expected_output_tokens for count in token_counts)
+    if not exact_output_tokens:
+        raise RuntimeError(
+            f"expected {expected_output_tokens} output tokens per request, "
+            f"got {token_counts}"
+        )
+    if not semantic_pass:
+        raise RuntimeError("semantic output check failed: expected Beijing")
+
+    total_output_tokens = sum(token_counts)
+    return {
+        "batch_size": batch_size,
+        "elapsed_s": elapsed_s,
+        "output_tokens": total_output_tokens,
+        "output_tokens_per_s": total_output_tokens / elapsed_s,
+        "exact_output_tokens": exact_output_tokens,
+        "semantic_pass": semantic_pass,
+        "texts": texts,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True, help="local model path or ID")
+    parser.add_argument("--policy", choices=("upstream", "auto"), required=True)
+    parser.add_argument("--max-num-seqs", type=int, default=64)
+    parser.add_argument(
+        "--batch-sequence",
+        type=_parse_sequence,
+        default="1,16,4,16,1,2,16",
+    )
+    parser.add_argument("--warmup-sequence", type=_parse_sequence, default="1,16,4")
+    parser.add_argument("--input-tokens", type=int, default=256)
+    parser.add_argument("--output-tokens", type=int, default=128)
+    parser.add_argument("--max-num-batched-tokens", type=int, default=8192)
+    parser.add_argument(
+        "--cudagraph-capture-sizes",
+        type=_parse_sequence,
+        default="1,2,4,16,64",
+    )
+    parser.add_argument("--seed", type=int, default=20260826)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    max_batch = max(args.batch_sequence + args.warmup_sequence)
+    if args.max_num_seqs < max_batch:
+        raise ValueError("max_num_seqs must cover every replay batch")
+    if args.input_tokens > 512:
+        raise ValueError(
+            "graph-bucket selector replay is limited to <=512 input tokens; "
+            "use exact base-vs-head AUTO serving arms for long-prefill gates"
+        )
+    required_capture_sizes = {1, 2, 4}
+    if not required_capture_sizes.issubset(args.cudagraph_capture_sizes) or not any(
+        size >= 16 for size in args.cudagraph_capture_sizes
+    ):
+        raise ValueError(
+            "cudagraph_capture_sizes must include 1,2,4 and a fallback bucket >=16"
+        )
+
+    dispatch_policy = args.policy
+    import os
+
+    os.environ[DISPATCH_ENV] = dispatch_policy
+
+    import torchada  # noqa: F401 - activate MUSA compatibility first
+    from transformers import AutoTokenizer
+    from vllm import LLM, SamplingParams, TokensPrompt
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model,
+        trust_remote_code=True,
+        local_files_only=True,
+    )
+    token_ids = make_prompt_ids(tokenizer, args.input_tokens)
+    prompts = [TokensPrompt(prompt_token_ids=token_ids) for _ in range(max_batch)]
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        max_tokens=args.output_tokens,
+        min_tokens=args.output_tokens,
+        ignore_eos=True,
+    )
+
+    llm = LLM(
+        model=args.model,
+        tensor_parallel_size=4,
+        trust_remote_code=True,
+        enforce_eager=False,
+        dtype="bfloat16",
+        seed=args.seed,
+        max_model_len=max(8192, args.input_tokens + args.output_tokens + 128),
+        max_num_batched_tokens=args.max_num_batched_tokens,
+        max_num_seqs=args.max_num_seqs,
+        gpu_memory_utilization=0.9,
+        compilation_config=(
+            {"cudagraph_capture_sizes": args.cudagraph_capture_sizes}
+            if args.cudagraph_capture_sizes is not None
+            else None
+        ),
+    )
+
+    for batch_size in args.warmup_sequence:
+        _run_batch(
+            llm=llm,
+            prompts=prompts,
+            sampling_params=sampling_params,
+            batch_size=batch_size,
+            expected_output_tokens=args.output_tokens,
+        )
+
+    records = []
+    for step, batch_size in enumerate(args.batch_sequence):
+        record = _run_batch(
+            llm=llm,
+            prompts=prompts,
+            sampling_params=sampling_params,
+            batch_size=batch_size,
+            expected_output_tokens=args.output_tokens,
+        )
+        record["step"] = step
+        records.append(record)
+
+    grouped: dict[int, list[float]] = defaultdict(list)
+    for record in records:
+        grouped[record["batch_size"]].append(record["output_tokens_per_s"])
+    per_batch = {
+        str(batch_size): {
+            "samples": values,
+            "median_output_tokens_per_s": statistics.median(values),
+        }
+        for batch_size, values in sorted(grouped.items())
+    }
+
+    compile_state = inspect_compile_state(llm)
+    if compile_state is None or not compile_state["compile_active"]:
+        raise RuntimeError(
+            "vLLM resolved cudagraph mode is unavailable or disabled; "
+            "refusing to record a compiled replay result"
+        )
+    required_full_sizes = {1, 2, 4, 16}
+    for worker_state in compile_state["worker_states"]:
+        full_sizes = {
+            descriptor["num_tokens"]
+            for descriptor in worker_state["capture_descriptors"].get("FULL", [])
+            if descriptor["num_reqs"] == descriptor["num_tokens"]
+            and descriptor["uniform"] is True
+            and descriptor["has_lora"] is False
+            and descriptor["num_active_loras"] == 0
+        }
+        if not required_full_sizes.issubset(full_sizes):
+            raise RuntimeError(
+                "worker FULL capture descriptors do not cover selector/fallback "
+                f"buckets: required={sorted(required_full_sizes)}, "
+                f"observed={sorted(full_sizes)}, state={worker_state}"
+            )
+
+    result = {
+        "policy": args.policy,
+        "model": args.model,
+        "tensor_parallel_size": 4,
+        "max_num_seqs": args.max_num_seqs,
+        "batch_sequence": args.batch_sequence,
+        "warmup_sequence": args.warmup_sequence,
+        "input_tokens": args.input_tokens,
+        "output_tokens": args.output_tokens,
+        "max_num_batched_tokens": args.max_num_batched_tokens,
+        "cudagraph_capture_sizes": args.cudagraph_capture_sizes,
+        "dispatch_policy": dispatch_policy,
+        "seed": args.seed,
+        "enforce_eager": False,
+        "compile_state": compile_state,
+        "compiled_or_captured": True,
+        "semantic_pass": all(record["semantic_pass"] for record in records),
+        "exact_output_tokens": all(record["exact_output_tokens"] for record in records),
+        "per_batch": per_batch,
+        "records": records,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    del llm
+    gc.collect()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/serving/benchmark_qwen35_mp_ab.py
+++ b/benchmarks/serving/benchmark_qwen35_mp_ab.py
@@ -1,0 +1,234 @@
+"""Compiled/captured Qwen3.5 TP4 same-source selector attribution.
+
+This diagnostic compares the explicit upstream rollback with AUTO on one source
+tree. Exact base-vs-head serving gates must keep AUTO in both source arms.
+Each process should use a fresh container/cache so graph and JIT compilation
+costs cannot leak from one policy arm into the other.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+# Keep the benchmark portable: model storage is fleet-specific and must be
+# supplied by the caller rather than baked into a published script.
+DEFAULT_MODEL = None
+DISPATCH_ENV = "VLLM_MUSA_FUSED_MOE_DISPATCH"
+
+
+def inspect_compile_state(llm: Any) -> dict[str, Any] | None:
+    """Return client intent plus every worker's resolved dispatcher state."""
+    engine = getattr(llm, "llm_engine", None)
+    vllm_config = getattr(engine, "vllm_config", None)
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    if compilation_config is None:
+        return None
+    mode = getattr(compilation_config, "cudagraph_mode", None)
+    mode_name = getattr(mode, "name", None) or str(mode)
+    capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None)
+    worker_states = llm.collective_rpc("get_musa_cudagraph_runtime_state", timeout=60)
+    worker_runtime_modes = {state["resolved_cudagraph_mode"] for state in worker_states}
+    workers_active = bool(
+        worker_states
+        and len(worker_states) == 4
+        and len(worker_runtime_modes) == 1
+        and worker_runtime_modes != {"NONE"}
+        and all(state["keys_initialized"] for state in worker_states)
+        and all(state["capture_descriptors"] for state in worker_states)
+    )
+    return {
+        "client_cudagraph_mode": mode_name,
+        "client_cudagraph_capture_sizes": list(capture_sizes or []),
+        "worker_states": worker_states,
+        "compile_active": bool(
+            mode_name.upper() not in {"NONE", "NONE_MODE"} and workers_active
+        ),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True, help="local model path or ID")
+    parser.add_argument("--policy", choices=("upstream", "auto"), required=True)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--max-num-seqs", type=int)
+    parser.add_argument("--input-tokens", type=int, default=256)
+    parser.add_argument("--output-tokens", type=int, default=128)
+    parser.add_argument("--warmup", type=int, default=4)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.90)
+    return parser.parse_args()
+
+
+def _instruction(tokenizer: Any) -> list[int]:
+    encoded = tokenizer.apply_chat_template(
+        [
+            {
+                "role": "user",
+                "content": (
+                    "What is the capital of China? Answer in English with one word."
+                ),
+            }
+        ],
+        tokenize=True,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+    if hasattr(encoded, "input_ids"):
+        encoded = encoded.input_ids
+    elif isinstance(encoded, dict):
+        encoded = encoded["input_ids"]
+    return list(encoded)
+
+
+def make_prompt_ids(tokenizer: Any, input_tokens: int) -> list[int]:
+    if input_tokens < 32:
+        raise ValueError("input_tokens must be at least 32")
+    suffix = _instruction(tokenizer)
+    filler = tokenizer.encode(
+        "The following context is neutral and contains no additional instructions. ",
+        add_special_tokens=False,
+    )
+    ids: list[int] = []
+    while len(ids) + len(suffix) < input_tokens:
+        ids.extend(filler)
+    ids.extend(suffix)
+    return ids[-input_tokens:]
+
+
+def run_batch(
+    llm: Any,
+    prompt_ids: list[int],
+    batch_size: int,
+    sampling: Any,
+) -> tuple[float, list[str], int]:
+    from vllm import TokensPrompt
+
+    prompts = [TokensPrompt(prompt_token_ids=prompt_ids) for _ in range(batch_size)]
+    start = time.perf_counter()
+    outputs = llm.generate(prompts, sampling)
+    elapsed = time.perf_counter() - start
+    texts = [item.outputs[0].text for item in outputs]
+    generated = sum(len(item.outputs[0].token_ids) for item in outputs)
+    return elapsed, texts, generated
+
+
+def main() -> int:
+    args = parse_args()
+    if (
+        args.batch_size < 1
+        or args.repeats < 1
+        or args.warmup < 0
+        or (args.max_num_seqs is not None and args.max_num_seqs < args.batch_size)
+    ):
+        raise ValueError(
+            "batch_size/repeats must be positive, warmup non-negative, and "
+            "max_num_seqs must cover batch_size"
+        )
+
+    if args.input_tokens > 512:
+        raise ValueError(
+            "same-source selector attribution is limited to <=512 input tokens; "
+            "use exact base-vs-head AUTO serving arms for long-prefill gates"
+        )
+    max_num_seqs = args.max_num_seqs or args.batch_size
+    dispatch_policy = args.policy
+    os.environ[DISPATCH_ENV] = dispatch_policy
+
+    import torchada  # noqa: F401 - activate MUSA compatibility first
+    from transformers import AutoTokenizer
+    from vllm import LLM, SamplingParams
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    prompt_ids = make_prompt_ids(tokenizer, args.input_tokens)
+    llm = LLM(
+        model=args.model,
+        tensor_parallel_size=4,
+        trust_remote_code=True,
+        enforce_eager=False,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        max_model_len=args.input_tokens + args.output_tokens + 256,
+        max_num_seqs=max_num_seqs,
+    )
+    sampling = SamplingParams(
+        temperature=0.0,
+        max_tokens=args.output_tokens,
+        ignore_eos=True,
+    )
+
+    warmup_records = []
+    for _ in range(args.warmup):
+        elapsed, _, generated = run_batch(llm, prompt_ids, args.batch_size, sampling)
+        warmup_records.append({"elapsed_s": elapsed, "generated_tokens": generated})
+
+    records: list[dict[str, Any]] = []
+    for index in range(args.repeats):
+        elapsed, texts, generated = run_batch(
+            llm, prompt_ids, args.batch_size, sampling
+        )
+        if generated != args.batch_size * args.output_tokens:
+            raise AssertionError(
+                f"run {index} generated {generated}, expected "
+                f"{args.batch_size * args.output_tokens}"
+            )
+        records.append(
+            {
+                "index": index,
+                "elapsed_s": elapsed,
+                "generated_tokens": generated,
+                "output_tokens_per_s": generated / elapsed,
+                "semantic_text_sample": texts[0][:256],
+            }
+        )
+
+    semantic_sampling = SamplingParams(temperature=0.0, max_tokens=32)
+    _, semantic_texts, _ = run_batch(llm, _instruction(tokenizer), 1, semantic_sampling)
+    semantic_text = semantic_texts[0]
+    if "beijing" not in semantic_text.lower():
+        raise AssertionError(
+            f"semantic check did not contain Beijing: {semantic_text!r}"
+        )
+
+    compile_state = inspect_compile_state(llm)
+    if compile_state is None or not compile_state["compile_active"]:
+        raise RuntimeError(
+            "vLLM resolved cudagraph mode is unavailable or disabled; "
+            "refusing to record a compiled A/B result"
+        )
+
+    throughputs = [record["output_tokens_per_s"] for record in records]
+    result = {
+        "policy": args.policy,
+        "model": args.model,
+        "tensor_parallel_size": 4,
+        "compile_state": compile_state,
+        "compiled_or_captured": True,
+        "enforce_eager": False,
+        "batch_size": args.batch_size,
+        "max_num_seqs": max_num_seqs,
+        "dispatch_policy": dispatch_policy,
+        "input_tokens": args.input_tokens,
+        "output_tokens": args.output_tokens,
+        "warmup": warmup_records,
+        "records": records,
+        "median_output_tokens_per_s": statistics.median(throughputs),
+        "mean_output_tokens_per_s": statistics.mean(throughputs),
+        "semantic_text": semantic_text,
+        "semantic_pass": True,
+        "argv": list(os.sys.argv),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(result, indent=2), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/csrc/musa/cache_kernels.mu
+++ b/csrc/musa/cache_kernels.mu
@@ -55,19 +55,14 @@ __global__ void __launch_bounds__(BLOCK_X, 1)
   }
 }
 
-template <typename T>
-void dispatch_reshape_and_cache_flash_nhd(
+template <typename T, int BLOCK_X>
+void launch_reshape_and_cache_flash_nhd(
     const T* key, const T* value, T* key_cache, T* value_cache,
     const int64_t* slot_mapping, int num_tokens, int num_heads, int head_size,
     int block_size, int64_t key_stride, int64_t value_stride,
-    int64_t block_stride, int64_t page_stride, musaStream_t stream) {
-  constexpr int BLOCK_X = 512;
+    int64_t block_stride, int64_t page_stride, musaStream_t stream,
+    int forced_tokens_per_block) {
   const int vecs_per_token = (num_heads * head_size) / 8;
-
-  static const int forced_tokens_per_block = []() {
-    const char* env = std::getenv("VLLM_MUSA_RESHAPE_CACHE_TOKENS_PER_BLOCK");
-    return env == nullptr ? 0 : std::atoi(env);
-  }();
 
 #define LAUNCH(TPB)                                                        \
   reshape_and_cache_flash_nhd_kernel<T, BLOCK_X, TPB>                      \
@@ -97,12 +92,51 @@ void dispatch_reshape_and_cache_flash_nhd(
 #undef LAUNCH
 }
 
+template <typename T>
+void dispatch_reshape_and_cache_flash_nhd(
+    const T* key, const T* value, T* key_cache, T* value_cache,
+    const int64_t* slot_mapping, int num_tokens, int num_heads, int head_size,
+    int block_size, int64_t key_stride, int64_t value_stride,
+    int64_t block_stride, int64_t page_stride, musaStream_t stream,
+    int64_t requested_block_x) {
+  // Nonzero BLOCK_X values are a per-call benchmark seam. Production callers
+  // pass 0, which preserves the fixed 512-thread launch.
+  const int block_x = requested_block_x == 0 ? 512 : requested_block_x;
+  static const int forced_tokens_per_block = []() {
+    const char* env = std::getenv("VLLM_MUSA_RESHAPE_CACHE_TOKENS_PER_BLOCK");
+    return env == nullptr ? 0 : std::atoi(env);
+  }();
+
+#define DISPATCH(BLOCK_X)                                                  \
+  launch_reshape_and_cache_flash_nhd<T, BLOCK_X>(                          \
+      key, value, key_cache, value_cache, slot_mapping, num_tokens,        \
+      num_heads, head_size, block_size, key_stride, value_stride,          \
+      block_stride, page_stride, stream, forced_tokens_per_block)
+
+  if (block_x == 128) {
+    DISPATCH(128);
+  } else if (block_x == 256) {
+    DISPATCH(256);
+  } else if (block_x == 512) {
+    DISPATCH(512);
+  } else {
+    DISPATCH(1024);
+  }
+
+#undef DISPATCH
+}
+
 }  // namespace vllm_musa
 
 void musa_reshape_and_cache_flash_nhd(torch::Tensor& key, torch::Tensor& value,
                                       torch::Tensor& key_cache,
                                       torch::Tensor& value_cache,
-                                      torch::Tensor& slot_mapping) {
+                                      torch::Tensor& slot_mapping,
+                                      int64_t block_x) {
+  TORCH_CHECK(block_x == 0 || block_x == 128 || block_x == 256 ||
+                  block_x == 512 || block_x == 1024,
+              "block_x must be 0 (production default) or one of 128, 256, "
+              "512, or 1024");
   TORCH_CHECK(key.device().is_privateuseone(), "key must be a MUSA tensor");
   TORCH_CHECK(value.device().is_privateuseone(), "value must be a MUSA tensor");
   TORCH_CHECK(key_cache.device().is_privateuseone(),
@@ -182,7 +216,7 @@ void musa_reshape_and_cache_flash_nhd(torch::Tensor& key, torch::Tensor& value,
         static_cast<__half*>(value_cache.data_ptr()),
         slot_mapping.data_ptr<int64_t>(), num_tokens, num_heads, head_size,
         block_size, key_stride, value_stride, block_stride, page_stride,
-        stream);
+        stream, block_x);
   } else if (key.scalar_type() == at::ScalarType::BFloat16) {
     vllm_musa::dispatch_reshape_and_cache_flash_nhd<__mt_bfloat16>(
         static_cast<const __mt_bfloat16*>(key.data_ptr()),
@@ -191,7 +225,7 @@ void musa_reshape_and_cache_flash_nhd(torch::Tensor& key, torch::Tensor& value,
         static_cast<__mt_bfloat16*>(value_cache.data_ptr()),
         slot_mapping.data_ptr<int64_t>(), num_tokens, num_heads, head_size,
         block_size, key_stride, value_stride, block_stride, page_stride,
-        stream);
+        stream, block_x);
   } else {
     TORCH_CHECK(false, "only fp16 and bf16 are supported");
   }

--- a/csrc/musa/gemv.mu
+++ b/csrc/musa/gemv.mu
@@ -540,6 +540,15 @@ bool IsForcedBlockConfigValid(const BlockConfig& config, int nr_n, int hidden_si
            (hidden_size % (config.block_k * vlen) == 0);
 }
 
+bool IsDenseGemvBlockConfigSupported(const BlockConfig& config) {
+    return (config.block_n == 4 && config.block_k == 32) ||
+           (config.block_n == 8 && (config.block_k == 16 || config.block_k == 32)) ||
+           (config.block_n == 16 && (config.block_k == 8 || config.block_k == 16)) ||
+           (config.block_n == 32 &&
+            (config.block_k == 1 || config.block_k == 4 || config.block_k == 8)) ||
+           (config.block_n == 128 && config.block_k == 1);
+}
+
 bool ShouldUseQwenFp8Moe32x4(
     int current_arch,
     bool is_fp8,
@@ -618,6 +627,7 @@ bool ShouldUseDeepSeekV4Fp8MoeSplitTile(
 
 bool SelectDeepSeekV4Fp8OProjTile(
     int current_arch,
+    int num_mp,
     bool is_fp8,
     bool use_swigelu,
     bool use_rms_norm,
@@ -635,12 +645,57 @@ bool SelectDeepSeekV4Fp8OProjTile(
         return false;
     }
 
-    // DeepSeek-V4 TP8 O-proj is [M,4096] x [1024,4096]^T.  The platform's
-    // VLLM_MUSA_GEMV_MOE_BLOCK=16x8 default belongs to routed MoE, but the
-    // non-MoE GEMV historically consumed it too.  Cold-L2 calibration on an
-    // S5000 mp60 shows that the production graph-capture ladder needs more N
-    // tiles at small M and different K reductions as M grows.  Match only the
-    // exact O-proj contract; unsupported/eager sizes retain the generic path.
+    // Qualified exact active-MP policy for the DSV4 TP8 O-proj shape. Unknown
+    // MP/shape combinations intentionally fall through to the original
+    // capture ladder below; measurement receipts remain out of tree.
+    if (num_mp == 48) {
+        switch (bseqlen) {
+            case 1:
+                *config = BlockConfig{8, 32, 0.f, true};
+                return IsForcedBlockConfigValid(
+                    *config, nr_n, hidden_size, vlen);
+            case 8:
+                *config = BlockConfig{16, 8, 0.f, true};
+                return IsForcedBlockConfigValid(
+                    *config, nr_n, hidden_size, vlen);
+            case 32:
+            case 64:
+                *config = BlockConfig{32, 4, 0.f, true};
+                return IsForcedBlockConfigValid(
+                    *config, nr_n, hidden_size, vlen);
+            default:
+                break;
+        }
+    } else if (num_mp == 56) {
+        switch (bseqlen) {
+            case 8:
+                *config = BlockConfig{16, 16, 0.f, true};
+                return IsForcedBlockConfigValid(
+                    *config, nr_n, hidden_size, vlen);
+            case 64:
+                *config = BlockConfig{32, 4, 0.f, true};
+                return IsForcedBlockConfigValid(
+                    *config, nr_n, hidden_size, vlen);
+            default:
+                break;
+        }
+    } else if (num_mp == 60) {
+        switch (bseqlen) {
+            case 8:
+                *config = BlockConfig{8, 16, 0.f, true};
+                return IsForcedBlockConfigValid(
+                    *config, nr_n, hidden_size, vlen);
+            case 64:
+                *config = BlockConfig{32, 4, 0.f, true};
+                return IsForcedBlockConfigValid(
+                    *config, nr_n, hidden_size, vlen);
+            default:
+                break;
+        }
+    }
+
+    // Preserve the original cross-MP capture ladder for every exact miss,
+    // including every unknown active-MP value.
     switch (bseqlen) {
         case 1:
         case 2:
@@ -697,7 +752,9 @@ void musa_fused_gemv(
     bool use_swigelu,
     bool use_rms_norm,
     const c10::optional<torch::Tensor> &gamma,
-    double eps) {
+    double eps,
+    int64_t requested_block_n,
+    int64_t requested_block_k) {
 
     TORCH_CHECK(A.dim() == 2, "A must be dim 2.")
     TORCH_CHECK(B.dim() == 2, "B must be dim 2.")
@@ -801,10 +858,33 @@ void musa_fused_gemv(
         fallback_config = BlockConfig{128, 1, -1.0f, false};
     }
     BlockConfig forced_config{0, 0, 0.f, false};
+    BlockConfig requested_config{
+        static_cast<int>(requested_block_n),
+        static_cast<int>(requested_block_k),
+        0.f,
+        false};
     BlockConfig deepseek_v4_linear_config{0, 0, 0.f, false};
     BlockConfig* best_config = &fallback_config;
-    if (SelectDeepSeekV4Fp8OProjTile(
+    TORCH_CHECK(
+        (requested_block_n == 0 && requested_block_k == 0) ||
+            (requested_block_n > 0 && requested_block_k > 0),
+        "dense GEMV block_n and block_k must both be zero or positive, got ",
+        requested_block_n, "x", requested_block_k);
+    if (requested_block_n > 0) {
+        TORCH_CHECK(
+            IsDenseGemvBlockConfigSupported(requested_config),
+            "unsupported dense GEMV requested block ", requested_block_n, "x",
+            requested_block_k);
+        TORCH_CHECK(
+            IsForcedBlockConfigValid(requested_config, nr_n, hidden_size, vlen),
+            "dense GEMV requested block ", requested_block_n, "x",
+            requested_block_k, " is invalid for nr_n=", nr_n,
+            ", hidden_size=", hidden_size, ", vlen=", vlen);
+        requested_config.valid = true;
+        best_config = &requested_config;
+    } else if (SelectDeepSeekV4Fp8OProjTile(
             current_arch,
+            num_mp,
             is_fp8,
             use_swigelu,
             use_rms_norm,

--- a/csrc/musa/musa_ops.h
+++ b/csrc/musa/musa_ops.h
@@ -31,7 +31,9 @@ void musa_fused_gemv(
     bool use_swigelu,
     bool use_rms_norm,
     const c10::optional<torch::Tensor> &gamma,
-    double eps);
+    double eps,
+    int64_t block_n,
+    int64_t block_k);
 
 void musa_fused_add_rms_norm(
     torch::Tensor &input,
@@ -45,19 +47,20 @@ void musa_reshape_and_cache_flash_nhd(
     torch::Tensor &value,
     torch::Tensor &key_cache,
     torch::Tensor &value_cache,
-    torch::Tensor &slot_mapping);
+    torch::Tensor &slot_mapping,
+    int64_t block_x);
 
 void silu_and_mul_per_token_group_fp8_quant(
     const torch::Tensor& input,
     torch::Tensor& output_q, torch::Tensor& output_s,
     int64_t group_size, double eps, double fp8_min,
-    double fp8_max);
+    double fp8_max, int64_t groups_per_block);
 
 void silu_and_mul_clamp_per_token_group_fp8_quant(
     const torch::Tensor& input,
     torch::Tensor& output_q, torch::Tensor& output_s,
     int64_t group_size, double eps, double fp8_min,
-    double fp8_max, double swiglu_limit);
+    double fp8_max, double swiglu_limit, int64_t groups_per_block);
 
 void fused_add_rms_norm_per_token_group_fp8_quant(
     const torch::Tensor& input, const torch::Tensor& residual,
@@ -68,7 +71,7 @@ void per_token_group_quant_8bit_vec(
     const torch::Tensor& input,
     torch::Tensor& output_q, torch::Tensor& output_s,
     int64_t group_size, double eps, double min_8bit,
-    double max_8bit);
+    double max_8bit, int64_t groups_per_block);
 
 void musa_top_k_top_p_sampling_from_probs(
     at::Tensor probs,

--- a/csrc/musa/quantization/per_token_group_quant_8bit_vec.cu
+++ b/csrc/musa/quantization/per_token_group_quant_8bit_vec.cu
@@ -111,7 +111,8 @@ void per_token_group_quant_8bit_vec(const torch::Tensor& input,
                                     torch::Tensor& output_q,
                                     torch::Tensor& output_s, int64_t group_size,
                                     double eps, double min_8bit,
-                                    double max_8bit) {
+                                    double max_8bit,
+                                    int64_t requested_groups_per_block) {
   TORCH_CHECK(input.is_contiguous());
   TORCH_CHECK(output_q.is_contiguous());
   TORCH_CHECK(output_s.dim() == 2);
@@ -131,7 +132,18 @@ void per_token_group_quant_8bit_vec(const torch::Tensor& input,
   const int num_groups = static_cast<int>(input.numel() / group_size);
   if (num_groups == 0) return;
 
-  const int groups_per_block = GetGroupsPerBlock(num_groups);
+  int groups_per_block = GetGroupsPerBlock(num_groups);
+  if (requested_groups_per_block != 0) {
+    TORCH_CHECK(
+        requested_groups_per_block == 1 || requested_groups_per_block == 2 ||
+            requested_groups_per_block == 4 ||
+            requested_groups_per_block == 8 ||
+            requested_groups_per_block == 16,
+        "groups_per_block must be one of 0,1,2,4,8,16.");
+    TORCH_CHECK(num_groups % requested_groups_per_block == 0,
+                "num_groups must be divisible by requested groups_per_block.");
+    groups_per_block = static_cast<int>(requested_groups_per_block);
+  }
   const int num_blocks = num_groups / groups_per_block;
   const int num_threads = groups_per_block * THREADS_PER_GROUP;
 

--- a/csrc/musa/quantization/silu_and_mul_per_token_group_fp8_quant.cu
+++ b/csrc/musa/quantization/silu_and_mul_per_token_group_fp8_quant.cu
@@ -133,7 +133,8 @@ template <bool APPLY_CLAMP>
 void silu_and_mul_per_token_group_fp8_quant_impl(
     const torch::Tensor& input, torch::Tensor& output_q,
     torch::Tensor& output_s, int64_t group_size, double eps, double fp8_min,
-    double fp8_max, double swiglu_limit) {
+    double fp8_max, double swiglu_limit,
+    int64_t requested_groups_per_block) {
   TORCH_CHECK(input.is_contiguous());
   TORCH_CHECK(output_q.is_contiguous());
   TORCH_CHECK(output_s.is_contiguous());
@@ -159,7 +160,16 @@ void silu_and_mul_per_token_group_fp8_quant_impl(
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   constexpr int THREADS_PER_GROUP = 16;
-  const int groups_per_block = GetGroupsPerBlock(num_groups);
+  int groups_per_block = GetGroupsPerBlock(num_groups);
+  if (requested_groups_per_block != 0) {
+    TORCH_CHECK(
+        requested_groups_per_block == 1 || requested_groups_per_block == 2 ||
+            requested_groups_per_block == 4 ||
+            requested_groups_per_block == 8 ||
+            requested_groups_per_block == 16,
+        "groups_per_block must be one of 0,1,2,4,8,16.");
+    groups_per_block = static_cast<int>(requested_groups_per_block);
+  }
   const int num_blocks = (num_groups + groups_per_block - 1) / groups_per_block;
   const int num_threads = groups_per_block * THREADS_PER_GROUP;
   auto dst_type = output_q.scalar_type();
@@ -196,18 +206,19 @@ void silu_and_mul_per_token_group_fp8_quant_impl(
 void silu_and_mul_per_token_group_fp8_quant(
     const torch::Tensor& input, torch::Tensor& output_q,
     torch::Tensor& output_s, int64_t group_size, double eps, double fp8_min,
-    double fp8_max) {
+    double fp8_max, int64_t groups_per_block) {
   silu_and_mul_per_token_group_fp8_quant_impl<false>(
-      input, output_q, output_s, group_size, eps, fp8_min, fp8_max, 0.0);
+      input, output_q, output_s, group_size, eps, fp8_min, fp8_max, 0.0,
+      groups_per_block);
 }
 
 void silu_and_mul_clamp_per_token_group_fp8_quant(
     const torch::Tensor& input, torch::Tensor& output_q,
     torch::Tensor& output_s, int64_t group_size, double eps, double fp8_min,
-    double fp8_max, double swiglu_limit) {
+    double fp8_max, double swiglu_limit, int64_t groups_per_block) {
   TORCH_CHECK(std::isfinite(swiglu_limit) && swiglu_limit > 0.0,
               "swiglu_limit must be finite and positive.");
   silu_and_mul_per_token_group_fp8_quant_impl<true>(
       input, output_q, output_s, group_size, eps, fp8_min, fp8_max,
-      swiglu_limit);
+      swiglu_limit, groups_per_block);
 }

--- a/csrc/musa/torch_bindings.cpp
+++ b/csrc/musa/torch_bindings.cpp
@@ -19,7 +19,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
   musa_ops.def(
       "musa_fused_gemv(Tensor! A, Tensor! B, Tensor! C, Tensor? A_scale, Tensor? B_scale,"
       "bool use_int4_w4a16, bool use_swigelu, bool use_rms_norm, Tensor? gamma,"
-      "float eps) -> ()");
+      "float eps, int block_n=0, int block_k=0) -> ()");
   musa_ops.impl("musa_fused_gemv", torch::kMUSA, &musa_fused_gemv);
 
   musa_ops.def(
@@ -30,21 +30,23 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
 
   musa_ops.def(
       "musa_reshape_and_cache_flash_nhd(Tensor key, Tensor value, "
-      "Tensor! key_cache, Tensor! value_cache, Tensor slot_mapping) -> ()");
+      "Tensor! key_cache, Tensor! value_cache, Tensor slot_mapping, "
+      "int block_x=0) -> ()");
   musa_ops.impl("musa_reshape_and_cache_flash_nhd", torch::kMUSA,
                 &musa_reshape_and_cache_flash_nhd);
 
   musa_ops.def(
       "silu_and_mul_per_token_group_fp8_quant(Tensor input, Tensor! output_q, "
       "Tensor! output_s, int group_size, float eps, float fp8_min, "
-      "float fp8_max) -> ()");
+      "float fp8_max, int groups_per_block=0) -> ()");
   musa_ops.impl("silu_and_mul_per_token_group_fp8_quant", torch::kMUSA,
                 &silu_and_mul_per_token_group_fp8_quant);
 
   musa_ops.def(
       "silu_and_mul_clamp_per_token_group_fp8_quant(Tensor input, "
       "Tensor! output_q, Tensor! output_s, int group_size, float eps, "
-      "float fp8_min, float fp8_max, float swiglu_limit) -> ()");
+      "float fp8_min, float fp8_max, float swiglu_limit, "
+      "int groups_per_block=0) -> ()");
   musa_ops.impl("silu_and_mul_clamp_per_token_group_fp8_quant", torch::kMUSA,
                 &silu_and_mul_clamp_per_token_group_fp8_quant);
 
@@ -58,7 +60,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _musa_ops), musa_ops) {
   musa_ops.def(
       "per_token_group_quant_8bit_vec(Tensor input, Tensor! output_q, "
       "Tensor! output_s, int group_size, float eps, float min_8bit, "
-      "float max_8bit) -> ()");
+      "float max_8bit, int groups_per_block=0) -> ()");
   musa_ops.impl("per_token_group_quant_8bit_vec", torch::kMUSA,
                 &per_token_group_quant_8bit_vec);
   musa_ops.def(

--- a/docs/vllm_musa/README.md
+++ b/docs/vllm_musa/README.md
@@ -2,6 +2,13 @@
 
 Python package that plugs into vLLM's platform and general plugin system to enable inference on Moore Threads MUSA GPUs (MTGPU).
 
+The checked-in `benchmarks/kernel_tactics/full_kernel_sweep.json` is a
+source-only AOT/JIT inventory. It intentionally contains no host identity,
+driver/runtime receipt, timing sample, or qualification result. Campaign
+recipes live beside the benchmark harness; reports and raw measurements are
+ticket-linked local artifacts under `generated/` and are not part of the
+published source tree.
+
 ## Package Entry Points
 
 | Entry Point | Function | Purpose |
@@ -52,15 +59,15 @@ Custom `forward_oot` implementations registered for MUSA dispatch:
 
 #### FP8 MoE backend dispatch
 
-On S5000, block-128 E4M3 MoE layers use a shape-keyed `auto` policy. Only
-offline-calibrated per-rank shapes select native GEMV for small token batches.
-For large eligible prefill invocations, `auto` preserves the default-on
-contiguous DeepGEMM path; intermediate and unsupported shapes use
-the established upstream fused-MoE implementation. The experimental grouped
-backend added by this dispatcher remains disabled unless both its operator and
-serving gates produce a validated threshold. The policy is also keyed by graph
-mode and active MP count, so thresholds are not reused across incompatible
-devices.
+Block-128 E4M3 MoE layers use a shape-keyed `auto` policy. Exact runtime
+hardware/shape/graph keys may select native GEMV for small token batches. For
+large eligible prefill invocations, `auto` preserves the default-on contiguous
+DeepGEMM path; intermediate and unsupported shapes use the established
+upstream fused-MoE implementation. The experimental grouped backend remains
+disabled unless its operator and serving gates produce a validated threshold.
+The policy is keyed by the runtime MP count and graph mode, so thresholds are
+not reused across incompatible devices. Qualification receipts stay outside
+the source distribution.
 
 `VLLM_MUSA_FUSED_MOE_DISPATCH` is a diagnostic force/rollback control with the
 values `auto` (default), `upstream`, `gemv`, or `grouped_gemm`. Forced modes do

--- a/docs/vllm_musa/hardware-aware-kernel-tactics.md
+++ b/docs/vllm_musa/hardware-aware-kernel-tactics.md
@@ -1,0 +1,232 @@
+# Hardware-aware kernel tactics on MUSA
+
+This document defines the vLLM-MUSA policy for kernels whose launch geometry
+depends on the number of available multiprocessors (MPs). It applies to AOT,
+MUBIN, JIT, TileLang, Triton, MATE, and vendor-library providers.
+
+## Why architecture alone is not enough
+
+Two devices can implement the same ISA while exposing different
+`multi_processor_count` values. A fixed grid or tile can therefore cross a
+wave boundary on one device but not another. A launch that fills an integer
+number of waves on one device may leave a tail wave on another. The resulting
+discontinuity can be much larger than the nominal difference in peak
+throughput.
+
+Use the runtime MP count, not a product-name substring or an assumed default.
+Do not derive a marketing core-bin label from MP count unless that mapping has
+been verified for the exact fleet.
+
+## Combined design pattern
+
+vLLM-MUSA adopts the common ground between three kernel ecosystems:
+
+- **MATE:** resolve the physical MP count at runtime, use it for persistent
+  grids and config selection, and share generated configurations between JIT
+  and AOT packaging.
+- **NVIDIA CUDA/CUTLASS:** pass queried SM count into persistent tile
+  schedulers and use grid/SM wave or remainder terms when choosing split-K and
+  tile geometry.
+- **AMD ROCm:** pass CU count into skinny GEMM, split-K, and attention grids;
+  use offline tuned solutions or bounded online tuning where the vendor
+  library supports it.
+
+The vLLM-MUSA serving hot path must remain deterministic:
+
+1. Query `MusaKernelHardware(device_capability, multiprocessor_count)` once.
+2. Look up an exact, evidence-backed tactic key containing the MP count.
+3. If no exact entry exists, apply a documented integer heuristic only when
+   that heuristic has an independently validated safe envelope.
+4. Otherwise use the established fallback implementation.
+
+Runtime serving must not benchmark, synchronize device data to the host, or
+silently borrow the nearest MP-count entry.
+
+## Tactic and cache identity
+
+At minimum, an offline result or runtime cache entry must include:
+
+```text
+kernel/provider identity
+source and dependency revisions
+MUSA architecture and multiprocessor_count
+driver, runtime, compiler, MATE, and TileLang/Triton versions
+dtype and layout
+shape/workload bucket
+host-visible workload class and any data-dependent scheduling class
+tile, stages, warps/squads, split count, and persistent-block count
+eager/compile/CUDAGraph mode
+```
+
+Changing any compiled launch constant must change the JIT cache identity.
+Runtime-only scheduling values need not force another binary when the kernel
+ABI already accepts them, but the timing-cache/tactic key must still include
+the MP count.
+
+Keep the **compiled-binary cache** and the **measured-winner map** separate.
+The binary cache answers whether an implementation already exists; the winner
+map answers whether that implementation was qualified for the current device
+and workload. A practical winner key is:
+
+```text
+(schema_version, kernel_abi, source_revision,
+ architecture, active_mp, op_stage,
+ exact_or_bucketed_shape, dtype, layout, quantization)
+```
+
+Record driver and compiler versions with the evidence. Do not make the driver
+an exact selector dimension until a same-device A/B demonstrates that it
+changes the winner. Invalidate or requalify entries when the kernel ABI,
+library release, source revision, or result schema changes.
+
+Use a fail-closed lookup ladder:
+
+1. exact architecture, MP count, and shape;
+2. a validated shape bucket on the same MP count;
+3. an architecture-common tactic proven robust on all required MP bins; then
+4. the current production default.
+
+Never substitute the nearest MP count. Store the winning margin, sample count,
+dispersion, correctness status, and covered route distributions with each map
+entry so a narrow or noisy result cannot masquerade as a stable policy.
+
+## AOT versus JIT
+
+Prefer **AOT plus runtime dispatch** when the candidate set is small, compile
+cost is high, or the same binary accepts a runtime grid/split value. Package a
+bounded fat set of validated tactics and select one by exact key.
+
+Prefer **JIT** when the MP-sensitive choice changes compile-time constants,
+the source template is small, and prewarming can hide compilation. JIT output
+must use a persistent cache and fall back to a validated AOT provider on cache,
+compile, or device-query failure.
+
+Do not move a kernel to JIT solely because different device bins exist. First
+show that the winning compile-time tactic changes across real devices and that
+the end-to-end gain pays for added startup and cache complexity.
+
+JIT does not by itself solve data-dependent scheduling. For example, an MoE
+GEMV tile can depend on both the physical MP count and whether routed tokens
+are balanced across experts or concentrated on a hot expert. If that route
+class exists only in device memory, do not add a host-side MP-only override or
+synchronize it to the CPU on the serving hot path. Prefer, in order:
+
+1. a route-invariant tactic that stays within the accepted regression envelope;
+2. metadata already computed on-device by the production routing path;
+3. a device-side or persistent scheduler that consumes that metadata; or
+4. the established fallback when the route class is unknown.
+
+A timing-cache entry may include a route class only when production can obtain
+the same class without introducing a new synchronization or scan.
+
+For the current native MoE GEMV path, `topk_ids` and `topk_weights` are already
+GPU-resident and replay-safe, but a per-expert histogram is not. The existing
+DeepGEMM count/offset buffers belong to a different large-prefill backend, and
+the optional routed-expert capture buffer is intended for later host return.
+Neither should be borrowed implicitly by decode GEMV.
+
+If route-aware selection is pursued, the smallest graph-safe experiment is a
+GPU classifier that writes a fixed-size route-class buffer followed by a
+bounded set of graph-static AOT launches guarded by that device value. Measure
+classifier and suppressed-launch overhead as part of the candidate. A stronger
+long-term design is one fixed resident grid, normally derived from active MP
+count, that consumes device-side counts/offsets in a persistent work loop.
+Neither design requires copying expert IDs to the host, and neither assumes a
+device-side dynamic launch facility.
+
+## Qualification matrix
+
+For every proposed tactic-map entry:
+
+1. Run on the exact physical MP-count bin; `set_num_mps()` is useful for
+   scheduler experiments but is not evidence for another physical device.
+2. Compare baseline and candidate on the same physical device with identical
+   source/image, shape, dtype, and benchmark method. Record the driver and
+   cooling class as provenance; they need not match another MP-count type when
+   the decision is based on within-device normalized uplift rather than
+   cross-device absolute latency.
+3. Interleave candidates, flush L2 for weight-streaming kernels, retain all raw
+   samples, and report median, p95, and IQR.
+4. Check outputs against the production fallback, including NaN/Inf and
+   poison-output checks.
+5. Explain the result with tile count, resident blocks per MP, wave count, and
+   tail-wave utilization. Treat this model as a ranking aid, not proof.
+6. Validate the winning tactic through the compiled/captured production path
+   and a model-level regression before enabling it by default.
+7. For kernels with data-dependent grids or reuse, sweep representative input
+   distributions (for example balanced and hot-expert routing). Reject a
+   static MP-only entry when its winner changes with a distribution that the
+   host dispatcher cannot observe safely.
+
+Across MP-count types, compare the identity of the winning tactic and its
+same-device speedup over the local baseline. Do not rank hardware types by raw
+latency when their driver, cooling, clocks, or host stack differ.
+
+The current fused-MoE dispatch policy is the reference implementation: its
+shape key includes `multiprocessor_count`, and unknown counts fail closed.
+Provider-specific paths use the same rule and fall back until scheduler
+equivalence is proven.
+
+The campaign harness and its fail-closed promotion logic live under
+`benchmarks/kernel_tactics/`.  It records the effective selector arm (so a
+special-case kernel cannot be misreported as a requested block), route
+histograms, cold-cache samples, source identity, and an optional Amdahl
+prediction tuple.  This keeps the high-throughput op-bench funnel separate
+from the final model-level E2E gate.
+
+Empirical measurements, host/runtime provenance, and qualification decisions
+are intentionally kept in ticket-linked local artifacts under `generated/`.
+They are not part of this public policy document.
+
+## Cross-vendor implementation guidance
+
+The policy above intentionally combines mechanisms instead of copying one
+vendor stack wholesale:
+
+- AMD AITER keys tuned dense GEMM results by both `gfx` and `cu_num`, then by
+  shape, dtype, layout, and quantization fields. Its MoE selector extends the
+  key with token, expert, and top-k dimensions and retains bounded fallbacks.
+  This is the closest existing schema to an `(architecture, active_mp, shape)`
+  map.
+- hipBLASLt supports offline problem-to-solution tuning but scopes solution
+  indices to a library release and device architecture. Reuse that invalidation
+  discipline; do not treat a numeric tactic ID as permanently portable.
+- Composable Kernel retains a finite catalog of AOT instances, filters invalid
+  arguments, and profiles the survivors. Its grouped-GEMM tile loop consumes
+  group metadata on-device with a persistent grid, demonstrating that a small
+  AOT catalog and device-side dynamic scheduling are complementary.
+- Triton persistent matmul and CUTLASS grouped scheduling query the real SM
+  count and bound a resident grid by it. CUTLASS explicitly provides a
+  device-only grouped scheduler for metadata produced by an earlier GPU
+  kernel, avoiding a host synchronization.
+- MATE supplies the MUSA-side JIT/code-generation and cache layer. Use it when
+  a winning tactic changes compile-time constants or the AOT catalog would
+  grow without bound; keep a small, stable AOT catalog otherwise.
+
+The resulting best practice is therefore not a blanket AOT-to-JIT migration.
+It is a versioned offline winner map keyed by active MP count, a bounded
+AOT/JIT implementation catalog, a robust fallback ladder, and device-side
+persistent scheduling for truly data-dependent work.
+
+## Source references
+
+- CUDA device properties:
+  <https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html>
+- NVIDIA CUTLASS persistent schedulers:
+  <https://github.com/NVIDIA/cutlass/tree/main/include/cutlass/gemm/kernel>
+- HIP device properties:
+  <https://rocm.docs.amd.com/projects/HIP/en/latest/reference/api-reference.html>
+- AMD hipBLASLt tuning:
+  <https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/how-to/use-hipblaslt.html>
+- AMD AITER dense and MoE tuned selectors:
+  <https://github.com/ROCm/aiter/blob/7cb8f3389aeaf76c820ea692f295273f02e6071e/aiter/tuned_gemm.py>
+  and
+  <https://github.com/ROCm/aiter/blob/7cb8f3389aeaf76c820ea692f295273f02e6071e/aiter/fused_moe.py>
+- AMD Composable Kernel grouped tile-loop scheduler:
+  <https://github.com/ROCm/rocm-libraries/blob/fb3b576286941d15f63b5037c63844eaf7b53f29/projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/device_grouped_gemm_multiple_d_xdl_cshuffle_tile_loop.hpp>
+- Triton persistent matmul:
+  <https://triton-lang.org/main/getting-started/tutorials/09-persistent-matmul.html>
+- CUTLASS device-only grouped scheduler:
+  <https://docs.nvidia.com/cutlass/latest/media/docs/cpp/grouped_scheduler.html>
+- MATE runtime MP resolution:
+  <https://github.com/MooreThreads/mate/blob/main/mate/mate_runtime.py>

--- a/tests/test_bf16_moe_crossover_source.py
+++ b/tests/test_bf16_moe_crossover_source.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+BENCHMARK = (
+    Path(__file__).resolve().parents[1]
+    / "benchmarks"
+    / "fused_moe"
+    / "benchmark_dispatch_crossover.py"
+)
+
+
+def _source() -> str:
+    return BENCHMARK.read_text(encoding="utf-8")
+
+
+def test_bf16_crossover_uses_production_native_gate() -> None:
+    source = _source()
+    assert '"--weight-dtype"' in source
+    assert 'choices=("fp8", "bf16")' in source
+    assert "_can_use_musa_native_bf16_moe_gemv" in source
+    assert '"BF16 requires exactly gemv and upstream backends"' in source
+
+
+def test_bf16_crossover_has_upstream_correctness_reference() -> None:
+    source = _source()
+    assert 'oracle_outputs["upstream"].float()' in source
+    assert 'oracle_reference = "upstream-bf16"' in source
+    assert "w1_scale = None" in source
+    assert "w2_scale = None" in source
+
+
+def test_bf16_crossover_primes_hardware_and_records_archive_source() -> None:
+    source = _source()
+    assert "prime_musa_kernel_hardware" in source
+    assert "frozen MUSA hardware fingerprint changed" in source
+    assert '"--source-revision"' in source
+    assert '"source_kind": "archive"' in source
+
+
+def test_bf16_crossover_accepts_intentional_prefix_fallback() -> None:
+    source = _source()
+    assert "expected_backend(requested: str)" in source
+    assert "shape_matcher_max_tokens" in source
+    assert '"expected_backend": resolved' in source

--- a/tests/test_deepseek_v4_gemv_contract_source.py
+++ b/tests/test_deepseek_v4_gemv_contract_source.py
@@ -17,8 +17,11 @@ def test_contract_selected_gemv_block_reaches_custom_op_schema() -> None:
     assert "block_k: int = 0" in custom_ops
     assert "block_n,\n        block_k," in custom_ops
     assert "_requested_gemv_block(shape)" in fused_moe
-    assert "block_n=gemv_block_n" in fused_moe
-    assert "block_k=gemv_block_k" in fused_moe
+    assert "_requested_gemv_stage_tactic(" in fused_moe
+    assert "block_n=w1_block_n" in fused_moe
+    assert "block_k=w1_block_k" in fused_moe
+    assert "block_n=w2_block_n" in fused_moe
+    assert "block_k=w2_block_k" in fused_moe
 
 
 def test_requested_tile_preserves_dsv4_and_environment_precedence() -> None:
@@ -48,3 +51,15 @@ def test_contract_selector_does_not_forward_explicit_environment_override() -> N
     assert "os.environ.get(_GEMV_MOE_BLOCK_ENV) is not None" in helper
     assert 'shape.gemv_block != "16x8"' in helper
     assert "return 0, 0" in helper
+
+
+def test_fused_moe_reads_only_worker_primed_hardware() -> None:
+    fused_moe = _source("vllm_musa/model_executor/layers/fused_moe/fused_moe.py")
+
+    helper = fused_moe[
+        fused_moe.index("def _musa_device_fingerprint(") : fused_moe.index(
+            "def _tensor_meta("
+        )
+    ]
+    assert "get_primed_musa_kernel_hardware(device_index)" in helper
+    assert "query_cached_musa_kernel_hardware" not in helper

--- a/tests/test_deepseek_v4_gemv_tactic_numeric.py
+++ b/tests/test_deepseek_v4_gemv_tactic_numeric.py
@@ -1,0 +1,74 @@
+import logging
+
+import pytest
+
+# isort: off
+import torchada  # noqa: F401
+import torch
+# isort: on
+
+from vllm_musa import tuning
+from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(torch, "musa") or not torch.musa.is_available(),
+    reason="requires MUSA",
+)
+
+
+def _fp8_constant(shape: tuple[int, ...]) -> torch.Tensor:
+    return torch.full(shape, 0x20, dtype=torch.uint8, device="musa").view(
+        torch.float8_e4m3fn
+    )
+
+
+def test_mp60_dsv4_m2_dispatches_stage_tactic_and_matches_legacy(
+    monkeypatch,
+    caplog,
+):
+    hardware = tuning.prime_musa_kernel_hardware(0)
+    if hardware != tuning.MusaKernelHardware((3, 1), 60):
+        pytest.skip(f"requires exact MP60 S5000, got {hardware.cache_key}")
+
+    monkeypatch.delenv("VLLM_MUSA_FUSED_MOE_DISPATCH", raising=False)
+    monkeypatch.delenv("VLLM_MUSA_GEMV_MOE_BLOCK", raising=False)
+    torch.manual_seed(20260828)
+    hidden = torch.randn((2, 4096), dtype=torch.bfloat16, device="musa") * 0.01
+    w1 = _fp8_constant((256, 512, 4096))
+    w2 = _fp8_constant((256, 4096, 256))
+    w1_scale = torch.ones((256, 4, 32), dtype=torch.float32, device="musa")
+    w2_scale = torch.ones((256, 32, 2), dtype=torch.float32, device="musa")
+    topk_ids = torch.tensor(
+        [[0, 1, 2, 3, 4, 5], [6, 7, 8, 9, 10, 11]],
+        dtype=torch.int32,
+        device="musa",
+    )
+    topk_weights = torch.full((2, 6), 1.0 / 6.0, dtype=torch.float32, device="musa")
+    kwargs = {
+        "hidden_states": hidden,
+        "w1": w1,
+        "w2": w2,
+        "topk_weights": topk_weights,
+        "topk_ids": topk_ids,
+        "activation": "silu",
+        "use_fp8_w8a8": True,
+        "w1_scale": w1_scale,
+        "w2_scale": w2_scale,
+        "block_shape": [128, 128],
+    }
+
+    legacy = fused_moe.fused_experts_impl(
+        **kwargs,
+        inplace=False,
+        _allow_deepgemm_prefill=False,
+        _gemv_block=(16, 8),
+    )
+    with caplog.at_level(logging.INFO):
+        production = fused_moe._musa_fused_experts_impl_dispatch(**kwargs)
+    torch.musa.synchronize()
+
+    assert production.shape == legacy.shape == (2, 4096)
+    assert torch.isfinite(production).all()
+    torch.testing.assert_close(production, legacy, rtol=0, atol=0)
+    assert "dsv4-fp8-m2-route-policy-v1" in caplog.text
+    assert "blocks=(w1=(8, 16),w2=(16, 8))" in caplog.text

--- a/tests/test_deepseek_v4_mhc_tactic_source.py
+++ b/tests/test_deepseek_v4_mhc_tactic_source.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def _source(relative: str) -> str:
+    return (Path(__file__).parents[1] / relative).read_text(encoding="utf-8")
+
+
+def test_weighted_rmsnorm_provider_reads_frozen_hardware_and_exact_tactic():
+    source = _source("vllm_musa/deepseek_v4_mhc.py")
+    helper = source[
+        source.index("def _try_mhc_weighted_rms_norm_musa(") : source.index(
+            "def mhc_pre_musa_with_norm("
+        )
+    ]
+
+    assert "get_primed_musa_kernel_hardware(device_index)" in helper
+    assert "select_mhc_weighted_rmsnorm_tactic(" in helper
+    assert "threads if tactic is None else tactic.threads" in helper
+    assert "VLLM_MUSA_MHC_WEIGHTED_RMSNORM_THREADS" not in source
+    assert "diagnostic_threads" not in helper
+    assert "if not torch.compiler.is_compiling():" in helper
+    assert "query_musa_kernel_hardware" not in helper
+    assert "torch.musa.get_device_properties" not in helper

--- a/tests/test_deepseek_v4_o_proj_dispatch.py
+++ b/tests/test_deepseek_v4_o_proj_dispatch.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
-
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[1]
@@ -11,9 +11,7 @@ MODULE_PATH = (
     / "fp8_einsum.py"
 )
 GEMV_PATH = Path(__file__).resolve().parents[1] / "csrc" / "musa" / "gemv.mu"
-CUSTOM_OPS_PATH = (
-    Path(__file__).resolve().parents[1] / "vllm_musa" / "_custom_ops.py"
-)
+CUSTOM_OPS_PATH = Path(__file__).resolve().parents[1] / "vllm_musa" / "_custom_ops.py"
 
 
 def _module_tree() -> ast.Module:
@@ -28,8 +26,7 @@ def test_o_proj_uses_fixed_deepgemm_threshold() -> None:
         for node in tree.body
         if isinstance(node, ast.Assign)
         and any(
-            isinstance(target, ast.Name)
-            and target.id == "_DEEPGEMM_MIN_TOKENS"
+            isinstance(target, ast.Name) and target.id == "_DEEPGEMM_MIN_TOKENS"
             for target in node.targets
         )
     )
@@ -84,6 +81,13 @@ def test_o_proj_gemv_uses_calibrated_capture_ladder_tiles() -> None:
     assert "hidden_size != 4096" in helper
     assert "nr_n != 1024" in helper
     assert "scale_k_group_tile != 128" in helper
+    assert "int num_mp" in helper
+    assert "num_mp == 48" in helper
+    assert "num_mp == 56" in helper
+    assert "num_mp == 60" in helper
+    assert "BlockConfig{8, 32" in helper
+    assert "BlockConfig{16, 8" in helper
+    assert "BlockConfig{16, 16" in helper
     assert "case 1:" in helper and "case 2:" in helper and "case 8:" in helper
     assert "BlockConfig{4, 32" in helper
     assert "case 4:" in helper and "case 32:" in helper and "case 64:" in helper
@@ -96,6 +100,50 @@ def test_o_proj_gemv_uses_calibrated_capture_ladder_tiles() -> None:
     assert dispatch.index("SelectDeepSeekV4Fp8OProjTile(") < dispatch.index(
         "ParseForcedBlockConfig(&forced_config)"
     )
+    assert "current_arch,\n            num_mp," in dispatch
+
+
+def test_o_proj_gemv_mp_tile_table_is_exact() -> None:
+    source = GEMV_PATH.read_text(encoding="utf-8")
+    helper = source[
+        source.index("bool SelectDeepSeekV4Fp8OProjTile(") : source.index(
+            "bool SelectDeepSeekV4Fp8SharedGateUpTile("
+        )
+    ]
+    expected = {
+        48: {1: (8, 32), 8: (16, 8), (32, 64): (32, 4)},
+        56: {8: (16, 16), 64: (32, 4)},
+        60: {8: (8, 16), 64: (32, 4)},
+    }
+    for mp, cases in expected.items():
+        next_mp = min(
+            (candidate for candidate in expected if candidate > mp), default=None
+        )
+        end = (
+            helper.index(f"    }} else if (num_mp == {next_mp}) {{")
+            if next_mp is not None
+            else helper.index("    // Preserve the original cross-MP capture ladder")
+        )
+        start_token = (
+            f"    if (num_mp == {mp}) {{"
+            if mp == 48
+            else f"    }} else if (num_mp == {mp}) {{"
+        )
+        body = helper[helper.index(start_token) : end]
+        for tokens, block in cases.items():
+            token_cases = (
+                rf"case {tokens}:"
+                if isinstance(tokens, int)
+                else "".join(rf"case {item}:\s*" for item in tokens)
+            )
+            pattern = (
+                rf"{token_cases}\s*\*config = BlockConfig\{{"
+                rf"{block[0]}, {block[1]}, 0\.f, true\}};"
+            )
+            assert re.search(pattern, body, re.DOTALL), (
+                f"MP{mp} tokens={tokens} must map to BlockConfig{block}, "
+                f"not an approximate substring"
+            )
 
 
 def test_o_proj_gemv_writes_one_group_result_directly() -> None:

--- a/tests/test_deepseek_v4_weighted_rmsnorm_tactic_numeric.py
+++ b/tests/test_deepseek_v4_weighted_rmsnorm_tactic_numeric.py
@@ -1,0 +1,99 @@
+import logging
+
+import pytest
+
+# isort: off
+import torchada  # noqa: F401
+import torch
+# isort: on
+
+from vllm_musa import deepseek_v4_mhc as mhc
+from vllm_musa import tuning
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(torch, "musa") or not torch.musa.is_available(),
+    reason="requires MUSA",
+)
+
+
+def _reference(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    x_fp32 = x.float()
+    return (
+        x_fp32
+        * torch.rsqrt(x_fp32.pow(2).mean(dim=-1, keepdim=True) + 1e-6)
+        * weight.float()
+    ).to(x.dtype)
+
+
+@pytest.mark.parametrize("use_graph", [False, True])
+def test_mp48_m5_weighted_rmsnorm_tactic_numeric_and_replay(
+    monkeypatch,
+    caplog,
+    use_graph,
+):
+    hardware = tuning.prime_musa_kernel_hardware(0)
+    if hardware != tuning.MusaKernelHardware((3, 1), 48):
+        pytest.skip(f"requires exact MP48 S5000, got {hardware.cache_key}")
+
+    torch.manual_seed(20260828)
+    x = torch.randn((5, 4096), dtype=torch.bfloat16, device="musa")
+    weight = torch.randn((4096,), dtype=torch.bfloat16, device="musa")
+    expected = _reference(x, weight)
+
+    # Compile the exact 256-thread variant before graph capture.
+    mhc._LOGGED_WEIGHTED_RMSNORM_TACTICS.clear()
+    with caplog.at_level(logging.INFO, logger=mhc.__name__):
+        output = mhc._try_mhc_weighted_rms_norm_musa(x, weight, 1e-6)
+    assert output is not None
+    torch.musa.synchronize()
+    torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)
+    assert "threads=256" in caplog.text
+
+    if not use_graph:
+        monkeypatch.setattr(
+            torch.musa,
+            "get_device_properties",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("provider must only read frozen hardware")
+            ),
+        )
+        output = mhc._try_mhc_weighted_rms_norm_musa(x, weight, 1e-6)
+        assert output is not None
+        torch.musa.synchronize()
+        torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)
+        return
+
+    graph = torch.musa.MUSAGraph()
+    with torch.musa.graph(graph):
+        output = mhc._try_mhc_weighted_rms_norm_musa(x, weight, 1e-6)
+        assert output is not None
+    for seed in (7, 17, 20260826):
+        torch.manual_seed(seed)
+        x.copy_(torch.randn_like(x))
+        expected = _reference(x, weight)
+        graph.replay()
+        torch.musa.synchronize()
+        torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_mp48_weighted_rmsnorm_compiling_guard(monkeypatch):
+    hardware = tuning.prime_musa_kernel_hardware(0)
+    if hardware != tuning.MusaKernelHardware((3, 1), 48):
+        pytest.skip(f"requires exact MP48 S5000, got {hardware.cache_key}")
+
+    x = torch.randn((5, 4096), dtype=torch.bfloat16, device="musa")
+    weight = torch.randn((4096,), dtype=torch.bfloat16, device="musa")
+    expected = _reference(x, weight)
+
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    monkeypatch.setattr(
+        mhc,
+        "select_mhc_weighted_rmsnorm_tactic",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("Dynamo tracing must retain the legacy tactic")
+        ),
+    )
+    output = mhc._try_mhc_weighted_rms_norm_musa(x, weight, 1e-6)
+    assert output is not None
+    torch.musa.synchronize()
+    torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)

--- a/tests/test_dense_gemv_tactic_benchmark.py
+++ b/tests/test_dense_gemv_tactic_benchmark.py
@@ -1,0 +1,94 @@
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+BENCH_PATH = ROOT / "benchmarks/kernel_tactics/benchmark_dense_fp8_gemv_blocks.py"
+sys.path.insert(0, str(BENCH_PATH.parent))
+SPEC = importlib.util.spec_from_file_location(
+    "benchmark_dense_fp8_gemv_blocks", BENCH_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+BENCH = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BENCH
+SPEC.loader.exec_module(BENCH)
+
+
+@pytest.mark.parametrize("value", ["4x32", "8X16", "32x4", "128x1"])
+def test_parse_block_accepts_compiled_dense_gemv_variants(value):
+    assert BENCH.parse_block(value) in BENCH.SUPPORTED_BLOCKS
+
+
+@pytest.mark.parametrize("value", ["bad", "0x8", "4x4", "64x8"])
+def test_parse_block_rejects_uncompiled_variants(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        BENCH.parse_block(value)
+
+
+@pytest.mark.parametrize(
+    ("tokens", "block"),
+    [
+        (1, (4, 32)),
+        (2, (4, 32)),
+        (4, (8, 16)),
+        (8, (4, 32)),
+        (16, (32, 4)),
+        (32, (8, 16)),
+        (64, (8, 16)),
+    ],
+)
+def test_dsv4_o_proj_production_ladder(tokens, block):
+    assert BENCH.production_block("dsv4_o_proj", tokens) == block
+
+
+@pytest.mark.parametrize(
+    ("mp", "tokens", "block"),
+    [
+        (48, 1, (8, 32)),
+        (48, 8, (16, 8)),
+        (48, 32, (32, 4)),
+        (48, 64, (32, 4)),
+        (56, 8, (16, 16)),
+        (56, 64, (32, 4)),
+        (60, 8, (8, 16)),
+        (60, 64, (32, 4)),
+    ],
+)
+def test_dsv4_o_proj_exact_mp_ladder(mp, tokens, block):
+    assert BENCH.production_block("dsv4_o_proj", tokens, mp) == block
+
+
+def test_dense_gemv_exposes_default_preserving_per_call_blocks():
+    bindings = (ROOT / "csrc/musa/torch_bindings.cpp").read_text()
+    header = (ROOT / "csrc/musa/musa_ops.h").read_text()
+    kernel = (ROOT / "csrc/musa/gemv.mu").read_text()
+    wrapper = (ROOT / "vllm_musa/_custom_ops.py").read_text()
+
+    assert 'float eps, int block_n=0, int block_k=0) -> ()"' in bindings
+    assert "int64_t block_n" in header
+    assert "int64_t block_k" in header
+    assert "int64_t requested_block_n" in kernel
+    assert "int64_t requested_block_k" in kernel
+    assert "if (requested_block_n > 0)" in kernel
+    assert "best_config = &requested_config" in kernel
+    assert "block_n: int = 0" in wrapper
+    assert "block_k: int = 0" in wrapper
+
+
+def test_dense_gemv_production_direct_call_keeps_auto_tactic():
+    source = (
+        ROOT / "vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py"
+    ).read_text()
+    start = source.index("torch.ops._C_musa_ops.musa_fused_gemv(")
+    call = source[start : source.index("return output", start)]
+    assert call.rstrip().endswith("0,\n        0,\n    )")
+
+
+def test_dense_gemv_requires_lease_device_fence():
+    source = BENCH_PATH.read_text()
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"lease_device_fence": lease_device_fence' in source

--- a/tests/test_fp8_quant_tactic_benchmark.py
+++ b/tests/test_fp8_quant_tactic_benchmark.py
@@ -1,0 +1,76 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+BENCH_PATH = ROOT / "benchmarks/kernel_tactics/benchmark_fp8_quant_groups.py"
+BENCH_DIR = BENCH_PATH.parent
+sys.path.insert(0, str(BENCH_DIR))
+SPEC = importlib.util.spec_from_file_location("benchmark_fp8_quant_groups", BENCH_PATH)
+assert SPEC is not None and SPEC.loader is not None
+BENCH = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BENCH
+SPEC.loader.exec_module(BENCH)
+
+HEADER = ROOT / "csrc/musa/musa_ops.h"
+BINDINGS = ROOT / "csrc/musa/torch_bindings.cpp"
+QUANT = ROOT / "csrc/musa/quantization/per_token_group_quant_8bit_vec.cu"
+SILU = ROOT / "csrc/musa/quantization/silu_and_mul_per_token_group_fp8_quant.cu"
+SHAPES = ROOT / "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json"
+
+
+@pytest.mark.parametrize(
+    ("num_groups", "expected"),
+    [(1, 1), (8, 8), (12, 4), (24, 8), (32, 16), (40, 8), (56, 8), (64, 16)],
+)
+def test_production_groups_per_block(num_groups, expected):
+    assert BENCH.production_groups_per_block(num_groups) == expected
+
+
+def test_quant_schemas_keep_default_preserving_benchmark_override():
+    bindings = BINDINGS.read_text(encoding="utf-8")
+    assert bindings.count("int groups_per_block=0") == 3
+    header = HEADER.read_text(encoding="utf-8")
+    assert header.count("int64_t groups_per_block") == 3
+    assert "requested_groups_per_block" in QUANT.read_text(encoding="utf-8")
+    assert "requested_groups_per_block" in SILU.read_text(encoding="utf-8")
+
+
+def test_quant_override_validates_supported_geometry():
+    quant = QUANT.read_text(encoding="utf-8")
+    silu = SILU.read_text(encoding="utf-8")
+    for value in (1, 2, 4, 8, 16):
+        assert f"requested_groups_per_block == {value}" in quant
+        assert f"requested_groups_per_block == {value}" in silu
+    assert "num_groups % requested_groups_per_block == 0" in quant
+
+
+def test_fp8_quant_benchmark_has_required_evidence_contract():
+    source = BENCH_PATH.read_text(encoding="utf-8")
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"lease_device_fence": lease_device_fence' in source
+    assert "candidate_q.fill_(fp8_info.min)" in source
+    assert "torch.equal(reference_q.float(), candidate_q.float())" in source
+    assert '"paired_alternating_order": True' in source
+    assert "flush.zero_()" in source
+
+
+def test_quant_shape_manifest_distinguishes_model_and_intermediate_widths():
+    payload = json.loads(SHAPES.read_text(encoding="utf-8"))
+    families = payload["families"]
+
+    assert families["activation_quant"]["deepseek_v4_tp8"]["hidden_sizes"] == [4096]
+    assert families["silu_clamp_shared_mlp"]["deepseek_v4_tp8"]["hidden_sizes"] == [256]
+    assert families["silu_routed_moe"]["qwen_tp8_topk8"]["hidden_sizes"] == [128]
+    assert (
+        320 in families["silu_dense_fallback"]["m2_5_local_after_sphere_gate"]["rows"]
+    )
+
+    for family in families.values():
+        for model in family.values():
+            assert set(model["rows"]) <= set(BENCH.PRODUCTION_TOKENS)
+            assert set(model["hidden_sizes"]) <= set(BENCH.PRODUCTION_HIDDEN_SIZES)

--- a/tests/test_full_kernel_inventory.py
+++ b/tests/test_full_kernel_inventory.py
@@ -1,0 +1,119 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "benchmarks/kernel_tactics/inventory_vllm_musa_kernels.py"
+SPEC = importlib.util.spec_from_file_location("inventory_vllm_musa_kernels", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+INVENTORY = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = INVENTORY
+SPEC.loader.exec_module(INVENTORY)
+
+CATALOG_SCRIPT = ROOT / "benchmarks/kernel_tactics/kernel_sweep_catalog.py"
+CATALOG_SPEC = importlib.util.spec_from_file_location(
+    "kernel_sweep_catalog", CATALOG_SCRIPT
+)
+assert CATALOG_SPEC is not None and CATALOG_SPEC.loader is not None
+CATALOG = importlib.util.module_from_spec(CATALOG_SPEC)
+sys.modules[CATALOG_SPEC.name] = CATALOG
+CATALOG_SPEC.loader.exec_module(CATALOG)
+
+MANIFEST_PATH = ROOT / "benchmarks/kernel_tactics/full_kernel_sweep.json"
+
+
+def test_inventory_is_unique_and_source_complete():
+    entries = INVENTORY.discover(ROOT)
+    assert entries
+    assert len({entry.id for entry in entries}) == len(entries)
+    for entry in entries:
+        assert (ROOT / entry.source).is_file(), entry
+
+
+def test_inventory_covers_all_owned_backend_classes():
+    payload = INVENTORY.payload(ROOT)
+    assert payload["schema"] == INVENTORY.SCHEMA
+    counts = payload["counts"]
+    assert counts["aot-native"] >= 30
+    assert counts["jit-native"] >= 10
+    assert counts["jit-native-ffi"] >= 15
+    assert counts["jit-triton"] >= 7
+    assert counts["jit-tilelang"] >= 20
+    assert counts == {
+        "aot-native": 34,
+        "jit-native": 10,
+        "jit-native-ffi": 19,
+        "jit-tilelang": 31,
+        "jit-triton": 7,
+    }
+
+
+def test_known_production_kernels_are_discovered():
+    ids = {entry.id for entry in INVENTORY.discover(ROOT)}
+    expected_suffixes = {
+        "musa_fused_gemv_moe",
+        "musa_csrc_fused_add_rmsnorm",
+        "vllm_musa_custom_ar_launch_registered",
+        "_gated_qk_norm_rope_token_kernel",
+        "_qwen2_rope_kv_cache_kernel",
+        "mhc_weighted_rmsnorm_mudnn_like_kernel",
+        "musa_sparse_attention_fwd_kernel_v1",
+    }
+    for suffix in expected_suffixes:
+        assert any(entry.endswith(f":{suffix}") for entry in ids), suffix
+
+
+def test_full_sweep_manifest_covers_every_entry_exactly_once():
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    discovered = INVENTORY.discover(ROOT)
+    discovered_ids = {entry.id for entry in discovered}
+    manifest_members = [
+        member for family in manifest["families"] for member in family["members"]
+    ]
+
+    assert manifest["schema"] == CATALOG.SCHEMA
+    assert len(manifest_members) == len(set(manifest_members))
+    assert set(manifest_members) == discovered_ids
+    assert len(manifest["families"]) == len(
+        {family["id"] for family in manifest["families"]}
+    )
+
+
+def test_manifest_family_grouping_matches_reviewed_catalog_rules():
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    manifest_families = {
+        family["id"]: set(family["members"]) for family in manifest["families"]
+    }
+    expected = {
+        family: {entry.id for entry in entries}
+        for family, entries in CATALOG.grouped_families(ROOT).items()
+    }
+
+    assert manifest_families == expected
+
+
+def test_every_family_has_an_explicit_public_disposition():
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    allowed = set(manifest["allowed_dispositions"])
+    for family in manifest["families"]:
+        assert family["disposition"] in allowed
+        if family["disposition"] == "no-tunable-seam":
+            # A fixed-geometry kernel can still be production reachable on
+            # every device; no-tunable means there is no safe selector seam,
+            # not that the family is out of scope.
+            assert family["tunable_parameters"] == []
+            if family.get("production_consumers"):
+                assert family["production_consumers"]
+
+
+def test_public_catalog_contains_no_fleet_evidence():
+    manifest_text = MANIFEST_PATH.read_text(encoding="utf-8")
+    manifest = json.loads(manifest_text)
+    assert manifest["schema"] == CATALOG.SCHEMA
+    assert "created_against" not in manifest
+    assert "target_mp_bins" not in manifest["scope"]
+    assert "evidence" not in manifest_text
+    assert "generated/MUSA-" not in manifest_text
+    assert "archive_sha256" not in manifest_text
+    assert "model_e2e" not in manifest_text

--- a/tests/test_fused_moe_chunking.py
+++ b/tests/test_fused_moe_chunking.py
@@ -102,6 +102,55 @@ def test_musa_fused_experts_preserves_output_shape_across_chunks(monkeypatch):
     assert torch.all(result[chunk_size:] == 23.0)
 
 
+def test_musa_fused_experts_applies_stage_specific_gemv_blocks(monkeypatch):
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    blocks = []
+
+    def fake_musa_fused_gemv_moe(
+        _input,
+        _weight,
+        output,
+        _bias,
+        _scale,
+        _topk_weights,
+        topk_ids,
+        *_args,
+        use_swigelu,
+        block_n,
+        block_k,
+    ):
+        blocks.append((use_swigelu, block_n, block_k))
+        tokens = topk_ids.shape[0]
+        if use_swigelu:
+            output[:tokens].fill_(1)
+        else:
+            output[:tokens].fill_(2)
+
+    monkeypatch.setattr(
+        fused_moe.musa_ops,
+        "musa_fused_gemv_moe",
+        fake_musa_fused_gemv_moe,
+    )
+    monkeypatch.setattr(
+        fused_moe.ops,
+        "moe_sum",
+        lambda intermediate, output: output.copy_(intermediate.sum(dim=1)),
+    )
+
+    fused_moe.fused_experts_impl(
+        hidden_states=torch.zeros(2, 4),
+        w1=torch.zeros(2, 8, 4),
+        w2=torch.zeros(2, 4, 4),
+        topk_weights=torch.ones(2, 1),
+        topk_ids=torch.zeros(2, 1, dtype=torch.int64),
+        _gemv_block=(16, 8),
+        _gemv_blocks=((8, 16), (16, 8)),
+    )
+
+    assert blocks == [(True, 8, 16), (False, 16, 8)]
+
+
 def test_musa_fused_moe_shape_inventory_is_disabled_by_default(monkeypatch, tmp_path):
     from vllm_musa.model_executor.layers.fused_moe import fused_moe
 
@@ -500,6 +549,25 @@ def test_musa_capture_probe_fails_safe(monkeypatch):
     assert fused_moe._musa_stream_is_capturing() is True
 
 
+def test_gemv_block_environment_override_preempts_stage_tactic(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_musa.model_executor.layers.fused_moe import fused_moe
+
+    monkeypatch.setenv("VLLM_MUSA_GEMV_MOE_BLOCK", "32x4")
+    monkeypatch.setattr(
+        fused_moe,
+        "gemv_stage_tactic_for_shape",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("production tactic must not be queried")
+        ),
+    )
+    shape = SimpleNamespace(gemv_block="16x8")
+
+    assert fused_moe._requested_gemv_block(shape) == (0, 0)
+    assert fused_moe._requested_gemv_stage_tactic(shape, 2) is None
+
+
 def test_musa_dispatcher_routes_forced_backends(monkeypatch):
     from vllm_musa.model_executor.layers.fused_moe import fused_moe
 
@@ -545,22 +613,30 @@ def test_musa_dispatcher_routes_forced_backends(monkeypatch):
     assert grouped_calls[0]["inplace"] is False
 
 
-@pytest.mark.parametrize(("tokens", "expect_gemv"), [(5, True), (6, False)])
+@pytest.mark.parametrize(
+    ("tokens", "stream_is_capturing", "expect_gemv", "expected_stage_blocks"),
+    [
+        (2, False, True, ((8, 16), (16, 8))),
+        (2, True, False, None),
+        (5, False, True, None),
+        (6, False, False, None),
+    ],
+)
 def test_musa_dispatcher_auto_preserves_dsv4_fp8_gemv_threshold(
-    monkeypatch, tokens, expect_gemv
+    monkeypatch,
+    tokens,
+    stream_is_capturing,
+    expect_gemv,
+    expected_stage_blocks,
 ):
     from vllm_musa.model_executor.layers.fused_moe import fused_moe
 
     monkeypatch.delenv("VLLM_MUSA_GEMV_MOE_BLOCK", raising=False)
     kwargs = _deepgemm_gate_kwargs(torch)
     kwargs.update(
-        hidden_states=torch.empty(
-            (tokens, 4096), device="meta", dtype=torch.bfloat16
-        ),
+        hidden_states=torch.empty((tokens, 4096), device="meta", dtype=torch.bfloat16),
         topk_ids=torch.empty((tokens, 6), device="meta", dtype=torch.int32),
-        topk_weights=torch.empty(
-            (tokens, 6), device="meta", dtype=torch.float32
-        ),
+        topk_weights=torch.empty((tokens, 6), device="meta", dtype=torch.float32),
     )
     native_output = torch.empty((1,), device="meta")
     upstream_output = torch.empty((2,), device="meta")
@@ -576,7 +652,11 @@ def test_musa_dispatcher_auto_preserves_dsv4_fp8_gemv_threshold(
         "_musa_device_fingerprint",
         lambda *_args, **_kwargs: ((3, 1), 60),
     )
-    monkeypatch.setattr(fused_moe, "_musa_stream_is_capturing", lambda: True)
+    monkeypatch.setattr(
+        fused_moe,
+        "_musa_stream_is_capturing",
+        lambda: stream_is_capturing,
+    )
     monkeypatch.setattr(
         fused_moe,
         "fused_experts_impl",
@@ -595,11 +675,14 @@ def test_musa_dispatcher_auto_preserves_dsv4_fp8_gemv_threshold(
     if expect_gemv:
         assert result is native_output
         assert len(native_calls) == 1
-        assert native_calls[0][1] == {
+        expected_kwargs = {
             "inplace": False,
             "_allow_deepgemm_prefill": False,
             "_gemv_block": (16, 8),
         }
+        if expected_stage_blocks is not None:
+            expected_kwargs["_gemv_blocks"] = expected_stage_blocks
+        assert native_calls[0][1] == expected_kwargs
         assert not upstream_calls
     else:
         assert result is upstream_output
@@ -821,9 +904,7 @@ def test_musa_dispatcher_explicit_upstream_bypasses_deepgemm(monkeypatch):
 
 def _qwen36_bf16_moe_meta_inputs(tokens: int):
     return {
-        "hidden_states": torch.empty(
-            tokens, 4096, dtype=torch.bfloat16, device="meta"
-        ),
+        "hidden_states": torch.empty(tokens, 4096, dtype=torch.bfloat16, device="meta"),
         "w1": torch.empty(257, 2048, 4096, dtype=torch.bfloat16, device="meta"),
         "w2": torch.empty(257, 4096, 1024, dtype=torch.bfloat16, device="meta"),
     }

--- a/tests/test_fused_moe_dispatch_graph_benchmark.py
+++ b/tests/test_fused_moe_dispatch_graph_benchmark.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+BENCHMARK = (
+    Path(__file__).resolve().parents[1]
+    / "benchmarks"
+    / "fused_moe"
+    / "benchmark_dispatch_graph.py"
+)
+
+
+def _source() -> str:
+    return BENCHMARK.read_text(encoding="utf-8")
+
+
+def test_graph_harness_supports_bf16_without_fp8_scales() -> None:
+    source = _source()
+    assert '"--weight-dtype"' in source
+    assert 'choices=("fp8", "bf16")' in source
+    assert "_make_bf16_weights(" in source
+    assert 'kwargs["global_num_experts"] = args.experts' in source
+    assert 'kwargs["apply_router_weight_on_input"] = False' in source
+    assert "w1_scale = None" in source
+    assert "w2_scale = None" in source
+    assert "block_size = None" in source
+    assert "args.graph_bucket_num_reqs not in (1, 2, 4, 8)" in source
+    assert "args.graph_bucket_num_reqs != args.tokens" in source
+
+
+def test_graph_harness_fails_closed_on_lease_device_mismatch() -> None:
+    source = _source()
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"--expected-multiprocessor-count", type=int, required=True' in source
+    assert '"--graph-bucket-num-reqs"' in source
+    assert 'runtime_mode="FULL"' in source
+    assert "lease_device_fence = verify_lease_device_fence(" in source
+    assert '"lease_device_fence": lease_device_fence' in source
+    assert "primed_hardware = prime_musa_kernel_hardware(0)" in source
+    assert '"primed_hardware": {' in source
+    assert '"source": source_identity(Path(__file__))' in source
+
+
+def test_graph_harness_checks_production_backend_and_replays_routes() -> None:
+    source = _source()
+    assert 'choices=("gemv", "upstream")' in source
+    assert 'route_modes = ("balanced", "unique_random", "hot")' in source
+    assert (
+        "production_dispatch = fused_moe._upstream_fused_moe.fused_experts_impl"
+        in source
+    )
+    assert "captured_output = production_dispatch(**kwargs)" in source
+    assert (
+        "fused_moe._upstream_fused_moe.fused_experts_impl = counted_upstream"
+        not in source
+    )
+    assert "capture_calls == expected_capture_calls" in source
+    assert 'captured_gemv_launch_kwargs.get("_gemv_blocks")' in source
+    assert '"gemv_stage_tactic_passed": gemv_stage_tactic_passed' in source
+    assert "and gemv_stage_tactic_passed" in source
+    assert 'item["bitwise_equal"] and item["upstream_reference_passed"]' in source
+
+
+def test_graph_harness_records_real_bf16_gates_and_upstream_quality() -> None:
+    source = _source()
+    assert "_can_use_qwen35_bf16_moe_decode_gemv = traced_qwen35_gate" in source
+    assert "_can_use_musa_native_bf16_moe_gemv = traced_native_bf16_gate" in source
+    assert '"capability_trace": capability_trace' in source
+    assert '"device_fingerprint_trace": device_fingerprint_trace' in source
+    assert '"backend_call_trace": backend_call_trace' in source
+    assert '"policy_trace": policy_trace' in source
+    assert '"selection_observed": selection_observed' in source
+    assert '"capability_passed": capability_passed' in source
+    assert '"multiprocessor_count_passed": multiprocessor_count_passed' in source
+    assert "and multiprocessor_count_passed" in source
+    assert "**captured_gemv_launch_kwargs" in source
+    assert "upstream_reference = original_upstream(**kwargs).detach().clone()" in source
+    assert 'item["upstream_reference_passed"]' in source

--- a/tests/test_fused_moe_dispatch_policy.py
+++ b/tests/test_fused_moe_dispatch_policy.py
@@ -1,4 +1,5 @@
 import ast
+import dataclasses
 import importlib.util
 import sys
 from pathlib import Path
@@ -17,9 +18,13 @@ SPEC.loader.exec_module(POLICY)
 
 MUSA_FUSED_MOE_DISPATCH_ENV = POLICY.MUSA_FUSED_MOE_DISPATCH_ENV
 MusaFusedMoeBackend = POLICY.MusaFusedMoeBackend
+MusaFusedMoeGemvStageTactic = POLICY.MusaFusedMoeGemvStageTactic
 MusaFusedMoeShape = POLICY.MusaFusedMoeShape
 MusaFusedMoeThresholds = POLICY.MusaFusedMoeThresholds
+MusaForwardGraphBucket = POLICY.MusaForwardGraphBucket
+gemv_stage_tactic_for_shape = POLICY.gemv_stage_tactic_for_shape
 parse_dispatch_backend = POLICY.parse_dispatch_backend
+resolve_fused_moe_graph_mode = POLICY.resolve_fused_moe_graph_mode
 select_fused_moe_backend = POLICY.select_fused_moe_backend
 thresholds_for_shape = POLICY.thresholds_for_shape
 FUSED_MOE_PATH = (
@@ -95,6 +100,52 @@ def test_grouped_gemm_is_never_selected_during_capture():
     )
 
 
+def test_compile_mode_is_always_fail_closed():
+    shape = _shape(graph_mode="compile")
+
+    for requested in MusaFusedMoeBackend:
+        assert (
+            select_fused_moe_backend(
+                shape=shape,
+                num_tokens=1,
+                can_use_gemv=True,
+                can_use_grouped_gemm=True,
+                stream_is_capturing=False,
+                requested=requested,
+                thresholds=MusaFusedMoeThresholds(
+                    gemv_max_tokens=4,
+                    grouped_gemm_min_tokens=1,
+                    source="must-not-specialize-during-compile",
+                ),
+            )
+            == MusaFusedMoeBackend.UPSTREAM
+        )
+
+
+def test_graph_mode_resolution_prioritizes_symbolic_compile():
+    assert (
+        resolve_fused_moe_graph_mode(
+            is_compiling=True,
+            stream_is_capturing=True,
+        )
+        == "compile"
+    )
+    assert (
+        resolve_fused_moe_graph_mode(
+            is_compiling=False,
+            stream_is_capturing=True,
+        )
+        == "capture"
+    )
+    assert (
+        resolve_fused_moe_graph_mode(
+            is_compiling=False,
+            stream_is_capturing=False,
+        )
+        == "eager"
+    )
+
+
 def test_calibrated_threshold_boundaries_and_device_identity(monkeypatch):
     shape = _shape()
     thresholds = MusaFusedMoeThresholds(
@@ -161,7 +212,7 @@ def test_calibrated_dimension_prefilter(monkeypatch):
     )
 
 
-def test_s5000_calibrated_shapes_use_route_worst_boundaries():
+def test_mp_keyed_calibrated_shapes_use_route_worst_boundaries():
     qwen = _shape(
         multiprocessor_count=60,
         local_experts=256,
@@ -218,7 +269,303 @@ def test_s5000_calibrated_shapes_use_route_worst_boundaries():
     assert thresholds_for_shape(dsv2_capture).grouped_gemm_min_tokens is None
 
 
-def test_s5000_calibration_remains_exact_for_layout_and_mp_count():
+def test_qwen35_bf16_mp48_uses_exact_eight_token_boundary_and_tile():
+    shape = _shape(
+        multiprocessor_count=48,
+        local_experts=257,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=9,
+        hidden_dtype="torch.bfloat16",
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+        block_n=0,
+        block_k=0,
+        activation="silu",
+        expert_parallel=False,
+    )
+    assert thresholds_for_shape(shape).gemv_max_tokens == 8
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=8,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=False,
+        )
+        == MusaFusedMoeBackend.GEMV
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=shape,
+            num_tokens=9,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=False,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+    tactic = gemv_stage_tactic_for_shape(shape=shape, num_tokens=8)
+    assert tactic is not None
+    assert tactic.w1_block == (32, 4)
+    assert tactic.w2_block == (32, 4)
+
+
+def test_qwen35_bf16_mp48_policy_mismatches_fail_closed():
+    shape = _shape(
+        multiprocessor_count=48,
+        local_experts=257,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=9,
+        hidden_dtype="torch.bfloat16",
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+        block_n=0,
+        block_k=0,
+        activation="silu",
+        expert_parallel=False,
+    )
+    for field, value in (
+        ("device_capability", (3, 0)),
+        ("multiprocessor_count", 47),
+        ("multiprocessor_count", 49),
+        ("local_experts", 256),
+        ("w1_output_size", 512),
+        ("w2_input_size", 256),
+        ("hidden_size", 3072),
+        ("top_k", 8),
+        ("hidden_dtype", "torch.float16"),
+        ("weight_dtype", "torch.float16"),
+        ("activation", "gelu"),
+        ("expert_parallel", True),
+    ):
+        mismatch = dataclasses.replace(shape, **{field: value})
+        assert thresholds_for_shape(mismatch).source == "uncalibrated-shape"
+        assert gemv_stage_tactic_for_shape(shape=mismatch, num_tokens=1) is None
+        assert (
+            select_fused_moe_backend(
+                shape=mismatch,
+                num_tokens=1,
+                can_use_gemv=True,
+                can_use_grouped_gemm=False,
+                stream_is_capturing=False,
+            )
+            == MusaFusedMoeBackend.UPSTREAM
+        )
+
+
+def test_qwen35_bf16_mp48_capture_buckets_fail_closed_outside_exact_bucket():
+    eager = _shape(
+        multiprocessor_count=48,
+        local_experts=257,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=9,
+        hidden_dtype="torch.bfloat16",
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+        block_n=0,
+        block_k=0,
+        activation="silu",
+        expert_parallel=False,
+    )
+    for bucket in (1, 2, 4, 8):
+        capture = dataclasses.replace(
+            eager,
+            graph_mode="capture",
+            max_num_seqs=8,
+            graph_bucket=MusaForwardGraphBucket(
+                num_tokens=bucket,
+                num_reqs=bucket,
+                uniform=True,
+                runtime_mode="FULL",
+                has_lora=False,
+                num_active_loras=0,
+                present=True,
+            ),
+        )
+        assert thresholds_for_shape(capture).gemv_max_tokens == 8
+        tactic = gemv_stage_tactic_for_shape(shape=capture, num_tokens=bucket)
+        assert tactic is not None
+        assert tactic.w1_block == (32, 4)
+        assert tactic.w2_block == (32, 4)
+        assert f"capture-maxseq{bucket}" in tactic.source
+    uncaptured = dataclasses.replace(
+        eager,
+        graph_mode="capture",
+        max_num_seqs=16,
+        graph_bucket=MusaForwardGraphBucket(
+            num_tokens=16,
+            num_reqs=16,
+            uniform=True,
+            runtime_mode="FULL",
+            has_lora=False,
+            num_active_loras=0,
+            present=True,
+        ),
+    )
+    assert thresholds_for_shape(uncaptured).source == "uncalibrated-shape"
+    assert gemv_stage_tactic_for_shape(shape=uncaptured, num_tokens=16) is None
+
+
+def test_qwen35_bf16_mp48_capture_tactic_requires_exact_full_bucket():
+    capture = _shape(
+        multiprocessor_count=48,
+        local_experts=257,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=9,
+        hidden_dtype="torch.bfloat16",
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+        block_n=0,
+        block_k=0,
+        activation="silu",
+        expert_parallel=False,
+        graph_mode="capture",
+        max_num_seqs=8,
+    )
+    assert gemv_stage_tactic_for_shape(shape=capture, num_tokens=1) is None
+
+    for field, value in (
+        ("runtime_mode", "PIECEWISE"),
+        ("uniform", False),
+        ("num_reqs", 2),
+        ("has_lora", True),
+        ("num_active_loras", 1),
+        ("present", False),
+    ):
+        bucket = MusaForwardGraphBucket(
+            num_tokens=1,
+            num_reqs=1,
+            uniform=True,
+            runtime_mode="FULL",
+            has_lora=False,
+            num_active_loras=0,
+            present=True,
+        )
+        malformed = dataclasses.replace(bucket, **{field: value})
+        assert (
+            gemv_stage_tactic_for_shape(
+                shape=dataclasses.replace(capture, graph_bucket=malformed),
+                num_tokens=1,
+            )
+            is None
+        )
+
+
+def test_dsv4_mp60_m2_uses_exact_eager_w1_stage_tactic():
+    shape = _shape(
+        multiprocessor_count=60,
+        local_experts=256,
+        w1_output_size=512,
+        w2_input_size=256,
+        hidden_size=4096,
+        top_k=6,
+        w1_scale_shape=(256, 4, 32),
+        w2_scale_shape=(256, 32, 2),
+        gemv_block="16x8",
+    )
+
+    assert gemv_stage_tactic_for_shape(shape=shape, num_tokens=2) == (
+        MusaFusedMoeGemvStageTactic(
+            w1_block=(8, 16),
+            w2_block=(16, 8),
+            source="mp60-dsv4-fp8-m2-route-policy-v1",
+        )
+    )
+
+
+def test_dsv4_stage_tactic_mismatches_fail_closed():
+    shape = _shape(
+        multiprocessor_count=60,
+        local_experts=256,
+        w1_output_size=512,
+        w2_input_size=256,
+        hidden_size=4096,
+        top_k=6,
+        w1_scale_shape=(256, 4, 32),
+        w2_scale_shape=(256, 32, 2),
+        gemv_block="16x8",
+    )
+
+    assert gemv_stage_tactic_for_shape(shape=shape, num_tokens=1) is None
+    assert gemv_stage_tactic_for_shape(shape=shape, num_tokens=4) is None
+    for field, value in (
+        ("device_capability", (3, 0)),
+        ("multiprocessor_count", 56),
+        ("local_experts", 255),
+        ("w1_output_size", 256),
+        ("w2_input_size", 128),
+        ("hidden_size", 2048),
+        ("top_k", 8),
+        ("block_n", 64),
+        ("block_k", 64),
+        ("activation", "gelu"),
+        ("expert_parallel", True),
+        ("hidden_dtype", "torch.float16"),
+        ("weight_dtype", "torch.bfloat16"),
+        ("scale_dtype", "torch.bfloat16"),
+        ("w1_scale_shape", (256, 32, 4)),
+        ("w2_scale_shape", (256, 2, 32)),
+        ("gemv_block", "auto"),
+        ("graph_mode", "capture"),
+    ):
+        assert (
+            gemv_stage_tactic_for_shape(
+                shape=dataclasses.replace(shape, **{field: value}),
+                num_tokens=2,
+            )
+            is None
+        )
+
+
+def test_dsv4_stage_tactic_ignores_scheduler_projection_after_backend_gate():
+    shape = _shape(
+        multiprocessor_count=60,
+        local_experts=256,
+        w1_output_size=512,
+        w2_input_size=256,
+        hidden_size=4096,
+        top_k=6,
+        w1_scale_shape=(256, 4, 32),
+        w2_scale_shape=(256, 32, 2),
+        gemv_block="16x8",
+    )
+    projected = dataclasses.replace(
+        shape,
+        max_num_seqs=64,
+        graph_bucket=MusaForwardGraphBucket(
+            num_tokens=2,
+            num_reqs=None,
+            uniform=False,
+            runtime_mode="NONE",
+            has_lora=False,
+            num_active_loras=0,
+            present=True,
+        ),
+    )
+
+    assert gemv_stage_tactic_for_shape(
+        shape=projected,
+        num_tokens=2,
+    ) == gemv_stage_tactic_for_shape(shape=shape, num_tokens=2)
+
+
+def test_mp_calibration_remains_exact_for_layout_and_mp_count():
     shape = _shape(
         multiprocessor_count=60,
         local_experts=64,
@@ -255,7 +602,7 @@ def test_pr113_folded_qwen_shape_requires_fresh_calibration():
     assert thresholds_for_shape(folded_qwen).source == "uncalibrated-shape"
 
 
-def test_qwen35_bf16_decode_gemv_uses_tp4_local_crossover():
+def test_qwen35_bf16_decode_gemv_uses_mp60_route_worst_crossover():
     shape = _shape(
         multiprocessor_count=60,
         local_experts=257,
@@ -271,8 +618,8 @@ def test_qwen35_bf16_decode_gemv_uses_tp4_local_crossover():
         w2_scale_shape=(),
     )
 
-    assert thresholds_for_shape(shape).gemv_max_tokens == 12
-    for token_count in (1, 4, 8, 12):
+    assert thresholds_for_shape(shape).gemv_max_tokens == 4
+    for token_count in (1, 4):
         assert (
             select_fused_moe_backend(
                 shape=shape,
@@ -283,18 +630,19 @@ def test_qwen35_bf16_decode_gemv_uses_tp4_local_crossover():
             )
             == MusaFusedMoeBackend.GEMV
         )
-    assert (
-        select_fused_moe_backend(
-            shape=shape,
-            num_tokens=16,
-            can_use_gemv=True,
-            can_use_grouped_gemm=False,
-            stream_is_capturing=False,
+    for token_count in (8, 16):
+        assert (
+            select_fused_moe_backend(
+                shape=shape,
+                num_tokens=token_count,
+                can_use_gemv=True,
+                can_use_grouped_gemm=False,
+                stream_is_capturing=False,
+            )
+            == MusaFusedMoeBackend.UPSTREAM
         )
-        == MusaFusedMoeBackend.UPSTREAM
-    )
     capture_shape = _shape(**{**shape.__dict__, "graph_mode": "capture"})
-    assert thresholds_for_shape(capture_shape).gemv_max_tokens == 12
+    assert thresholds_for_shape(capture_shape).gemv_max_tokens == 4
 
     unfolded = _shape(
         multiprocessor_count=60,
@@ -311,6 +659,394 @@ def test_qwen35_bf16_decode_gemv_uses_tp4_local_crossover():
         w2_scale_shape=(),
     )
     assert thresholds_for_shape(unfolded).gemv_max_tokens == 12
+    assert (
+        thresholds_for_shape(
+            dataclasses.replace(unfolded, max_num_seqs=16)
+        ).gemv_max_tokens
+        == 12
+    )
+
+
+def test_graph_bucket_guard_preserves_existing_mp60_runtime_modes():
+    qwen = _shape(
+        multiprocessor_count=60,
+        local_experts=257,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=9,
+        block_n=0,
+        block_k=0,
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+    )
+    dsv4 = _shape(
+        multiprocessor_count=60,
+        local_experts=256,
+        w1_output_size=512,
+        w2_input_size=256,
+        hidden_size=4096,
+        top_k=6,
+        w1_scale_shape=(256, 4, 32),
+        w2_scale_shape=(256, 32, 2),
+        gemv_block="32x8",
+    )
+    runtime_cases = (
+        (
+            "eager",
+            MusaForwardGraphBucket(
+                num_tokens=4,
+                num_reqs=None,
+                uniform=False,
+                runtime_mode="NONE",
+                has_lora=False,
+                num_active_loras=0,
+                present=True,
+            ),
+        ),
+        (
+            "capture",
+            MusaForwardGraphBucket(
+                num_tokens=4,
+                num_reqs=None,
+                uniform=False,
+                runtime_mode="PIECEWISE",
+                has_lora=False,
+                num_active_loras=0,
+                present=True,
+            ),
+        ),
+        (
+            "capture",
+            MusaForwardGraphBucket(
+                num_tokens=4,
+                num_reqs=4,
+                uniform=True,
+                runtime_mode="FULL",
+                has_lora=False,
+                num_active_loras=0,
+                present=True,
+            ),
+        ),
+    )
+
+    for base_shape in (qwen, dsv4):
+        for graph_mode, descriptor in runtime_cases:
+            shape = dataclasses.replace(
+                base_shape,
+                graph_mode=graph_mode,
+                graph_bucket=descriptor,
+            )
+            thresholds = thresholds_for_shape(shape)
+            assert thresholds.gemv_max_tokens is not None
+            assert (
+                select_fused_moe_backend(
+                    shape=shape,
+                    num_tokens=4,
+                    can_use_gemv=True,
+                    can_use_grouped_gemm=False,
+                    stream_is_capturing=graph_mode == "capture",
+                    thresholds=thresholds,
+                )
+                == MusaFusedMoeBackend.GEMV
+            )
+
+    for descriptor in (
+        MusaForwardGraphBucket.invalid(),
+        MusaForwardGraphBucket(
+            num_tokens=1,
+            num_reqs=1,
+            uniform=True,
+            runtime_mode="NONE",
+            has_lora=True,
+            num_active_loras=1,
+            present=True,
+        ),
+        MusaForwardGraphBucket(
+            num_tokens=4,
+            num_reqs=2,
+            uniform=True,
+            runtime_mode="FULL",
+            has_lora=False,
+            num_active_loras=0,
+            present=True,
+        ),
+    ):
+        shape = dataclasses.replace(qwen, graph_bucket=descriptor)
+        assert (
+            select_fused_moe_backend(
+                shape=shape,
+                num_tokens=1,
+                can_use_gemv=True,
+                can_use_grouped_gemm=False,
+                stream_is_capturing=False,
+            )
+            == MusaFusedMoeBackend.UPSTREAM
+        )
+
+
+def test_qwen35_bf16_decode_gemv_uses_mp56_route_worst_crossover():
+    base_shape = _shape(
+        multiprocessor_count=56,
+        local_experts=257,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=9,
+        block_n=0,
+        block_k=0,
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+    )
+    assert thresholds_for_shape(base_shape).gemv_max_tokens is None
+    assert (
+        thresholds_for_shape(
+            dataclasses.replace(base_shape, max_num_seqs=16)
+        ).gemv_max_tokens
+        is None
+    )
+    # The engine-static profile is part of the key: a larger profile must not
+    # accidentally inherit the small-batch GEMV entry during symbolic compile.
+    assert all(
+        key.max_num_seqs in (None, 1, 2, 4)
+        for key in POLICY._CALIBRATED_THRESHOLDS
+        if key.multiprocessor_count == 56
+    )
+    assert all(
+        key.graph_mode != "compile"
+        for key in POLICY._CALIBRATED_THRESHOLDS
+        if key.multiprocessor_count == 56
+    )
+    for graph_mode in ("eager", "capture"):
+        for max_num_seqs in (1, 2, 4):
+            shape = dataclasses.replace(
+                base_shape,
+                graph_mode=graph_mode,
+                max_num_seqs=max_num_seqs,
+            )
+            thresholds = thresholds_for_shape(shape)
+            assert thresholds.gemv_max_tokens == 4
+            assert "mp56" in thresholds.source
+            assert "e257" in thresholds.source
+            assert f"maxseq{max_num_seqs}" in thresholds.source
+            assert "route-policy" in thresholds.source
+            assert select_fused_moe_backend(
+                shape=shape,
+                num_tokens=4,
+                can_use_gemv=True,
+                can_use_grouped_gemm=False,
+                stream_is_capturing=graph_mode == "capture",
+            ) == (
+                MusaFusedMoeBackend.GEMV
+                if graph_mode == "eager"
+                else MusaFusedMoeBackend.UPSTREAM
+            )
+            assert (
+                select_fused_moe_backend(
+                    shape=shape,
+                    num_tokens=5,
+                    can_use_gemv=True,
+                    can_use_grouped_gemm=False,
+                    stream_is_capturing=graph_mode == "capture",
+                )
+                == MusaFusedMoeBackend.UPSTREAM
+            )
+
+
+def test_qwen_mp56_uses_only_exact_full_decode_graph_buckets():
+    base_shape = _shape(
+        multiprocessor_count=56,
+        local_experts=257,
+        w1_output_size=256,
+        w2_input_size=128,
+        hidden_size=2048,
+        top_k=9,
+        block_n=0,
+        block_k=0,
+        weight_dtype="torch.bfloat16",
+        scale_dtype="none",
+        w1_scale_shape=(),
+        w2_scale_shape=(),
+        graph_mode="capture",
+        max_num_seqs=64,
+    )
+
+    for graph_bucket in ((1, 1, True), (2, 2, True), (4, 4, True)):
+        descriptor = MusaForwardGraphBucket(
+            num_tokens=graph_bucket[0],
+            num_reqs=graph_bucket[1],
+            uniform=graph_bucket[2],
+            runtime_mode="FULL",
+            has_lora=False,
+            num_active_loras=0,
+            present=True,
+        )
+        thresholds = thresholds_for_shape(
+            dataclasses.replace(base_shape, graph_bucket=descriptor)
+        )
+        assert thresholds.gemv_max_tokens == 4
+        assert f"maxseq{graph_bucket[0]}" in thresholds.source
+        assert (
+            select_fused_moe_backend(
+                shape=dataclasses.replace(base_shape, graph_bucket=descriptor),
+                num_tokens=graph_bucket[0],
+                can_use_gemv=True,
+                can_use_grouped_gemm=False,
+                stream_is_capturing=True,
+                requested=MusaFusedMoeBackend.AUTO,
+                thresholds=thresholds,
+            )
+            == MusaFusedMoeBackend.GEMV
+        )
+
+    bucket_one_shape = dataclasses.replace(
+        base_shape,
+        graph_bucket=MusaForwardGraphBucket(
+            num_tokens=1,
+            num_reqs=1,
+            uniform=True,
+            runtime_mode="FULL",
+            has_lora=False,
+            num_active_loras=0,
+            present=True,
+        ),
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=bucket_one_shape,
+            num_tokens=2,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=True,
+            requested=MusaFusedMoeBackend.AUTO,
+            thresholds=thresholds_for_shape(bucket_one_shape),
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+
+    eager_none = MusaForwardGraphBucket(
+        num_tokens=4,
+        num_reqs=None,
+        uniform=False,
+        runtime_mode="NONE",
+        has_lora=False,
+        num_active_loras=0,
+        present=True,
+    )
+    eager_shape = dataclasses.replace(
+        base_shape,
+        graph_mode="eager",
+        max_num_seqs=4,
+        graph_bucket=eager_none,
+    )
+    eager_thresholds = thresholds_for_shape(eager_shape)
+    assert eager_thresholds.gemv_max_tokens == 4
+    assert (
+        select_fused_moe_backend(
+            shape=eager_shape,
+            num_tokens=4,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=False,
+            thresholds=eager_thresholds,
+        )
+        == MusaFusedMoeBackend.GEMV
+    )
+
+    # Missing ForwardContext is tolerated only for eager direct-operator
+    # callers. It cannot specialize a graph capture.
+    assert (
+        select_fused_moe_backend(
+            shape=base_shape,
+            num_tokens=1,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=True,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+
+    for graph_bucket in (
+        (16, 16, True),
+        (4, 2, True),
+        (4, None, False),
+        (1, None, False),
+    ):
+        descriptor = MusaForwardGraphBucket(
+            num_tokens=graph_bucket[0],
+            num_reqs=graph_bucket[1],
+            uniform=graph_bucket[2],
+            runtime_mode="FULL" if graph_bucket[2] else "PIECEWISE",
+            has_lora=False,
+            num_active_loras=0,
+            present=True,
+        )
+        invalid_shape = dataclasses.replace(base_shape, graph_bucket=descriptor)
+        thresholds = thresholds_for_shape(invalid_shape)
+        assert thresholds.source == "uncalibrated-shape"
+        assert (
+            select_fused_moe_backend(
+                shape=invalid_shape,
+                num_tokens=graph_bucket[0],
+                can_use_gemv=True,
+                can_use_grouped_gemm=False,
+                stream_is_capturing=True,
+                requested=MusaFusedMoeBackend.AUTO,
+                thresholds=thresholds,
+            )
+            == MusaFusedMoeBackend.UPSTREAM
+        )
+
+    for descriptor in (
+        MusaForwardGraphBucket(
+            num_tokens=1,
+            num_reqs=1,
+            uniform=True,
+            runtime_mode="FULL",
+            has_lora=True,
+            num_active_loras=1,
+            present=True,
+        ),
+        MusaForwardGraphBucket.invalid(),
+    ):
+        shape = dataclasses.replace(base_shape, graph_bucket=descriptor)
+        assert thresholds_for_shape(shape).source == "uncalibrated-shape"
+        assert (
+            select_fused_moe_backend(
+                shape=shape,
+                num_tokens=1,
+                can_use_gemv=True,
+                can_use_grouped_gemm=False,
+                stream_is_capturing=True,
+                requested=MusaFusedMoeBackend.AUTO,
+                thresholds=thresholds_for_shape(shape),
+            )
+            == MusaFusedMoeBackend.UPSTREAM
+        )
+        assert (
+            select_fused_moe_backend(
+                shape=shape,
+                num_tokens=1,
+                can_use_gemv=True,
+                can_use_grouped_gemm=False,
+                stream_is_capturing=False,
+                requested=MusaFusedMoeBackend.GEMV,
+                thresholds=thresholds_for_shape(shape),
+            )
+            == MusaFusedMoeBackend.UPSTREAM
+        )
+
+    assert thresholds_for_shape(base_shape).source == "uncalibrated-shape"
+    assert (
+        thresholds_for_shape(
+            dataclasses.replace(base_shape, multiprocessor_count=48)
+        ).source
+        == "uncalibrated-shape"
+    )
 
 
 def test_force_modes_preserve_eligibility_checks():
@@ -369,6 +1105,29 @@ def test_forced_gemv_preserves_capture_calibration_boundary(monkeypatch):
     assert (
         select_fused_moe_backend(
             shape=capture_shape,
+            num_tokens=4,
+            can_use_gemv=True,
+            can_use_grouped_gemm=False,
+            stream_is_capturing=True,
+            requested=MusaFusedMoeBackend.GEMV,
+        )
+        == MusaFusedMoeBackend.UPSTREAM
+    )
+    capture_shape_with_context = dataclasses.replace(
+        capture_shape,
+        graph_bucket=MusaForwardGraphBucket(
+            num_tokens=4,
+            num_reqs=4,
+            uniform=True,
+            runtime_mode="FULL",
+            has_lora=False,
+            num_active_loras=0,
+            present=True,
+        ),
+    )
+    assert (
+        select_fused_moe_backend(
+            shape=capture_shape_with_context,
             num_tokens=4,
             can_use_gemv=True,
             can_use_grouped_gemm=False,

--- a/tests/test_jit_rmsnorm_tactic_benchmark.py
+++ b/tests/test_jit_rmsnorm_tactic_benchmark.py
@@ -1,0 +1,124 @@
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+BENCH_PATH = ROOT / "benchmarks/kernel_tactics/benchmark_jit_rmsnorm_threads.py"
+API_PATH = ROOT / "vllm_musa/jit_kernel/csrc/norm.py"
+sys.path.insert(0, str(BENCH_PATH.parent))
+SPEC = importlib.util.spec_from_file_location(
+    "benchmark_jit_rmsnorm_threads", BENCH_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+BENCH = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BENCH
+SPEC.loader.exec_module(BENCH)
+
+
+@pytest.mark.parametrize("value", ["32", "128", "640", "1024"])
+def test_parse_threads_accepts_compiled_launch_geometry(value):
+    assert BENCH.parse_threads(value) == int(value)
+
+
+@pytest.mark.parametrize("value", ["bad", "0", "31", "129", "768"])
+def test_parse_threads_rejects_unlisted_geometry(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        BENCH.parse_threads(value)
+
+
+@pytest.mark.parametrize(
+    ("mode", "rows", "hidden_size", "expected"),
+    [
+        ("plain", 1, 1024, None),
+        ("plain", 16, 2048, None),
+        ("plain", 32, 4096, 256),
+        ("plain", 512, 4096, 128),
+        ("plain", 1, 5120, 512),
+        ("fused", 64, 5120, 640),
+        ("fused_gemma", 4, 1536, 192),
+    ],
+)
+def test_production_thread_resolver(mode, rows, hidden_size, expected):
+    assert BENCH.production_threads(mode, rows, hidden_size) == expected
+
+
+def test_jit_rmsnorm_contract_exposes_default_preserving_requested_threads():
+    wrapper = (ROOT / "vllm_musa/jit_kernel/csrc/norm.py").read_text()
+    kernel = (ROOT / "vllm_musa/jit_kernel/csrc/norm/rmsnorm.mu").read_text()
+
+    assert wrapper.count("block_threads: int = 0") >= 3
+    assert "int requested_threads" in kernel
+    assert "check_requested_threads" in kernel
+    assert "requested_threads == 0 ||" in kernel
+    assert "requested_threads > 0 ? requested_threads" in kernel
+    assert "requested_threads == 0 && rows <= 16 && hidden == 1024" in kernel
+
+
+def test_jit_rmsnorm_timing_resets_mutable_inputs_outside_events():
+    source = BENCH_PATH.read_text()
+    launch = source[
+        source.index("            def launch(") : source.index(
+            "            reset_mutable_inputs()",
+            source.index("            def launch("),
+        )
+    ]
+    assert "copy_(" not in launch
+    assert "reset_mutable_inputs()\n                        flush.zero_()" in source
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"lease_device_fence": lease_device_fence' in source
+
+
+def test_jit_rmsnorm_benchmark_primes_hardware_for_production_baselines():
+    benchmark = BENCH_PATH.read_text(encoding="utf-8")
+    assert "prime_musa_kernel_hardware" in benchmark
+    assert '"primed_hardware": {' in benchmark
+
+
+def test_jit_rmsnorm_runtime_uses_exact_primed_hardware_tactic():
+    source = API_PATH.read_text(encoding="utf-8")
+    assert "get_primed_musa_kernel_hardware" in source
+    assert "select_jit_rmsnorm_tactic" in source
+    assert 'mode="fused_gemma" if gemma else "fused"' in source
+    assert "return tactic.block_threads if tactic is not None else 0" in source
+
+
+@pytest.mark.parametrize(
+    ("mode", "rows"),
+    [
+        ("plain", 512),
+        ("gemma", 512),
+        ("gemma", 4096),
+        ("fused_gemma", 512),
+    ],
+)
+def test_production_thread_resolver_uses_exact_mp60_h5120_tactic(mode, rows):
+    assert BENCH.production_threads(mode, rows, 5120, 60) == 320
+    assert BENCH.production_threads(mode, rows, 5120, 48) != 320
+    if rows == 512:
+        assert BENCH.production_threads(mode, rows, 5120, 56) == 320
+    else:
+        assert BENCH.production_threads(mode, rows, 5120, 56) != 320
+
+
+@pytest.mark.parametrize("mode", ["plain", "gemma", "fused", "fused_gemma"])
+def test_production_thread_resolver_uses_exact_mp56_h5120_tactic(mode):
+    assert BENCH.production_threads(mode, 512, 5120, 56) == 320
+    assert BENCH.production_threads(mode, 512, 5120, 48) != 320
+
+
+def test_production_thread_resolver_uses_exact_mp48_plain_h5120_tactic():
+    assert BENCH.production_threads("plain", 512, 5120, 48) == 256
+
+
+@pytest.mark.parametrize(
+    ("mode", "fallback_threads"),
+    [("gemma", 512), ("fused", 640), ("fused_gemma", 640)],
+)
+def test_production_thread_resolver_rejects_non_plain_mp48_tactic(
+    mode, fallback_threads
+):
+    assert BENCH.production_threads(mode, 512, 5120, 48) == fallback_threads

--- a/tests/test_jit_topk_tactic_benchmark.py
+++ b/tests/test_jit_topk_tactic_benchmark.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+BENCH_PATH = ROOT / "benchmarks/kernel_tactics/benchmark_jit_topk_warps.py"
+KERNEL_PATH = ROOT / "vllm_musa/jit_kernel/csrc/topk/topk_gating.mu"
+sys.path.insert(0, str(BENCH_PATH.parent))
+SPEC = importlib.util.spec_from_file_location("benchmark_jit_topk_warps", BENCH_PATH)
+assert SPEC is not None and SPEC.loader is not None
+BENCH = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BENCH
+SPEC.loader.exec_module(BENCH)
+
+
+def test_topk_families_follow_checked_production_buckets() -> None:
+    families = BENCH.load_production_families()
+
+    qwen = families["qwen_softmax_e256_k8"]
+    assert (qwen.input_experts, qwen.routed_topk, qwen.output_topk) == (256, 8, 8)
+    assert qwen.production_rows == (1, 2, 4, 8, 12, 16, 32, 36, 64)
+    assert tuple(row // qwen.routed_topk for row in qwen.routed_rows) == (
+        qwen.production_rows
+    )
+
+    folded = families["qwen35_folded_softmax_e257_k9"]
+    assert (folded.input_experts, folded.routed_topk, folded.output_topk) == (
+        257,
+        8,
+        9,
+    )
+    assert folded.num_fused_shared_experts == 1
+    assert folded.production_rows == qwen.production_rows
+
+    deepseek = families["deepseek_v4_sigmoid_e256_k6_local_no_bias"]
+    assert (deepseek.input_experts, deepseek.routed_topk) == (256, 6)
+    assert deepseek.production_reachable is False
+    assert "MATE grouped correction-bias router is excluded" in deepseek.scope_note
+    assert deepseek.production_rows == (
+        1,
+        2,
+        4,
+        5,
+        8,
+        16,
+        20,
+        32,
+        64,
+        80,
+        128,
+        256,
+        320,
+    )
+    biased = families["deepseek_v4_sigmoid_e256_k6_correction_bias"]
+    assert (biased.input_experts, biased.routed_topk) == (256, 6)
+    assert biased.production_reachable is True
+    assert biased.has_correction_bias is True
+
+
+@pytest.mark.parametrize("value", ["1", "2", "4", "8"])
+def test_parse_warps_accepts_compiled_tactics(value: str) -> None:
+    assert BENCH.parse_warps_per_cta(value) == int(value)
+
+
+@pytest.mark.parametrize("value", ["bad", "0", "3", "16"])
+def test_parse_warps_rejects_uncompiled_tactics(value: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        BENCH.parse_warps_per_cta(value)
+
+
+def test_launch_geometry_maps_one_warp_to_one_row() -> None:
+    assert BENCH.launch_geometry(65, 1) == {
+        "warps_per_cta": 1,
+        "threads_per_cta": 32,
+        "grid_ctas": 65,
+    }
+    assert BENCH.launch_geometry(65, 8) == {
+        "warps_per_cta": 8,
+        "threads_per_cta": 256,
+        "grid_ctas": 9,
+    }
+
+
+def test_row_override_must_stay_inside_each_family() -> None:
+    family = BENCH.load_production_families()["qwen_softmax_e256_k8"]
+    assert BENCH.selected_rows(family, [1, 64, 1]) == (1, 64)
+    with pytest.raises(ValueError, match="production buckets"):
+        BENCH.selected_rows(family, [5])
+
+
+@pytest.mark.parametrize("repeats", [2, 4, 32])
+def test_balanced_pairing_requires_positive_even_repeats(repeats: int) -> None:
+    BENCH.validate_timing_args(dry_runs=1, repeats=repeats)
+
+
+@pytest.mark.parametrize("repeats", [-2, 0, 1, 3, 31])
+def test_unbalanced_repeat_counts_are_rejected(repeats: int) -> None:
+    with pytest.raises(ValueError, match="balanced AB/BA"):
+        BENCH.validate_timing_args(dry_runs=1, repeats=repeats)
+
+
+def test_native_seam_is_benchmark_only_and_default_preserving() -> None:
+    source = KERNEL_PATH.read_text(encoding="utf-8")
+
+    assert "constexpr int kWarpsPerCta = 4;" in source
+    assert "int WarpsPerCta = kWarpsPerCta" in source
+    assert "if (warps_per_cta == 0)" in source
+    assert "dispatch_topk<IsSoftmax>(" in source
+    for warps in BENCH.VALID_WARPS_PER_CTA:
+        assert f"warps_per_cta == {warps}" in source
+    assert "Softmax benchmark tactics exclude correction-bias routing" in source
+    assert "Benchmark topk tactics exclude separate shared-gate routing" in source
+    assert "topk_sigmoid_warp_kernel<T, 256, 8, WarpsPerCta>" in source
+    assert "#if defined(VLLM_MUSA_TOPK_BENCHMARK_TACTICS)" in source
+    first_guard = source.index("#if defined(VLLM_MUSA_TOPK_BENCHMARK_TACTICS)")
+    launch_helper = source.index("void launch_topk_benchmark_tactic")
+    first_close = source.index("#endif", launch_helper)
+    assert first_guard < launch_helper < first_close
+    assert source.count("TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_topk_softmax") == 2
+    assert source.count("TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_topk_sigmoid") == 2
+    assert "sgl_musa_topk_softmax_benchmark_tactic" in source
+    assert "sgl_musa_topk_sigmoid_benchmark_tactic" in source
+
+
+def test_benchmark_has_cold_paired_poisoned_device_fence_contract() -> None:
+    source = BENCH_PATH.read_text(encoding="utf-8")
+
+    assert BENCH.L2_FLUSH_BYTES == 8_000_000_000
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"lease_device_fence": lease_device_fence' in source
+    assert 'weights.fill_(float("nan"))' in source
+    assert "ids.fill_(-1)" in source
+    assert "flush.zero_()" in source
+    assert '"paired_alternating_order": True' in source
+    assert '"cache_policy": "cold-l2-per-sample"' in source
+    assert '"implementation": "vllm-musa local native JIT only"' in source
+    assert "descending=True" in source
+    assert "stable=True" in source
+    assert 'else "local-native-default"' in source
+    assert '"-DVLLM_MUSA_TOPK_BENCHMARK_TACTICS=1"' in source
+    assert "module.sgl_musa_topk_softmax(" in source
+    assert "module.sgl_musa_topk_sigmoid(" in source
+    assert "deepseek_v4_sigmoid_e256_k6_correction_bias" in source
+    assert "selection_scores = scores + correction_bias" in source
+    assert "from mate" not in source

--- a/tests/test_kernel_benchmark_device_fence.py
+++ b/tests/test_kernel_benchmark_device_fence.py
@@ -1,0 +1,95 @@
+import pytest
+
+from benchmarks.kernel_tactics import _benchmark_utils as utils
+
+
+def test_device_fence_accepts_exact_visibility_and_uuid(monkeypatch):
+    for name in (
+        "MTHREADS_VISIBLE_DEVICES",
+        "MUSA_VISIBLE_DEVICES",
+        "CUDA_VISIBLE_DEVICES",
+    ):
+        monkeypatch.setenv(name, "2")
+    monkeypatch.setattr(
+        utils,
+        "command_output",
+        lambda command: (
+            "0, uuid-other, MTT TEST DEVICE\n"
+            "2, uuid-target, MTT TEST DEVICE\n"
+            "3, uuid-another, MTT TEST DEVICE"
+        ),
+    )
+
+    receipt = utils.verify_lease_device_fence(2, "uuid-target")
+
+    assert receipt["passed"] is True
+    assert receipt["actual_physical_device"] == 2
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("MTHREADS_VISIBLE_DEVICES", "1"),
+        ("MUSA_VISIBLE_DEVICES", "1"),
+        ("CUDA_VISIBLE_DEVICES", "1"),
+    ],
+)
+def test_device_fence_rejects_visibility_drift(monkeypatch, env_name, env_value):
+    for name in (
+        "MTHREADS_VISIBLE_DEVICES",
+        "MUSA_VISIBLE_DEVICES",
+        "CUDA_VISIBLE_DEVICES",
+    ):
+        monkeypatch.setenv(name, "2")
+    monkeypatch.setenv(env_name, env_value)
+
+    with pytest.raises(RuntimeError, match="visibility"):
+        utils.verify_lease_device_fence(2, "uuid-target")
+
+
+def test_device_fence_rejects_uuid_drift(monkeypatch):
+    for name in (
+        "MTHREADS_VISIBLE_DEVICES",
+        "MUSA_VISIBLE_DEVICES",
+        "CUDA_VISIBLE_DEVICES",
+    ):
+        monkeypatch.setenv(name, "2")
+    monkeypatch.setattr(
+        utils,
+        "command_output",
+        lambda command: "2, uuid-wrong, MTT TEST DEVICE",
+    )
+
+    with pytest.raises(RuntimeError, match="expected"):
+        utils.verify_lease_device_fence(2, "uuid-target")
+
+
+def test_device_fence_accepts_legacy_full_query(monkeypatch):
+    for name in (
+        "MTHREADS_VISIBLE_DEVICES",
+        "MUSA_VISIBLE_DEVICES",
+        "CUDA_VISIBLE_DEVICES",
+    ):
+        monkeypatch.setenv(name, "3")
+    outputs = iter(
+        [
+            None,
+            """GPU2 00000000:4b:00.0
+    Product Name : MTT TEST DEVICE
+    GPU UUID : uuid-other
+GPU3 00000000:5c:00.0
+    Product Name : MTT TEST DEVICE
+    GPU UUID : uuid-target
+GPU4 00000000:9a:00.0
+    Product Name : MTT TEST DEVICE
+    GPU UUID : uuid-another
+""",
+        ]
+    )
+    monkeypatch.setattr(utils, "command_output", lambda command: next(outputs))
+
+    receipt = utils.verify_lease_device_fence(3, "uuid-target")
+
+    assert receipt["passed"] is True
+    assert receipt["mthreads_gmi_query_mode"] == "legacy-full-query"
+    assert receipt["mthreads_gmi_query"] == ("3, uuid-target, MTT TEST DEVICE")

--- a/tests/test_kernel_tuning.py
+++ b/tests/test_kernel_tuning.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from vllm_musa import tuning
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_kernel_hardware_cache_key_keeps_mp_count_exact() -> None:
+    mp56 = tuning.MusaKernelHardware((3, 1), 56)
+    mp60 = tuning.MusaKernelHardware((3, 1), 60)
+
+    assert mp56.cache_key == "mp31-mps56"
+    assert mp60.cache_key == "mp31-mps60"
+    assert mp56.cache_key != mp60.cache_key
+    assert tuning.UNKNOWN_MUSA_KERNEL_HARDWARE.cache_key == "unknown"
+
+
+def test_query_kernel_hardware_reads_device_properties(monkeypatch) -> None:
+    monkeypatch.setattr(
+        tuning,
+        "_get_musa_device_properties",
+        lambda _index: SimpleNamespace(
+            major=3,
+            minor=1,
+            multi_processor_count=56,
+        ),
+    )
+
+    assert tuning.query_musa_kernel_hardware(0) == tuning.MusaKernelHardware((3, 1), 56)
+
+
+def test_query_kernel_hardware_fails_closed(monkeypatch) -> None:
+    def fail(_index):
+        raise RuntimeError("device query unavailable")
+
+    monkeypatch.setattr(
+        tuning,
+        "_get_musa_device_properties",
+        fail,
+    )
+
+    hardware = tuning.query_musa_kernel_hardware(0)
+    assert hardware == tuning.UNKNOWN_MUSA_KERNEL_HARDWARE
+    assert not hardware.is_known
+
+
+def test_query_kernel_hardware_recovers_after_early_unknown(monkeypatch) -> None:
+    results = iter(
+        (
+            RuntimeError("runtime not initialized"),
+            SimpleNamespace(major=3, minor=1, multi_processor_count=60),
+        )
+    )
+
+    def query(_index):
+        result = next(results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(tuning, "_get_musa_device_properties", query)
+
+    assert tuning.query_musa_kernel_hardware(0).cache_key == "unknown"
+    assert tuning.query_musa_kernel_hardware(0).cache_key == "mp31-mps60"
+
+
+def test_cached_kernel_hardware_does_not_cache_early_unknown(monkeypatch) -> None:
+    results = iter(
+        (
+            tuning.UNKNOWN_MUSA_KERNEL_HARDWARE,
+            tuning.MusaKernelHardware((3, 1), 60),
+        )
+    )
+    calls = 0
+
+    def query(_index):
+        nonlocal calls
+        calls += 1
+        return next(results)
+
+    monkeypatch.setattr(tuning, "_MUSA_KERNEL_HARDWARE_CACHE", {})
+    monkeypatch.setattr(tuning, "query_musa_kernel_hardware", query)
+
+    assert tuning.query_cached_musa_kernel_hardware(0).cache_key == "unknown"
+    assert tuning.query_cached_musa_kernel_hardware(0).cache_key == "mp31-mps60"
+    assert tuning.query_cached_musa_kernel_hardware(0).cache_key == "mp31-mps60"
+    assert calls == 2
+
+
+def test_primed_kernel_hardware_freezes_unknown(monkeypatch) -> None:
+    results = iter(
+        (
+            tuning.UNKNOWN_MUSA_KERNEL_HARDWARE,
+            tuning.MusaKernelHardware((3, 1), 60),
+        )
+    )
+    calls = 0
+
+    def query(_index):
+        nonlocal calls
+        calls += 1
+        return next(results)
+
+    monkeypatch.setattr(tuning, "_FROZEN_MUSA_KERNEL_HARDWARE", {})
+    monkeypatch.setattr(tuning, "query_musa_kernel_hardware", query)
+
+    assert tuning.prime_musa_kernel_hardware(0).cache_key == "unknown"
+    assert tuning.prime_musa_kernel_hardware(0).cache_key == "unknown"
+    assert tuning.get_primed_musa_kernel_hardware(0).cache_key == "unknown"
+    assert calls == 1
+
+
+def test_primed_kernel_hardware_is_exact_per_device(monkeypatch) -> None:
+    monkeypatch.setattr(tuning, "_FROZEN_MUSA_KERNEL_HARDWARE", {})
+    monkeypatch.setattr(
+        tuning,
+        "query_musa_kernel_hardware",
+        lambda index: tuning.MusaKernelHardware((3, 1), 56 + index * 4),
+    )
+
+    assert tuning.prime_musa_kernel_hardware(0).cache_key == "mp31-mps56"
+    assert tuning.prime_musa_kernel_hardware(1).cache_key == "mp31-mps60"
+    assert tuning.get_primed_musa_kernel_hardware(2).cache_key == "unknown"
+
+
+def test_worker_primes_hardware_after_device_init() -> None:
+    worker_source = (ROOT / "vllm_musa/worker.py").read_text()
+    init_source = worker_source.split("def init_device(self) -> None:", 1)[1].split(
+        "def ", 1
+    )[0]
+    assert init_source.index("super().init_device()") < init_source.index(
+        "prime_musa_kernel_hardware"
+    )
+
+
+def test_query_kernel_hardware_fails_closed_on_unexpected_probe_error(
+    monkeypatch,
+) -> None:
+    def raise_unexpected(_device_index):
+        raise OSError("transient MUSA property query failure")
+
+    monkeypatch.setattr(tuning, "_get_musa_device_properties", raise_unexpected)
+    assert tuning.query_musa_kernel_hardware(0) == tuning.UNKNOWN_MUSA_KERNEL_HARDWARE
+
+
+def test_engine_scheduler_profile_is_fail_closed(monkeypatch) -> None:
+    monkeypatch.delenv(tuning._ENGINE_MAX_NUM_SEQS_ENV, raising=False)
+    assert tuning.query_musa_engine_max_num_seqs() is None
+
+    tuning.configure_musa_engine_scheduler_profile(4)
+    assert tuning.query_musa_engine_max_num_seqs() == 4
+
+    monkeypatch.setenv(tuning._ENGINE_MAX_NUM_SEQS_ENV, "invalid")
+    assert tuning.query_musa_engine_max_num_seqs() is None
+
+    tuning.configure_musa_engine_scheduler_profile(None)
+    assert tuning.query_musa_engine_max_num_seqs() is None
+
+
+def test_platform_publishes_resolved_scheduler_profile(monkeypatch) -> None:
+    monkeypatch.delenv(tuning._ENGINE_MAX_NUM_SEQS_ENV, raising=False)
+
+    tuning.configure_musa_engine_scheduler_profile_from_config(
+        SimpleNamespace(scheduler_config=SimpleNamespace(max_num_seqs=64))
+    )
+    assert tuning.query_musa_engine_max_num_seqs() == 64
+
+    tuning.configure_musa_engine_scheduler_profile_from_config(SimpleNamespace())
+    assert tuning.query_musa_engine_max_num_seqs() is None
+
+
+def test_forward_graph_bucket_query_is_validated_and_fail_closed(monkeypatch) -> None:
+    vllm_module = ModuleType("vllm")
+    vllm_module.__path__ = []
+    forward_context = ModuleType("vllm.forward_context")
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+    monkeypatch.setitem(sys.modules, "vllm.forward_context", forward_context)
+
+    forward_context.is_forward_context_available = lambda: False
+    forward_context.get_forward_context = lambda: SimpleNamespace(
+        batch_descriptor=SimpleNamespace(
+            num_tokens=1,
+            num_reqs=1,
+            uniform=True,
+            has_lora=False,
+            num_active_loras=0,
+        ),
+        cudagraph_runtime_mode=SimpleNamespace(name="FULL"),
+    )
+    assert tuning.query_musa_forward_graph_bucket() is None
+
+    forward_context.is_forward_context_available = lambda: True
+    forward_context.get_forward_context = lambda: SimpleNamespace(
+        batch_descriptor=SimpleNamespace(
+            num_tokens=1,
+            num_reqs=1,
+            uniform=True,
+            has_lora=False,
+            num_active_loras=0,
+        ),
+        cudagraph_runtime_mode=SimpleNamespace(name="FULL"),
+    )
+    bucket = tuning.query_musa_forward_graph_bucket()
+    assert bucket is not None
+    assert bucket.num_tokens == 1
+    assert bucket.runtime_mode == "FULL"
+    assert bucket.has_lora is False
+    assert bucket.num_active_loras == 0
+
+    for descriptor in (
+        None,
+        SimpleNamespace(
+            num_tokens=0,
+            num_reqs=1,
+            uniform=True,
+            has_lora=False,
+            num_active_loras=0,
+        ),
+        SimpleNamespace(
+            num_tokens=4,
+            num_reqs=0,
+            uniform=True,
+            has_lora=False,
+            num_active_loras=0,
+        ),
+        SimpleNamespace(
+            num_tokens=4,
+            num_reqs=4,
+            uniform=1,
+            has_lora=False,
+            num_active_loras=0,
+        ),
+    ):
+        forward_context.get_forward_context = lambda descriptor=descriptor: (
+            SimpleNamespace(
+                batch_descriptor=descriptor,
+                cudagraph_runtime_mode=SimpleNamespace(name="FULL"),
+            )
+        )
+        assert tuning.query_musa_forward_graph_bucket().present
+
+    for mode, has_lora, active_loras in (("PIECEWISE", False, 0), ("FULL", True, 1)):
+        forward_context.get_forward_context = (
+            lambda mode=mode,
+            has_lora=has_lora,
+            active_loras=active_loras: SimpleNamespace(
+                batch_descriptor=SimpleNamespace(
+                    num_tokens=1,
+                    num_reqs=1,
+                    uniform=True,
+                    has_lora=has_lora,
+                    num_active_loras=active_loras,
+                ),
+                cudagraph_runtime_mode=SimpleNamespace(name=mode),
+            )
+        )
+        bucket = tuning.query_musa_forward_graph_bucket()
+        assert bucket.present
+        assert bucket.runtime_mode == mode
+
+    forward_context.get_forward_context = lambda: SimpleNamespace(
+        batch_descriptor=SimpleNamespace(
+            num_tokens=1,
+            num_reqs=1,
+            uniform=True,
+            has_lora=False,
+            num_active_loras=0,
+        ),
+        cudagraph_runtime_mode=SimpleNamespace(name="FULL_DECODE_ONLY"),
+    )
+    assert tuning.query_musa_forward_graph_bucket() == (
+        tuning.MusaForwardGraphBucket.invalid()
+    )
+
+
+def test_forward_graph_bucket_api_drift_is_present_invalid(monkeypatch) -> None:
+    vllm_module = ModuleType("vllm")
+    vllm_module.__path__ = []
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+    monkeypatch.delitem(sys.modules, "vllm.forward_context", raising=False)
+
+    bucket = tuning.query_musa_forward_graph_bucket()
+    assert bucket is not None
+    assert bucket.present
+    assert bucket.num_tokens is None
+    assert bucket.runtime_mode is None
+
+
+def test_forward_graph_bucket_matches_pinned_vllm_context_objects() -> None:
+    forward_context = pytest.importorskip("vllm.forward_context")
+    vllm_config = pytest.importorskip("vllm.config")
+
+    cases = (
+        (
+            vllm_config.CUDAGraphMode.FULL,
+            forward_context.BatchDescriptor(1, 1, True, False, 0),
+            (1, 1, True, "FULL", False, 0),
+        ),
+        (
+            vllm_config.CUDAGraphMode.PIECEWISE,
+            forward_context.BatchDescriptor(4, None, False, False, 0),
+            (4, None, False, "PIECEWISE", False, 0),
+        ),
+        (
+            vllm_config.CUDAGraphMode.NONE,
+            forward_context.BatchDescriptor(4),
+            (4, None, False, "NONE", False, 0),
+        ),
+        (
+            vllm_config.CUDAGraphMode.FULL,
+            forward_context.BatchDescriptor(1, 1, True, True, 1),
+            (1, 1, True, "FULL", True, 1),
+        ),
+    )
+    for mode, descriptor, expected in cases:
+        context = forward_context.ForwardContext(
+            {},
+            {},
+            {},
+            cudagraph_runtime_mode=mode,
+            batch_descriptor=descriptor,
+        )
+        with forward_context.override_forward_context(context):
+            bucket = tuning.query_musa_forward_graph_bucket()
+        assert bucket is not None
+        assert (
+            bucket.num_tokens,
+            bucket.num_reqs,
+            bucket.uniform,
+            bucket.runtime_mode,
+            bucket.has_lora,
+            bucket.num_active_loras,
+        ) == expected
+
+
+@pytest.mark.parametrize(
+    ("multiprocessor_count", "expected_waves", "expected_tail", "expected_util"),
+    [
+        (52, 3, 16, 120 / 156),
+        (56, 3, 8, 120 / 168),
+        (60, 2, 60, 1.0),
+        (64, 2, 56, 120 / 128),
+    ],
+)
+def test_wave_quantization_exposes_core_bin_discontinuity(
+    multiprocessor_count: int,
+    expected_waves: int,
+    expected_tail: int,
+    expected_util: float,
+) -> None:
+    estimate = tuning.estimate_wave_quantization(120, multiprocessor_count)
+
+    assert estimate.waves == expected_waves
+    assert estimate.tail_tiles == expected_tail
+    assert estimate.overall_slot_utilization == pytest.approx(expected_util)
+
+
+def test_wave_quantization_validates_inputs() -> None:
+    with pytest.raises(ValueError, match="total_tiles"):
+        tuning.estimate_wave_quantization(-1, 60)
+    with pytest.raises(ValueError, match="multiprocessor_count"):
+        tuning.estimate_wave_quantization(1, 0)
+    with pytest.raises(ValueError, match="blocks_per_multiprocessor"):
+        tuning.estimate_wave_quantization(1, 60, blocks_per_multiprocessor=0)
+
+
+def _dsv4_m5_weighted_rmsnorm_tactic(
+    hardware: tuning.MusaKernelHardware,
+    **overrides,
+):
+    contract = {
+        "hardware": hardware,
+        "rows": 5,
+        "hidden_size": 4096,
+        "input_dtype": "torch.bfloat16",
+        "weight_dtype": "torch.bfloat16",
+        "contiguous": True,
+    }
+    contract.update(overrides)
+    return tuning.select_mhc_weighted_rmsnorm_tactic(**contract)
+
+
+def test_mp48_dsv4_m5_weighted_rmsnorm_uses_exact_jit_tactic():
+    assert _dsv4_m5_weighted_rmsnorm_tactic(
+        tuning.MusaKernelHardware((3, 1), 48)
+    ) == tuning.MusaMhcWeightedRmsnormTactic(
+        threads=256,
+        source="mp48-dsv4-mtp4-m5-wrms-256t-v1",
+    )
+
+
+@pytest.mark.parametrize(
+    ("hardware", "overrides"),
+    [
+        (tuning.UNKNOWN_MUSA_KERNEL_HARDWARE, {}),
+        (tuning.MusaKernelHardware((3, 0), 48), {}),
+        (tuning.MusaKernelHardware((3, 1), 56), {}),
+        (tuning.MusaKernelHardware((3, 1), 60), {}),
+        (tuning.MusaKernelHardware((3, 1), 48), {"rows": 1}),
+        (tuning.MusaKernelHardware((3, 1), 48), {"rows": 20}),
+        (tuning.MusaKernelHardware((3, 1), 48), {"hidden_size": 5120}),
+        (
+            tuning.MusaKernelHardware((3, 1), 48),
+            {"input_dtype": "torch.float16"},
+        ),
+        (
+            tuning.MusaKernelHardware((3, 1), 48),
+            {"weight_dtype": "torch.float32"},
+        ),
+        (tuning.MusaKernelHardware((3, 1), 48), {"contiguous": False}),
+    ],
+)
+def test_weighted_rmsnorm_tactic_mismatch_falls_back(hardware, overrides):
+    assert _dsv4_m5_weighted_rmsnorm_tactic(hardware, **overrides) is None
+
+
+@pytest.mark.parametrize(
+    ("mode", "rows"),
+    [
+        ("plain", 512),
+        ("gemma", 512),
+        ("gemma", 4096),
+        ("fused_gemma", 512),
+    ],
+)
+def test_mp60_h5120_uses_exact_jit_rmsnorm_tactic(mode, rows):
+    assert tuning.select_jit_rmsnorm_tactic(
+        hardware=tuning.MusaKernelHardware((3, 1), 60),
+        mode=mode,
+        rows=rows,
+        hidden_size=5120,
+        input_dtype="torch.bfloat16",
+        weight_dtype="torch.bfloat16",
+        contiguous=True,
+    ) == tuning.MusaJitRMSNormTactic(
+        block_threads=320,
+        source=("mp60-jit-rmsnorm-h5120-320t-" f"{mode}-m{rows}-v1"),
+    )
+
+
+@pytest.mark.parametrize("mode", ["plain", "gemma", "fused", "fused_gemma"])
+def test_mp56_h5120_uses_exact_jit_rmsnorm_tactic(mode):
+    assert tuning.select_jit_rmsnorm_tactic(
+        hardware=tuning.MusaKernelHardware((3, 1), 56),
+        mode=mode,
+        rows=512,
+        hidden_size=5120,
+        input_dtype="torch.bfloat16",
+        weight_dtype="torch.bfloat16",
+        contiguous=True,
+    ) == tuning.MusaJitRMSNormTactic(
+        block_threads=320,
+        source=("mp56-jit-rmsnorm-h5120-320t-" f"{mode}-m512-v1"),
+    )
+
+
+def test_mp48_plain_h5120_uses_exact_jit_rmsnorm_tactic():
+    assert tuning.select_jit_rmsnorm_tactic(
+        hardware=tuning.MusaKernelHardware((3, 1), 48),
+        mode="plain",
+        rows=512,
+        hidden_size=5120,
+        input_dtype="torch.bfloat16",
+        weight_dtype="torch.bfloat16",
+        contiguous=True,
+    ) == tuning.MusaJitRMSNormTactic(
+        block_threads=256,
+        source="mp48-jit-rmsnorm-h5120-256t-plain-m512-v1",
+    )
+
+
+@pytest.mark.parametrize(
+    ("hardware", "overrides"),
+    [
+        (tuning.UNKNOWN_MUSA_KERNEL_HARDWARE, {}),
+        (tuning.MusaKernelHardware((3, 0), 60), {}),
+        (tuning.MusaKernelHardware((3, 1), 48), {"mode": "gemma"}),
+        (tuning.MusaKernelHardware((3, 1), 48), {"mode": "fused"}),
+        (tuning.MusaKernelHardware((3, 1), 48), {"mode": "fused_gemma"}),
+        (tuning.MusaKernelHardware((3, 1), 60), {"mode": "fused"}),
+        (tuning.MusaKernelHardware((3, 1), 60), {"rows": 128}),
+        (tuning.MusaKernelHardware((3, 1), 60), {"hidden_size": 4096}),
+        (
+            tuning.MusaKernelHardware((3, 1), 60),
+            {"input_dtype": "torch.float16"},
+        ),
+        (tuning.MusaKernelHardware((3, 1), 60), {"contiguous": False}),
+    ],
+)
+def test_jit_rmsnorm_tactic_mismatch_falls_back(hardware, overrides):
+    contract = {
+        "hardware": hardware,
+        "mode": "plain",
+        "rows": 512,
+        "hidden_size": 5120,
+        "input_dtype": "torch.bfloat16",
+        "weight_dtype": "torch.bfloat16",
+        "contiguous": True,
+    }
+    contract.update(overrides)
+    assert tuning.select_jit_rmsnorm_tactic(**contract) is None

--- a/tests/test_mhc_post_tactic_benchmark.py
+++ b/tests/test_mhc_post_tactic_benchmark.py
@@ -1,0 +1,61 @@
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+BENCH_PATH = (
+    Path(__file__).parents[1]
+    / "benchmarks/kernel_tactics/benchmark_dsv4_mhc_post_jit.py"
+)
+sys.path.insert(0, str(BENCH_PATH.parent))
+SPEC = importlib.util.spec_from_file_location("benchmark_dsv4_mhc_post_jit", BENCH_PATH)
+assert SPEC is not None and SPEC.loader is not None
+BENCH = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BENCH
+SPEC.loader.exec_module(BENCH)
+
+
+def test_parse_config_accepts_full_write_geometry():
+    assert BENCH.parse_config("64x64") == (64, 64)
+    assert BENCH.parse_config("128X256") == (128, 256)
+
+
+@pytest.mark.parametrize("value", ["bad", "0x64", "128x64", "64x0"])
+def test_parse_config_rejects_invalid_or_partial_write_geometry(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        BENCH.parse_config(value)
+
+
+def test_production_config_matches_current_provider_defaults():
+    source = (
+        Path(__file__).parents[1] / "vllm_musa/deepseek_v4_jit/tilelang_kernels.py"
+    ).read_text(encoding="utf-8")
+    assert BENCH.PRODUCTION_CONFIG == (256, 256)
+    assert (
+        "def mhc_post_kernel(hidden_size: int, hidden_block: int = 256, threads: int = 256)"
+        in source
+    )
+
+
+def test_default_tokens_are_production_standalone_post_buckets(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(BENCH_PATH),
+            "--expected-physical-device",
+            "0",
+            "--expected-device-uuid",
+            "test-uuid",
+        ],
+    )
+    assert BENCH.parse_args().tokens == [20, 80, 320]
+
+
+def test_mhc_post_benchmark_requires_lease_device_fence():
+    source = BENCH_PATH.read_text(encoding="utf-8")
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"lease_device_fence": lease_device_fence' in source

--- a/tests/test_mp_tactic_campaign.py
+++ b/tests/test_mp_tactic_campaign.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+BENCHMARK_DIR = ROOT / "benchmarks/kernel_tactics"
+sys.path.insert(0, str(BENCHMARK_DIR))
+
+import run_mp_tactic_campaign as runner  # noqa: E402
+import summarize_mp_tactic_campaign as summary  # noqa: E402
+from _benchmark_utils import effective_gemv_block, source_identity  # noqa: E402
+from benchmark_dsv4_mhc_jit import production_split_for_path  # noqa: E402
+
+
+def test_campaign_manifest_has_executable_reviewed_cells() -> None:
+    campaign = runner.load_campaign(BENCHMARK_DIR / "mp_tactic_campaign.json")
+    assert campaign["schema"] == "vllm-musa-mp-tactic-campaign.v2"
+    assert "hardware" not in campaign
+    assert campaign["methodology"]["inner_iters"] == 1
+    assert campaign["methodology"]["cache_policy"] == "cold-l2-per-sample"
+    assert campaign["methodology"]["isolated_device_required_for_promotion"] is True
+
+    enabled = [cell for cell in campaign["cells"] if cell["enabled"]]
+    assert {cell["id"] for cell in enabled} >= {
+        "qwen35-folded-bf16-moe-blocks",
+        "dsv4-fp8-moe-blocks",
+        "dsv4-fused-add-rmsnorm-aot",
+        "dsv4-mhc-jit-fuse",
+        "dsv4-mhc-jit-standalone",
+    }
+    for cell in enabled:
+        assert (ROOT / cell["script"]).is_file()
+        assert set(cell["modes"]) == {"quick", "full"}
+        assert "prediction" not in cell
+
+
+def test_disabled_cells_cannot_be_selected() -> None:
+    campaign = runner.load_campaign(BENCHMARK_DIR / "mp_tactic_campaign.json")
+    with pytest.raises(ValueError, match="requested disabled"):
+        runner.selected_cells(campaign, ["dsv4-dense-fp8-gemv"])
+
+
+def test_visible_device_contract_is_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MUSA_VISIBLE_DEVICES", "0")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+    assert runner.verify_visible_device_contract() == {
+        "MUSA_VISIBLE_DEVICES": "0",
+        "CUDA_VISIBLE_DEVICES": "0",
+    }
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+    with pytest.raises(RuntimeError, match="must both be set"):
+        runner.verify_visible_device_contract()
+
+
+def test_campaign_appends_lease_device_fence() -> None:
+    command = runner.add_device_fence_args(
+        ["bench.py", "--output", "x.json"], 0, "uuid"
+    )
+    assert command[-4:] == [
+        "--expected-physical-device",
+        "0",
+        "--expected-device-uuid",
+        "uuid",
+    ]
+    with pytest.raises(ValueError, match="require --expected-physical-device"):
+        runner.add_device_fence_args(["bench.py"], None, None)
+
+
+def test_amdahl_prediction_uses_time_share_and_hit_rate() -> None:
+    predicted = summary.amdahl_prediction(0.8, 0.25, 0.5)
+    assert predicted == pytest.approx((1 / 0.975 - 1) * 100)
+    assert summary.amdahl_prediction(0.8, None, 0.5) is None
+
+
+def test_mp_only_key_drops_route_for_moe() -> None:
+    schema = "musa-fused-gemv-moe-aot-paired-ab.v2"
+    assert summary.mp_only_key(schema, ("qwen", 4, "hot", "w1")) == (
+        "qwen",
+        4,
+        "w1",
+    )
+
+
+def test_dsv4_one_token_special_arm_is_not_mislabeled() -> None:
+    assert effective_gemv_block("dsv4_fp8", 1, "w1", (32, 4)) == (
+        (4, 32),
+        False,
+        "dsv4-one-token-split-tile",
+    )
+    assert effective_gemv_block("dsv4_fp8", 1, "w2", (32, 4))[1] is True
+
+
+def test_mhc_schema_has_pairable_key_and_tactic() -> None:
+    schema = "musa-dsv4-mhc-jit-aot-paired-ab.v1"
+    row = {
+        "production_path": "fused_post_prenorm",
+        "tokens": 1,
+        "split_k": 4,
+        "threads": 128,
+        "hidden_block": 512,
+        "pass_config": "burst",
+    }
+    assert summary.row_key(schema, row) == ("fused_post_prenorm", 1, 4)
+    assert summary.tactic(schema, row) == "128x512xburst"
+    assert summary.key_dict(schema, ("fused_post_prenorm", 1, 4)) == {
+        "production_path": "fused_post_prenorm",
+        "tokens": 1,
+        "split_k": 4,
+    }
+    row.update(
+        {
+            "median_ratio": 0.9,
+            "ratio_p95": 0.95,
+            "correctness_pass": True,
+            "poison_output": False,
+            "is_production_split": True,
+        }
+    )
+    assert summary.promotion_pass(
+        row, {"median_ratio_max": 0.98, "ratio_p95_max": 1.02}
+    )
+    row["is_production_split"] = False
+    assert not summary.promotion_pass(
+        row, {"median_ratio_max": 0.98, "ratio_p95_max": 1.02}
+    )
+
+
+@pytest.mark.parametrize(
+    ("tokens", "expected"), [(1, 8), (2, 8), (4, 8), (8, 4), (16, 4)]
+)
+def test_fused_mhc_production_split(tokens: int, expected: int) -> None:
+    assert (
+        production_split_for_path("fused_post_prenorm", tokens, 4096, lambda *_: -1)
+        == expected
+    )
+
+
+def test_standalone_mhc_production_split_uses_resolver() -> None:
+    calls: list[tuple[int, int]] = []
+
+    def resolve(tokens: int, hc_hidden_size: int) -> int:
+        calls.append((tokens, hc_hidden_size))
+        return 64
+
+    assert production_split_for_path("standalone", 1, 4096, resolve) == 64
+    assert calls == [(1, 16384)]
+
+
+def test_summarizer_accepts_mhc_result_bundle(tmp_path: Path) -> None:
+    campaign_path = BENCHMARK_DIR / "mp_tactic_campaign.json"
+    campaign_bytes = campaign_path.read_bytes()
+    (tmp_path / "campaign.json").write_bytes(campaign_bytes)
+    result = {
+        "schema": "musa-dsv4-mhc-jit-aot-paired-ab.v1",
+        "multiprocessor_count": 56,
+        "provenance": {"hostname": "mhc-host"},
+        "rows": [
+            {
+                "production_path": "standalone",
+                "tokens": 1,
+                "split_k": 1,
+                "threads": 128,
+                "hidden_block": 512,
+                "pass_config": "safe",
+                "median_ms": 1.0,
+                "p90_ms": 1.0,
+                "p99_ms": 1.0,
+                "baseline_median_ms": 1.0,
+                "median_ratio": 1.0,
+                "ratio_p95": 1.0,
+                "ratio_p99": 1.0,
+                "speedup_pct": 0.0,
+                "correctness_pass": True,
+                "poison_output": False,
+                "is_production_config": True,
+            },
+            {
+                "production_path": "standalone",
+                "tokens": 1,
+                "split_k": 1,
+                "threads": 256,
+                "hidden_block": 512,
+                "pass_config": "safe",
+                "median_ms": 0.8,
+                "p90_ms": 0.9,
+                "p99_ms": 0.9,
+                "baseline_median_ms": 1.0,
+                "median_ratio": 0.8,
+                "ratio_p95": 0.9,
+                "ratio_p99": 0.9,
+                "speedup_pct": 25.0,
+                "correctness_pass": True,
+                "poison_output": False,
+                "is_production_config": False,
+            },
+        ],
+    }
+    result_path = tmp_path / "mhc.json"
+    result_path.write_text(json.dumps(result))
+    (tmp_path / "run-manifest.json").write_text(
+        json.dumps(
+            {
+                "schema": "vllm-musa-mp-tactic-run.v1",
+                "campaign_sha256": hashlib.sha256(campaign_bytes).hexdigest(),
+                "expected_mp": 56,
+                "lease_isolated": True,
+                "exploratory": False,
+                "runs": [
+                    {
+                        "run_id": "mhc",
+                        "cell": "dsv4-mhc-jit-fuse",
+                        "variant": "seed20260827",
+                        "result": str(result_path),
+                        "returncode": 0,
+                        "error": None,
+                    }
+                ],
+            }
+        )
+    )
+    output = tmp_path / "summary.json"
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["summarize_mp_tactic_campaign.py", str(tmp_path), "--output", str(output)],
+    )
+    try:
+        assert summary.main() == 0
+    finally:
+        monkeypatch.undo()
+    payload = json.loads(output.read_text())
+    assert payload["observation_count"] == 1
+    assert payload["mp_only_candidates"][0]["winner"] == "256x512xsafe"
+
+
+def test_gpu_benches_reject_warm_inner_loop_evidence() -> None:
+    for filename in (
+        "benchmark_fused_gemv_moe_blocks.py",
+        "benchmark_fused_add_rmsnorm_paired_ab.py",
+    ):
+        source = (BENCHMARK_DIR / filename).read_text()
+        assert "cold-L2 evidence requires --inner-iters 1" in source
+        assert "flush_buffer.zero_()" in source
+        assert '"cache_policy": "cold-l2-per-sample"' in source
+        assert '"--expected-physical-device"' in source
+        assert '"--expected-device-uuid"' in source
+        assert "verify_lease_device_fence" in source
+        assert '"lease_device_fence"' in source
+        assert (
+            "variance is not a correctness oracle" in source
+            or "constant normalized row" in source
+        )
+        if "gemv" in filename:
+            assert "requested_block_applied" in source
+            assert '"--baseline-block"' in source
+
+
+def test_campaign_json_is_canonical_object() -> None:
+    payload = json.loads((BENCHMARK_DIR / "mp_tactic_campaign.json").read_text())
+    assert payload["schema"] == "vllm-musa-mp-tactic-campaign.v2"
+    assert "hardware" not in payload
+    assert "historical_seeds" not in payload
+    assert "generated/MUSA-" not in json.dumps(payload)
+
+
+def test_source_identity_accepts_archive_revision_marker(tmp_path: Path) -> None:
+    script = tmp_path / "benchmarks/kernel_tactics/bench.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("# synthetic\n")
+    (tmp_path / ".source-revision").write_text("deadbeef\n")
+    identity = source_identity(script)
+    assert identity["head"] == "deadbeef"
+    assert identity["archive_marker"] == "deadbeef"
+    assert identity["dirty"] is False
+
+
+def test_source_identity_accepts_shallow_script_path(tmp_path: Path) -> None:
+    script = tmp_path / "bench.py"
+    script.write_text("# synthetic\n")
+    (tmp_path / ".source-revision").write_text("abc123\n")
+    assert source_identity(script)["head"] == "abc123"
+
+
+def test_summarizer_requires_same_winner_across_routes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    campaign_path = BENCHMARK_DIR / "mp_tactic_campaign.json"
+    campaign_bytes = campaign_path.read_bytes()
+    (tmp_path / "campaign.json").write_bytes(campaign_bytes)
+    result_path = tmp_path / "result.json"
+    rows = []
+    for route in ("balanced", "hot"):
+        for block, ratio in (((16, 8), 0.90), ((32, 4), 0.95)):
+            rows.append(
+                {
+                    "family": "qwen35_folded_bf16",
+                    "tokens": 4,
+                    "route": route,
+                    "stage": "w1",
+                    "candidate_block": list(block),
+                    "median_ratio": ratio,
+                    "ratio_p95": ratio + 0.01,
+                    "speedup_pct": (1 / ratio - 1) * 100,
+                    "correctness_pass": True,
+                    "poison_output": False,
+                }
+            )
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema": "musa-fused-gemv-moe-aot-paired-ab.v2",
+                "multiprocessor_count": 56,
+                "provenance": {"hostname": "mp56-host"},
+                "rows": rows,
+            }
+        )
+    )
+    (tmp_path / "run-manifest.json").write_text(
+        json.dumps(
+            {
+                "schema": "vllm-musa-mp-tactic-run.v1",
+                "campaign_sha256": hashlib.sha256(campaign_bytes).hexdigest(),
+                "expected_mp": 56,
+                "lease_isolated": True,
+                "exploratory": False,
+                "runs": [
+                    {
+                        "run_id": "synthetic",
+                        "cell": "qwen35-folded-bf16-moe-blocks",
+                        "variant": "seed7",
+                        "result": str(result_path),
+                        "returncode": 0,
+                        "error": None,
+                    }
+                ],
+            }
+        )
+    )
+    output = tmp_path / "summary.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["summarize_mp_tactic_campaign.py", str(tmp_path), "--output", str(output)],
+    )
+    assert summary.main() == 0
+    payload = json.loads(output.read_text())
+    assert payload["mp_only_candidates"][0]["winner"] == "16x8"
+    assert payload["mp_only_candidates"][0]["promotion_ready"] is True
+
+    manifest_path = tmp_path / "run-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["lease_isolated"] = False
+    manifest["exploratory"] = True
+    manifest_path.write_text(json.dumps(manifest))
+    exploratory_output = tmp_path / "exploratory-summary.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "summarize_mp_tactic_campaign.py",
+            str(tmp_path),
+            "--output",
+            str(exploratory_output),
+        ],
+    )
+    assert summary.main() == 0
+    exploratory = json.loads(exploratory_output.read_text())
+    assert exploratory["route_candidates"][0]["evidence_eligible"] is False
+    assert exploratory["mp_only_candidates"][0]["promotion_ready"] is False
+
+
+def test_fused_moe_gemv_benchmark_requires_lease_device_fence() -> None:
+    source = (BENCHMARK_DIR / "benchmark_fused_gemv_moe_blocks.py").read_text(
+        encoding="utf-8"
+    )
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"lease_device_fence": lease_device_fence' in source
+    assert 'choices=("eager", "graph"), default="eager"' in source
+    assert "graph = torch.cuda.CUDAGraph()" in source
+    assert '"execution_mode": args.execution_mode' in source
+    assert '"qwen_bf16": Family("qwen_bf16", 32,' in source
+    assert '"qwen35_folded_bf16", 33,' in source
+
+
+def test_mhc_pre_benchmark_requires_lease_device_fence() -> None:
+    source = (BENCHMARK_DIR / "benchmark_dsv4_mhc_jit.py").read_text(encoding="utf-8")
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"lease_device_fence": lease_device_fence' in source

--- a/tests/test_physical_kernel_inventory.py
+++ b/tests/test_physical_kernel_inventory.py
@@ -1,0 +1,80 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "benchmarks/kernel_tactics/inventory_vllm_musa_physical_kernels.py"
+SPEC = importlib.util.spec_from_file_location(
+    "inventory_vllm_musa_physical_kernels", SCRIPT
+)
+assert SPEC is not None and SPEC.loader is not None
+INVENTORY = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = INVENTORY
+SPEC.loader.exec_module(INVENTORY)
+
+CATALOG_SCRIPT = ROOT / "benchmarks/kernel_tactics/kernel_sweep_catalog.py"
+CATALOG_SPEC = importlib.util.spec_from_file_location(
+    "physical_kernel_sweep_catalog", CATALOG_SCRIPT
+)
+assert CATALOG_SPEC is not None and CATALOG_SPEC.loader is not None
+CATALOG = importlib.util.module_from_spec(CATALOG_SPEC)
+sys.modules[CATALOG_SPEC.name] = CATALOG
+CATALOG_SPEC.loader.exec_module(CATALOG)
+
+MANIFEST_PATH = ROOT / "benchmarks/kernel_tactics/full_kernel_sweep.json"
+
+
+def test_physical_inventory_is_unique_and_source_complete():
+    entries = INVENTORY.discover(ROOT)
+    assert entries
+    assert len({entry.id for entry in entries}) == len(entries)
+    for entry in entries:
+        assert (ROOT / entry.source).is_file(), entry
+
+
+def test_physical_inventory_covers_every_backend_class():
+    payload = INVENTORY.payload(ROOT)
+    assert payload["schema"] == INVENTORY.SCHEMA
+    assert payload["counts"] == {
+        "aot-native-physical": 36,
+        "jit-native-physical": 77,
+        "jit-tilelang-physical": 32,
+        "jit-triton-physical": 7,
+    }
+
+
+def test_known_physical_kernels_are_discovered():
+    symbols = {entry.symbol for entry in INVENTORY.discover(ROOT)}
+    assert {
+        "musa_gemv_kernel",
+        "deepseek_v4_indexer_topk_prefill_q_cache_partialsort_kernel",
+        "fused_add_rmsnorm_vec8_kernel",
+        "topk_softmax_no_bias_warp_kernel_fixed_k",
+        "deep_gemm_contig_preprocess_prefix_counts_no_pad",
+        "main",
+        "_qwen2_rope_kv_cache_kernel",
+    } <= symbols
+
+
+def test_plain_tilelang_primfunc_helper_is_not_a_callable_entrypoint():
+    callable_entries = CATALOG.INVENTORY.discover(ROOT)
+    physical_entries = INVENTORY.discover(ROOT)
+
+    assert not any(
+        entry.symbol == "_prefix_counts_no_pad_kernel" for entry in callable_entries
+    )
+    assert any(
+        entry.owner == "_prefix_counts_no_pad_kernel" for entry in physical_entries
+    )
+
+
+def test_every_physical_kernel_maps_to_a_manifest_family():
+    entries = INVENTORY.discover(ROOT)
+    coverage = CATALOG.physical_coverage(ROOT)
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    family_ids = {family["id"] for family in manifest["families"]}
+
+    assert set(coverage) == {entry.id for entry in entries}
+    assert all(families for families in coverage.values())
+    assert all(set(families) <= family_ids for families in coverage.values())

--- a/tests/test_public_kernel_artifacts.py
+++ b/tests/test_public_kernel_artifacts.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+PUBLIC_ARTIFACTS = (
+    ROOT / "benchmarks/kernel_tactics/full_kernel_sweep.json",
+    ROOT / "benchmarks/kernel_tactics/mp_tactic_campaign.json",
+    ROOT / "benchmarks/kernel_tactics/qwen_dsv4_fp8_quant_shapes.json",
+    ROOT / "benchmarks/kernel_tactics/qwen_dsv4_rmsnorm_shapes.json",
+    ROOT / "docs/vllm_musa/README.md",
+    ROOT / "docs/vllm_musa/hardware-aware-kernel-tactics.md",
+)
+FLEET_RECEIPT_MARKERS = (
+    "10.20.",
+    "archive_sha256",
+    "generated/MUSA-",
+    "GPU UUID :",
+    "driver_version",
+)
+
+
+def test_public_kernel_artifacts_exclude_fleet_receipts() -> None:
+    for path in PUBLIC_ARTIFACTS:
+        content = path.read_text(encoding="utf-8")
+        assert not any(marker in content for marker in FLEET_RECEIPT_MARKERS), path
+
+
+def test_public_json_artifacts_are_parseable() -> None:
+    for path in PUBLIC_ARTIFACTS[:4]:
+        json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_qwen35_mp_ab_source.py
+++ b/tests/test_qwen35_mp_ab_source.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "benchmarks"
+    / "serving"
+    / "benchmark_qwen35_mp_ab.py"
+)
+REPLAY_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "benchmarks"
+    / "serving"
+    / "benchmark_qwen35_graph_bucket_replay.py"
+)
+WORKER_SOURCE = Path(__file__).resolve().parents[1] / "vllm_musa" / "worker.py"
+
+
+def test_qwen35_ab_uses_compiled_capture_path() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+    assert "tensor_parallel_size=4" in source
+    assert "enforce_eager=False" in source
+    assert "TokensPrompt(prompt_token_ids=prompt_ids)" in source
+    assert "encoded.input_ids" in source
+    assert "ignore_eos=True" in source
+    assert "semantic_pass" in source
+    assert '"get_musa_cudagraph_runtime_state", timeout=60' in source
+    assert "len(worker_states) == 4" in source
+    worker_source = WORKER_SOURCE.read_text(encoding="utf-8")
+    assert "def get_musa_cudagraph_runtime_state" in worker_source
+    assert 'getattr(runner, "cudagraph_dispatcher", None)' in worker_source
+    assert '"resolved_cudagraph_mode": "NONE"' in worker_source
+    assert '"capture_descriptors": {}' in worker_source
+    assert '"resolved_cudagraph_mode": dispatcher.cudagraph_mode.name' in worker_source
+
+
+def test_qwen35_ab_requires_exact_output_and_semantics() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+    assert 'parser.add_argument("--model", required=True' in source
+    assert 'parser.add_argument("--warmup", type=int, default=4)' in source
+    assert 'parser.add_argument("--repeats", type=int, default=5)' in source
+    assert 'parser.add_argument("--max-num-seqs", type=int)' in source
+    assert "max_num_seqs = args.max_num_seqs or args.batch_size" in source
+    assert "max_num_seqs=max_num_seqs" in source
+    assert 'choices=("upstream", "auto")' in source
+    assert "dispatch_policy = args.policy" in source
+    assert "args.input_tokens > 512" in source
+    assert "os.environ[DISPATCH_ENV] = dispatch_policy" in source
+    assert "generated != args.batch_size * args.output_tokens" in source
+    assert '"beijing" not in semantic_text.lower()' in source
+
+
+def test_qwen35_graph_bucket_replay_uses_one_general_engine() -> None:
+    source = REPLAY_SOURCE.read_text(encoding="utf-8")
+    assert 'parser.add_argument("--max-num-seqs", type=int, default=64)' in source
+    assert 'default="1,16,4,16,1,2,16"' in source
+    assert "llm = LLM(" in source
+    assert "max_num_seqs=args.max_num_seqs" in source
+    assert '"--cudagraph-capture-sizes"' in source
+    assert 'default="1,2,4,16,64"' in source
+    assert "required_capture_sizes = {1, 2, 4}" in source
+    assert '"cudagraph_capture_sizes": args.cudagraph_capture_sizes' in source
+    assert 'choices=("upstream", "auto")' in source
+    assert "dispatch_policy = args.policy" in source
+    assert "args.input_tokens > 512" in source
+    assert "os.environ[DISPATCH_ENV] = dispatch_policy" in source
+    assert "for step, batch_size in enumerate(args.batch_sequence):" in source
+    assert "enforce_eager=False" in source
+    assert "inspect_compile_state(llm)" in source
+    assert '"compile_state": compile_state' in source
+    assert "required_full_sizes = {1, 2, 4, 16}" in source
+    assert 'worker_state["capture_descriptors"].get("FULL", [])' in source
+    assert 'descriptor["num_reqs"] == descriptor["num_tokens"]' in source
+    assert 'descriptor["uniform"] is True' in source
+    assert 'descriptor["num_active_loras"] == 0' in source
+    assert "del llm" in source
+    assert "gc.collect()" in source

--- a/tests/test_reshape_cache_nhd_tactic_benchmark.py
+++ b/tests/test_reshape_cache_nhd_tactic_benchmark.py
@@ -1,0 +1,107 @@
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+BENCH_PATH = ROOT / "benchmarks/kernel_tactics/benchmark_reshape_cache_nhd_blocks.py"
+sys.path.insert(0, str(BENCH_PATH.parent))
+SPEC = importlib.util.spec_from_file_location(
+    "benchmark_reshape_cache_nhd_blocks",
+    BENCH_PATH,
+)
+assert SPEC is not None and SPEC.loader is not None
+BENCH = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BENCH
+SPEC.loader.exec_module(BENCH)
+
+
+@pytest.mark.parametrize("value", ["128", "256", "512", "1024"])
+def test_parse_block_x_accepts_compiled_launch_geometry(value):
+    assert BENCH.parse_block_x(value) == int(value)
+
+
+@pytest.mark.parametrize("value", ["bad", "0", "32", "64", "2048"])
+def test_parse_block_x_rejects_uncompiled_launch_geometry(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        BENCH.parse_block_x(value)
+
+
+@pytest.mark.parametrize("value", ["1", "6", "64", "256", "4096"])
+def test_parse_tokens_accepts_checked_production_buckets(value):
+    assert BENCH.parse_production_tokens(value) == int(value)
+
+
+@pytest.mark.parametrize("value", ["bad", "0", "7", "65", "8192"])
+def test_parse_tokens_rejects_untracked_buckets(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        BENCH.parse_production_tokens(value)
+
+
+@pytest.mark.parametrize(
+    ("shape_name", "expected_vecs", "expected_tokens_per_block"),
+    [
+        ("qwen2-kv2-d64", 16, 8),
+        ("qwen3-kv8-d128", 128, 4),
+        ("qwen3-kv1-d256", 32, 8),
+        ("qwen3-kv2-d256", 64, 8),
+    ],
+)
+def test_production_shapes_match_native_tokens_per_block_selector(
+    shape_name,
+    expected_vecs,
+    expected_tokens_per_block,
+):
+    shape = BENCH.PRODUCTION_SHAPES[shape_name]
+    assert shape.vecs_per_token == expected_vecs
+    assert BENCH.production_tokens_per_block(shape) == expected_tokens_per_block
+
+
+def test_native_op_exposes_default_preserving_per_call_block_x():
+    bindings = (ROOT / "csrc/musa/torch_bindings.cpp").read_text()
+    header = (ROOT / "csrc/musa/musa_ops.h").read_text()
+    kernel = (ROOT / "csrc/musa/cache_kernels.mu").read_text()
+    wrapper = (ROOT / "vllm_musa/_custom_ops.py").read_text()
+    production_caller = (
+        ROOT / "vllm_musa/v1/attention/backends/fa_utils.py"
+    ).read_text()
+    call_start = production_caller.index("musa_ops.musa_reshape_and_cache_flash_nhd(")
+    call = production_caller[
+        call_start : production_caller.index("\n            return", call_start)
+    ]
+
+    assert "int block_x=0) -> ()" in bindings
+    assert "int64_t block_x" in header
+    assert "int64_t requested_block_x" in kernel
+    assert "requested_block_x == 0 ? 512 : requested_block_x" in kernel
+    assert "block_x: int = 0" in wrapper
+    assert "block_x" not in call
+
+
+def test_native_op_rejects_every_uncompiled_block_before_empty_return():
+    kernel = (ROOT / "csrc/musa/cache_kernels.mu").read_text()
+    public_start = kernel.index("void musa_reshape_and_cache_flash_nhd(")
+    public_body = kernel[public_start:]
+
+    for block_x in BENCH.SUPPORTED_BLOCK_X:
+        assert f"block_x == {block_x}" in public_body
+    assert "block_x == 0" in public_body
+    assert "block_x must be 0 (production default)" in public_body
+    assert public_body.index("block_x == 0") < public_body.index("num_tokens == 0")
+
+
+def test_benchmark_has_paired_cold_l2_correctness_and_device_fence():
+    source = BENCH_PATH.read_text()
+
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"lease_device_fence": lease_device_fence' in source
+    assert '"inner_iters": 1' in source
+    assert '"paired_alternating_order": True' in source
+    assert "flush.zero_()" in source
+    assert "torch.equal(expected_key, actual_key)" in source
+    assert "negative_slot_unchanged" in source
+    assert "changed_from_poison" in source
+    assert "VLLM_MUSA_RESHAPE_CACHE_TOKENS_PER_BLOCK" in source

--- a/tests/test_rmsnorm_inductor_benchmark.py
+++ b/tests/test_rmsnorm_inductor_benchmark.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCHMARK = ROOT / "benchmarks" / "kernel_tactics" / "benchmark_rmsnorm_inductor.py"
+CANDIDATE = ROOT / "benchmarks" / "kernel_tactics" / "_rmsnorm_inductor_candidate.py"
+
+
+def test_inductor_rmsnorm_benchmark_is_paired_cold_l2_and_fenced() -> None:
+    source = BENCHMARK.read_text(encoding="utf-8")
+    assert '"--num-warps"' in source
+    assert 'choices=("op", "scale")' in source
+    assert "verify_lease_device_fence(" in source
+    assert '"paired_alternating_order": True' in source
+    assert '"flush_before_every_timed_launch": True' in source
+    assert '"inductor_cache_disabled": True' in source
+    assert '"candidate_kind": "exploratory-rejected"' in source
+    assert "vllm_musa.kernels.rmsnorm_inductor" not in source
+
+
+def test_inductor_rmsnorm_candidate_has_no_ir_registration_side_effect() -> None:
+    source = CANDIDATE.read_text(encoding="utf-8")
+    assert "wrap_triton(_rms_norm_kernel)[grid](" in source
+    assert "register_impl" not in source
+    assert "direct_register_custom_op" not in source
+    assert "vllm_musa.kernels" not in source

--- a/tests/test_weighted_rmsnorm_tactic_benchmark.py
+++ b/tests/test_weighted_rmsnorm_tactic_benchmark.py
@@ -1,0 +1,50 @@
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+BENCH_PATH = (
+    Path(__file__).parents[1]
+    / "benchmarks/kernel_tactics/benchmark_dsv4_weighted_rmsnorm_jit.py"
+)
+sys.path.insert(0, str(BENCH_PATH.parent))
+SPEC = importlib.util.spec_from_file_location(
+    "benchmark_dsv4_weighted_rmsnorm_jit", BENCH_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+BENCH = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BENCH
+SPEC.loader.exec_module(BENCH)
+
+
+@pytest.mark.parametrize("value", ["64", "128", "256"])
+def test_parse_threads_accepts_supported_launch_geometry(value):
+    assert BENCH.parse_threads(value) == int(value)
+
+
+@pytest.mark.parametrize("value", ["bad", "32", "192", "512"])
+def test_parse_threads_rejects_unqualified_launch_geometry(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        BENCH.parse_threads(value)
+
+
+def test_production_threads_match_current_provider():
+    assert BENCH.PRODUCTION_THREADS == 128
+
+
+def test_candidate_kernel_has_complete_256_thread_reduction_stage():
+    source = (
+        Path(__file__).parents[1] / "vllm_musa/deepseek_v4_jit/tilelang_kernels.py"
+    ).read_text()
+    assert "assert threads in (64, 128, 256)" in source
+    assert "if threads >= 256:" in source
+    assert "sumsq[0] += shared[tx + 128]" in source
+
+
+def test_weighted_rmsnorm_benchmark_requires_lease_device_fence():
+    source = BENCH_PATH.read_text(encoding="utf-8")
+    assert '"--expected-physical-device", type=int, required=True' in source
+    assert '"--expected-device-uuid", required=True' in source
+    assert '"lease_device_fence": lease_device_fence' in source

--- a/vllm_musa/_custom_ops.py
+++ b/vllm_musa/_custom_ops.py
@@ -61,6 +61,8 @@ def musa_fused_gemv(
     gamma: torch.Tensor = None,
     eps: float = 1e-6,
     output: torch.Tensor | None = None,
+    block_n: int = 0,
+    block_k: int = 0,
 ):
     use_int4_w4a16 = False
     out_shape = x.shape[:-1] + (
@@ -103,6 +105,8 @@ def musa_fused_gemv(
             use_rms_norm,
             gamma,
             eps,
+            block_n,
+            block_k,
         )
         return output
     # w4a16 gemv
@@ -129,6 +133,8 @@ def musa_fused_gemv(
             use_rms_norm,
             gamma,
             eps,
+            block_n,
+            block_k,
         )
         return output
     # general gemv
@@ -146,6 +152,8 @@ def musa_fused_gemv(
             use_rms_norm,
             gamma,
             eps,
+            block_n,
+            block_k,
         )
         return output
 
@@ -172,13 +180,16 @@ def musa_reshape_and_cache_flash_nhd(
     key_cache: torch.Tensor,
     value_cache: torch.Tensor,
     slot_mapping: torch.Tensor,
+    block_x: int = 0,
 ) -> None:
+    # Nonzero BLOCK_X is reserved for the paired kernel-tactic benchmark.
     return torch.ops._C_musa_ops.musa_reshape_and_cache_flash_nhd(
         key,
         value,
         key_cache,
         value_cache,
         slot_mapping,
+        block_x,
     )
 
 
@@ -209,7 +220,7 @@ def _get_musa_device_capability(device_id: int) -> tuple[int, int]:
 
 
 def _is_validated_musa_device(device: torch.device) -> bool:
-    """Return whether the tensor's device is the validated S5000 target."""
+    """Return whether the tensor's device has the supported architecture."""
     try:
         device_id = _musa_device_index(device)
         if device_id is None:

--- a/vllm_musa/deepseek_v4_jit/tilelang_kernels.py
+++ b/vllm_musa/deepseek_v4_jit/tilelang_kernels.py
@@ -2,7 +2,7 @@
 """TileLang kernels for DeepSeek-V4 MUSA JIT helpers."""
 
 import math
-from functools import lru_cache
+from functools import cache
 
 import tilelang
 import tilelang.language as T
@@ -91,7 +91,7 @@ def _mhc_tme_ws_pass_configs(tilelang_module):
     return pass_configs or None
 
 
-@lru_cache(maxsize=None)
+@cache
 def mhc_pre_split_sinkhorn_kernel(hc_mult: int, sinkhorn_repeat: int):
     hc_mult3 = hc_mult * (2 + hc_mult)
 
@@ -166,7 +166,7 @@ def mhc_pre_split_sinkhorn_kernel(hc_mult: int, sinkhorn_repeat: int):
     return _mhc_pre_split_sinkhorn_kernel()
 
 
-@lru_cache(maxsize=None)
+@cache
 def mhc_prenorm_splitk_x_tme_cast_kernel(
     mhc_mult3: int,
     hc_hidden_size: int,
@@ -235,8 +235,7 @@ def mhc_prenorm_splitk_x_tme_cast_kernel(
                         T.copy(
                             x[
                                 px * token_block : (px + 1) * token_block,
-                                k_base
-                                + pz * hidden_block : k_base
+                                k_base + pz * hidden_block : k_base
                                 + (pz + 1) * hidden_block,
                             ],
                             x_bf16_shared,
@@ -246,8 +245,7 @@ def mhc_prenorm_splitk_x_tme_cast_kernel(
                         T.copy(
                             fn[
                                 0:32,
-                                k_base
-                                + pz * hidden_block : k_base
+                                k_base + pz * hidden_block : k_base
                                 + (pz + 1) * hidden_block,
                             ],
                             fn_shared,
@@ -304,7 +302,7 @@ def mhc_prenorm_splitk_x_tme_cast_kernel(
     return _mhc_prenorm_splitk_x_tme_cast_kernel()
 
 
-@lru_cache(maxsize=None)
+@cache
 def mhc_fused_post_prenorm_kernel(
     hidden_size: int,
     n_out: int = 24,
@@ -400,9 +398,7 @@ def mhc_fused_post_prenorm_kernel(
                     hidden_idx = hidden_start + hidden_iter * threads + thread_id
 
                     for row in T.unroll(hc_mult):
-                        new_residual[row] = (
-                            post_local[row] * x_in[token_id, hidden_idx]
-                        )
+                        new_residual[row] = post_local[row] * x_in[token_id, hidden_idx]
                         for source_row in T.unroll(hc_mult):
                             new_residual[row] += (
                                 comb_local[source_row, row]
@@ -427,8 +423,7 @@ def mhc_fused_post_prenorm_kernel(
                         weight_row = out_tile_id * tile_n + out_idx
                         for row in T.unroll(hc_mult):
                             accum[out_idx] += (
-                                weight[weight_row, row, hidden_idx]
-                                * new_residual[row]
+                                weight[weight_row, row, hidden_idx] * new_residual[row]
                             )
 
                 for out_idx in T.unroll(tile_n):
@@ -464,7 +459,7 @@ def mhc_fused_post_prenorm_kernel(
     return _mhc_fused_post_prenorm_kernel()
 
 
-@lru_cache(maxsize=None)
+@cache
 def mhc_pre_big_fuse_kernel(
     hidden_size: int,
     rms_eps: float,
@@ -611,7 +606,7 @@ def mhc_pre_big_fuse_kernel(
     return _mhc_pre_big_fuse_kernel()
 
 
-@lru_cache(maxsize=None)
+@cache
 def mhc_pre_big_fuse_decode_split_kernel(
     hidden_size: int,
     rms_eps: float,
@@ -770,7 +765,7 @@ def mhc_pre_big_fuse_decode_split_kernel(
     return _mhc_pre_big_fuse_decode_split_kernel()
 
 
-@lru_cache(maxsize=None)
+@cache
 def mhc_weighted_rmsnorm_kernel(
     hidden_size: int,
     threads: int = 128,
@@ -835,7 +830,7 @@ def mhc_weighted_rmsnorm_kernel(
     return _mhc_weighted_rmsnorm_kernel()
 
 
-@lru_cache(maxsize=None)
+@cache
 def mhc_weighted_rmsnorm_mudnn_like_kernel(
     hidden_size: int,
     threads: int = 128,
@@ -846,7 +841,7 @@ def mhc_weighted_rmsnorm_mudnn_like_kernel(
     chunks = hidden_size // (threads * elements_per_thread)
     assert hidden_size > 0
     assert hidden_size % (threads * elements_per_thread) == 0
-    assert threads == 128
+    assert threads in (64, 128, 256)
 
     @tilelang.jit(target="musa", pass_configs={})
     def _mhc_weighted_rmsnorm_mudnn_like_kernel():
@@ -867,13 +862,18 @@ def mhc_weighted_rmsnorm_mudnn_like_kernel(
                 sumsq[0] = 0.0
                 for chunk in T.serial(chunks):
                     base = (
-                        chunk * threads * elements_per_thread
-                        + tx * elements_per_thread
+                        chunk * threads * elements_per_thread + tx * elements_per_thread
                     )
                     for elem in T.serial(elements_per_thread):
                         value = T.cast(x[row_id, base + elem], T.float32)
                         sumsq[0] += value * value
 
+                if threads >= 256:
+                    if tx >= 128:
+                        shared[tx] = sumsq[0]
+                    T.sync_threads()
+                    if tx < 128:
+                        sumsq[0] += shared[tx + 128]
                 if threads >= 128:
                     if tx >= 64:
                         shared[tx] = sumsq[0]
@@ -911,8 +911,7 @@ def mhc_weighted_rmsnorm_mudnn_like_kernel(
 
                 for chunk in T.serial(chunks):
                     base = (
-                        chunk * threads * elements_per_thread
-                        + tx * elements_per_thread
+                        chunk * threads * elements_per_thread + tx * elements_per_thread
                     )
                     for elem in T.serial(elements_per_thread):
                         value = T.cast(x[row_id, base + elem], T.float32)
@@ -1108,7 +1107,7 @@ def kv_rope_pack_kernel():
     return _kv_rope_pack_kernel
 
 
-@lru_cache(maxsize=None)
+@cache
 def mhc_post_kernel(hidden_size: int, hidden_block: int = 256, threads: int = 256):
     hidden_block = math.gcd(hidden_block, hidden_size)
     if hidden_block <= 0 or hidden_size % hidden_block != 0:

--- a/vllm_musa/deepseek_v4_mhc.py
+++ b/vllm_musa/deepseek_v4_mhc.py
@@ -4,7 +4,17 @@
 
 from __future__ import annotations
 
+import logging
+
 import torch
+
+from vllm_musa.tuning import (
+    get_primed_musa_kernel_hardware,
+    select_mhc_weighted_rmsnorm_tactic,
+)
+
+logger = logging.getLogger(__name__)
+_LOGGED_WEIGHTED_RMSNORM_TACTICS: set[str] = set()
 
 
 def mhc_pre_musa(
@@ -158,7 +168,31 @@ def _try_mhc_weighted_rms_norm_musa(
             if hidden_size == 4096
             else mhc_weighted_rmsnorm_kernel
         )
-        kernel_factory(hidden_size, threads=threads)(
+        device_index = x.device.index if x.device.index is not None else 0
+        hardware = get_primed_musa_kernel_hardware(device_index)
+        tactic = None
+        if not torch.compiler.is_compiling():
+            tactic = select_mhc_weighted_rmsnorm_tactic(
+                hardware=hardware,
+                rows=x_2d.shape[0],
+                hidden_size=hidden_size,
+                input_dtype=str(x.dtype),
+                weight_dtype=str(norm_weight.dtype),
+                contiguous=(x_2d.is_contiguous() and norm_weight.is_contiguous()),
+            )
+        selected_threads = threads if tactic is None else tactic.threads
+        if tactic is not None and tactic.source not in _LOGGED_WEIGHTED_RMSNORM_TACTICS:
+            logger.info(
+                "MUSA DSV4 weighted-RMSNorm JIT tactic hit source=%s "
+                "for M=%d H=%d mp=%d threads=%d",
+                tactic.source,
+                x_2d.shape[0],
+                hidden_size,
+                hardware.multiprocessor_count,
+                selected_threads,
+            )
+            _LOGGED_WEIGHTED_RMSNORM_TACTICS.add(tactic.source)
+        kernel_factory(hidden_size, threads=selected_threads)(
             x_2d,
             norm_weight,
             out_2d,

--- a/vllm_musa/jit_kernel/csrc/norm.py
+++ b/vllm_musa/jit_kernel/csrc/norm.py
@@ -7,6 +7,10 @@ from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_musa.jit_kernel.csrc.jit import load_musa_jit
 from vllm_musa.jit_kernel.utils import cache_once
+from vllm_musa.tuning import (
+    get_primed_musa_kernel_hardware,
+    select_jit_rmsnorm_tactic,
+)
 
 
 @cache_once
@@ -48,11 +52,19 @@ def rmsnorm(
     eps: float = 1e-6,
     out: torch.Tensor | None = None,
     enable_pdl: bool | None = None,
+    block_threads: int = 0,
 ) -> torch.Tensor:
     _ = enable_pdl
     if out is None:
         out = torch.empty_like(input)
-    torch.ops.vllm.musa_csrc_rmsnorm(input, weight, out, float(eps), False)
+    torch.ops.vllm.musa_csrc_rmsnorm(
+        input,
+        weight,
+        out,
+        float(eps),
+        False,
+        int(block_threads),
+    )
     return out
 
 
@@ -62,11 +74,19 @@ def gemma_rmsnorm(
     eps: float = 1e-6,
     out: torch.Tensor | None = None,
     enable_pdl: bool | None = None,
+    block_threads: int = 0,
 ) -> torch.Tensor:
     _ = enable_pdl
     if out is None:
         out = torch.empty_like(input)
-    torch.ops.vllm.musa_csrc_rmsnorm(input, weight, out, float(eps), True)
+    torch.ops.vllm.musa_csrc_rmsnorm(
+        input,
+        weight,
+        out,
+        float(eps),
+        True,
+        int(block_threads),
+    )
     return out
 
 
@@ -77,6 +97,7 @@ def fused_add_rmsnorm(
     eps: float = 1e-6,
     *,
     gemma: bool = False,
+    block_threads: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """In-place fused residual add and RMSNorm using the JIT MUSA kernel.
 
@@ -89,9 +110,39 @@ def fused_add_rmsnorm(
     with Gemma's ``+1`` already applied and therefore uses ``gemma=False``.
     """
     torch.ops.vllm.musa_csrc_fused_add_rmsnorm(
-        input, residual, weight, float(eps), bool(gemma)
+        input,
+        residual,
+        weight,
+        float(eps),
+        bool(gemma),
+        int(block_threads),
     )
     return input, residual
+
+
+def _production_block_threads(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    mode: str,
+    contiguous: bool,
+    requested: int,
+) -> int:
+    if requested != 0:
+        return requested
+    hidden_size = input.shape[-1]
+    rows = input.numel() // hidden_size
+    device_index = input.device.index if input.device.index is not None else 0
+    tactic = select_jit_rmsnorm_tactic(
+        hardware=get_primed_musa_kernel_hardware(device_index),
+        mode=mode,
+        rows=rows,
+        hidden_size=hidden_size,
+        input_dtype=str(input.dtype),
+        weight_dtype=str(weight.dtype),
+        contiguous=contiguous,
+    )
+    return tactic.block_threads if tactic is not None else 0
 
 
 def _rmsnorm_custom(
@@ -100,8 +151,25 @@ def _rmsnorm_custom(
     out: torch.Tensor,
     eps: float,
     gemma: bool,
+    block_threads: int,
 ) -> None:
-    _norm_module().sgl_musa_rmsnorm(input, weight, out, float(eps), bool(gemma))
+    block_threads = _production_block_threads(
+        input,
+        weight,
+        mode="gemma" if gemma else "plain",
+        contiguous=(
+            input.is_contiguous() and weight.is_contiguous() and out.is_contiguous()
+        ),
+        requested=block_threads,
+    )
+    _norm_module().sgl_musa_rmsnorm(
+        input,
+        weight,
+        out,
+        float(eps),
+        bool(gemma),
+        int(block_threads),
+    )
 
 
 def _rmsnorm_custom_fake(
@@ -110,6 +178,7 @@ def _rmsnorm_custom_fake(
     out: torch.Tensor,
     eps: float,
     gemma: bool,
+    block_threads: int,
 ) -> None:
     return
 
@@ -128,9 +197,26 @@ def _fused_add_rmsnorm_custom(
     weight: torch.Tensor,
     eps: float,
     gemma: bool,
+    block_threads: int,
 ) -> None:
+    block_threads = _production_block_threads(
+        input,
+        weight,
+        mode="fused_gemma" if gemma else "fused",
+        contiguous=(
+            input.is_contiguous()
+            and residual.is_contiguous()
+            and weight.is_contiguous()
+        ),
+        requested=block_threads,
+    )
     _norm_module().sgl_musa_fused_add_rmsnorm(
-        input, residual, weight, float(eps), bool(gemma)
+        input,
+        residual,
+        weight,
+        float(eps),
+        bool(gemma),
+        int(block_threads),
     )
 
 
@@ -140,6 +226,7 @@ def _fused_add_rmsnorm_custom_fake(
     weight: torch.Tensor,
     eps: float,
     gemma: bool,
+    block_threads: int,
 ) -> None:
     return
 

--- a/vllm_musa/jit_kernel/csrc/norm/rmsnorm.mu
+++ b/vllm_musa/jit_kernel/csrc/norm/rmsnorm.mu
@@ -544,7 +544,9 @@ void check_fused_inputs(ffi::TensorView input, ffi::TensorView residual, ffi::Te
 }
 
 template <typename T, bool GEMMA>
-void launch_rmsnorm(ffi::TensorView input, ffi::TensorView weight, ffi::TensorView out, float eps) {
+void launch_rmsnorm(ffi::TensorView input, ffi::TensorView weight,
+                    ffi::TensorView out, float eps,
+                    int requested_threads) {
   const int rows = static_cast<int>(input.size(0));
   const int hidden = static_cast<int>(input.size(1));
   const int64_t input_row_stride = static_cast<int64_t>(input.stride(0));
@@ -553,7 +555,7 @@ void launch_rmsnorm(ffi::TensorView input, ffi::TensorView weight, ffi::TensorVi
   musaStream_t stream = get_stream(input.device());
 
   if ((hidden % 8) == 0 && hidden <= 32768) {
-    if (rows <= 16 && hidden == 1024) {
+    if (requested_threads == 0 && rows <= 16 && hidden == 1024) {
       constexpr int threads = 128;
       constexpr int smem_bytes = 4 * static_cast<int>(sizeof(float));
       rmsnorm_small_h_one_vec_register_kernel<T, GEMMA, 1024, 4><<<rows, threads, smem_bytes, stream>>>(
@@ -568,7 +570,7 @@ void launch_rmsnorm(ffi::TensorView input, ffi::TensorView weight, ffi::TensorVi
           eps);
       return;
     }
-    if (rows <= 16 && hidden == 2048) {
+    if (requested_threads == 0 && rows <= 16 && hidden == 2048) {
       constexpr int threads = 256;
       constexpr int smem_bytes = 8 * static_cast<int>(sizeof(float));
       rmsnorm_small_h_one_vec_register_kernel<T, GEMMA, 2048, 8><<<rows, threads, smem_bytes, stream>>>(
@@ -583,7 +585,8 @@ void launch_rmsnorm(ffi::TensorView input, ffi::TensorView weight, ffi::TensorVi
           eps);
       return;
     }
-    const int threads = rmsnorm_block_threads(rows, hidden);
+    const int threads =
+        requested_threads > 0 ? requested_threads : rmsnorm_block_threads(rows, hidden);
     if (hidden <= 8192) {
       rmsnorm_vec8_kernel<T, GEMMA, true><<<rows, threads, cached_vec8_shared_bytes(hidden, threads, 8192), stream>>>(
           static_cast<const T*>(input.data_ptr()),
@@ -625,7 +628,8 @@ void launch_rmsnorm(ffi::TensorView input, ffi::TensorView weight, ffi::TensorVi
 
 template <typename T, typename WeightT, bool GEMMA>
 void launch_fused_add_rmsnorm(ffi::TensorView input, ffi::TensorView residual,
-                              ffi::TensorView weight, float eps) {
+                              ffi::TensorView weight, float eps,
+                              int requested_threads) {
   // Match the proven plain-RMSNorm cache limit: at H8192 this uses about 33 KiB
   // of dynamic shared memory. Larger vec8 shapes re-read the stored residual
   // and need only the block-reduction workspace.
@@ -638,7 +642,8 @@ void launch_fused_add_rmsnorm(ffi::TensorView input, ffi::TensorView residual,
   musaStream_t stream = get_stream(input.device());
 
   if ((hidden % 8) == 0 && hidden <= 32768) {
-    const int threads = fused_block_threads(hidden);
+    const int threads =
+        requested_threads > 0 ? requested_threads : fused_block_threads(hidden);
     if (hidden <= kCachedHiddenLimit) {
       fused_add_rmsnorm_vec8_kernel<T, WeightT, GEMMA, true>
           <<<rows, threads,
@@ -671,20 +676,42 @@ void launch_fused_add_rmsnorm(ffi::TensorView input, ffi::TensorView residual,
   }
 }
 
-void sgl_musa_rmsnorm(ffi::TensorView input, ffi::TensorView weight, ffi::TensorView out, double eps, bool gemma) {
+void check_requested_threads(ffi::TensorView input, int64_t requested_threads) {
+  TVM_FFI_ICHECK(
+      requested_threads == 0 ||
+      (requested_threads >= 32 && requested_threads <= 1024 &&
+       requested_threads % 32 == 0))
+      << "requested RMSNorm threads must be zero or a multiple of 32 in "
+         "[32, 1024]";
+  if (requested_threads != 0) {
+    TVM_FFI_ICHECK_EQ(input.size(1) % 8, 0)
+        << "requested RMSNorm threads require the vec8 kernel";
+    TVM_FFI_ICHECK_LE(input.size(1), 32768)
+        << "requested RMSNorm threads require the vec8 kernel";
+  }
+}
+
+void sgl_musa_rmsnorm(ffi::TensorView input, ffi::TensorView weight,
+                      ffi::TensorView out, double eps, bool gemma,
+                      int64_t requested_threads) {
   check_rmsnorm_inputs(input, weight, out);
+  check_requested_threads(input, requested_threads);
   ffi::MUSADeviceGuard device_guard(input.device().device_id);
   if (dtype_equal(input.dtype(), dl_float16)) {
     if (gemma) {
-      launch_rmsnorm<half, true>(input, weight, out, static_cast<float>(eps));
+      launch_rmsnorm<half, true>(input, weight, out, static_cast<float>(eps),
+                                 requested_threads);
     } else {
-      launch_rmsnorm<half, false>(input, weight, out, static_cast<float>(eps));
+      launch_rmsnorm<half, false>(input, weight, out, static_cast<float>(eps),
+                                  requested_threads);
     }
   } else if (dtype_equal(input.dtype(), dl_bfloat16)) {
     if (gemma) {
-      launch_rmsnorm<__mt_bfloat16, true>(input, weight, out, static_cast<float>(eps));
+      launch_rmsnorm<__mt_bfloat16, true>(
+          input, weight, out, static_cast<float>(eps), requested_threads);
     } else {
-      launch_rmsnorm<__mt_bfloat16, false>(input, weight, out, static_cast<float>(eps));
+      launch_rmsnorm<__mt_bfloat16, false>(
+          input, weight, out, static_cast<float>(eps), requested_threads);
     }
   } else {
     TVM_FFI_THROW(ValueError) << "sgl_musa_rmsnorm only supports fp16/bf16";
@@ -694,40 +721,46 @@ void sgl_musa_rmsnorm(ffi::TensorView input, ffi::TensorView weight, ffi::Tensor
 }
 
 void sgl_musa_fused_add_rmsnorm(
-    ffi::TensorView input, ffi::TensorView residual, ffi::TensorView weight, double eps, bool gemma) {
+    ffi::TensorView input, ffi::TensorView residual, ffi::TensorView weight,
+    double eps, bool gemma, int64_t requested_threads) {
   check_fused_inputs(input, residual, weight);
+  check_requested_threads(input, requested_threads);
   ffi::MUSADeviceGuard device_guard(input.device().device_id);
   if (dtype_equal(input.dtype(), dl_float16)) {
     if (dtype_equal(weight.dtype(), dl_float32)) {
       if (gemma) {
         launch_fused_add_rmsnorm<half, float, true>(input, residual, weight,
-                                                    static_cast<float>(eps));
+                                                    static_cast<float>(eps),
+                                                    requested_threads);
       } else {
         launch_fused_add_rmsnorm<half, float, false>(input, residual, weight,
-                                                     static_cast<float>(eps));
+                                                     static_cast<float>(eps),
+                                                     requested_threads);
       }
     } else if (gemma) {
       launch_fused_add_rmsnorm<half, half, true>(input, residual, weight,
-                                                 static_cast<float>(eps));
+                                                 static_cast<float>(eps),
+                                                 requested_threads);
     } else {
       launch_fused_add_rmsnorm<half, half, false>(input, residual, weight,
-                                                  static_cast<float>(eps));
+                                                  static_cast<float>(eps),
+                                                  requested_threads);
     }
   } else if (dtype_equal(input.dtype(), dl_bfloat16)) {
     if (dtype_equal(weight.dtype(), dl_float32)) {
       if (gemma) {
         launch_fused_add_rmsnorm<__mt_bfloat16, float, true>(
-            input, residual, weight, static_cast<float>(eps));
+            input, residual, weight, static_cast<float>(eps), requested_threads);
       } else {
         launch_fused_add_rmsnorm<__mt_bfloat16, float, false>(
-            input, residual, weight, static_cast<float>(eps));
+            input, residual, weight, static_cast<float>(eps), requested_threads);
       }
     } else if (gemma) {
       launch_fused_add_rmsnorm<__mt_bfloat16, __mt_bfloat16, true>(
-          input, residual, weight, static_cast<float>(eps));
+          input, residual, weight, static_cast<float>(eps), requested_threads);
     } else {
       launch_fused_add_rmsnorm<__mt_bfloat16, __mt_bfloat16, false>(
-          input, residual, weight, static_cast<float>(eps));
+          input, residual, weight, static_cast<float>(eps), requested_threads);
     }
   } else {
     TVM_FFI_THROW(ValueError)

--- a/vllm_musa/jit_kernel/csrc/topk/topk_gating.mu
+++ b/vllm_musa/jit_kernel/csrc/topk/topk_gating.mu
@@ -146,16 +146,18 @@ __launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_softmax_warp_kernel(
   }
 }
 
-template <typename T, int NumExperts, int ValuesPerThread>
-__global__
-__launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_sigmoid_warp_kernel(
+template <typename T, int NumExperts, int ValuesPerThread,
+          int WarpsPerCta = kWarpsPerCta>
+__global__ __launch_bounds__(
+    WarpsPerCta *kWarpSize,
+    1) void topk_sigmoid_warp_kernel(
     const T *__restrict__ gating_output, float *__restrict__ topk_weights,
     int32_t *__restrict__ topk_ids, const float *__restrict__ correction_bias,
     int num_tokens, int topk, bool renormalize, bool has_correction_bias) {
   const int tid = threadIdx.x;
   const int warp_id = tid / kWarpSize;
   const int lane = lane_id();
-  const int row = blockIdx.x * kWarpsPerCta + warp_id;
+  const int row = blockIdx.x * WarpsPerCta + warp_id;
   if (row >= num_tokens) {
     return;
   }
@@ -215,9 +217,10 @@ __launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_sigmoid_warp_kernel(
   }
 }
 
-template <typename T, int NumExperts, int ValuesPerThread>
+template <typename T, int NumExperts, int ValuesPerThread,
+          int WarpsPerCta = kWarpsPerCta>
 __global__ __launch_bounds__(
-    kWarpsPerCta *kWarpSize,
+    WarpsPerCta *kWarpSize,
     1) void topk_sigmoid_no_bias_warp_kernel(const T
                                                  *__restrict__ gating_output,
                                              float *__restrict__ topk_weights,
@@ -227,7 +230,7 @@ __global__ __launch_bounds__(
   const int tid = threadIdx.x;
   const int warp_id = tid / kWarpSize;
   const int lane = lane_id();
-  const int row = blockIdx.x * kWarpsPerCta + warp_id;
+  const int row = blockIdx.x * WarpsPerCta + warp_id;
   if (row >= num_tokens) {
     return;
   }
@@ -281,9 +284,10 @@ __global__ __launch_bounds__(
   }
 }
 
-template <typename T, int NumExperts, int ValuesPerThread, int TopK>
+template <typename T, int NumExperts, int ValuesPerThread, int TopK,
+          int WarpsPerCta = kWarpsPerCta>
 __global__ __launch_bounds__(
-    kWarpsPerCta *kWarpSize,
+    WarpsPerCta *kWarpSize,
     1) void topk_softmax_no_bias_warp_kernel_fixed_k(const T
                                                          *__restrict__ gating_output,
                                                      float
@@ -295,7 +299,7 @@ __global__ __launch_bounds__(
   const int tid = threadIdx.x;
   const int warp_id = tid / kWarpSize;
   const int lane = lane_id();
-  const int row = blockIdx.x * kWarpsPerCta + warp_id;
+  const int row = blockIdx.x * WarpsPerCta + warp_id;
   if (row >= num_tokens) {
     return;
   }
@@ -455,15 +459,16 @@ __launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_softmax_no_bias_warp_sha
   }
 }
 
-template <typename T, int NumExperts, int ValuesPerThread, int TopK>
+template <typename T, int NumExperts, int ValuesPerThread, int TopK,
+          int WarpsPerCta = kWarpsPerCta>
 __global__
-__launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_softmax_no_bias_renorm_warp_kernel_fixed_k(
+__launch_bounds__(WarpsPerCta *kWarpSize, 1) void topk_softmax_no_bias_renorm_warp_kernel_fixed_k(
     const T *__restrict__ gating_output, float *__restrict__ topk_weights,
     int32_t *__restrict__ topk_ids, int num_tokens) {
   const int tid = threadIdx.x;
   const int warp_id = tid / kWarpSize;
   const int lane = lane_id();
-  const int row = blockIdx.x * kWarpsPerCta + warp_id;
+  const int row = blockIdx.x * WarpsPerCta + warp_id;
   if (row >= num_tokens) {
     return;
   }
@@ -528,9 +533,10 @@ __launch_bounds__(kWarpsPerCta *kWarpSize, 1) void topk_softmax_no_bias_renorm_w
   }
 }
 
-template <typename T, int NumExperts, int ValuesPerThread, int TopK>
+template <typename T, int NumExperts, int ValuesPerThread, int TopK,
+          int WarpsPerCta = kWarpsPerCta>
 __global__ __launch_bounds__(
-    kWarpsPerCta * kWarpSize,
+    WarpsPerCta * kWarpSize,
     1) void topk_softmax_no_bias_renorm_warp_combined_shared1_kernel_fixed_k(
     const T *__restrict__ combined_gating_output,
     float *__restrict__ topk_weights, int32_t *__restrict__ topk_ids,
@@ -541,7 +547,7 @@ __global__ __launch_bounds__(
   const int tid = threadIdx.x;
   const int warp_id = tid / kWarpSize;
   const int lane = lane_id();
-  const int row = blockIdx.x * kWarpsPerCta + warp_id;
+  const int row = blockIdx.x * WarpsPerCta + warp_id;
   if (row >= num_tokens) {
     return;
   }
@@ -1205,6 +1211,118 @@ void launch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
       << "MUSA topk kernel failed: " << musaGetErrorString(err);
 }
 
+#if defined(VLLM_MUSA_TOPK_BENCHMARK_TACTICS)
+// Benchmark-only launch seam. Production entry points continue through
+// launch_topk() with kWarpsPerCta; only the dedicated FFI functions below can
+// select a different per-call geometry. Keep all benchmark-only templates out
+// of the normal production JIT translation unit.
+template <typename T, bool IsSoftmax, int WarpsPerCta>
+void launch_topk_benchmark_tactic(ffi::TensorView topk_weights,
+                                  ffi::TensorView topk_ids,
+                                  ffi::TensorView gating_output,
+                                  bool renormalize,
+                                  ffi::TensorView correction_bias,
+                                  bool has_correction_bias,
+                                  int num_fused_shared_experts) {
+  static_assert(WarpsPerCta == 1 || WarpsPerCta == 2 || WarpsPerCta == 4 ||
+                WarpsPerCta == 8);
+  const int num_tokens = static_cast<int>(gating_output.size(0));
+  const int num_experts = static_cast<int>(gating_output.size(1));
+  const int output_topk = static_cast<int>(topk_weights.size(1));
+  if (num_tokens == 0 || output_topk == 0) {
+    return;
+  }
+
+  const T *input_ptr = static_cast<const T *>(gating_output.data_ptr());
+  const float *bias_ptr = has_correction_bias
+                              ? static_cast<const float *>(
+                                    correction_bias.data_ptr())
+                              : nullptr;
+  float *weights_ptr = static_cast<float *>(topk_weights.data_ptr());
+  int32_t *ids_ptr = static_cast<int32_t *>(topk_ids.data_ptr());
+  ffi::MUSADeviceGuard device_guard(gating_output.device().device_id);
+  musaStream_t stream = get_stream(gating_output.device());
+  const int blocks = (num_tokens + WarpsPerCta - 1) / WarpsPerCta;
+
+  if constexpr (IsSoftmax) {
+    TVM_FFI_ICHECK(renormalize)
+        << "Benchmark topk softmax tactics require renormalize=true";
+    if (num_fused_shared_experts == 1) {
+      TVM_FFI_ICHECK_EQ(num_experts, 257)
+          << "Benchmark folded Qwen topk tactics require E=257";
+      TVM_FFI_ICHECK_EQ(output_topk, 9)
+          << "Benchmark folded Qwen topk tactics require output topk=9";
+      topk_softmax_no_bias_renorm_warp_combined_shared1_kernel_fixed_k<
+          T, 256, 8, 8, WarpsPerCta>
+          <<<blocks, WarpsPerCta * kWarpSize, 0, stream>>>(
+              input_ptr, weights_ptr, ids_ptr, num_tokens);
+    } else {
+      TVM_FFI_ICHECK_EQ(num_fused_shared_experts, 0);
+      TVM_FFI_ICHECK_EQ(num_experts, 256)
+          << "Benchmark Qwen topk tactics require E=256";
+      TVM_FFI_ICHECK_EQ(output_topk, 8)
+          << "Benchmark Qwen topk tactics require topk=8";
+      topk_softmax_no_bias_renorm_warp_kernel_fixed_k<T, 256, 8, 8,
+                                                       WarpsPerCta>
+          <<<blocks, WarpsPerCta * kWarpSize, 0, stream>>>(
+              input_ptr, weights_ptr, ids_ptr, num_tokens);
+    }
+  } else {
+    TVM_FFI_ICHECK_EQ(num_fused_shared_experts, 0);
+    TVM_FFI_ICHECK_EQ(num_experts, 256)
+        << "Benchmark DeepSeek topk tactics require E=256";
+    TVM_FFI_ICHECK_EQ(output_topk, 6)
+        << "Benchmark DeepSeek topk tactics require topk=6";
+    if (has_correction_bias) {
+      topk_sigmoid_warp_kernel<T, 256, 8, WarpsPerCta>
+          <<<blocks, WarpsPerCta * kWarpSize, 0, stream>>>(
+              input_ptr, weights_ptr, ids_ptr, bias_ptr, num_tokens,
+              output_topk, renormalize, true);
+    } else {
+      topk_sigmoid_no_bias_warp_kernel<T, 256, 8, WarpsPerCta>
+          <<<blocks, WarpsPerCta * kWarpSize, 0, stream>>>(
+              input_ptr, weights_ptr, ids_ptr, num_tokens, output_topk,
+              renormalize);
+    }
+  }
+
+  const musaError_t err = musaGetLastError();
+  TVM_FFI_ICHECK_EQ(err, musaSuccess)
+      << "MUSA benchmark topk tactic failed: " << musaGetErrorString(err);
+}
+
+template <typename T, bool IsSoftmax>
+void dispatch_topk_benchmark_warps(ffi::TensorView topk_weights,
+                                   ffi::TensorView topk_ids,
+                                   ffi::TensorView gating_output,
+                                   bool renormalize,
+                                   ffi::TensorView correction_bias,
+                                   bool has_correction_bias,
+                                   int num_fused_shared_experts,
+                                   int warps_per_cta) {
+#define LAUNCH_BENCHMARK_TOPK(WARPS)                                       \
+  launch_topk_benchmark_tactic<T, IsSoftmax, WARPS>(                       \
+      topk_weights, topk_ids, gating_output, renormalize, correction_bias, \
+      has_correction_bias,                                                 \
+      num_fused_shared_experts)
+
+  if (warps_per_cta == 1) {
+    LAUNCH_BENCHMARK_TOPK(1);
+  } else if (warps_per_cta == 2) {
+    LAUNCH_BENCHMARK_TOPK(2);
+  } else if (warps_per_cta == 4) {
+    LAUNCH_BENCHMARK_TOPK(4);
+  } else if (warps_per_cta == 8) {
+    LAUNCH_BENCHMARK_TOPK(8);
+  } else {
+    TVM_FFI_THROW(ValueError)
+        << "warps_per_cta must be one of 1, 2, 4, or 8";
+  }
+
+#undef LAUNCH_BENCHMARK_TOPK
+}
+#endif
+
 void check_topk_inputs(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
                        ffi::TensorView gating_output,
                        ffi::TensorView correction_bias,
@@ -1326,6 +1444,51 @@ void dispatch_topk(ffi::TensorView topk_weights, ffi::TensorView topk_ids,
   }
 }
 
+#if defined(VLLM_MUSA_TOPK_BENCHMARK_TACTICS)
+template <bool IsSoftmax>
+void dispatch_topk_benchmark_tactic(
+    ffi::TensorView topk_weights, ffi::TensorView topk_ids,
+    ffi::TensorView gating_output, bool renormalize, float moe_softcapping,
+    ffi::TensorView correction_bias, bool has_correction_bias,
+    ffi::TensorView shared_gate_output, int num_fused_shared_experts,
+    bool has_shared_experts, int warps_per_cta) {
+  if (warps_per_cta == 0) {
+    dispatch_topk<IsSoftmax>(
+        topk_weights, topk_ids, gating_output, renormalize, moe_softcapping,
+        correction_bias, has_correction_bias, shared_gate_output,
+        num_fused_shared_experts, has_shared_experts);
+    return;
+  }
+
+  if constexpr (IsSoftmax) {
+    TVM_FFI_ICHECK(!has_correction_bias)
+        << "Softmax benchmark tactics exclude correction-bias routing";
+  }
+  TVM_FFI_ICHECK(!has_shared_experts)
+      << "Benchmark topk tactics exclude separate shared-gate routing";
+  TVM_FFI_ICHECK(moe_softcapping <= 0.0f)
+      << "Benchmark topk tactics exclude softcapping";
+
+#define DISPATCH_BENCHMARK_TOPK(DType)                                     \
+  dispatch_topk_benchmark_warps<DType, IsSoftmax>(                         \
+      topk_weights, topk_ids, gating_output, renormalize, correction_bias, \
+      has_correction_bias,                                                 \
+      num_fused_shared_experts, warps_per_cta)
+
+  if (dtype_equal(gating_output.dtype(), dl_float32)) {
+    DISPATCH_BENCHMARK_TOPK(float);
+  } else if (dtype_equal(gating_output.dtype(), dl_float16)) {
+    DISPATCH_BENCHMARK_TOPK(half);
+  } else if (dtype_equal(gating_output.dtype(), dl_bfloat16)) {
+    DISPATCH_BENCHMARK_TOPK(__mt_bfloat16);
+  } else {
+    TVM_FFI_THROW(ValueError) << "Unsupported gating_output dtype";
+  }
+
+#undef DISPATCH_BENCHMARK_TOPK
+}
+#endif
+
 void sgl_musa_topk_softmax(
     ffi::TensorView topk_weights, ffi::TensorView topk_ids,
     ffi::TensorView gating_output, bool renormalize, double moe_softcapping,
@@ -1357,5 +1520,48 @@ void sgl_musa_topk_sigmoid(ffi::TensorView topk_weights,
                        num_fused_shared_experts, has_shared_experts);
 }
 
+#if defined(VLLM_MUSA_TOPK_BENCHMARK_TACTICS)
+void sgl_musa_topk_softmax_benchmark_tactic(
+    ffi::TensorView topk_weights, ffi::TensorView topk_ids,
+    ffi::TensorView gating_output, bool renormalize, double moe_softcapping,
+    ffi::TensorView correction_bias, bool has_correction_bias,
+    ffi::TensorView shared_gate_output, int num_fused_shared_experts,
+    bool has_shared_experts, int warps_per_cta) {
+  check_topk_inputs(topk_weights, topk_ids, gating_output, correction_bias,
+                    has_correction_bias, shared_gate_output,
+                    num_fused_shared_experts, has_shared_experts);
+  dispatch_topk_benchmark_tactic<true>(
+      topk_weights, topk_ids, gating_output, renormalize,
+      static_cast<float>(moe_softcapping), correction_bias,
+      has_correction_bias, shared_gate_output, num_fused_shared_experts,
+      has_shared_experts, warps_per_cta);
+}
+
+void sgl_musa_topk_sigmoid_benchmark_tactic(
+    ffi::TensorView topk_weights, ffi::TensorView topk_ids,
+    ffi::TensorView gating_output, bool renormalize,
+    ffi::TensorView correction_bias, bool has_correction_bias,
+    ffi::TensorView shared_gate_output, int num_fused_shared_experts,
+    bool has_shared_experts, int warps_per_cta) {
+  check_topk_inputs(topk_weights, topk_ids, gating_output, correction_bias,
+                    has_correction_bias, shared_gate_output,
+                    num_fused_shared_experts, has_shared_experts);
+  dispatch_topk_benchmark_tactic<false>(
+      topk_weights, topk_ids, gating_output, renormalize, 0.0f,
+      correction_bias, has_correction_bias, shared_gate_output,
+      num_fused_shared_experts, has_shared_experts, warps_per_cta);
+}
+#endif
+
+#if defined(VLLM_MUSA_TOPK_BENCHMARK_TACTICS)
+// The benchmark builds a separate JIT module under a distinct cache name. It
+// keeps the two established FFI names but exposes the explicit tactic arity;
+// the normal production module below retains its original ABI.
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_topk_softmax,
+                              sgl_musa_topk_softmax_benchmark_tactic);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_topk_sigmoid,
+                              sgl_musa_topk_sigmoid_benchmark_tactic);
+#else
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_topk_softmax, sgl_musa_topk_softmax);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(sgl_musa_topk_sigmoid, sgl_musa_topk_sigmoid);
+#endif

--- a/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm_musa/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -525,6 +525,8 @@ def _musa_fp8_small_m_gemv_op(
         False,
         None,
         1e-6,
+        0,
+        0,
     )
     return output
 

--- a/vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py
+++ b/vllm_musa/model_executor/layers/fused_moe/dispatch_policy.py
@@ -4,16 +4,21 @@
 """Model-agnostic MUSA fused-MoE backend selection.
 
 The hot path must not benchmark, synchronize device data to the host, or key
-off a model architecture name.  Offline S5000 sweeps populate exact shape
-entries below; unknown shapes keep the established upstream backend.
+off a model architecture name. Offline qualification populates exact
+hardware/shape entries below; unknown shapes keep the established upstream
+backend. Measurement receipts remain outside the source distribution.
 """
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Final
 
+from vllm_musa.tuning import MusaForwardGraphBucket
+
 MUSA_FUSED_MOE_DISPATCH_ENV: Final = "VLLM_MUSA_FUSED_MOE_DISPATCH"
+MP48_QWEN35_CALIBRATED_DECODE_BUCKETS: Final = (1, 2, 4, 8)
+MP56_QWEN35_CALIBRATED_DECODE_BUCKETS: Final = (1, 2, 4)
 
 
 class MusaFusedMoeBackend(str, Enum):
@@ -45,6 +50,8 @@ class MusaFusedMoeShape:
     w2_scale_shape: tuple[int, ...]
     gemv_block: str
     graph_mode: str
+    max_num_seqs: int | None = None
+    graph_bucket: MusaForwardGraphBucket | None = None
 
 
 @dataclass(frozen=True)
@@ -54,8 +61,26 @@ class MusaFusedMoeThresholds:
     source: str
 
 
-# Unknown shapes stay on the established upstream path until an exact S5000
-# sweep is recorded.
+@dataclass(frozen=True)
+class MusaFusedMoeGemvStageTactic:
+    """Per-stage AOT GEMV blocks for one exact production contract."""
+
+    w1_block: tuple[int, int]
+    w2_block: tuple[int, int]
+    source: str
+
+
+def resolve_fused_moe_graph_mode(
+    *, is_compiling: bool, stream_is_capturing: bool
+) -> str:
+    """Resolve selector state with symbolic compile taking precedence."""
+    if is_compiling:
+        return "compile"
+    return "capture" if stream_is_capturing else "eager"
+
+
+# Unknown shapes stay on the established upstream path until an exact policy is
+# qualified.
 _DEFAULT_THRESHOLDS: Final = MusaFusedMoeThresholds(
     gemv_max_tokens=None,
     grouped_gemm_min_tokens=None,
@@ -63,7 +88,7 @@ _DEFAULT_THRESHOLDS: Final = MusaFusedMoeThresholds(
 )
 
 
-def _s5000_fp8_shape(
+def _supported_fp8_shape(
     *,
     local_experts: int,
     w1_output_size: int,
@@ -97,8 +122,12 @@ def _s5000_fp8_shape(
     )
 
 
-def _s5000_qwen35_bf16_decode_shape(
-    *, graph_mode: str, folded_shared_expert: bool
+def _qwen35_bf16_decode_shape(
+    *,
+    multiprocessor_count: int,
+    graph_mode: str,
+    folded_shared_expert: bool,
+    max_num_seqs: int | None = None,
 ) -> MusaFusedMoeShape:
     """TP4-local Qwen3.5/3.6 BF16 decode shape."""
 
@@ -107,7 +136,7 @@ def _s5000_qwen35_bf16_decode_shape(
 
     return MusaFusedMoeShape(
         device_capability=(3, 1),
-        multiprocessor_count=60,
+        multiprocessor_count=multiprocessor_count,
         local_experts=experts,
         w1_output_size=256,
         w2_input_size=128,
@@ -124,10 +153,11 @@ def _s5000_qwen35_bf16_decode_shape(
         w2_scale_shape=(),
         gemv_block="auto",
         graph_mode=graph_mode,
+        max_num_seqs=max_num_seqs,
     )
 
 
-def _s5000_bf16_shape(
+def _supported_bf16_shape(
     *,
     local_experts: int,
     w1_output_size: int,
@@ -136,7 +166,7 @@ def _s5000_bf16_shape(
     top_k: int,
     graph_mode: str,
 ) -> MusaFusedMoeShape:
-    """Generic S5000 BF16 decode shape for independently calibrated models."""
+    """Generic BF16 decode shape for the supported architecture."""
 
     return MusaFusedMoeShape(
         device_capability=(3, 1),
@@ -172,13 +202,11 @@ def _thresholds(
     )
 
 
-# Exact entries are keyed by the actual per-rank kernel shape. These S5000
-# entries use the worst boundary across balanced, unique-random, and hot routes
-# with three independent seeds. Capture entries additionally passed eight
-# bitwise-equal CUDAGraph replays. Unknown shapes remain on the established
+# Exact entries are keyed by the actual per-rank kernel shape. Qualification
+# receipts are retained out of tree. Unknown shapes remain on the established
 # base path, which may itself select the large-M DeepGEMM prefill backend.
 _CALIBRATED_THRESHOLDS: Final[dict[MusaFusedMoeShape, MusaFusedMoeThresholds]] = {
-    _s5000_fp8_shape(
+    _supported_fp8_shape(
         local_experts=256,
         w1_output_size=256,
         w2_input_size=128,
@@ -191,13 +219,13 @@ _CALIBRATED_THRESHOLDS: Final[dict[MusaFusedMoeShape, MusaFusedMoeThresholds]] =
     ): _thresholds(
         gemv_max_tokens=13,
         grouped_gemm_min_tokens=None,
-        source=f"s5000-mp60-20260721-e256-n256-k2048-{graph_mode}-dense-v5",
+        source=f"mp60-e256-n256-k2048-{graph_mode}-dense-v5",
     )
     for graph_mode in ("eager", "capture")
 }
 _CALIBRATED_THRESHOLDS.update(
     {
-        _s5000_fp8_shape(
+        _supported_fp8_shape(
             local_experts=256,
             w1_output_size=512,
             w2_input_size=256,
@@ -210,14 +238,64 @@ _CALIBRATED_THRESHOLDS.update(
         ): _thresholds(
             gemv_max_tokens=5,
             grouped_gemm_min_tokens=None,
-            source=f"s5000-mp60-20260721-e256-n512-k4096-{graph_mode}-block32-dense-v5",
+            source=f"mp60-e256-n512-k4096-{graph_mode}-block32-dense-v5",
         )
         for graph_mode in ("eager", "capture")
     }
 )
 _CALIBRATED_THRESHOLDS.update(
     {
-        _s5000_fp8_shape(
+        _qwen35_bf16_decode_shape(
+            multiprocessor_count=48,
+            graph_mode=graph_mode,
+            folded_shared_expert=True,
+            max_num_seqs=max_num_seqs,
+        ): _thresholds(
+            # Keep the graph-static bucket in the key so a graph compiled for
+            # M<=8 is not reused for a larger request batch.
+            gemv_max_tokens=8,
+            grouped_gemm_min_tokens=None,
+            source=(
+                f"mp48-qwen35-bf16-e257-n256-k2048-v128-"
+                f"{graph_mode}-maxseq{max_num_seqs}-route-policy-v1"
+            ),
+        )
+        for graph_mode in ("eager", "capture")
+        for max_num_seqs in (
+            (None,) if graph_mode == "eager" else MP48_QWEN35_CALIBRATED_DECODE_BUCKETS
+        )
+    }
+)
+_CALIBRATED_THRESHOLDS.update(
+    {
+        _qwen35_bf16_decode_shape(
+            multiprocessor_count=56,
+            graph_mode=graph_mode,
+            folded_shared_expert=folded_shared_expert,
+            max_num_seqs=max_num_seqs,
+        ): _thresholds(
+            # Register the conservative route-invariant boundary only for an
+            # engine whose graph-static max_num_seqs cannot cross it. Selecting
+            # from replay-time M alone can bake the small-M arm into a graph
+            # reused by larger batches.
+            gemv_max_tokens=4,
+            grouped_gemm_min_tokens=None,
+            source=(
+                f"mp56-qwen35-bf16-e"
+                f"{257 if folded_shared_expert else 256}-n256-k2048-v128-"
+                f"{graph_mode}-maxseq{max_num_seqs}-route-policy-v2"
+            ),
+        )
+        for graph_mode in ("eager", "capture")
+        for folded_shared_expert in (True,)
+        # These engine profiles are also reused only for an exact full, uniform
+        # graph descriptor. Raw replay-time M is never a selector key.
+        for max_num_seqs in MP56_QWEN35_CALIBRATED_DECODE_BUCKETS
+    }
+)
+_CALIBRATED_THRESHOLDS.update(
+    {
+        _supported_fp8_shape(
             local_experts=256,
             w1_output_size=512,
             w2_input_size=256,
@@ -230,14 +308,14 @@ _CALIBRATED_THRESHOLDS.update(
         ): _thresholds(
             gemv_max_tokens=5,
             grouped_gemm_min_tokens=None,
-            source=f"s5000-mp60-20260721-e256-n512-k4096-{graph_mode}-block16-dense-v5",
+            source=f"mp60-e256-n512-k4096-{graph_mode}-block16-dense-v5",
         )
         for graph_mode in ("eager", "capture")
     }
 )
 _CALIBRATED_THRESHOLDS.update(
     {
-        _s5000_fp8_shape(
+        _supported_fp8_shape(
             local_experts=64,
             w1_output_size=2816,
             w2_input_size=1408,
@@ -248,15 +326,14 @@ _CALIBRATED_THRESHOLDS.update(
             gemv_block="auto",
             graph_mode=graph_mode,
         ): _thresholds(
-            # Capture-mode A/B on S5000 shows a GEMV win at M=1, but a
-            # regression at M=2/3.  Keep the wider eager boundary and use
-            # GEMV only for the single-token decode case under capture.
+            # The capture policy uses GEMV only for the single-token decode
+            # case, while eager mode retains the wider qualified boundary.
             gemv_max_tokens=3 if graph_mode == "eager" else 1,
             # No production-safe grouped crossover is currently established
             # for this shape; retain upstream for the large-token regime.
             grouped_gemm_min_tokens=None,
             source=(
-                f"s5000-mp60-20260721-e64-n2816-k2048-{graph_mode}-"
+                f"mp60-e64-n2816-k2048-{graph_mode}-"
                 f"{'m1-' if graph_mode == 'capture' else ''}serving-gated"
             ),
         )
@@ -265,18 +342,21 @@ _CALIBRATED_THRESHOLDS.update(
 )
 _CALIBRATED_THRESHOLDS.update(
     {
-        _s5000_qwen35_bf16_decode_shape(
+        _qwen35_bf16_decode_shape(
+            multiprocessor_count=60,
             graph_mode=graph_mode,
             folded_shared_expert=folded_shared_expert,
         ): _thresholds(
-            # Exact TP4-local Qwen crossover: M=1/2/4/8/12 are faster on
-            # native GEMV, while M>=16 is not a stable production win.
-            gemv_max_tokens=12,
+            # The folded profile uses the conservative M<=4 boundary; the
+            # unfolded profile retains its independently qualified M<=12
+            # boundary.
+            gemv_max_tokens=4 if folded_shared_expert else 12,
             grouped_gemm_min_tokens=None,
             source=(
-                f"s5000-mp60-20260806-qwen35-36-bf16-e"
+                f"mp60-qwen35-36-bf16-e"
                 f"{257 if folded_shared_expert else 256}-"
-                f"n256-k2048-v128-{graph_mode}-crossover-v1"
+                f"n256-k2048-v128-{graph_mode}-"
+                f"route-policy-{'v2' if folded_shared_expert else 'v1'}"
             ),
         )
         for graph_mode in ("eager", "capture")
@@ -285,7 +365,7 @@ _CALIBRATED_THRESHOLDS.update(
 )
 _CALIBRATED_THRESHOLDS.update(
     {
-        _s5000_bf16_shape(
+        _supported_bf16_shape(
             local_experts=257,
             w1_output_size=256,
             w2_input_size=128,
@@ -295,12 +375,65 @@ _CALIBRATED_THRESHOLDS.update(
         ): _thresholds(
             gemv_max_tokens=10,
             grouped_gemm_min_tokens=None,
+            source=(f"mp60-qwen35-bf16-folded-" f"e257-n256-k3072-{graph_mode}"),
+        )
+        for graph_mode in ("eager", "capture")
+    }
+)
+
+# Keep tile selection independent from backend crossover selection. A kernel
+# may already be production-reachable while only one stage and one exact token
+# bucket benefits from a different AOT block. Unknown keys retain the caller's
+# established per-stage blocks; there is no nearest-MP or nearest-shape match.
+_CALIBRATED_GEMV_STAGE_TACTICS: Final[
+    dict[tuple[MusaFusedMoeShape, int], MusaFusedMoeGemvStageTactic]
+] = {
+    (
+        _supported_fp8_shape(
+            local_experts=256,
+            w1_output_size=512,
+            w2_input_size=256,
+            hidden_size=4096,
+            top_k=6,
+            w1_scale_shape=(256, 4, 32),
+            w2_scale_shape=(256, 32, 2),
+            gemv_block="16x8",
+            graph_mode="eager",
+        ),
+        2,
+    ): MusaFusedMoeGemvStageTactic(
+        w1_block=(8, 16),
+        w2_block=(16, 8),
+        source="mp60-dsv4-fp8-m2-route-policy-v1",
+    )
+}
+
+# Keep the MP48 32x4 stage map independent from the backend threshold: if a
+# future qualification changes the threshold, the stage tile still requires
+# its own policy entry.
+_CALIBRATED_GEMV_STAGE_TACTICS.update(
+    {
+        (
+            _qwen35_bf16_decode_shape(
+                multiprocessor_count=48,
+                graph_mode=graph_mode,
+                folded_shared_expert=True,
+                max_num_seqs=max_num_seqs,
+            ),
+            num_tokens,
+        ): MusaFusedMoeGemvStageTactic(
+            w1_block=(32, 4),
+            w2_block=(32, 4),
             source=(
-                f"s5000-mp60-20260806-qwen35-bf16-folded-"
-                f"e257-n256-k3072-{graph_mode}"
+                f"mp48-qwen35-bf16-e257-m{num_tokens}-32x4-"
+                f"{graph_mode}-maxseq{max_num_seqs}-route-policy-v1"
             ),
         )
         for graph_mode in ("eager", "capture")
+        for max_num_seqs in (
+            (None,) if graph_mode == "eager" else MP48_QWEN35_CALIBRATED_DECODE_BUCKETS
+        )
+        for num_tokens in range(1, 9)
     }
 )
 
@@ -314,6 +447,17 @@ _CALIBRATED_DIMENSIONS: Final = frozenset(
     )
     for shape in _CALIBRATED_THRESHOLDS
 )
+_PROFILED_SHAPES: Final = frozenset(
+    replace(shape, max_num_seqs=None)
+    for shape in _CALIBRATED_THRESHOLDS
+    if shape.max_num_seqs is not None
+)
+
+
+def _uses_graph_bucket_profile(shape: MusaFusedMoeShape) -> bool:
+    """Whether ``shape`` requires an exact calibrated graph descriptor."""
+    lookup_shape = replace(shape, graph_bucket=None)
+    return replace(lookup_shape, max_num_seqs=None) in _PROFILED_SHAPES
 
 
 def parse_dispatch_backend(value: str | None = None) -> MusaFusedMoeBackend:
@@ -341,7 +485,111 @@ def parse_dispatch_backend(value: str | None = None) -> MusaFusedMoeBackend:
 
 
 def thresholds_for_shape(shape: MusaFusedMoeShape) -> MusaFusedMoeThresholds:
-    return _CALIBRATED_THRESHOLDS.get(shape, _DEFAULT_THRESHOLDS)
+    lookup_shape = replace(shape, graph_bucket=None)
+    profiled_shape = replace(lookup_shape, max_num_seqs=None)
+
+    if profiled_shape in _PROFILED_SHAPES and shape.graph_bucket is not None:
+        graph_bucket = shape.graph_bucket
+        # Eager execution can use the engine-static profile because no graph is
+        # reused across runtime token counts. The pinned vLLM NONE descriptor
+        # carries the exact token count but deliberately has no request count.
+        if (
+            shape.graph_mode == "eager"
+            and graph_bucket.present
+            and graph_bucket.runtime_mode == "NONE"
+            and graph_bucket.has_lora is False
+            and graph_bucket.num_active_loras == 0
+            and graph_bucket.num_tokens is not None
+            and graph_bucket.num_tokens > 0
+            and graph_bucket.num_reqs is None
+            and graph_bucket.uniform is False
+            and (
+                shape.max_num_seqs is None
+                or graph_bucket.num_tokens <= shape.max_num_seqs
+            )
+        ):
+            return _CALIBRATED_THRESHOLDS.get(lookup_shape, _DEFAULT_THRESHOLDS)
+
+        # Graph replay is calibrated only for full, uniform, one-token decode.
+        # Speculative and piecewise descriptors retain the established backend.
+        if (
+            not graph_bucket.present
+            or graph_bucket.runtime_mode != "FULL"
+            or graph_bucket.has_lora is not False
+            or graph_bucket.num_active_loras != 0
+            or not graph_bucket.uniform
+            or graph_bucket.num_reqs is None
+            or graph_bucket.num_tokens != graph_bucket.num_reqs
+            or graph_bucket.num_reqs <= 0
+            or (
+                shape.max_num_seqs is not None
+                and graph_bucket.num_reqs > shape.max_num_seqs
+            )
+        ):
+            return _DEFAULT_THRESHOLDS
+        thresholds = _CALIBRATED_THRESHOLDS.get(
+            replace(lookup_shape, max_num_seqs=graph_bucket.num_reqs)
+        )
+        return thresholds or _DEFAULT_THRESHOLDS
+
+    thresholds = _CALIBRATED_THRESHOLDS.get(lookup_shape)
+    if thresholds is not None:
+        return thresholds
+    if lookup_shape.max_num_seqs is not None:
+        # Existing hardware/shape policies predate the scheduler-profile key.
+        # Fall back only to an explicitly calibrated generic entry; MP56 has
+        # no generic entry and requires an exact graph descriptor or profile.
+        thresholds = _CALIBRATED_THRESHOLDS.get(
+            replace(lookup_shape, max_num_seqs=None)
+        )
+        if thresholds is not None:
+            return thresholds
+    return _DEFAULT_THRESHOLDS
+
+
+def gemv_stage_tactic_for_shape(
+    *, shape: MusaFusedMoeShape, num_tokens: int
+) -> MusaFusedMoeGemvStageTactic | None:
+    """Return an exact calibrated stage tactic without probing the device.
+
+    Scheduler-profile and ForwardContext fields gate backend eligibility, but
+    do not change the already-selected GEMV kernel's block geometry. The
+    tactic catalog remains exact for hardware, tensor contract, token count,
+    and eager/capture mode.
+    """
+
+    max_num_seqs = None
+    if shape.graph_mode == "capture":
+        graph_bucket = shape.graph_bucket
+        # Capture tactics are qualified against exact FULL decode buckets.
+        # Project the validated bucket into the catalog key instead of using
+        # the engine-wide max_num_seqs value, which is identical for several
+        # captured token counts. Direct or malformed capture callers fail
+        # closed even if they happen to match the tensor dimensions.
+        if (
+            graph_bucket is None
+            or not graph_bucket.present
+            or graph_bucket.runtime_mode != "FULL"
+            or graph_bucket.has_lora is not False
+            or graph_bucket.num_active_loras != 0
+            or not graph_bucket.uniform
+            or graph_bucket.num_tokens != num_tokens
+            or graph_bucket.num_reqs != num_tokens
+            or graph_bucket.num_reqs <= 0
+            or (
+                shape.max_num_seqs is not None
+                and graph_bucket.num_reqs > shape.max_num_seqs
+            )
+        ):
+            return None
+        max_num_seqs = graph_bucket.num_reqs
+
+    lookup_shape = replace(
+        shape,
+        max_num_seqs=max_num_seqs,
+        graph_bucket=None,
+    )
+    return _CALIBRATED_GEMV_STAGE_TACTICS.get((lookup_shape, num_tokens))
 
 
 def has_calibrated_dimensions(
@@ -378,6 +626,59 @@ def select_fused_moe_backend(
     Forced modes are diagnostic controls, not correctness bypasses: if a
     requested backend is ineligible the established upstream path is used.
     """
+
+    # Backend overrides are runtime diagnostics. They must not specialize a
+    # native backend while Dynamo is still tracing symbolic inputs.
+    if shape.graph_mode == "compile":
+        return MusaFusedMoeBackend.UPSTREAM
+    if shape.graph_bucket is None and (
+        stream_is_capturing
+        or (_uses_graph_bucket_profile(shape) and shape.graph_mode == "capture")
+    ):
+        # Capture without ForwardContext has no graph-static specialization
+        # identity. Reserve the legacy missing-context fallback for eager
+        # direct-operator callers only.
+        return MusaFusedMoeBackend.UPSTREAM
+    if shape.graph_bucket is not None:
+        graph_bucket = shape.graph_bucket
+        # Invalid API/context projections and LoRA-specialized descriptors are
+        # unsafe for every calibrated native kernel.
+        if (
+            not graph_bucket.present
+            or graph_bucket.has_lora is not False
+            or graph_bucket.num_active_loras != 0
+            or graph_bucket.runtime_mode not in {"NONE", "PIECEWISE", "FULL"}
+        ):
+            return MusaFusedMoeBackend.UPSTREAM
+        # FULL descriptors are graph-static for every calibrated MP. Reject
+        # speculative/nonuniform or mismatched callers globally; only legacy
+        # NONE/PIECEWISE behavior remains an MP60 compatibility exception.
+        if graph_bucket.runtime_mode == "FULL" and (
+            graph_bucket.num_tokens != num_tokens
+            or not graph_bucket.uniform
+            or graph_bucket.num_reqs != graph_bucket.num_tokens
+        ):
+            return MusaFusedMoeBackend.UPSTREAM
+        # Only the new MP56 profile was calibrated by exact FULL decode graph
+        # buckets. Existing MP60 entries are separately keyed as eager/capture
+        # and were calibrated under vLLM's legacy NONE/PIECEWISE descriptor
+        # semantics; this PR must not silently disable those padded paths.
+        if _uses_graph_bucket_profile(shape):
+            eager_none = (
+                shape.graph_mode == "eager"
+                and graph_bucket.runtime_mode == "NONE"
+                and graph_bucket.num_tokens == num_tokens
+                and graph_bucket.num_reqs is None
+                and graph_bucket.uniform is False
+            )
+            full_decode = (
+                graph_bucket.num_tokens == num_tokens
+                and graph_bucket.runtime_mode == "FULL"
+                and graph_bucket.uniform
+                and graph_bucket.num_reqs == graph_bucket.num_tokens
+            )
+            if not eager_none and not full_decode:
+                return MusaFusedMoeBackend.UPSTREAM
 
     if requested == MusaFusedMoeBackend.GEMV:
         # Forced GEMV remains useful for eager diagnostics, but graph capture
@@ -428,10 +729,13 @@ def select_fused_moe_backend(
 __all__ = [
     "MUSA_FUSED_MOE_DISPATCH_ENV",
     "MusaFusedMoeBackend",
+    "MusaFusedMoeGemvStageTactic",
     "MusaFusedMoeShape",
     "MusaFusedMoeThresholds",
+    "gemv_stage_tactic_for_shape",
     "has_calibrated_dimensions",
     "parse_dispatch_backend",
+    "resolve_fused_moe_graph_mode",
     "select_fused_moe_backend",
     "thresholds_for_shape",
 ]

--- a/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_musa/model_executor/layers/fused_moe/fused_moe.py
@@ -4,7 +4,6 @@
 import json
 import os
 import time
-from functools import cache
 
 import torch
 from vllm import _custom_ops as ops
@@ -30,9 +29,12 @@ from vllm_musa import _custom_ops as musa_ops
 from vllm_musa.jit_kernel.csrc.moe import maybe_fast_moe_sum
 from vllm_musa.model_executor.layers.fused_moe.dispatch_policy import (
     MusaFusedMoeBackend,
+    MusaFusedMoeGemvStageTactic,
     MusaFusedMoeShape,
+    gemv_stage_tactic_for_shape,
     has_calibrated_dimensions,
     parse_dispatch_backend,
+    resolve_fused_moe_graph_mode,
     select_fused_moe_backend,
     thresholds_for_shape,
 )
@@ -40,8 +42,17 @@ from vllm_musa.optimization_contract import (
     matches_qwen35_moe_bf16_decode_gemv_layer,
     matches_qwen35_moe_bf16_prefill_layer,
 )
+from vllm_musa.tuning import (
+    get_primed_musa_kernel_hardware,
+    query_musa_engine_max_num_seqs,
+    query_musa_forward_graph_bucket,
+)
 
 logger = init_logger(__name__)
+
+
+def _current_max_num_seqs() -> int | None:
+    return query_musa_engine_max_num_seqs()
 
 
 def disable_inplace() -> bool:
@@ -99,12 +110,11 @@ def _env_int(name: str, default: int) -> int:
 
 
 def _requested_gemv_block(shape: MusaFusedMoeShape | None) -> tuple[int, int]:
-    """Return a graph-static tile request for a contract-selected GEMV shape.
+    """Return the established graph-static block for a selected GEMV shape.
 
     The explicit environment override remains owned by the C++ op. Passing
     zeroes here lets that override (and the one-token DeepSeek-V4 split-tile
-    rule) retain their existing precedence.  Only a selector produced by the
-    Python policy, with no explicit environment override, is forwarded.
+    rule) retain their existing precedence.
     """
 
     if shape is None or os.environ.get(_GEMV_MOE_BLOCK_ENV) is not None:
@@ -114,6 +124,16 @@ def _requested_gemv_block(shape: MusaFusedMoeShape | None) -> tuple[int, int]:
     if shape.gemv_block != "16x8":
         return 0, 0
     return 16, 8
+
+
+def _requested_gemv_stage_tactic(
+    shape: MusaFusedMoeShape | None,
+    num_tokens: int,
+) -> MusaFusedMoeGemvStageTactic | None:
+    """Return an exact stage tactic while preserving diagnostic precedence."""
+    if shape is None or os.environ.get(_GEMV_MOE_BLOCK_ENV) is not None:
+        return None
+    return gemv_stage_tactic_for_shape(shape=shape, num_tokens=num_tokens)
 
 
 def _tensors_share_device(
@@ -143,23 +163,11 @@ def _musa_moe_routes_are_supported(
     )
 
 
-@cache
 def _musa_device_fingerprint(
     device_index: int,
 ) -> tuple[tuple[int, int], int]:
-    try:
-        capability = current_platform.get_device_capability(device_index)
-        device_capability = (
-            (int(capability[0]), int(capability[1]))
-            if capability is not None
-            else (-1, -1)
-        )
-        multiprocessor_count = int(
-            torch.musa.get_device_properties(device_index).multi_processor_count
-        )
-        return device_capability, multiprocessor_count
-    except Exception:
-        return (-1, -1), -1
+    hardware = get_primed_musa_kernel_hardware(device_index)
+    return hardware.device_capability, hardware.multiprocessor_count
 
 
 def _tensor_meta(tensor: torch.Tensor | None) -> dict[str, object] | None:
@@ -943,6 +951,7 @@ def _moe_deepgemm_bf16_prefill_impl(
         get_mk_alignment_for_contiguous_layout,
         mk_alignment_scope,
     )
+
     from vllm_musa.jit_kernel.post_reorder import post_reorder_triton_kernel
     from vllm_musa.jit_kernel.tilelang.deep_gemm_contig_preprocess import (
         can_use_bf16_tilelang,
@@ -1552,6 +1561,7 @@ def _musa_fused_moe_shape(
             and block_k == 128
         )
         gemv_block = "16x8" if is_deepseek_v4_flash_tp8_shape else "auto"
+    is_compiling = torch.compiler.is_compiling()
     return MusaFusedMoeShape(
         device_capability=device_capability,
         multiprocessor_count=multiprocessor_count,
@@ -1570,7 +1580,16 @@ def _musa_fused_moe_shape(
         w1_scale_shape=tuple(w1_scale.shape) if w1_scale is not None else (),
         w2_scale_shape=tuple(w2_scale.shape) if w2_scale is not None else (),
         gemv_block=gemv_block,
-        graph_mode="capture" if stream_is_capturing else "eager",
+        # Do not select a small-batch GEMV arm while Dynamo is tracing the
+        # symbolic graph. The trace may be reused for a larger capture shape;
+        # concrete capture/eager execution may use an exact vLLM graph
+        # descriptor or the conservative engine-static fallback profile.
+        graph_mode=resolve_fused_moe_graph_mode(
+            is_compiling=is_compiling,
+            stream_is_capturing=stream_is_capturing,
+        ),
+        max_num_seqs=_current_max_num_seqs(),
+        graph_bucket=None if is_compiling else query_musa_forward_graph_bucket(),
     )
 
 
@@ -1648,6 +1667,7 @@ def fused_experts_impl(
     inplace: bool = False,
     _allow_deepgemm_prefill: bool = True,
     _gemv_block: tuple[int, int] = (0, 0),
+    _gemv_blocks: tuple[tuple[int, int], tuple[int, int]] | None = None,
 ) -> torch.Tensor:
     # Check constraints.
     if use_int4_w4a16:
@@ -1807,7 +1827,8 @@ def fused_experts_impl(
         "Triton MoE JSON config lookup.",
         scope="global",
     )
-    gemv_block_n, gemv_block_k = _gemv_block
+    gemv_blocks = (_gemv_block, _gemv_block) if _gemv_blocks is None else _gemv_blocks
+    (w1_block_n, w1_block_k), (w2_block_n, w2_block_k) = gemv_blocks
     CHUNK_SIZE = 16384
     M = min(num_tokens, CHUNK_SIZE)
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
@@ -1842,8 +1863,8 @@ def fused_experts_impl(
             topk_ids.shape[1],
             use_int4_w4a16,
             use_swigelu=True,
-            block_n=gemv_block_n,
-            block_k=gemv_block_k,
+            block_n=w1_block_n,
+            block_k=w1_block_k,
         )
         musa_ops.musa_fused_gemv_moe(
             curr_intermediate_cache2,
@@ -1857,8 +1878,8 @@ def fused_experts_impl(
             1,
             use_int4_w4a16,
             use_swigelu=False,
-            block_n=gemv_block_n,
-            block_k=gemv_block_k,
+            block_n=w2_block_n,
+            block_k=w2_block_k,
         )
         # ========================== END ====================
         moe_sum_input = curr_intermediate_cache3.view(*curr_intermediate_cache3.size())
@@ -1907,6 +1928,7 @@ def _musa_fused_experts_impl_dispatch(
     policy = None
     shape = None
     requested_gemv_block = (0, 0)
+    gemv_stage_tactic = None
 
     # Keep the expensive contract matcher off unrelated MoE calls.  The
     # tensor geometry is the runtime half of the Qwen3.5/3.6 model contract;
@@ -2006,8 +2028,8 @@ def _musa_fused_experts_impl_dispatch(
                 device_index = 0
         device_capability, multiprocessor_count = _musa_device_fingerprint(device_index)
 
-        # The policy is calibrated only for S5000/MP31. Other MUSA
-        # architectures retain the established upstream implementation.
+        # The policy is qualified only for the supported architecture. Other
+        # MUSA architectures retain the established upstream implementation.
         if device_capability == (3, 1):
             # The calibrated GEMV sweeps use router weights after the expert
             # projection.  Fail closed for the alternate input-weighting
@@ -2097,6 +2119,21 @@ def _musa_fused_experts_impl_dispatch(
                 )
                 if backend == MusaFusedMoeBackend.GEMV:
                     requested_gemv_block = _requested_gemv_block(shape)
+                    gemv_stage_tactic = _requested_gemv_stage_tactic(
+                        shape,
+                        hidden_states.shape[0],
+                    )
+                    if gemv_stage_tactic is not None:
+                        logger.info_once(
+                            "MUSA fused-MoE GEMV stage tactic hit source=%s "
+                            "for M=%d mp=%d blocks=(w1=%s,w2=%s).",
+                            gemv_stage_tactic.source,
+                            hidden_states.shape[0],
+                            shape.multiprocessor_count,
+                            gemv_stage_tactic.w1_block,
+                            gemv_stage_tactic.w2_block,
+                            scope="local",
+                        )
 
     # Native GEMV records inside ``fused_experts_impl`` after expanding any
     # per-tensor scales.  Record every other dispatcher outcome here so the
@@ -2129,16 +2166,27 @@ def _musa_fused_experts_impl_dispatch(
         assert shape is not None
         logger.info_once(
             "MUSA fused-MoE dispatcher selected backend=%s policy=%s for "
-            "shape=(E=%d,N=%d,K=%d,topk=%d,graph=%s,mp=%d,gemv_block=%s).",
+            "shape=(E=%d,N=%d,K=%d,topk=%d,M=%d,graph=%s,mp=%d,maxseq=%s,"
+            "graph_bucket=%s,gemv_block=%s,gemv_stage_blocks=%s,"
+            "gemv_stage_tactic=%s).",
             backend.value,
             policy.source,
             shape.local_experts,
             shape.w1_output_size,
             shape.hidden_size,
             shape.top_k,
+            hidden_states.shape[0],
             shape.graph_mode,
             shape.multiprocessor_count,
+            shape.max_num_seqs,
+            shape.graph_bucket,
             shape.gemv_block,
+            (
+                (gemv_stage_tactic.w1_block, gemv_stage_tactic.w2_block)
+                if gemv_stage_tactic is not None
+                else (requested_gemv_block, requested_gemv_block)
+            ),
+            None if gemv_stage_tactic is None else gemv_stage_tactic.source,
         )
 
     if backend == MusaFusedMoeBackend.GROUPED_GEMM:
@@ -2178,6 +2226,11 @@ def _musa_fused_experts_impl_dispatch(
         }
         if requested_gemv_block != (0, 0):
             gemv_kwargs["_gemv_block"] = requested_gemv_block
+        if gemv_stage_tactic is not None:
+            gemv_kwargs["_gemv_blocks"] = (
+                gemv_stage_tactic.w1_block,
+                gemv_stage_tactic.w2_block,
+            )
         return fused_experts_impl(
             hidden_states,
             w1,

--- a/vllm_musa/platform.py
+++ b/vllm_musa/platform.py
@@ -35,11 +35,9 @@ import pymtml as pynvml
 from vllm_musa.optimization_contract import (
     ModelFamily,
     OptimizationFeature,
-)
-from vllm_musa.optimization_contract import policy as contract_policy
-from vllm_musa.optimization_contract import (
     resolve_optimization_contract,
 )
+from vllm_musa.optimization_contract import policy as contract_policy
 from vllm_musa.tuning import FUSED_ADD_RMSNORM_MIN_ROWS
 
 logger = init_logger(__name__)
@@ -430,6 +428,11 @@ class MUSAPlatformBase(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        from vllm_musa.tuning import (
+            configure_musa_engine_scheduler_profile_from_config,
+        )
+
+        configure_musa_engine_scheduler_profile_from_config(vllm_config)
         # when dflash spec-decode is active, coerce the draft-loop
         # CUDAGraph capture to block-aligned FULL sizes (see below). The dflash
         # source patch (DFlashProposer.dummy_run signature) is applied at BUILD
@@ -857,7 +860,9 @@ class MUSAPlatformBase(Platform):
 
     @classmethod
     def get_device_communicator_cls(cls) -> str:
-        return "vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
+        return (
+            "vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
+        )
 
     @classmethod
     def supports_fp8(cls) -> bool:

--- a/vllm_musa/tuning.py
+++ b/vllm_musa/tuning.py
@@ -1,7 +1,419 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Shared empirically measured kernel-selection thresholds."""
+"""Shared primitives for hardware-aware kernel tactic selection.
 
-# Minimum rows where the MUSA JIT fused-add RMSNorm provider was measured to
-# outperform the fallback for contiguous BF16 H5120 workloads on S5000.
+The platform publishes the resolved graph profile before worker spawn, workers
+freeze the physical MP identity, and serving selectors use exact
+hardware/shape/graph keys with fallback on a miss. Keep runtime selection
+deterministic and cheap. Offline benchmarks may add exact entries to a tactic
+catalog, but the serving hot path must only query a stable hardware identity
+and perform integer cost calculations. The wave estimator at the end of this
+module is an offline diagnostic and does not select production kernels.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+# Minimum rows for the qualified MUSA JIT fused-add RMSNorm profile on
+# contiguous BF16 H5120 workloads.
 FUSED_ADD_RMSNORM_MIN_ROWS = 64
+_ENGINE_MAX_NUM_SEQS_ENV = "_VLLM_MUSA_ENGINE_MAX_NUM_SEQS"
+
+
+@dataclass(frozen=True)
+class MusaForwardGraphBucket:
+    """Validated projection of vLLM's graph dispatch descriptor.
+
+    ``present`` distinguishes a missing context (where a legacy static profile
+    may still be safe) from a present but ineligible descriptor (which must
+    fail closed).
+    """
+
+    num_tokens: int | None = None
+    num_reqs: int | None = None
+    uniform: bool | None = None
+    runtime_mode: str | None = None
+    has_lora: bool | None = None
+    num_active_loras: int | None = None
+    present: bool = False
+
+    @classmethod
+    def invalid(cls) -> MusaForwardGraphBucket:
+        return cls(present=True)
+
+
+def configure_musa_engine_scheduler_profile(max_num_seqs: int | None) -> None:
+    """Publish the engine-static scheduler profile to spawned workers.
+
+    This is written only by the MUSA platform from the resolved VllmConfig; it
+    is not a user-facing override. Environment transport is used because vLLM
+    spawns worker processes after platform config validation.
+    """
+    if isinstance(max_num_seqs, int) and max_num_seqs > 0:
+        os.environ[_ENGINE_MAX_NUM_SEQS_ENV] = str(max_num_seqs)
+    else:
+        os.environ.pop(_ENGINE_MAX_NUM_SEQS_ENV, None)
+
+
+def configure_musa_engine_scheduler_profile_from_config(vllm_config: Any) -> None:
+    """Publish the resolved scheduler profile from a vLLM config object.
+
+    A missing scheduler config or profile deliberately clears the inherited
+    value so hardware selectors fail closed.
+    """
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    configure_musa_engine_scheduler_profile(
+        getattr(scheduler_config, "max_num_seqs", None)
+    )
+
+
+def query_musa_forward_graph_bucket() -> MusaForwardGraphBucket | None:
+    """Read vLLM's graph-static batch key and fail closed if unavailable."""
+    try:
+        from vllm.forward_context import (
+            get_forward_context,
+            is_forward_context_available,
+        )
+
+        if not is_forward_context_available():
+            return None
+        context = get_forward_context()
+        descriptor = context.batch_descriptor
+        if descriptor is None:
+            return MusaForwardGraphBucket.invalid()
+        num_tokens = descriptor.num_tokens
+        num_reqs = descriptor.num_reqs
+        uniform = descriptor.uniform
+        runtime_mode = getattr(context.cudagraph_runtime_mode, "name", None)
+        has_lora = descriptor.has_lora
+        num_active_loras = descriptor.num_active_loras
+        if (
+            type(num_tokens) is not int
+            or num_tokens <= 0
+            or (num_reqs is not None and (type(num_reqs) is not int or num_reqs <= 0))
+            or type(uniform) is not bool
+            or type(runtime_mode) is not str
+            or runtime_mode not in {"NONE", "PIECEWISE", "FULL"}
+            or type(has_lora) is not bool
+            or type(num_active_loras) is not int
+            or num_active_loras < 0
+        ):
+            return MusaForwardGraphBucket.invalid()
+        return MusaForwardGraphBucket(
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            uniform=uniform,
+            runtime_mode=runtime_mode,
+            has_lora=has_lora,
+            num_active_loras=num_active_loras,
+            present=True,
+        )
+    except ImportError:
+        # A missing ForwardContext API is dependency drift, not an absent
+        # context.  Mark it present-but-invalid so engine-static profiles
+        # cannot bypass the descriptor, runtime-mode, and LoRA safety checks.
+        return MusaForwardGraphBucket.invalid()
+    except (
+        AssertionError,
+        AttributeError,
+        LookupError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        return MusaForwardGraphBucket.invalid()
+
+
+def query_musa_engine_max_num_seqs() -> int | None:
+    value = os.environ.get(_ENGINE_MAX_NUM_SEQS_ENV)
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+@dataclass(frozen=True, slots=True)
+class MusaKernelHardware:
+    """Device fields that can change a kernel's optimal launch tactic."""
+
+    device_capability: tuple[int, int]
+    multiprocessor_count: int
+
+    @property
+    def is_known(self) -> bool:
+        major, minor = self.device_capability
+        return major >= 0 and minor >= 0 and self.multiprocessor_count > 0
+
+    @property
+    def cache_key(self) -> str:
+        """Stable key fragment for AOT maps and JIT/timing caches."""
+        if not self.is_known:
+            return "unknown"
+        major, minor = self.device_capability
+        return f"mp{major}{minor}-mps{self.multiprocessor_count}"
+
+
+@dataclass(frozen=True, slots=True)
+class MusaMhcWeightedRmsnormTactic:
+    """Exact JIT launch geometry for one weighted-RMSNorm contract."""
+
+    threads: int
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class MusaJitRMSNormTactic:
+    """Exact launch geometry for one native JIT RMSNorm contract."""
+
+    block_threads: int
+    source: str
+
+
+UNKNOWN_MUSA_KERNEL_HARDWARE = MusaKernelHardware(
+    device_capability=(-1, -1),
+    multiprocessor_count=-1,
+)
+_MUSA_KERNEL_HARDWARE_CACHE: dict[int, MusaKernelHardware] = {}
+_FROZEN_MUSA_KERNEL_HARDWARE: dict[int, MusaKernelHardware] = {}
+_MHC_WEIGHTED_RMSNORM_TACTICS: dict[
+    tuple[tuple[int, int], int, int, int, str, str],
+    MusaMhcWeightedRmsnormTactic,
+] = {
+    (
+        (3, 1),
+        48,
+        5,
+        4096,
+        "torch.bfloat16",
+        "torch.bfloat16",
+    ): MusaMhcWeightedRmsnormTactic(
+        threads=256,
+        source="mp48-dsv4-mtp4-m5-wrms-256t-v1",
+    )
+}
+_JIT_RMSNORM_TACTICS: dict[
+    tuple[tuple[int, int], int, str, int, int, str, str],
+    MusaJitRMSNormTactic,
+] = {
+    (
+        (3, 1),
+        60,
+        mode,
+        rows,
+        5120,
+        "torch.bfloat16",
+        "torch.bfloat16",
+    ): MusaJitRMSNormTactic(
+        block_threads=320,
+        source=("mp60-jit-rmsnorm-h5120-320t-" f"{mode}-m{rows}-v1"),
+    )
+    for mode, rows in (
+        ("plain", 512),
+        ("gemma", 512),
+        ("gemma", 4096),
+        ("fused_gemma", 512),
+    )
+} | {
+    (
+        (3, 1),
+        56,
+        mode,
+        512,
+        5120,
+        "torch.bfloat16",
+        "torch.bfloat16",
+    ): MusaJitRMSNormTactic(
+        block_threads=320,
+        source=("mp56-jit-rmsnorm-h5120-320t-" f"{mode}-m512-v1"),
+    )
+    for mode in ("plain", "gemma", "fused", "fused_gemma")
+}
+_JIT_RMSNORM_TACTICS[
+    (
+        (3, 1),
+        48,
+        "plain",
+        512,
+        5120,
+        "torch.bfloat16",
+        "torch.bfloat16",
+    )
+] = MusaJitRMSNormTactic(
+    block_threads=256,
+    source="mp48-jit-rmsnorm-h5120-256t-plain-m512-v1",
+)
+
+
+def query_musa_kernel_hardware(device_index: int) -> MusaKernelHardware:
+    """Return the exact MUSA kernel identity, or an explicit unknown value.
+
+    Do not substitute a common MP count on failure: doing so can select a
+    tactic qualified for a different core-count bin. The query itself is not
+    cached because a call made before device initialization may return unknown;
+    long-lived consumers should cache a successful result at their own boundary.
+    """
+    try:
+        properties = _get_musa_device_properties(device_index)
+        return MusaKernelHardware(
+            device_capability=(int(properties.major), int(properties.minor)),
+            multiprocessor_count=int(properties.multi_processor_count),
+        )
+    except Exception:  # noqa: BLE001 - hardware probing must fail closed
+        return UNKNOWN_MUSA_KERNEL_HARDWARE
+
+
+def query_cached_musa_kernel_hardware(device_index: int) -> MusaKernelHardware:
+    """Cache a known device identity while allowing an early probe to recover."""
+    cached = _MUSA_KERNEL_HARDWARE_CACHE.get(device_index)
+    if cached is not None:
+        return cached
+
+    hardware = query_musa_kernel_hardware(device_index)
+    if hardware.is_known:
+        _MUSA_KERNEL_HARDWARE_CACHE[device_index] = hardware
+    return hardware
+
+
+def prime_musa_kernel_hardware(device_index: int) -> MusaKernelHardware:
+    """Freeze one hardware fingerprint for the lifetime of a worker process.
+
+    Unlike the retryable query cache, an unknown result is intentionally
+    frozen. A worker must not change tactics after compilation or graph capture
+    merely because a later device-property query succeeds.
+    """
+    normalized_index = int(device_index)
+    hardware = _FROZEN_MUSA_KERNEL_HARDWARE.get(normalized_index)
+    if hardware is None:
+        hardware = query_musa_kernel_hardware(normalized_index)
+        _FROZEN_MUSA_KERNEL_HARDWARE[normalized_index] = hardware
+    return hardware
+
+
+def get_primed_musa_kernel_hardware(device_index: int) -> MusaKernelHardware:
+    """Return the frozen fingerprint, or unknown before worker priming."""
+    return _FROZEN_MUSA_KERNEL_HARDWARE.get(
+        int(device_index), UNKNOWN_MUSA_KERNEL_HARDWARE
+    )
+
+
+def select_mhc_weighted_rmsnorm_tactic(
+    *,
+    hardware: MusaKernelHardware,
+    rows: int,
+    hidden_size: int,
+    input_dtype: str,
+    weight_dtype: str,
+    contiguous: bool,
+) -> MusaMhcWeightedRmsnormTactic | None:
+    """Resolve an exact production JIT tactic, with legacy fallback on miss."""
+    if not hardware.is_known or not contiguous:
+        return None
+    return _MHC_WEIGHTED_RMSNORM_TACTICS.get(
+        (
+            hardware.device_capability,
+            hardware.multiprocessor_count,
+            rows,
+            hidden_size,
+            input_dtype,
+            weight_dtype,
+        )
+    )
+
+
+def select_jit_rmsnorm_tactic(
+    *,
+    hardware: MusaKernelHardware,
+    mode: str,
+    rows: int,
+    hidden_size: int,
+    input_dtype: str,
+    weight_dtype: str,
+    contiguous: bool,
+) -> MusaJitRMSNormTactic | None:
+    """Resolve an exact native JIT RMSNorm tactic; never use a nearest MP."""
+    if not hardware.is_known or not contiguous:
+        return None
+    return _JIT_RMSNORM_TACTICS.get(
+        (
+            hardware.device_capability,
+            hardware.multiprocessor_count,
+            mode,
+            rows,
+            hidden_size,
+            input_dtype,
+            weight_dtype,
+        )
+    )
+
+
+def _get_musa_device_properties(device_index: int) -> Any:
+    # Import lazily so offline tactic-map tooling does not require a torch/MUSA
+    # runtime merely to use the integer wave model.
+    import torch
+
+    return torch.musa.get_device_properties(device_index)
+
+
+@dataclass(frozen=True, slots=True)
+class WaveQuantization:
+    """Integer occupancy estimate for a tiled or persistent launch."""
+
+    total_tiles: int
+    resident_slots: int
+    waves: int
+    tail_tiles: int
+    last_wave_utilization: float
+    overall_slot_utilization: float
+
+
+def estimate_wave_quantization(
+    total_tiles: int,
+    multiprocessor_count: int,
+    *,
+    blocks_per_multiprocessor: int = 1,
+) -> WaveQuantization:
+    """Estimate tail-wave loss for one launch geometry.
+
+    This is a ranking signal, not a performance model.  Register pressure,
+    memory traffic, tensor-core efficiency, and synchronization still require
+    measurement on the exact hardware bin.
+    """
+    if total_tiles < 0:
+        raise ValueError(f"total_tiles must be non-negative, got {total_tiles}")
+    if multiprocessor_count <= 0:
+        raise ValueError(
+            "multiprocessor_count must be positive, " f"got {multiprocessor_count}"
+        )
+    if blocks_per_multiprocessor <= 0:
+        raise ValueError(
+            "blocks_per_multiprocessor must be positive, "
+            f"got {blocks_per_multiprocessor}"
+        )
+
+    resident_slots = multiprocessor_count * blocks_per_multiprocessor
+    if total_tiles == 0:
+        return WaveQuantization(
+            total_tiles=0,
+            resident_slots=resident_slots,
+            waves=0,
+            tail_tiles=0,
+            last_wave_utilization=0.0,
+            overall_slot_utilization=0.0,
+        )
+
+    waves = (total_tiles + resident_slots - 1) // resident_slots
+    tail_tiles = total_tiles - (waves - 1) * resident_slots
+    return WaveQuantization(
+        total_tiles=total_tiles,
+        resident_slots=resident_slots,
+        waves=waves,
+        tail_tiles=tail_tiles,
+        last_wave_utilization=tail_tiles / resident_slots,
+        overall_slot_utilization=total_tiles / (waves * resident_slots),
+    )

--- a/vllm_musa/worker.py
+++ b/vllm_musa/worker.py
@@ -4,6 +4,8 @@
 from vllm.config import VllmConfig
 from vllm.v1.worker.gpu_worker import Worker
 
+from vllm_musa.tuning import prime_musa_kernel_hardware
+
 
 class MTGPUWorker(Worker):
     """A worker class that executes (a partition of) the model on a MTGPU.
@@ -27,8 +29,54 @@ class MTGPUWorker(Worker):
             is_driver_worker=is_driver_worker,
         )
 
+    def init_device(self) -> None:
+        super().init_device()
+        device_index = self.device.index
+        prime_musa_kernel_hardware(0 if device_index is None else device_index)
+
     def execute_dummy_batch(self) -> None:
         self.model_runner._dummy_run(
             self.model_runner.uniform_decode_query_len,
             uniform_decode=True,
         )
+
+    def get_musa_cudagraph_runtime_state(self) -> dict[str, object]:
+        """Return the resolved, msgpack-safe cudagraph state for evidence."""
+        runner = self.model_runner
+        dispatcher = getattr(runner, "cudagraph_dispatcher", None)
+        configured_mode = getattr(
+            getattr(runner, "compilation_config", None), "cudagraph_mode", None
+        )
+        if dispatcher is None:
+            return {
+                "rank": self.rank,
+                "local_rank": self.local_rank,
+                "configured_cudagraph_mode": getattr(
+                    configured_mode, "name", str(configured_mode)
+                ),
+                "resolved_cudagraph_mode": "NONE",
+                "keys_initialized": False,
+                "capture_descriptors": {},
+            }
+        capture_descriptors: dict[str, list[dict[str, object]]] = {}
+        for runtime_mode, descriptors in dispatcher.get_capture_descs():
+            capture_descriptors[runtime_mode.name] = [
+                {
+                    "num_tokens": descriptor.num_tokens,
+                    "num_reqs": descriptor.num_reqs,
+                    "uniform": descriptor.uniform,
+                    "has_lora": descriptor.has_lora,
+                    "num_active_loras": descriptor.num_active_loras,
+                }
+                for descriptor in descriptors
+            ]
+        return {
+            "rank": self.rank,
+            "local_rank": self.local_rank,
+            "configured_cudagraph_mode": getattr(
+                configured_mode, "name", str(configured_mode)
+            ),
+            "resolved_cudagraph_mode": dispatcher.cudagraph_mode.name,
+            "keys_initialized": dispatcher.keys_initialized,
+            "capture_descriptors": capture_descriptors,
+        }


### PR DESCRIPTION
## Summary

Select vLLM-MUSA AOT/JIT tiling and dispatch tactics from the runtime MUSA
multi-processor count and validated shape/graph fences. Unsupported shapes keep
the established fallback implementation.

This pull request contains the implementation and reproducible benchmark
harness. Device-specific qualification receipts are kept in the ticket-linked
private evidence bundle and are intentionally not published here.

## Production changes

- Qwen folded-BF16 MoE dispatch has exact runtime hardware/shape/graph policy
  keys with fail-closed fallback behavior.
- DeepSeek-V4 GEMV/O-proj uses an exact runtime MP/shape policy where the
  production ABI exposes a safe selector.
- Top-k, RMSNorm, and provider-owned attention paths remain on their existing
  fallback unless a production-safe selector seam exists.
- Benchmark-only controls stay in the benchmark harness; the serving path does
  not read benchmark override variables.
- GDN, FlashAttention, and FlashMLA remain MATE-provided and outside this PR.

## Publication boundary

- `benchmarks/kernel_tactics/full_kernel_sweep.json` is a source-only callable
  and physical-kernel inventory. It has no timing, result, host, UUID, driver,
  lease, image, or archive metadata.
- `benchmarks/kernel_tactics/mp_tactic_campaign.json` is a portable benchmark
  recipe. Device and fleet qualification parameters are supplied at runtime.
- Model shape JSON files contain only public workload-shape inputs.
- `generated/` is ignored and is not part of the source distribution. Do not
  commit result JSON, device fences, hostnames, package receipts, or timing
  samples.

## Validation

- Static source, catalog, campaign, and benchmark-contract tests pass in the
  clean checkout.
- MUSA model/operator validation was run separately; the exact hardware and
  runtime receipts remain ticket-local and are not reproduced in this public
  description.
- CI and independent reviewer/QA sign-off remain pending.

## Review limits

- Coverage is limited to the declared workload recipes and exact runtime policy
  keys; unknown hardware/shape combinations fail closed.
- A benchmark win is not treated as an end-to-end claim without a production
  path and model-level gate.

## History

The branch was rebuilt as a single commit on the current `v0.28.0-dev` base so
machine-specific qualification receipts are no longer part of the branch
history. Please review the current head after the history rewrite.
