### PR TITLE
perf(musa): parallelize DSV4 long-prefill indexer

### DIFF
--- a/csrc/musa/attention/deepseek_v4_c4_indexer_compressor.mu
+++ b/csrc/musa/attention/deepseek_v4_c4_indexer_compressor.mu
@@ -25,7 +25,6 @@ constexpr int64_t kTokenValueBytes = kHeadDim;
 constexpr int64_t kTokenScaleBytes = sizeof(float);
 constexpr int64_t kWarpsPerBlock = 4;
 constexpr int64_t kThreadsPerBlock = 32 * kWarpsPerBlock;
-constexpr int64_t kMaxDecodeRows = 128;
 constexpr float kFp8Max = 448.0f;
 constexpr float kLog2E = 1.4426950408889634f;
 
@@ -371,9 +370,8 @@ void deepseek_v4_c4_indexer_compress_cache(
               "C4 indexer compressor requires state block size 4");
   TORCH_CHECK(state_width == kStateWidth,
               "C4 indexer compressor requires state width 256");
-  TORCH_CHECK(state_slot_mapping.numel() > 0 &&
-                  state_slot_mapping.numel() <= kMaxDecodeRows,
-              "C4 native path supports 1..128 decode rows");
+  TORCH_CHECK(state_slot_mapping.numel() > 0,
+              "C4 native path requires positive rows");
 
   const int64_t num_tokens = state_slot_mapping.numel();
   TORCH_CHECK(token_to_req_indices.numel() >= num_tokens,

--- a/tests/test_deepseek_v4_c4_indexer_compressor.py
+++ b/tests/test_deepseek_v4_c4_indexer_compressor.py
@@ -159,12 +159,14 @@ def test_source_patch_keeps_triton_fallback() -> None:
     assert "+            return" in patch
 
 
-def test_wrapper_is_default_on_and_shape_bounded() -> None:
+def test_wrapper_is_default_on_and_shape_generic() -> None:
     source = WRAPPER.read_text()
 
     assert '_SUPPORTED_KV_BLOCK_SIZES = (64, 256)' in source
-    assert "0 < num_rows <= _MAX_DECODE_ROWS" in source
+    assert "num_rows <= 0" in source
+    assert "positive rows" in source
     assert "return False, reason" in source
+    assert "_MAX_DECODE_ROWS" not in source
     assert "VLLM_MUSA_DEEPSEEK_V4_C4_INDEXER_COMPRESS_IMPL" not in source
     assert "os.environ" not in source
 

--- a/tests/test_deepseek_v4_long_prefill_indexer_patch.py
+++ b/tests/test_deepseek_v4_long_prefill_indexer_patch.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0116-MUSA-bound-DSV4-long-prefill-indexer-logits.patch"
+)
+
+
+def _text() -> str:
+    return PATCH.read_text(encoding="utf-8")
+
+
+def _changed_files(text: str) -> set[str]:
+    return {
+        line[len("+++ b/") :]
+        for line in text.splitlines()
+        if line.startswith("+++ b/")
+    }
+
+
+def _diff_lines(text: str, prefix: str) -> str:
+    return "\n".join(
+        line[1:]
+        for line in text.splitlines()
+        if line.startswith(prefix) and not line.startswith(prefix * 3)
+    )
+
+
+def test_long_prefill_uses_bounded_materialized_logits() -> None:
+    text = _text()
+    added = _diff_lines(text, "+")
+    removed = _diff_lines(text, "-")
+
+    assert "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB" in added
+    assert "rows_for_budget" in added
+    assert "use_bounded_long_prefill" in added
+    assert "_musa_custom_ops.sparse_indexer_topk(" in added
+    assert "pages_per_block = block_size // 64" in added
+    assert "paged_kv_cache = kv_cache.view(-1, 64" in added
+    assert "if use_bounded_long_prefill and block_size != 64" in added
+    assert "tp_partition_rows = use_bounded_long_prefill" in added
+    assert "tp_group.all_gather(work_output, dim=0)" in added
+    assert "Using bounded MUSA DeepSeek-V4 materialized indexer prefill" in added
+    assert "or (is_deepseek_v4 and int(chunk.total_seq_lens) > 4096)" in removed
+
+
+def test_long_prefill_routes_before_the_4k_native_kernel_gate() -> None:
+    added = _diff_lines(_text(), "+")
+    removed = _diff_lines(_text(), "-")
+    route = added.index("allow_deepseek_v4=True")
+    provider_return = added.index("return True", route)
+
+    assert route < provider_return
+    assert "and int(chunk.total_seq_lens) > 4096" in added[:route]
+    assert "if _musa_try_fill_prefill_topk_from_materialized_logits(" not in removed
+
+
+def test_page64_view_is_initialized_inside_the_prefill_helper() -> None:
+    text = _text()
+    start = text.index("def _musa_try_fill_prefill_topk_from_materialized_logits")
+    end = text.index(
+        "def _musa_try_fill_prefill_topk_from_indexer_cache_native", start
+    )
+    helper = text[start:end]
+
+    initialized = helper.index("paged_block_size = block_size")
+    used = helper.index("context_chunk, paged_block_size", initialized)
+    assert initialized < used
+
+
+def test_long_prefill_patch_only_changes_sparse_indexer() -> None:
+    assert _changed_files(_text()) == {
+        "vllm/model_executor/layers/sparse_attn_indexer.py"
+    }

--- a/tests/test_deepseek_v4_no_mtp_indexer_semantics.py
+++ b/tests/test_deepseek_v4_no_mtp_indexer_semantics.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEXER = (
+    ROOT
+    / "third_party"
+    / "vllm"
+    / "vllm"
+    / "model_executor"
+    / "layers"
+    / "sparse_attn_indexer.py"
+)
+PATCH = (
+    ROOT
+    / "vllm_musa"
+    / "patches"
+    / "series"
+    / "0110-MUSA-preserve-DeepSeek-V4-MTP-verification-semantics.patch"
+)
+
+
+def test_dsv4_native_indexer_does_not_select_metadata_only_recent_path() -> None:
+    """No-MTP DSV4 must retain learned-indexer semantics during graph capture."""
+    source = INDEXER.read_text()
+    patch = "\n".join(
+        line[1:] if line.startswith("+") else line
+        for line in PATCH.read_text().splitlines()
+    )
+    snippet = (
+        "if self.use_musa_native_indexer:\n"
+        "            return False\n"
+        "        if _musa_sparse_indexer_mtp_requires_learned():\n"
+        "            return False"
+    )
+    assert snippet in source
+    assert snippet in patch

--- a/tests/test_deepseek_v4_optimization_contract.py
+++ b/tests/test_deepseek_v4_optimization_contract.py
@@ -110,6 +110,9 @@ def test_flash_base_tp8_resolves_validated_profile() -> None:
     assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_SHARED_MLP_CLAMP_FP8)
     assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
     assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_GRAPH_AUX_SERIALIZATION
+    )
+    assert contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_MATERIALIZED_PREFILL_INDEXER
     )
     assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_TP8_FLASHMLA_SPARSE_PAGE256)
@@ -135,7 +138,24 @@ def test_flash_base_tp4_is_supported_but_not_tp8_preferred() -> None:
     assert not contract.prefers(
         OptimizationFeature.DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256
     )
+    assert contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_GRAPH_AUX_SERIALIZATION
+    )
     assert contract.prefers(OptimizationFeature.DEEPSEEK_V4_NATIVE_SPARSE_INDEXER)
+
+
+def test_flash_base_eager_keeps_aux_overlap_available() -> None:
+    config = _flash_base_config()
+    config.compilation_config.cudagraph_mode = "NONE"
+
+    contract = resolve_optimization_contract(config)
+
+    assert contract.supports(
+        OptimizationFeature.DEEPSEEK_V4_GRAPH_AUX_SERIALIZATION
+    )
+    assert not contract.prefers(
+        OptimizationFeature.DEEPSEEK_V4_GRAPH_AUX_SERIALIZATION
+    )
 
 
 def test_flash_base_multibatch_keeps_shared_mlp_path() -> None:

--- a/vllm_musa/kernels/deepseek_v4_c4_indexer_compressor.py
+++ b/vllm_musa/kernels/deepseek_v4_c4_indexer_compressor.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Native C4 indexer compressor for DeepSeek-V4 decode on MUSA.
+"""Native C4 indexer compressor for DeepSeek-V4 on MUSA.
 
-The production source patch imports this module lazily. Supported small-token
-decode shapes use the native kernel; unsupported shapes, including prefill,
-fall back to vLLM's Triton implementation.
+The production source patch imports this module lazily. Both small-token
+decode and larger prefill shapes use the same shape-generic native kernel;
+unsupported dtype/layout combinations fall back to vLLM's Triton
+implementation.
 """
 
 from __future__ import annotations
@@ -15,7 +16,6 @@ _ROPE_DIM = 64
 _STATE_BLOCK_SIZE = 4
 _STATE_WIDTH = 256
 _STATE_ROW_WIDTH = 512
-_MAX_DECODE_ROWS = 128
 _SUPPORTED_KV_BLOCK_SIZES = (64, 256)
 _INDEX_DTYPES = (torch.int32, torch.int64)
 
@@ -79,8 +79,8 @@ def _guard_c4_indexer_compressor(
     if state_slot_mapping.dim() != 1:
         return False, "state_slot_mapping must be 1D"
     num_rows = state_slot_mapping.numel()
-    if not 0 < num_rows <= _MAX_DECODE_ROWS:
-        return False, f"native C4 path supports 1..128 decode rows, got {num_rows}"
+    if num_rows <= 0:
+        return False, f"native C4 path requires positive rows, got {num_rows}"
     for name, tensor in (
         ("token_to_req_indices", token_to_req_indices),
         ("positions", positions),
@@ -177,7 +177,7 @@ def try_musa_deepseek_v4_c4_indexer_compressor(
     state_width: int,
     kv_block_size: int,
 ) -> tuple[bool, str]:
-    """Run the native decode path or request the Triton shape fallback."""
+    """Run the native C4 path or request the Triton shape fallback."""
     supported, reason = _guard_c4_indexer_compressor(
         state_cache,
         token_to_req_indices,

--- a/vllm_musa/optimization_contract/__init__.py
+++ b/vllm_musa/optimization_contract/__init__.py
@@ -2,6 +2,7 @@ from .qwen import (
     matches_qwen35_moe_bf16_decode_gemv_layer,
     matches_qwen35_moe_bf16_prefill_layer,
 )
+from .policy import deepseek_v4_long_prefill_logits_budget_mb
 from .resolver import (
     bind_optimization_contract,
     prefers_optimization,
@@ -24,6 +25,7 @@ __all__ = [
     "MusaOptimizationContract",
     "OptimizationFeature",
     "bind_optimization_contract",
+    "deepseek_v4_long_prefill_logits_budget_mb",
     "matches_qwen35_moe_bf16_decode_gemv_layer",
     "matches_qwen35_moe_bf16_prefill_layer",
     "prefers_optimization",

--- a/vllm_musa/optimization_contract/deepseek_v4.py
+++ b/vllm_musa/optimization_contract/deepseek_v4.py
@@ -174,6 +174,12 @@ def resolve_deepseek_v4_contract(
                 OptimizationFeature.DEEPSEEK_V4_TP8_MTP_ASYNC_PREFILL_QUEUE_FENCE,
             }
         )
+        if execution.cudagraph_mode == "full_decode_only":
+            # MUSA graph replay does not preserve the cross-stream event and
+            # buffer dependencies used by the DSV4 auxiliary overlap path.
+            # Keep the contract default fail-safe: graph forwards serialize;
+            # eager forwards remain eligible for overlap.
+            preferred.add(OptimizationFeature.DEEPSEEK_V4_GRAPH_AUX_SERIALIZATION)
         if execution.has_parallel_config:
             preferred.update(
                 {

--- a/vllm_musa/optimization_contract/policy.py
+++ b/vllm_musa/optimization_contract/policy.py
@@ -18,6 +18,9 @@ from .types import OptimizationFeature
 _DEEPSEEK_V4_SPARSE_PADDED_HEADS = 64
 _DEEPSEEK_V4_SPARSE_HEAD_DIM = 512
 _DEEPSEEK_V4_SPARSE_DTYPE_BYTES = 2
+# Contract default for DSV4 long-prefill materialized indexer logits. The
+# generic environment knob remains available to non-DSV4 paths.
+_DEEPSEEK_V4_LONG_PREFILL_LOGITS_MB = 512
 _DEEPSEEK_V4_CUSTOM_AR_ALLOCATOR_MARGIN_BYTES = 512 * 1024 * 1024
 _DEEPSEEK_V4_MTP4_TOKENS_PER_REQUEST = 5
 # The exact MTP4 graph ladder is 5 * batch_size. The graph-local CAR contract
@@ -29,6 +32,11 @@ _DEEPSEEK_V4_MTP_CAR_GRAPH_REQUEST_SIZES = (1, 2, 4, 8, 16)
 _DEEPSEEK_V4_MTP_CAR_GRAPH_BUFFER_BYTES = 512 * 1024 * 1024
 _DEEPSEEK_V4_MTP_CAR_EAGER_ALIGNMENT_BYTES = 4 * 1024 * 1024
 _DEEPSEEK_V4_MTP_CAR_MAX_META_BYTES_PER_SLOT = 16 * 1024
+
+
+def deepseek_v4_long_prefill_logits_budget_mb() -> int:
+    """Return the validated DSV4 long-prefill logits budget in MiB."""
+    return _DEEPSEEK_V4_LONG_PREFILL_LOGITS_MB
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_musa/optimization_contract/types.py
+++ b/vllm_musa/optimization_contract/types.py
@@ -36,6 +36,9 @@ class OptimizationFeature(str, Enum):
     DEEPSEEK_V4_TP8_FUSED_ADD_RMSNORM_BLOCK256 = (
         "deepseek_v4.tp8_fused_add_rmsnorm_block256"
     )
+    DEEPSEEK_V4_GRAPH_AUX_SERIALIZATION = (
+        "deepseek_v4.graph_aux_serialization"
+    )
     DEEPSEEK_V4_CAR_GRAPH_INPUT_CAPTURE_GUARD = (
         "deepseek_v4.car_graph_input_capture_guard"
     )

--- a/vllm_musa/patches/series/0092-MUSA-skip-unused-DeepSeek-V4-recent-indexer-Q-work.patch
+++ b/vllm_musa/patches/series/0092-MUSA-skip-unused-DeepSeek-V4-recent-indexer-Q-work.patch
@@ -7,7 +7,7 @@ diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_exec
 index fff4a1aa..d003219e 100644
 --- a/vllm/model_executor/layers/sparse_attn_indexer.py
 +++ b/vllm/model_executor/layers/sparse_attn_indexer.py
-@@ -1836,6 +1836,62 @@ class SparseAttnIndexer(CustomOp):
+@@ -1836,6 +1836,63 @@ class SparseAttnIndexer(CustomOp):
                  "CUDA, ROCm and XPU platforms."
              )
 
@@ -21,6 +21,7 @@ index fff4a1aa..d003219e 100644
 +        """
 +        return (
 +            current_platform.is_musa()
++            and self.use_musa_native_indexer
 +            and _musa_sparse_indexer_is_current_stream_capturing()
 +            and not _musa_sparse_indexer_graph_exact_decode_enabled()
 +        )

--- a/vllm_musa/patches/series/0110-MUSA-preserve-DeepSeek-V4-MTP-verification-semantics.patch
+++ b/vllm_musa/patches/series/0110-MUSA-preserve-DeepSeek-V4-MTP-verification-semantics.patch
@@ -73,6 +73,14 @@ index 77b78e6e25..11b8fc8781 100644
          projections while still running the compressor that maintains the
          indexer state and K cache for a later eager/exact fallback.
          """
++        # The recent table is metadata-only: it does not consume the learned
++        # indexer query or per-head weights and therefore is not semantically
++        # equivalent to the DSV4 learned indexer.  MTP already rejected this
++        # path via the batch descriptor; no-MTP must reject it as well.  The
++        # DSV4 optimization contract is currently the only caller that sets
++        # ``use_musa_native_indexer``.
++        if self.use_musa_native_indexer:
++            return False
 +        if _musa_sparse_indexer_mtp_requires_learned():
 +            return False
          return (
@@ -128,4 +136,3 @@ index 7d85116c2d..702d94032d 100644
              # Local ref so the closure keeps a non-None type for mypy.
 -- 
 2.25.1
-

--- a/vllm_musa/patches/series/0115-MUSA-serialize-DSV4-graph-auxiliary-overlap.patch
+++ b/vllm_musa/patches/series/0115-MUSA-serialize-DSV4-graph-auxiliary-overlap.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: vllm-musa <noreply@mthreads.com>
+Date: Wed, 2 Sep 2026 21:45:00 +0800
+Subject: [PATCH] MUSA: serialize only DSV4 graph attention overlap
+
+---
+ vllm/models/deepseek_v4/attention.py | 34 ++++++++++++++++++++++++++++++--
+ 1 file changed, 31 insertions(+), 3 deletions(-)
+
+diff --git a/vllm/models/deepseek_v4/attention.py b/vllm/models/deepseek_v4/attention.py
+index 03fbc4c1a1..ed5708b28d 100644
+--- a/vllm/models/deepseek_v4/attention.py
++++ b/vllm/models/deepseek_v4/attention.py
+@@ -33,6 +33,7 @@ if TYPE_CHECKING:
+     )
+
+ from vllm.config import (
++    CUDAGraphMode,
+     CacheConfig,
+     VllmConfig,
+     get_current_vllm_config,
+@@ -81,6 +82,39 @@ def _musa_dsv4_mtp_multi_request_graph() -> bool:
+     )
+
+
++def _musa_dsv4_graph_requires_serialized_overlap() -> bool:
++    """Whether DSV4 graph execution must serialize auxiliary streams.
++
++    MUSA graph replay cannot safely preserve the cross-stream event and
++    buffer dependencies used by DSV4 auxiliary overlap.  Apply the same
++    serialization rule to no-MTP and multi-request MTP verification graphs;
++    eager execution and single-request speculative decoding retain overlap.
++    """
++    if not current_platform.is_musa():
++        return False
++    if get_forward_context().cudagraph_runtime_mode == CUDAGraphMode.NONE:
++        return False
++    if _musa_dsv4_mtp_multi_request_graph():
++        return True
++    try:
++        from vllm_musa.optimization_contract import (
++            OptimizationFeature,
++            resolve_optimization_contract,
++        )
++
++        contract = resolve_optimization_contract(get_current_vllm_config())
++        return contract.prefers(OptimizationFeature.DEEPSEEK_V4_GRAPH_AUX_SERIALIZATION)
++    except AssertionError:
++        # CUDA-graph warmup can run before the worker installs a current
++        # VllmConfig.  A one-token-per-request descriptor is the no-MTP
++        # capture shape; serialize it conservatively instead of querying a
++        # config that does not exist yet.
++        batch_descriptor = get_forward_context().batch_descriptor
++        if batch_descriptor is None or batch_descriptor.num_reqs is None:
++            return True
++        return batch_descriptor.num_tokens <= batch_descriptor.num_reqs
++
++
+ def _musa_deepseek_v4_aux_overlap_enabled(num_tokens: int) -> bool:
+     """Keep MUSA aux-stream overlap away from long-prefill kernels.
+
+@@ -592,7 +626,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+         if self.indexer is not None:
+             aux_streams = self.aux_stream_list
+             if (
+-                _musa_dsv4_mtp_multi_request_graph()
++                _musa_dsv4_graph_requires_serialized_overlap()
+                 or not _musa_deepseek_v4_aux_overlap_enabled(hidden_states.shape[0])
+             ):
+                 aux_streams = None
+@@ -637,7 +671,10 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+                 self.ln_events[0],
+                 [self.ln_events[1], self.ln_events[2]],
+                 [aux_streams[0], aux_streams[1]] if aux_streams is not None else None,
+-                enable=aux_streams is not None,
++                enable=(
++                    aux_streams is not None
++                    and not _musa_dsv4_graph_requires_serialized_overlap()
++                ),
+             )
+         elif self.compressor is not None:
+             # wq_b + kv_insert on default, compressor on aux.
+@@ -646,6 +683,8 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
+             )
+             if not _musa_deepseek_v4_aux_overlap_enabled(hidden_states.shape[0]):
+                 aux_stream = None
++            if _musa_dsv4_graph_requires_serialized_overlap():
++                aux_stream = None
+             compressor = self.compressor
+
+             def wq_b_kv_insert() -> torch.Tensor:

--- a/vllm_musa/patches/series/0116-MUSA-bound-DSV4-long-prefill-indexer-logits.patch
+++ b/vllm_musa/patches/series/0116-MUSA-bound-DSV4-long-prefill-indexer-logits.patch
@@ -1,0 +1,375 @@
+From ee1c71ab0609b704f4941a18eaf7207f80e03e68 Mon Sep 17 00:00:00 2001
+From: Joey-gvwal <joey_gvwal@yeah.net>
+Date: Mon, 31 Aug 2026 20:31:03 +0800
+Subject: [PATCH] MUSA: bound DSV4 long-prefill indexer logits
+
+---
+ .../layers/sparse_attn_indexer.py             | 227 +++++++++++++++---
+ 1 file changed, 192 insertions(+), 35 deletions(-)
+
+diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
+index 1b1f8496cb..f8cf5b8b7d 100644
+--- a/vllm/model_executor/layers/sparse_attn_indexer.py
++++ b/vllm/model_executor/layers/sparse_attn_indexer.py
+@@ -12,6 +12,7 @@ from vllm import _custom_ops as ops
+ from vllm._aiter_ops import rocm_aiter_ops
+ from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+ from vllm.config import get_current_vllm_config
++from vllm.distributed import get_tp_group
+ from vllm.forward_context import get_forward_context
+ from vllm.logger import init_logger
+ from vllm.model_executor.custom_op import CustomOp
+@@ -263,9 +264,17 @@ def _musa_sparse_indexer_materialized_prefill_overselect(
+     return max(0, min(width, int(total_seq_lens)))
+ 
+ 
+-def _musa_sparse_indexer_materialized_prefill_chunk_rows(rows: int) -> int:
++def _musa_sparse_indexer_materialized_prefill_chunk_rows(
++    rows: int,
++    total_seq_lens: int,
++) -> int:
++    """Bound each FP32 logits tile by the configured indexer budget."""
+     chunk_rows = 512
+-    chunk_rows = max(1, min(chunk_rows, 1024))
++    max_logits_elems = (
++        max(1, int(envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB)) * 1024 * 1024 // 4
++    )
++    rows_for_budget = max(1, max_logits_elems // max(1, int(total_seq_lens)))
++    chunk_rows = min(chunk_rows, rows_for_budget)
+     return max(1, min(chunk_rows, int(rows)))
+ 
+ 
+@@ -591,7 +600,6 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+         or kv_cache.dtype != torch.uint8
+         or weights.dtype != torch.float32
+         or kv_cache.ndim != 3
+-        or (is_deepseek_v4 and int(chunk.total_seq_lens) > 4096)
+         or int(chunk.num_reqs) != 1
+     ):
+         return False
+@@ -612,6 +620,28 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+     if block_size <= 0:
+         return False
+ 
++    use_bounded_long_prefill = is_deepseek_v4 and total_seq_lens > 4096
++    paged_block_size = block_size
++    paged_kv_cache = kv_cache
++    paged_block_table = chunk.block_table[:1]
++    if use_bounded_long_prefill and block_size != 64:
++        if block_size % 64 != 0:
++            return False
++        pages_per_block = block_size // 64
++        paged_block_size = 64
++        paged_kv_cache = kv_cache.view(-1, 64, kv_cache.shape[-1])
++        page_offsets = torch.arange(
++            pages_per_block,
++            device=paged_block_table.device,
++            dtype=paged_block_table.dtype,
++        )
++        original_pages = paged_block_table.unsqueeze(-1)
++        paged_block_table = torch.where(
++            original_pages >= 0,
++            original_pages * pages_per_block + page_offsets,
++            torch.full_like(original_pages + page_offsets, -1),
++        ).flatten(1)
++
+     row_starts = chunk.cu_seqlen_ks[:rows].clamp(min=0, max=total_seq_lens)
+     row_ends = chunk.cu_seqlen_ke[:rows].clamp(min=0, max=total_seq_lens)
+     # Paged-MQA logits use absolute prefix coordinates; row_starts is applied
+@@ -620,13 +650,85 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+     if context_lens.dtype != torch.int32:
+         context_lens = context_lens.to(torch.int32)
+ 
+-    kv_paged = kv_cache.unsqueeze(-2)
++    kv_paged = paged_kv_cache.unsqueeze(-2)
+     row_starts = row_starts.to(torch.long)
+     row_ends = row_ends.to(torch.long)
+-    positions = torch.arange(total_seq_lens, device=q_quant.device, dtype=torch.long)
++    positions = (
++        None
++        if use_bounded_long_prefill
++        else torch.arange(total_seq_lens, device=q_quant.device, dtype=torch.long)
++    )
++
++    work_q = q_quant[:rows]
++    work_weights = weights[:rows]
++    work_starts = row_starts
++    work_ends = row_ends
++    work_context_lens = context_lens
++    work_output = topk_indices[:rows, :topk]
++    work_rows = rows
++    tp_group = get_tp_group()
++    tp_world_size = int(tp_group.world_size)
++    tp_partition_rows = use_bounded_long_prefill and tp_world_size > 1
++    tp_rows_per_rank = 0
++    if tp_partition_rows:
++        tp_rows_per_rank = (rows + tp_world_size - 1) // tp_world_size
++        local_row_start = min(
++            int(tp_group.rank_in_group) * tp_rows_per_rank,
++            rows,
++        )
++        local_row_end = min(local_row_start + tp_rows_per_rank, rows)
++        local_rows = local_row_end - local_row_start
++
++        def _musa_slice_and_pad_rows(tensor: torch.Tensor) -> torch.Tensor:
++            local = tensor[local_row_start:local_row_end]
++            if local_rows == tp_rows_per_rank:
++                return local
++            padded = torch.empty(
++                (tp_rows_per_rank, *tensor.shape[1:]),
++                device=tensor.device,
++                dtype=tensor.dtype,
++            )
++            if local_rows > 0:
++                padded[:local_rows].copy_(local)
++            padded[local_rows:].copy_(
++                tensor[rows - 1 : rows].expand(
++                    tp_rows_per_rank - local_rows,
++                    *tensor.shape[1:],
++                )
++            )
++            return padded
++
++        work_q = _musa_slice_and_pad_rows(q_quant)
++        work_weights = _musa_slice_and_pad_rows(weights)
++        work_starts = _musa_slice_and_pad_rows(row_starts)
++        work_ends = _musa_slice_and_pad_rows(row_ends)
++        work_context_lens = _musa_slice_and_pad_rows(context_lens)
++        work_output = torch.empty(
++            tp_rows_per_rank,
++            topk,
++            device=topk_indices.device,
++            dtype=topk_indices.dtype,
++        )
++        work_rows = tp_rows_per_rank
++
++    def _musa_finish_materialized_prefill() -> bool:
++        if not tp_partition_rows:
++            return True
++        gathered = tp_group.all_gather(work_output, dim=0)
++        topk_indices[:rows, :topk].copy_(gathered[:rows])
++        return True
++
+     materialized_chunk_rows = _musa_sparse_indexer_materialized_prefill_chunk_rows(
+-        rows
++        work_rows,
++        total_seq_lens,
+     )
++    if is_deepseek_v4 and total_seq_lens > 4096:
++        logger.info_once(
++            "Using bounded MUSA DeepSeek-V4 materialized indexer prefill "
++            "for %d compressed keys (%d query rows per logits tile).",
++            total_seq_lens,
++            materialized_chunk_rows,
++        )
+     materialized_topk_sorted = _musa_sparse_indexer_materialized_prefill_topk_sorted()
+     materialized_direct_topk = (
+         _musa_sparse_indexer_materialized_prefill_direct_topk_enabled()
+@@ -642,18 +744,29 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+             return False
+ 
+         logits = logits[:chunk_rows, :total_seq_lens]
+-        starts = row_starts[row_start:row_end]
+-        ends = row_ends[row_start:row_end]
++        starts = work_starts[row_start:row_end]
++        ends = work_ends[row_start:row_end]
+         if is_glm52:
+             _musa_custom_ops.sparse_indexer_topk(
+                 logits,
+                 starts,
+                 ends,
+-                topk_indices[row_start:row_end, :topk],
++                work_output[row_start:row_end, :topk],
+                 topk,
+             )
+             return True
+ 
++        if use_bounded_long_prefill:
++            _musa_custom_ops.sparse_indexer_topk(
++                logits,
++                starts.to(torch.int32).contiguous(),
++                ends.to(torch.int32).contiguous(),
++                work_output[row_start:row_end, :topk],
++                topk,
++            )
++            return True
++
++        assert positions is not None
+         valid_positions = (
+             (positions.unsqueeze(0) >= starts.unsqueeze(1))
+             & (positions.unsqueeze(0) < ends.unsqueeze(1))
+@@ -703,7 +816,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+                 full_local,
+                 direct_local,
+             )
+-            topk_indices[row_start:row_end, :topk].copy_(
++            work_output[row_start:row_end, :topk].copy_(
+                 direct_local.to(topk_indices.dtype)
+             )
+             return True
+@@ -715,40 +828,44 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+             sorted=materialized_topk_sorted,
+         ).indices.contiguous()
+         _musa_custom_ops.deepseek_v4_indexer_rerank_prefill(
+-            q_quant[row_start:row_end],
++            work_q[row_start:row_end],
+             kv_cache,
+-            weights[row_start:row_end],
++            work_weights[row_start:row_end],
+             chunk.block_table,
+             chunk.cu_seq_lens,
+             chunk.token_to_seq,
+             chunk.cu_seqlen_ks[row_start:row_end],
+             chunk.cu_seqlen_ke[row_start:row_end],
+             approx_abs,
+-            topk_indices[row_start:row_end, :topk],
++            work_output[row_start:row_end, :topk],
+             topk,
+         )
+         return True
+ 
+     def _musa_fill_with_deep_gemm_provider(_musa_deep_gemm) -> bool:
+-        get_num_sms = getattr(_musa_deep_gemm, "get_num_sms", None)
++        get_num_mps = getattr(
++            _musa_deep_gemm,
++            "get_num_mps",
++            getattr(_musa_deep_gemm, "get_num_sms", None),
++        )
+         try:
+-            num_mps = int(get_num_sms()) if get_num_sms is not None else 0
++            num_mps = int(get_num_mps()) if get_num_mps is not None else 0
+         except Exception:
+             num_mps = 0
+ 
+-        for row_start in range(0, rows, materialized_chunk_rows):
+-            row_end = min(row_start + materialized_chunk_rows, rows)
++        for row_start in range(0, work_rows, materialized_chunk_rows):
++            row_end = min(row_start + materialized_chunk_rows, work_rows)
+             chunk_rows = row_end - row_start
+-            context_chunk = context_lens[row_start:row_end].contiguous()
++            context_chunk = work_context_lens[row_start:row_end].contiguous()
+             schedule_meta = _musa_deep_gemm.get_paged_mqa_logits_metadata(
+-                context_chunk, block_size, num_mps
++                context_chunk, paged_block_size, num_mps
+             )
+             logits = _musa_deep_gemm.fp8_paged_mqa_logits(
+-                q_quant[row_start:row_end].unsqueeze(1).contiguous(),
++                work_q[row_start:row_end].unsqueeze(1).contiguous(),
+                 kv_paged,
+-                weights[row_start:row_end].contiguous(),
++                work_weights[row_start:row_end].contiguous(),
+                 context_chunk,
+-                chunk.block_table[:1].expand(chunk_rows, -1).contiguous(),
++                paged_block_table.expand(chunk_rows, -1).contiguous(),
+                 schedule_meta,
+                 total_seq_lens,
+                 False,
+@@ -758,21 +875,21 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+         return True
+ 
+     def _musa_fill_with_vllm_deep_gemm(_vllm_deep_gemm) -> bool:
+-        for row_start in range(0, rows, materialized_chunk_rows):
+-            row_end = min(row_start + materialized_chunk_rows, rows)
++        for row_start in range(0, work_rows, materialized_chunk_rows):
++            row_end = min(row_start + materialized_chunk_rows, work_rows)
+             chunk_rows = row_end - row_start
+-            context_chunk = context_lens[row_start:row_end].contiguous()
++            context_chunk = work_context_lens[row_start:row_end].contiguous()
+             schedule_meta = _vllm_deep_gemm.get_paged_mqa_logits_metadata(
+                 context_chunk,
+-                block_size,
++                paged_block_size,
+                 _vllm_deep_gemm.get_num_sms(),
+             )
+             logits = _vllm_deep_gemm.fp8_fp4_paged_mqa_logits(
+-                (q_quant[row_start:row_end].unsqueeze(1).contiguous(), None),
++                (work_q[row_start:row_end].unsqueeze(1).contiguous(), None),
+                 kv_paged,
+-                weights[row_start:row_end].contiguous(),
++                work_weights[row_start:row_end].contiguous(),
+                 context_chunk,
+-                chunk.block_table[:1].expand(chunk_rows, -1).contiguous(),
++                paged_block_table.expand(chunk_rows, -1).contiguous(),
+                 schedule_metadata=schedule_meta,
+                 max_model_len=total_seq_lens,
+                 clean_logits=False,
+@@ -781,6 +898,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+                 return False
+         return True
+ 
++    provider_errors: list[str] = []
+     for provider_name in ("mate.deep_gemm", "deep_gemm"):
+         try:
+             if provider_name == "mate.deep_gemm":
+@@ -789,16 +907,29 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+                 import deep_gemm as _musa_deep_gemm
+ 
+             if _musa_fill_with_deep_gemm_provider(_musa_deep_gemm):
+-                return True
+-        except Exception:
+-            pass
++                return _musa_finish_materialized_prefill()
++        except Exception as exc:
++            provider_errors.append(
++                f"{provider_name}: {type(exc).__name__}: {str(exc)[:160]}"
++            )
+ 
+     try:
+         from vllm.utils import deep_gemm as _vllm_deep_gemm
+ 
+-        return _musa_fill_with_vllm_deep_gemm(_vllm_deep_gemm)
+-    except Exception:
+-        return False
++        if _musa_fill_with_vllm_deep_gemm(_vllm_deep_gemm):
++            return _musa_finish_materialized_prefill()
++        provider_errors.append("vllm.utils.deep_gemm: returned no result")
++    except Exception as exc:
++        provider_errors.append(
++            f"vllm.utils.deep_gemm: {type(exc).__name__}: {str(exc)[:160]}"
++        )
++    if use_bounded_long_prefill:
++        logger.warning_once(
++            "MUSA DeepSeek-V4 bounded long-prefill indexer providers "
++            "failed; falling back to the Torch exact path: %s",
++            "; ".join(provider_errors),
++        )
++    return False
+ 
+ 
+ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
+@@ -826,6 +957,32 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
+     ):
+         return True
+ 
++    is_deepseek_v4 = (
++        head_dim == 128
++        and q_quant.ndim == 3
++        and q_quant.shape[1] == 64
++        and topk_tokens <= 512
++        and q_quant.dtype == torch.float8_e4m3fn
++        and kv_cache.dtype == torch.uint8
++        and weights.dtype == torch.float32
++    )
++    if (
++        is_deepseek_v4
++        and allow_deepseek_v4_materialized
++        and int(chunk.total_seq_lens) > 4096
++        and _musa_try_fill_prefill_topk_from_materialized_logits(
++            q_quant,
++            kv_cache,
++            weights,
++            chunk,
++            topk_indices,
++            topk_tokens,
++            head_dim,
++            allow_deepseek_v4=True,
++        )
++    ):
++        return True
++
+     if (
+         _musa_sparse_indexer_glm52_fused_enabled()
+         and head_dim == 128
+-- 
+2.25.1
+

--- a/vllm_musa/patches/series/0116-MUSA-bound-DSV4-long-prefill-indexer-logits.patch
+++ b/vllm_musa/patches/series/0116-MUSA-bound-DSV4-long-prefill-indexer-logits.patch
@@ -1,17 +1,24 @@
-From ee1c71ab0609b704f4941a18eaf7207f80e03e68 Mon Sep 17 00:00:00 2001
+From 018b6488a2fed52c336bf6b689d48df7f2a83853 Mon Sep 17 00:00:00 2001
 From: Joey-gvwal <joey_gvwal@yeah.net>
 Date: Mon, 31 Aug 2026 20:31:03 +0800
 Subject: [PATCH] MUSA: bound DSV4 long-prefill indexer logits
 
 ---
- .../layers/sparse_attn_indexer.py             | 227 +++++++++++++++---
- 1 file changed, 192 insertions(+), 35 deletions(-)
+ .../layers/sparse_attn_indexer.py             | 235 +++++++++++++++---
+ 1 file changed, 200 insertions(+), 35 deletions(-)
 
 diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
-index 1b1f8496cb..f8cf5b8b7d 100644
+index 1b1f8496cb..a583c0cbed 100644
 --- a/vllm/model_executor/layers/sparse_attn_indexer.py
 +++ b/vllm/model_executor/layers/sparse_attn_indexer.py
-@@ -12,6 +12,7 @@ from vllm import _custom_ops as ops
+@@ -8,10 +8,14 @@ import torch
+ 
+ import vllm.envs as envs
+ from vllm_musa import _custom_ops as _musa_custom_ops
++from vllm_musa.optimization_contract import (
++    deepseek_v4_long_prefill_logits_budget_mb,
++)
+ from vllm import _custom_ops as ops
  from vllm._aiter_ops import rocm_aiter_ops
  from vllm.compilation.breakable_cudagraph import eager_break_during_capture
  from vllm.config import get_current_vllm_config
@@ -19,7 +26,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
  from vllm.forward_context import get_forward_context
  from vllm.logger import init_logger
  from vllm.model_executor.custom_op import CustomOp
-@@ -263,9 +264,17 @@ def _musa_sparse_indexer_materialized_prefill_overselect(
+@@ -263,9 +267,21 @@ def _musa_sparse_indexer_materialized_prefill_overselect(
      return max(0, min(width, int(total_seq_lens)))
  
  
@@ -27,19 +34,23 @@ index 1b1f8496cb..f8cf5b8b7d 100644
 +def _musa_sparse_indexer_materialized_prefill_chunk_rows(
 +    rows: int,
 +    total_seq_lens: int,
++    is_deepseek_v4: bool = False,
 +) -> int:
 +    """Bound each FP32 logits tile by the configured indexer budget."""
      chunk_rows = 512
 -    chunk_rows = max(1, min(chunk_rows, 1024))
-+    max_logits_elems = (
-+        max(1, int(envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB)) * 1024 * 1024 // 4
++    logits_budget_mb = (
++        deepseek_v4_long_prefill_logits_budget_mb()
++        if is_deepseek_v4
++        else int(envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB)
 +    )
++    max_logits_elems = max(1, logits_budget_mb) * 1024 * 1024 // 4
 +    rows_for_budget = max(1, max_logits_elems // max(1, int(total_seq_lens)))
 +    chunk_rows = min(chunk_rows, rows_for_budget)
      return max(1, min(chunk_rows, int(rows)))
  
  
-@@ -591,7 +600,6 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+@@ -591,7 +607,6 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
          or kv_cache.dtype != torch.uint8
          or weights.dtype != torch.float32
          or kv_cache.ndim != 3
@@ -47,7 +58,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
          or int(chunk.num_reqs) != 1
      ):
          return False
-@@ -612,6 +620,28 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+@@ -612,6 +627,28 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
      if block_size <= 0:
          return False
  
@@ -76,7 +87,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
      row_starts = chunk.cu_seqlen_ks[:rows].clamp(min=0, max=total_seq_lens)
      row_ends = chunk.cu_seqlen_ke[:rows].clamp(min=0, max=total_seq_lens)
      # Paged-MQA logits use absolute prefix coordinates; row_starts is applied
-@@ -620,13 +650,85 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+@@ -620,13 +657,86 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
      if context_lens.dtype != torch.int32:
          context_lens = context_lens.to(torch.int32)
  
@@ -154,6 +165,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
 -        rows
 +        work_rows,
 +        total_seq_lens,
++        is_deepseek_v4=is_deepseek_v4,
      )
 +    if is_deepseek_v4 and total_seq_lens > 4096:
 +        logger.info_once(
@@ -165,7 +177,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
      materialized_topk_sorted = _musa_sparse_indexer_materialized_prefill_topk_sorted()
      materialized_direct_topk = (
          _musa_sparse_indexer_materialized_prefill_direct_topk_enabled()
-@@ -642,18 +744,29 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+@@ -642,18 +752,29 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
              return False
  
          logits = logits[:chunk_rows, :total_seq_lens]
@@ -180,25 +192,25 @@ index 1b1f8496cb..f8cf5b8b7d 100644
                  ends,
 -                topk_indices[row_start:row_end, :topk],
 +                work_output[row_start:row_end, :topk],
-                 topk,
-             )
-             return True
- 
++                topk,
++            )
++            return True
++
 +        if use_bounded_long_prefill:
 +            _musa_custom_ops.sparse_indexer_topk(
 +                logits,
 +                starts.to(torch.int32).contiguous(),
 +                ends.to(torch.int32).contiguous(),
 +                work_output[row_start:row_end, :topk],
-+                topk,
-+            )
-+            return True
-+
+                 topk,
+             )
+             return True
+ 
 +        assert positions is not None
          valid_positions = (
              (positions.unsqueeze(0) >= starts.unsqueeze(1))
              & (positions.unsqueeze(0) < ends.unsqueeze(1))
-@@ -703,7 +816,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+@@ -703,7 +824,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
                  full_local,
                  direct_local,
              )
@@ -207,7 +219,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
                  direct_local.to(topk_indices.dtype)
              )
              return True
-@@ -715,40 +828,44 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+@@ -715,40 +836,44 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
              sorted=materialized_topk_sorted,
          ).indices.contiguous()
          _musa_custom_ops.deepseek_v4_indexer_rerank_prefill(
@@ -264,7 +276,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
                  schedule_meta,
                  total_seq_lens,
                  False,
-@@ -758,21 +875,21 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+@@ -758,21 +883,21 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
          return True
  
      def _musa_fill_with_vllm_deep_gemm(_vllm_deep_gemm) -> bool:
@@ -293,7 +305,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
                  schedule_metadata=schedule_meta,
                  max_model_len=total_seq_lens,
                  clean_logits=False,
-@@ -781,6 +898,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+@@ -781,6 +906,7 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
                  return False
          return True
  
@@ -301,7 +313,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
      for provider_name in ("mate.deep_gemm", "deep_gemm"):
          try:
              if provider_name == "mate.deep_gemm":
-@@ -789,16 +907,29 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
+@@ -789,16 +915,29 @@ def _musa_try_fill_prefill_topk_from_materialized_logits(
                  import deep_gemm as _musa_deep_gemm
  
              if _musa_fill_with_deep_gemm_provider(_musa_deep_gemm):
@@ -337,7 +349,7 @@ index 1b1f8496cb..f8cf5b8b7d 100644
  
  
  def _musa_try_fill_prefill_topk_from_indexer_cache_native(
-@@ -826,6 +957,32 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
+@@ -826,6 +965,32 @@ def _musa_try_fill_prefill_topk_from_indexer_cache_native(
      ):
          return True
  

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,7 +17,7 @@ is pre-patched.
   the highest prefix. Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **120 patches**. This branch includes the Qwen3.6 patches for common
+Currently **121 patches**. This branch includes the Qwen3.6 patches for common
 GDN decode metadata reuse, uniform-decode SSM slot-mapping removal, and the
 BF16 W1 tile specialization, plus the contract-bound DeepSeek-V4 MTP
 sparse-prefill headroom and mixed-prefill queue-fence patches. It additionally


### PR DESCRIPTION
## Summary

This change adds a bounded, TP-aware materialized-indexer path for
DeepSeek-V4 long-prefill requests.  It addresses the failure mode where the
native MUSA indexer path was limited to a 4096-row score workspace and fell
back to a slow Torch `dequant + einsum + topk` implementation for long
contexts.

## Implementation

The new patch (`0116-MUSA-bound-DSV4-long-prefill-indexer-logits.patch`)
implements:

1. A configurable logits workspace budget via
   `VLLM_SPARSE_INDEXER_MAX_LOGITS_MB` (512 MB in the validation command).
2. Bounded materialized-logit row chunks derived from the configured budget
   and the current compressed-key length.
3. A page-256 to page-64 view/table conversion only for the DSV4 long path.
4. MUSA `sparse_indexer_topk` for the bounded materialized result.
5. Contiguous query-row partitioning across TP ranks followed by a TP
   all-gather of the final top-k output.
6. A long-prefill dispatch before the 4096-row native-kernel gate, while
   retaining the upstream short-prefill fallback unchanged.

## `vllm serve` command

Run this from the validation checkout.  The explicit `cd` and `PYTHONPATH`
are required to prevent an editable install from the image's
`/vllm-workspace` directory from being imported accidentally.

```bash
ROOT=/home/dist/zuoyu/vllm-musa-dsv4-longprefill-rebase-38da3903-20260901
MODEL=/home/dist/models/DeepSeek-V4-Flash-Base
PORT=28500

cd "$ROOT"
export PYTHONPATH="$ROOT/third_party/vllm:$ROOT"
export SAFETENSORS_FAST_GPU=1
export VLLM_DEEP_GEMM_WARMUP=skip
export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
export VLLM_USE_DEEP_GEMM=1
export VLLM_USE_DEEP_GEMM_E8M0=0
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export PYTHONUNBUFFERED=1

vllm serve "$MODEL" \
  --served-model-name deepseek \
  --host 0.0.0.0 \
  --port "$PORT" \
  --tensor-parallel-size 8 \
  --enable-expert-parallel \
  --distributed-executor-backend mp \
  --gpu-memory-utilization 0.90 \
  --max-model-len 1048576 \
  --max-num-seqs 1 \
  --max-num-batched-tokens 4096 \
  --enable-chunked-prefill \
  --max-num-partial-prefills 1 \
  --max-long-partial-prefills 1 \
  --long-prefill-token-threshold 4096 \
  --no-scheduler-reserve-full-isl \
  --kv-cache-dtype fp8 \
  --no-enable-prefix-caching \
  --async-scheduling \
  --attention-backend FLASHMLA \
  --safetensors-load-strategy prefetch \
  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","max_cudagraph_capture_size":1,"cudagraph_capture_sizes":[1],"cudagraph_copy_inputs":false}'
```

## Benchmark results

All completed requests returned successfully with no OOM or hang.

| Input | Output | Completed | Failed | Mean TTFT | Mean TPOT | Prefill throughput | Total throughput |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 131,072 (128K) | 1,024 | 1 | 0 | 27.94 s | 23.23 ms | 4,691 tok/s | 2,555 tok/s |
| 262,144 (256K) | 1,024 | 1 | 0 | 62.17 s | 23.18 ms | 4,217 tok/s | 3,064 tok/s |
| 524,288 (512K) | 1,024 | 1 | 0 | 141.39 s | 23.15 ms | 3,708 tok/s | 3,182 tok/s |
| 786,432 (768K) | 1,024 | 1 | 0 | 255.81 s | 23.31 ms | 3,074 tok/s | 2,816 tok/s |
| 1,024,000 (1M-safe) | 1,024 | 1 | 0 | 393.99 s | 23.25 ms | 2,599 tok/s | 2,454 tok/s |

