### PR TITLE
fix(musa): preserve DeepSeek-V4 MTP verification semantics

### DIFF
--- a/tests/test_deepseek_v4_mtp_cache_sharing_patch.py
+++ b/tests/test_deepseek_v4_mtp_cache_sharing_patch.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0112-MUSA-share-DSV4-MTP-indexer-cache-rows.patch"
+)
+
+
+def _text() -> str:
+    return PATCH.read_text(encoding="utf-8")
+
+
+def _changed_files(text: str) -> set[str]:
+    return {
+        line[len("+++ b/") :]
+        for line in text.splitlines()
+        if line.startswith("+++ b/")
+    }
+
+
+def test_mtp_indexer_gathers_cache_once_per_request() -> None:
+    text = _text()
+
+    assert "batch_size = int(getattr(batch_descriptor, \"num_reqs\", 0) or 0)" in text
+    assert "next_n = rows // batch_size" in text
+    assert "request_block_table = raw_block_table[::next_n]" in text
+    assert "+        batch_size,\n         max_pages,\n         total_dim," in text
+    assert ".reshape(batch_size, next_n * 64, 128)" in text
+    assert ".reshape(\n+        rows,\n+        64," in text
+
+
+def test_mtp_indexer_cache_sharing_patch_is_scoped() -> None:
+    assert _changed_files(_text()) == {
+        "vllm/model_executor/layers/sparse_attn_indexer.py"
+    }

--- a/tests/test_deepseek_v4_mtp_event_isolation_patch.py
+++ b/tests/test_deepseek_v4_mtp_event_isolation_patch.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0113-MUSA-isolate-DSV4-MTP-target-overlap-events.patch"
+)
+
+
+def _text() -> str:
+    return PATCH.read_text(encoding="utf-8")
+
+
+def _changed_files(text: str) -> set[str]:
+    return {
+        line[len("+++ b/") :]
+        for line in text.splitlines()
+        if line.startswith("+++ b/")
+    }
+
+
+def test_mtp_target_uses_independent_overlap_events() -> None:
+    text = _text()
+
+    assert "self.mtp_multi_ln_events = [torch.cuda.Event() for _ in range(4)]" in text
+    assert "is_mtp_multi = _musa_dsv4_mtp_multi_request_graph()" in text
+    assert "ln_events = self.mtp_multi_ln_events if is_mtp_multi else self.ln_events" in text
+    assert "aux_streams = self.aux_stream_list" in text
+    assert "ln_events[0]" in text
+    assert "ln_events[1:4]" in text
+
+
+def test_mtp_event_isolation_patch_only_changes_attention() -> None:
+    assert _changed_files(_text()) == {
+        "vllm/models/deepseek_v4/attention.py"
+    }

--- a/tests/test_deepseek_v4_mtp_indexer_patch.py
+++ b/tests/test_deepseek_v4_mtp_indexer_patch.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0111-MUSA-accelerate-DSV4-MTP-learned-indexer.patch"
+)
+
+
+def _patch_text() -> str:
+    return PATCH.read_text(encoding="utf-8")
+
+
+def test_mtp_indexer_preserves_cache_storage_stride() -> None:
+    text = _patch_text()
+
+    assert "_musa_indexer_cache_rows(kv_cache)" in text
+    assert "cache_rows.index_select(0, page_ids.reshape(-1))" in text
+    assert "page-tail scales" in text
+
+
+def test_mtp_indexer_decodes_fp8_and_uses_bf16_gemm() -> None:
+    text = _patch_text()
+
+    assert "q_quant[:rows].contiguous().view(torch.float8_e4m3fn)" in text
+    assert ".view(torch.float8_e4m3fn)" in text
+    assert "per_head = torch.bmm(q, k.transpose(1, 2))" in text
+    assert "_musa_try_fill_mtp_topk_bf16" in text
+
+
+def test_mtp_indexer_patch_is_scoped_to_sparse_indexer() -> None:
+    changed_files = {
+        line.removeprefix("+++ b/")
+        for line in _patch_text().splitlines()
+        if line.startswith("+++ b/")
+    }
+
+    assert changed_files == {
+        "vllm/model_executor/layers/sparse_attn_indexer.py",
+    }

--- a/tests/test_deepseek_v4_mtp_verification_source.py
+++ b/tests/test_deepseek_v4_mtp_verification_source.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0110-MUSA-preserve-DeepSeek-V4-MTP-verification-semantics.patch"
+)
+
+
+def _patch_text() -> str:
+    return PATCH.read_text(encoding="utf-8")
+
+
+def test_mtp_verification_uses_graph_descriptor_before_config() -> None:
+    text = _patch_text()
+
+    descriptor_pos = text.index(
+        "batch_descriptor = get_forward_context().batch_descriptor"
+    )
+    config_pos = text.index("config = get_current_vllm_config()")
+
+    assert descriptor_pos < config_pos
+    assert "batch_descriptor.num_tokens > batch_descriptor.num_reqs" in text
+    assert "speculative_config.method != \"mtp\"" in text
+
+
+def test_mtp_verification_keeps_learned_indexer_semantics() -> None:
+    text = _patch_text()
+
+    assert "or _musa_sparse_indexer_mtp_requires_learned()" in text
+    assert (
+        "if _musa_sparse_indexer_mtp_requires_learned():\n"
+        "+            return False"
+    ) in text
+
+
+def test_multi_request_mtp_graph_serializes_both_aux_groups() -> None:
+    text = _patch_text()
+
+    assert "and batch_descriptor.num_reqs > 1" in text
+    assert text.count("_musa_dsv4_mtp_multi_request_graph()") == 3
+    assert (
+        "_musa_dsv4_mtp_multi_request_graph()\n"
+        "+                or not _musa_deepseek_v4_aux_overlap_enabled"
+    ) in text
+
+
+def test_patch_is_scoped_to_deepseek_v4_runtime() -> None:
+    changed_files = {
+        line.removeprefix("+++ b/")
+        for line in _patch_text().splitlines()
+        if line.startswith("+++ b/")
+    }
+
+    assert changed_files == {
+        "vllm/model_executor/layers/sparse_attn_indexer.py",
+        "vllm/models/deepseek_v4/attention.py",
+    }

--- a/vllm_musa/patches/series/0110-MUSA-preserve-DeepSeek-V4-MTP-verification-semantics.patch
+++ b/vllm_musa/patches/series/0110-MUSA-preserve-DeepSeek-V4-MTP-verification-semantics.patch
@@ -1,0 +1,131 @@
+From 043cf3efaf6717e3d43d3028f10af524b31c18f8 Mon Sep 17 00:00:00 2001
+From: Joey-gvwal <joey_gvwal@yeah.net>
+Date: Wed, 26 Aug 2026 01:37:39 +0800
+Subject: [PATCH] MUSA: preserve DeepSeek-V4 MTP verification semantics
+
+---
+ .../layers/sparse_attn_indexer.py             | 38 ++++++++++++++++++-
+ vllm/models/deepseek_v4/attention.py          | 23 ++++++++++-
+ 2 files changed, 58 insertions(+), 3 deletions(-)
+
+diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
+index 77b78e6e25..11b8fc8781 100644
+--- a/vllm/model_executor/layers/sparse_attn_indexer.py
++++ b/vllm/model_executor/layers/sparse_attn_indexer.py
+@@ -11,6 +11,7 @@ from vllm_musa import _custom_ops as _musa_custom_ops
+ from vllm import _custom_ops as ops
+ from vllm._aiter_ops import rocm_aiter_ops
+ from vllm.compilation.breakable_cudagraph import eager_break_during_capture
++from vllm.config import get_current_vllm_config
+ from vllm.forward_context import get_forward_context
+ from vllm.logger import init_logger
+ from vllm.model_executor.custom_op import CustomOp
+@@ -199,6 +200,35 @@ def _musa_sparse_indexer_graph_exact_decode_enabled() -> bool:
+     return os.getenv("VLLM_MUSA_SPARSE_INDEXER_GRAPH_EXACT_DECODE", "0") == "1"
+ 
+ 
++def _musa_sparse_indexer_mtp_requires_learned() -> bool:
++    """MTP verification must use the learned indexer semantics."""
++    batch_descriptor = get_forward_context().batch_descriptor
++    if (
++        batch_descriptor is not None
++        and batch_descriptor.uniform
++        and batch_descriptor.num_reqs is not None
++        and batch_descriptor.num_reqs > 0
++    ):
++        # The target verification graph has multiple tokens per request,
++        # whereas ordinary decode and the MTP drafter have one. Derive this
++        # from the graph descriptor because capture runs without a current
++        # VllmConfig installed in the worker context.
++        return batch_descriptor.num_tokens > batch_descriptor.num_reqs
++
++    # KV-cache profiling invokes a dummy forward before the worker installs
++    # the request config. Outside a uniform graph, retain the conservative
++    # config-based MTP fallback.
++    try:
++        config = get_current_vllm_config()
++    except AssertionError:
++        return False
++    speculative_config = getattr(config, "speculative_config", None)
++    if speculative_config is None or speculative_config.method != "mtp":
++        return False
++    # Unknown/mixed MTP graph: use the exact learned semantics conservatively.
++    return True
++
++
+ def _musa_sparse_indexer_native_decode_enabled() -> bool:
+     # The native DeepSeek-V4 indexer implementation is the validated MUSA
+     # path. Keep it shape-gated at the call sites, but do not make production
+@@ -1226,7 +1256,11 @@ def _musa_fill_exact_sparse_indexer_indices(
+             and q_quant.shape[1] == 32
+             and _musa_sparse_indexer_glm52_materialized_enabled()
+         )
+-        if is_glm52_graph_path or _musa_sparse_indexer_graph_exact_decode_enabled():
++        if (
++            is_glm52_graph_path
++            or _musa_sparse_indexer_graph_exact_decode_enabled()
++            or _musa_sparse_indexer_mtp_requires_learned()
++        ):
+             return _musa_fill_exact_sparse_indexer_indices_capture(
+                 hidden_states,
+                 k_cache_prefix,
+@@ -1837,6 +1871,8 @@ class SparseAttnIndexer(CustomOp):
+         projections while still running the compressor that maintains the
+         indexer state and K cache for a later eager/exact fallback.
+         """
++        if _musa_sparse_indexer_mtp_requires_learned():
++            return False
+         return (
+             current_platform.is_musa()
+             and self.use_musa_native_indexer
+diff --git a/vllm/models/deepseek_v4/attention.py b/vllm/models/deepseek_v4/attention.py
+index 7d85116c2d..702d94032d 100644
+--- a/vllm/models/deepseek_v4/attention.py
++++ b/vllm/models/deepseek_v4/attention.py
+@@ -69,6 +69,18 @@ _MUSA_DEEPSEEK_V4_SCORE_FP32_DEEPGEMM_MAX_TOKENS = 16
+ _MUSA_DEEPSEEK_V4_AUX_OVERLAP_MAX_TOKENS = 1024
+ 
+ 
++def _musa_dsv4_mtp_multi_request_graph() -> bool:
++    """Whether this is a multi-request speculative verification graph."""
++    batch_descriptor = get_forward_context().batch_descriptor
++    return bool(
++        batch_descriptor is not None
++        and batch_descriptor.uniform
++        and batch_descriptor.num_reqs is not None
++        and batch_descriptor.num_reqs > 1
++        and batch_descriptor.num_tokens > batch_descriptor.num_reqs
++    )
++
++
+ def _musa_deepseek_v4_aux_overlap_enabled(num_tokens: int) -> bool:
+     """Keep MUSA aux-stream overlap away from long-prefill kernels.
+ 
+@@ -489,7 +501,11 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+         hidden_states: torch.Tensor,
+         use_recent_indexer: bool,
+     ) -> tuple[Any, ...]:
+-        aux_streams = self.aux_stream_list
++        aux_streams = (
++            None
++            if _musa_dsv4_mtp_multi_request_graph()
++            else self.aux_stream_list
++        )
+         if aux_streams is not None:
+             assert len(aux_streams) >= 3
+             aux_streams = aux_streams[:3]
+@@ -574,7 +590,10 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+         # overlap with default's GEMM + cache write.
+         if self.indexer is not None:
+             aux_streams = self.aux_stream_list
+-            if not _musa_deepseek_v4_aux_overlap_enabled(hidden_states.shape[0]):
++            if (
++                _musa_dsv4_mtp_multi_request_graph()
++                or not _musa_deepseek_v4_aux_overlap_enabled(hidden_states.shape[0])
++            ):
+                 aux_streams = None
+             indexer = self.indexer
+             # Local ref so the closure keeps a non-None type for mypy.
+-- 
+2.25.1
+

--- a/vllm_musa/patches/series/0111-MUSA-accelerate-DSV4-MTP-learned-indexer.patch
+++ b/vllm_musa/patches/series/0111-MUSA-accelerate-DSV4-MTP-learned-indexer.patch
@@ -1,0 +1,165 @@
+From 08619ad45f5c39cb7d3631875cd50b68c9a99e30 Mon Sep 17 00:00:00 2001
+From: Joey-gvwal <joey_gvwal@yeah.net>
+Date: Wed, 26 Aug 2026 20:58:34 +0800
+Subject: [PATCH] perf(musa): accelerate DSV4 MTP learned indexer
+
+---
+ .../layers/sparse_attn_indexer.py             | 135 +++++++++++++++++-
+ 1 file changed, 134 insertions(+), 1 deletion(-)
+
+diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
+index 11b8fc8781..15007b169f 100644
+--- a/vllm/model_executor/layers/sparse_attn_indexer.py
++++ b/vllm/model_executor/layers/sparse_attn_indexer.py
+@@ -915,6 +915,129 @@ def _musa_indexer_cache_rows(kv_cache: torch.Tensor) -> torch.Tensor:
+     )
+ 
+ 
++def _musa_try_fill_mtp_topk_bf16(
++    q_quant: torch.Tensor,
++    kv_cache: torch.Tensor,
++    weights: torch.Tensor,
++    decode_metadata,
++    topk_indices: torch.Tensor,
++    topk_tokens: int,
++    max_model_len: int,
++) -> bool:
++    """Run the learned MTP indexer with a graph-safe BF16 GEMM path.
++
++    The native decode kernel is intentionally not used for MTP verification:
++    its fixed-width path does not represent the request-to-token expansion.
++    This implementation follows sglang's paged formulation while preserving
++    vLLM's storage-stride view of the FP8 cache.  In particular, selecting a
++    complete physical page from ``_musa_indexer_cache_rows`` keeps the K bytes
++    and their page-tail scales in their original layout.
++    """
++    if (
++        not _musa_sparse_indexer_mtp_requires_learned()
++        or q_quant.dtype != torch.float8_e4m3fn
++        or q_quant.ndim != 3
++        or q_quant.shape[1] != 64
++        or q_quant.shape[2] != 128
++        or kv_cache.dtype != torch.uint8
++    ):
++        return False
++
++    seq_lens = decode_metadata.seq_lens.reshape(-1)
++    rows = min(
++        int(q_quant.shape[0]),
++        int(seq_lens.numel()),
++        int(topk_indices.shape[0]),
++    )
++    if rows <= 0:
++        return False
++
++    block_table = _musa_decode_block_table_for_token_rows(
++        decode_metadata.block_table,
++        rows,
++    )
++    if block_table is None or block_table.shape[1] <= 0:
++        return False
++
++    page_size = int(kv_cache.shape[1])
++    max_pages = min(
++        int(block_table.shape[1]),
++        (int(max_model_len) + page_size - 1) // page_size,
++    )
++    if max_pages <= 0:
++        return False
++
++    cache_rows = _musa_indexer_cache_rows(kv_cache)
++    total_dim = int(cache_rows.shape[1])
++    k_bytes = page_size * 128
++    scale_bytes = page_size * 4
++    if total_dim < k_bytes + scale_bytes:
++        return False
++
++    page_ids = block_table[:, :max_pages].clamp(min=0).to(torch.long)
++    gathered = cache_rows.index_select(0, page_ids.reshape(-1)).view(
++        rows,
++        max_pages,
++        total_dim,
++    )
++
++    k = (
++        gathered[..., :k_bytes]
++        .contiguous()
++        .view(torch.float8_e4m3fn)
++        .to(torch.bfloat16)
++        .reshape(rows, max_pages * page_size, 128)
++    )
++    scales = (
++        gathered[..., k_bytes : k_bytes + scale_bytes]
++        .contiguous()
++        .view(torch.float32)
++        .to(torch.bfloat16)
++        .reshape(rows, max_pages * page_size)
++    )
++    k = k * scales.unsqueeze(-1)
++    q = q_quant[:rows].contiguous().view(torch.float8_e4m3fn).to(
++        torch.bfloat16
++    )
++    per_head = torch.bmm(q, k.transpose(1, 2))
++    per_head = torch.relu(per_head)
++    logits = torch.bmm(
++        weights[:rows].to(torch.bfloat16).contiguous().unsqueeze(1),
++        per_head,
++    ).squeeze(1)
++
++    positions = torch.arange(
++        max_pages * page_size,
++        device=q_quant.device,
++    )
++    logits = logits.masked_fill(
++        positions.unsqueeze(0) >= seq_lens[:rows].unsqueeze(-1),
++        float("-inf"),
++    )
++    if logits.shape[1] < max_model_len:
++        logits = torch.nn.functional.pad(
++            logits,
++            (0, max_model_len - logits.shape[1]),
++            value=float("-inf"),
++        )
++    else:
++        logits = logits[:, :max_model_len]
++
++    topk = min(int(topk_tokens), int(topk_indices.shape[1]))
++    if topk <= 0:
++        return True
++    indices = torch.topk(logits, topk, dim=-1, sorted=True).indices
++    valid_counts = seq_lens[:rows].clamp(min=0, max=topk).unsqueeze(-1)
++    rank = torch.arange(topk, device=q_quant.device).unsqueeze(0)
++    indices = torch.where(
++        rank < valid_counts,
++        indices,
++        torch.full_like(indices, -1),
++    )
++    topk_indices[:rows, :topk].copy_(indices.to(topk_indices.dtype))
++    return True
++
++
+ def _musa_dequant_indexer_fp8_cache_row(
+     kv_cache: torch.Tensor,
+     block_id: int,
+@@ -1195,7 +1318,17 @@ def _musa_fill_exact_sparse_indexer_indices_capture(
+     topk_indices_buffer[: hidden_states.shape[0]] = -1
+ 
+     if metadata.num_decodes > 0 and metadata.decode is not None:
+-        if not _musa_try_fill_decode_topk_from_indexer_cache_native(
++        if _musa_try_fill_mtp_topk_bf16(
++            q_quant[: metadata.num_decode_tokens],
++            kv_cache,
++            weights[: metadata.num_decode_tokens],
++            metadata.decode,
++            topk_indices_buffer[: metadata.num_decode_tokens, :topk_tokens],
++            topk_tokens,
++            max_model_len,
++        ):
++            pass
++        elif not _musa_try_fill_decode_topk_from_indexer_cache_native(
+             q_quant[: metadata.num_decode_tokens],
+             kv_cache,
+             weights[: metadata.num_decode_tokens],
+-- 
+2.25.1
+

--- a/vllm_musa/patches/series/0112-MUSA-share-DSV4-MTP-indexer-cache-rows.patch
+++ b/vllm_musa/patches/series/0112-MUSA-share-DSV4-MTP-indexer-cache-rows.patch
@@ -1,0 +1,96 @@
+From eed3935880b8760e6f3c923bbfdd57196e68ed5e Mon Sep 17 00:00:00 2001
+From: Joey-gvwal <joey_gvwal@yeah.net>
+Date: Thu, 27 Aug 2026 22:24:17 +0800
+Subject: [PATCH] MUSA: share DSV4 MTP indexer cache rows
+
+---
+ .../layers/sparse_attn_indexer.py             | 45 +++++++++++++------
+ 1 file changed, 31 insertions(+), 14 deletions(-)
+
+diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
+index 15007b169f..1b1f8496cb 100644
+--- a/vllm/model_executor/layers/sparse_attn_indexer.py
++++ b/vllm/model_executor/layers/sparse_attn_indexer.py
+@@ -952,16 +952,25 @@ def _musa_try_fill_mtp_topk_bf16(
+     if rows <= 0:
+         return False
+ 
+-    block_table = _musa_decode_block_table_for_token_rows(
+-        decode_metadata.block_table,
+-        rows,
+-    )
+-    if block_table is None or block_table.shape[1] <= 0:
++    batch_descriptor = get_forward_context().batch_descriptor
++    batch_size = int(getattr(batch_descriptor, "num_reqs", 0) or 0)
++    if batch_size <= 0 or rows % batch_size != 0:
++        return False
++    next_n = rows // batch_size
++
++    raw_block_table = decode_metadata.block_table
++    if raw_block_table.shape[0] == batch_size:
++        request_block_table = raw_block_table
++    elif raw_block_table.shape[0] == rows:
++        request_block_table = raw_block_table[::next_n]
++    else:
++        return False
++    if request_block_table.shape[1] <= 0:
+         return False
+ 
+     page_size = int(kv_cache.shape[1])
+     max_pages = min(
+-        int(block_table.shape[1]),
++        int(request_block_table.shape[1]),
+         (int(max_model_len) + page_size - 1) // page_size,
+     )
+     if max_pages <= 0:
+@@ -974,9 +983,9 @@ def _musa_try_fill_mtp_topk_bf16(
+     if total_dim < k_bytes + scale_bytes:
+         return False
+ 
+-    page_ids = block_table[:, :max_pages].clamp(min=0).to(torch.long)
++    page_ids = request_block_table[:, :max_pages].clamp(min=0).to(torch.long)
+     gathered = cache_rows.index_select(0, page_ids.reshape(-1)).view(
+-        rows,
++        batch_size,
+         max_pages,
+         total_dim,
+     )
+@@ -986,21 +995,29 @@ def _musa_try_fill_mtp_topk_bf16(
+         .contiguous()
+         .view(torch.float8_e4m3fn)
+         .to(torch.bfloat16)
+-        .reshape(rows, max_pages * page_size, 128)
++        .reshape(batch_size, max_pages * page_size, 128)
+     )
+     scales = (
+         gathered[..., k_bytes : k_bytes + scale_bytes]
+         .contiguous()
+         .view(torch.float32)
+         .to(torch.bfloat16)
+-        .reshape(rows, max_pages * page_size)
++        .reshape(batch_size, max_pages * page_size)
+     )
+     k = k * scales.unsqueeze(-1)
+-    q = q_quant[:rows].contiguous().view(torch.float8_e4m3fn).to(
+-        torch.bfloat16
++    q = (
++        q_quant[:rows]
++        .contiguous()
++        .view(torch.float8_e4m3fn)
++        .to(torch.bfloat16)
++        .reshape(batch_size, next_n * 64, 128)
++    )
++    per_head = torch.bmm(q, k.transpose(1, 2)).reshape(
++        rows,
++        64,
++        max_pages * page_size,
+     )
+-    per_head = torch.bmm(q, k.transpose(1, 2))
+-    per_head = torch.relu(per_head)
++    per_head.relu_()
+     logits = torch.bmm(
+         weights[:rows].to(torch.bfloat16).contiguous().unsqueeze(1),
+         per_head,
+-- 
+2.25.1
+

--- a/vllm_musa/patches/series/0113-MUSA-isolate-DSV4-MTP-target-overlap-events.patch
+++ b/vllm_musa/patches/series/0113-MUSA-isolate-DSV4-MTP-target-overlap-events.patch
@@ -1,0 +1,52 @@
+From ef18f295e17159d03b58b78caa54e0a2ef5c6a35 Mon Sep 17 00:00:00 2001
+From: Joey-gvwal <joey_gvwal@yeah.net>
+Date: Thu, 27 Aug 2026 22:25:35 +0800
+Subject: [PATCH] MUSA: isolate DSV4 MTP target overlap events
+
+---
+ vllm/models/deepseek_v4/attention.py | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/vllm/models/deepseek_v4/attention.py b/vllm/models/deepseek_v4/attention.py
+index 702d94032d..03fbc4c1a1 100644
+--- a/vllm/models/deepseek_v4/attention.py
++++ b/vllm/models/deepseek_v4/attention.py
+@@ -400,6 +400,9 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+         # [1] doubles as post-GEMM event1. Reuse is safe: GEMM fully joins
+         # before post-GEMM starts.
+         self.ln_events = [torch.cuda.Event() for _ in range(4)]
++        # The MTP target and its single-token drafter are captured as distinct
++        # graphs. Do not share event generations across their graph replays.
++        self.mtp_multi_ln_events = [torch.cuda.Event() for _ in range(4)]
+ 
+         assert cache_config is not None, "DeepseekV4 attention requires cache_config"
+         # ---- Attention / KV-cache setup ----
+@@ -501,11 +504,9 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+         hidden_states: torch.Tensor,
+         use_recent_indexer: bool,
+     ) -> tuple[Any, ...]:
+-        aux_streams = (
+-            None
+-            if _musa_dsv4_mtp_multi_request_graph()
+-            else self.aux_stream_list
+-        )
++        is_mtp_multi = _musa_dsv4_mtp_multi_request_graph()
++        ln_events = self.mtp_multi_ln_events if is_mtp_multi else self.ln_events
++        aux_streams = self.aux_stream_list
+         if aux_streams is not None:
+             assert len(aux_streams) >= 3
+             aux_streams = aux_streams[:3]
+@@ -556,8 +557,8 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+         qr_kv, (kv_score, indexer_weights, indexer_kv_score) = execute_in_parallel(
+             fused_wqa_wkv,
+             aux_fns,
+-            self.ln_events[0],
+-            self.ln_events[1:4],
++            ln_events[0],
++            ln_events[1:4],
+             aux_streams,
+             enable=(
+                 hidden_states.shape[0]
+-- 
+2.25.1
+

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,7 +17,7 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **115 patches**. This branch includes the Qwen3.6 patches for common
+Currently **120 patches**. This branch includes the Qwen3.6 patches for common
 GDN decode metadata reuse, uniform-decode SSM slot-mapping removal, and the
 BF16 W1 tile specialization, plus the contract-bound DeepSeek-V4 MTP
 sparse-prefill headroom and mixed-prefill queue-fence patches. It additionally


### PR DESCRIPTION
## Summary

During DeepSeek-V4 MTP verification, one request expands to multiple target
verification tokens while the drafter and normal decode use one token per
request. The generic/native sparse-indexer path and the learned-indexer path
must therefore be selected from the actual graph batch shape. Reusing the
wrong semantic path can produce incorrect target logits and a low MTP
acceptance rate.

The target and drafter are also captured as different CUDA-graph instances.
Sharing the same layer-normalization event generations between those graph
replays can create cross-graph event reuse and synchronization hazards,
especially when auxiliary-stream overlap is enabled.

## Changes

- Preserve learned-indexer semantics for MTP target verification
- Graph-safe learned MTP indexer implementation
- Share request-level cache rows across speculative tokens
- Isolate MTP target overlap events

## Accuracy validation



Measured result:

| Metric | Correct | Total | Score |
|---|---:|---:|---:|
| flexible exact-match | 1214 | 1319 | **92.04%** |
| strict exact-match | 1215 | 1319 | **92.12%** |

## MTP4 performance validation

```bash
COMPILATION_CONFIG='{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","max_cudagraph_capture_size":320,"cudagraph_capture_sizes":[5,10,20,40,80,160,320],"cudagraph_copy_inputs":false}'
SPECULATIVE_CONFIG='{"method":"mtp","num_speculative_tokens":4}'

vllm serve /home/dist/models/DeepSeek-V4-Flash-Base \
  --served-model-name deepseek \
  --gpu-memory-utilization 0.95 \
  --max-model-len 6144 \
  --max-num-seqs 64 \
  --max-num-batched-tokens 8195 \
  --safetensors-load-strategy prefetch \
  --tensor-parallel-size 8 \
  -ac.backend FLASHMLA \
  --port 8522 \
  --host 0.0.0.0 \
  --kv-cache-dtype fp8 \
  --no-enable-prefix-caching \
  --async-scheduling \
  --compilation-config "$COMPILATION_CONFIG" \
  --speculative-config "$SPECULATIVE_CONFIG"
```


| Round | Input | Output | TPS | Acceptance rate | Acceptance length | Mean TTFT | Mean TPOT |
|---|---:|---:|---:|---:|---:|---:|---:|
| 1 | 4096 | 1024 | 83.49 | 47.66% | 2.91 | 822.60 ms | 11.18 ms |
| 2 | 4096 | 1024 | 101.73 | 64.29% | 3.57 | 814.96 ms | 9.04 ms |
| 3 | 4096 | 1024 | 89.68 | 52.96% | 3.12 | 812.98 ms | 10.37 ms |
| 4 | 4096 | 1024 | 75.39 | 39.97% | 2.60 | 824.39 ms | 12.47 ms |
| 5 | 4096 | 1024 | 108.51 | 71.24% | 3.85 | 818.21 ms | 8.42 ms |
