### PR TITLE
fix: avoid registered custom AR inputs in piecewise graphs

### DIFF
--- a/tests/test_musa_jit_custom_all_reduce_graph.py
+++ b/tests/test_musa_jit_custom_all_reduce_graph.py
@@ -310,6 +310,56 @@ def test_mtp_graph_registration_accepts_bounded_multi_capture_inputs():
     )
 
 
+@pytest.mark.parametrize(
+    ("piecewise_capture", "expected"),
+    [(False, True), (True, False)],
+)
+def test_graph_registered_inputs_skip_piecewise_capture(
+    monkeypatch: pytest.MonkeyPatch,
+    piecewise_capture: bool,
+    expected: bool,
+) -> None:
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+    impl._use_graph_registered_inputs = True
+    impl._graph_registered_input_enabled = True
+    impl._IS_CAPTURING = True
+    monkeypatch.setattr(impl, "_is_current_stream_capturing", lambda: True)
+    monkeypatch.setattr(
+        impl,
+        "_is_piecewise_cudagraph_capture",
+        lambda: piecewise_capture,
+        raising=False,
+    )
+    tensor = torch.empty((128, 2048), dtype=torch.bfloat16)
+
+    assert impl._use_registered_graph_input(tensor) is expected
+
+
+@pytest.mark.parametrize(
+    ("runtime_mode", "expected"),
+    [("FULL", False), ("PIECEWISE", True)],
+)
+def test_piecewise_capture_detects_forward_context(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_mode: str,
+    expected: bool,
+) -> None:
+    from vllm import forward_context
+    from vllm.config import CUDAGraphMode
+
+    monkeypatch.setattr(forward_context, "is_forward_context_available", lambda: True)
+    monkeypatch.setattr(
+        forward_context,
+        "get_forward_context",
+        lambda: SimpleNamespace(
+            cudagraph_runtime_mode=getattr(CUDAGraphMode, runtime_mode)
+        ),
+    )
+    impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
+
+    assert impl._is_piecewise_cudagraph_capture() is expected
+
+
 def test_graph_staging_uses_disjoint_preallocated_slots_per_ordinal(monkeypatch):
     impl = object.__new__(custom_ar._MusaJitCustomAllreduceImpl)
     impl._use_graph_staging_arena = True

--- a/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
+++ b/vllm_musa/distributed/device_communicators/musa_jit_custom_all_reduce.py
@@ -1094,12 +1094,26 @@ class _MusaJitCustomAllreduceImpl:
             <= self._GRAPH_REGISTERED_INPUT_MAX_BYTES
         )
 
+    def _is_piecewise_cudagraph_capture(self) -> bool:
+        try:
+            from vllm.config import CUDAGraphMode
+            from vllm.forward_context import (
+                get_forward_context,
+                is_forward_context_available,
+            )
+        except ImportError:
+            return False
+        if not is_forward_context_available():
+            return False
+        return get_forward_context().cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
+
     def _use_registered_graph_input(self, tensor: torch.Tensor) -> bool:
         return (
             self._use_graph_registered_inputs
             and self._graph_registered_input_eligible(tensor)
             and self._IS_CAPTURING
             and self._is_current_stream_capturing()
+            and not self._is_piecewise_cudagraph_capture()
         )
 
     def should_custom_ar(self, inp: torch.Tensor) -> bool:


### PR DESCRIPTION
## Summary

`FULL_AND_PIECEWISE` graph capture failed at capture size 128 with:

```text
RuntimeError: MUSA error: unknown error

The failure was caused by MUSA custom all-reduce registered inputs being used before their graph metadata was initialized during PIECEWISE capture. Size 128 is the first input size that enters the registered-input path;
larger sizes use the staging path and passed.

This change skips the registered-input fast path during PIECEWISE capture and uses the existing staging path instead. FULL graph capture and normal custom all-reduce behavior remain unchanged.

## Validation

- pytest -q tests/test_musa_jit_custom_all_reduce_graph.py
- Result: 41 passed
- vllm serve /home/dist/models/Qwen3.5-35B-A3B-FP8/ -tp 4  --port 8546  --served-model-name Qwen3.5-35B-A3B-FP8  --max-num-seqs 256  --no-enable-chunked-prefill  --no-enable-prefix-caching  -ac.backend FLASH_ATTN  --trust-remote-code  --max-model-len 8192  --mamba-ssm-cache-dtype float32  --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3}'  --compilation-config '{"mode":"VLLM_COMPILE","cudagraph_mode":"PIECEWISE","cudagraph_capture_sizes":[ 4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64, 68,72,76,80,84,88,92,96,100,104,108,112,116,120,124,128, 132,136,140,144,148,152,156,160,164,168,172,176,180,184,188,192, 196,200,204,208,212,216,220,224,228,232,236,240,244,248,252,256, 260,264,268,272,276,280,284,288,292,296,300,304,308,312,316,320, 324,328,332,336,340,344,348,352,356,360,364,368,372,376,380,384, 388,392,396,400,404,408,412,416,420,424,428,432,436,440,444,448, 452,456,460,464,468,472,476,480,484,488,492,496,500,504,508,512 ]}'  --gpu-memory-utilization 0.8  --max-num-batched-tokens 8192