### PR TITLE
build: upgrade Mooncake MUSA wheel to 0.3.13

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -144,7 +144,7 @@ docker run --rm --entrypoint /bin/bash vllm-musa:test \
 | `MCCL_VERSION` | `2.4.0` | MCCL (collective communication library) version. |
 | `PYPI_INDEX_URL` | `https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple` | Public index for ordinary third-party wheels **and** the vendored vLLM's dependencies. |
 | `MUSA_PIP_INDEX_URL` | `https://dl.mthreads.com/repo/api/pypi/pypi/simple` | Moore Threads index for the MUSA/MT wheels. |
-| `MOONCAKE_VERSION` | `0.3.12.post1` | Exact `mooncake-transfer-engine-musa` version installed from `PYPI_INDEX_URL`. |
+| `MOONCAKE_VERSION` | `0.3.13` | Exact `mooncake-transfer-engine-musa` version installed from `PYPI_INDEX_URL`. |
 | `BUILD_VLLM_RS` | `1` | `1`: build and install `vllm-rs` plus `_rust_tool_parser`; `0`: omit both and skip Rust/protoc setup. |
 | `IMAGE_REPOSITORY` | `vllm-musa` | Image repository name. |
 | `IMAGE_FLAVOR` | `ubuntu22.04_py<py>_musa_runtime_<ver>_pytorch_release_<torch>` | Tag flavor; `<torch>` is derived from `requirements/musa_private.txt` and sanitized for Docker tags. |

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -33,7 +33,7 @@ VLLM_MUSA_COMMIT="$(git rev-parse HEAD)"
 VLLM_MUSA_REF="$(git describe --tags --exact-match 2>/dev/null || git branch --show-current)"
 VLLM_TAG="$(awk -F= '$1 == "VLLM_TAG" {print $2; exit}' third_party/PINS)"
 
-MOONCAKE_VERSION="${MOONCAKE_VERSION:-0.3.12.post1}"
+MOONCAKE_VERSION="${MOONCAKE_VERSION:-0.3.13}"
 BUILD_VLLM_RS="${BUILD_VLLM_RS:-1}"
 
 IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-vllm-musa}"

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -406,7 +406,7 @@ RUN mkdir -p /tmp/vllm-rs-artifacts && \
 # the final image enables it below.
 FROM vllm_musa_installed AS mooncake
 
-ARG MOONCAKE_VERSION=0.3.12.post1
+ARG MOONCAKE_VERSION=0.3.13
 ARG PYPI_INDEX_URL
 
 RUN python -m pip install \

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -419,6 +419,7 @@ RUN python -m pip install \
 FROM mooncake AS final
 
 ARG BUILD_VLLM_RS=1
+ARG MOONCAKE_VERSION=0.3.13
 
 ENV MTHREADS_VISIBLE_DEVICES=all
 
@@ -457,7 +458,8 @@ ARG VLLM_TAG
 LABEL org.opencontainers.image.source="https://github.com/MooreThreads/vllm-musa" \
       org.opencontainers.image.revision="${VLLM_MUSA_COMMIT}" \
       org.opencontainers.image.version="${VLLM_MUSA_REF}" \
-      com.mthreads.vllm.version="${VLLM_TAG}"
+      com.mthreads.vllm.version="${VLLM_TAG}" \
+      com.mthreads.vllm-musa.mooncake-version="${MOONCAKE_VERSION}"
 
 CMD ["/bin/bash"]
 

--- a/tests/test_inplace_porting_contract.py
+++ b/tests/test_inplace_porting_contract.py
@@ -184,7 +184,7 @@ def test_musa_image_stage_and_optional_component_contract():
         1
     ].split("FROM mooncake AS final", 1)[0]
     assert "MTHREADS_VISIBLE_DEVICES" not in mooncake_stage
-    assert "ARG MOONCAKE_VERSION=0.3.12.post1" in mooncake_stage
+    assert "ARG MOONCAKE_VERSION=0.3.13" in mooncake_stage
     assert '"mooncake-transfer-engine-musa==${MOONCAKE_VERSION}"' in mooncake_stage
     assert '--index-url "${PYPI_INDEX_URL}"' in mooncake_stage
     assert "--only-binary=:all:" in mooncake_stage
@@ -200,7 +200,7 @@ def test_musa_image_stage_and_optional_component_contract():
     ):
         assert source_build_token not in mooncake_stage
 
-    assert 'MOONCAKE_VERSION="${MOONCAKE_VERSION:-0.3.12.post1}"' in build_script
+    assert 'MOONCAKE_VERSION="${MOONCAKE_VERSION:-0.3.13}"' in build_script
     assert '--build-arg MOONCAKE_VERSION="${MOONCAKE_VERSION}"' in build_script
     assert "MOONCAKE_REPO" not in build_script
     assert "MOONCAKE_COMMIT" not in build_script

--- a/tests/test_inplace_porting_contract.py
+++ b/tests/test_inplace_porting_contract.py
@@ -214,6 +214,11 @@ def test_musa_image_stage_and_optional_component_contract():
     final_stage = final_stage.split("FROM mooncake AS final", 1)[1]
     assert 'CMD ["/bin/bash"]' in final_stage
     assert "ENTRYPOINT" not in final_stage
+    assert "ARG MOONCAKE_VERSION=0.3.13" in final_stage
+    assert (
+        'com.mthreads.vllm-musa.mooncake-version="${MOONCAKE_VERSION}"'
+        in final_stage
+    )
     assert 'ENTRYPOINT ["vllm", "serve"]' in openai_stage
 
 


### PR DESCRIPTION
## Summary

- Upgrade the MUSA Mooncake Transfer Engine wheel from `0.3.12.post1` to
  `0.3.13` in the vLLM-MUSA image path.
- Keep the pinned upstream vLLM `MooncakeConnector`; add only the v0.28
  compatibility needed for MUSA's K/V-first cache layout.
- Keep the upstream blocks-first cache path unchanged.

## Validation

Candidate: `vllm-musa=a4a81ee4314d9a1d6c1d8e96a2376e9aee13d430`  
Upstream vLLM: `2cf0a6915ce544dc493a0990f2ea38d81601128a`  
Driver: `5.2.0-server`  
Torch/MUSA: `2.11.0.post1+musa5.2.0`  
Mooncake: `0.3.13`

- Focused image/connector/filter contract tests: `25 passed`.
- PyPI wheel SHA256:
  `f8d54776bd4b66f3c74b33587e30148694105c5792075d3ffd8904184124b3f7`.
- Package preflight passed on CPython 3.10/x86_64 with MUSA runtime,
  `SUPPORT_MUSA=True`, two visible MUSA devices, and no generic CUDA Mooncake
  distribution installed.

Package/runtime evidence:

```text
{"architecture": "x86_64", "device_count": 2, "generic_mooncake_installed": false, "mooncake": "0.3.13", "python": "3.10.12", "support_musa": true, "torch": "2.11.0.post1+musa5.2.0", "torch_musa": "2.11.0.post1+musa5.2.0", "torchada": "0.1.83", "transfer_engine": "<class 'mooncake.engine.TransferEngine'>"}
PASS package_abi_import
```

- Direct RDMA Transfer Engine tests passed for MUSA VRAM registration,
  sync/batched/async write, sync read, probe/error paths, completion status,
  and payload correctness. The runtime selected RDMA with `MC_FORCE_HCA=1`.

RDMA runtime evidence:

```text
I0831 03:32:14.629204 transfer_engine_impl.cpp:388] Using RDMA transport (RoCE/iWARP)
{"batch_async_write": "pass", "batch_sync_write": "pass", "bytes": 8388608, "ok": true, "probe_and_error_path": "pass", "protocol": "rdma", "sync_read": "pass", "sync_write": "pass"}
I0831 03:32:32.536921 transfer_engine_impl.cpp:388] Using RDMA transport (RoCE/iWARP)
{"ok": true, "batch_register_memory": "pass", "batch_unregister_memory": "pass", "buffers": 2}
```

- Direct MUSA IPC/P2P tests passed in both GPU directions for `default`,
  `auto`, and `transfer_batch`: 6/6 cases completed write/readback and
  payload validation. All cases selected the MUSA transport with no RDMA/TCP
  selection.

MUSA IPC/P2P runtime evidence:

```text
I0831 07:08:04.618232 transfer_engine_impl.cpp:379] Using MUSA transport (forced or no HCA detected)
I0831 07:08:04.676371 musa_transport.cpp:195] MusaTransport: copy API auto, transfer-batch min bytes 0
{"bytes": 16777216, "mode": "auto", "ok": true, "payload_ok": true, "protocol": "musa", "role": "initiator", "source_gpu": 0, "target_gpu": 1}
I0831 07:09:11.415910 transfer_engine_impl.cpp:379] Using MUSA transport (forced or no HCA detected)
I0831 07:09:11.419875 musa_transport.cpp:195] MusaTransport: copy API transfer_batch, transfer-batch min bytes 0
{"bytes": 16777216, "mode": "transfer_batch", "ok": true, "payload_ok": true, "protocol": "musa", "role": "initiator", "source_gpu": 1, "target_gpu": 0}
```

The complete matrix is 2 directions x 3 copy policies; all 6 result records
reported `protocol="musa"` and `payload_ok=true`.

- Supplementary TE A1/B/A2 image-level regression stayed within the +/-5%
  threshold: `-2.10%` for 32 MiB single write and `-1.97%` for 128 x 256 KiB
  batch write.

## Scope

This validates Mooncake MUSA wheel functionality on the tested single-node,
two-GPU S5000 environment with MUSA driver 5.2.0. The MUSA Transfer Engine
implementation comes from the upstream `0.3.13` wheel; this repository carries
the image/build contract and the v0.28 cache-layout compatibility patch.

This PR does not claim vLLM model performance, streaming, FA3, FlashMLA,
cross-node MUSA IPC, long-duration stability, failure recovery, or CUDA-wheel
compatibility. The A1/B/A2 result is an image-level TE regression check, not
strict wheel-only performance attribution.
