### PR TITLE
fix(qwen35): make FP8 shared-expert fold idempotent

### DIFF
--- a/tests/test_moe_fused_shared_topk_source.py
+++ b/tests/test_moe_fused_shared_topk_source.py
@@ -102,3 +102,14 @@ def test_qwen35_fold_stashes_owning_router() -> None:
     ).read_text()
 
     assert "+            routed._musa_shared_router = self.experts.router" in patch
+
+
+def test_fp8_fold_does_not_duplicate_combined_shared_route() -> None:
+    source = (
+        REPO_ROOT / "vllm_musa/model_executor/layers/quantization/fp8.py"
+    ).read_text()
+
+    assert "routed_topk = int(" in source
+    assert 'getattr(layer.moe_config, "experts_per_token"' in source
+    assert "if topk_ids.shape[1] == routed_topk:" in source
+    assert "topk_ids.shape[1] == routed_topk + 1" in source

--- a/tests/test_qwen_optimization_contract.py
+++ b/tests/test_qwen_optimization_contract.py
@@ -155,6 +155,29 @@ def test_qwen35_and_qwen36_share_the_current_hf_schema(checkpoint: str) -> None:
     assert contract.prefers(OptimizationFeature.QWEN35_INTERLEAVED_MROPE_QK)
 
 
+def test_qwen35_fp8_prefers_shared_expert_fold() -> None:
+    contract = resolve_optimization_contract(
+        _config(
+            architecture="Qwen3_5MoeForConditionalGeneration",
+            model_type="qwen3_5_moe",
+            quantization="fp8",
+            hidden_size=2048,
+            num_experts=256,
+            num_experts_per_tok=8,
+            moe_intermediate_size=512,
+            linear_num_key_heads=16,
+            linear_num_value_heads=32,
+            linear_key_head_dim=128,
+            linear_value_head_dim=128,
+            linear_conv_kernel_dim=4,
+            tp=4,
+        )
+    )
+
+    assert contract.model.quantization == "fp8"
+    assert contract.prefers(OptimizationFeature.QWEN35_SHARED_EXPERT_FOLD)
+
+
 def test_future_distinct_qwen36_schema_fails_closed() -> None:
     contract = resolve_optimization_contract(
         _config(

--- a/vllm_musa/model_executor/layers/quantization/fp8.py
+++ b/vllm_musa/model_executor/layers/quantization/fp8.py
@@ -230,9 +230,20 @@ def apply(
         assert (
             shared_experts is None and shared_experts_input is None
         ), "folded shared expert expects shared_experts=None"
-        topk_weights, topk_ids = _extend_routing_with_shared_expert(
-            layer, x, topk_weights, topk_ids
+        # The Qwen3.5 runner may fuse the routed and shared gate weights
+        # before routing. In that case the MUSA top-k kernel already returns
+        # the extra shared column; appending it again would create a duplicate
+        # shared route (top-k=10) and corrupt the folded FP8 result.
+        routed_topk = int(
+            getattr(layer.moe_config, "experts_per_token", topk_ids.shape[1])
         )
+        if topk_ids.shape[1] == routed_topk:
+            topk_weights, topk_ids = _extend_routing_with_shared_expert(
+                layer, x, topk_weights, topk_ids
+            )
+        else:
+            assert topk_ids.shape[1] == routed_topk + 1
+            assert topk_weights.shape[1] == routed_topk + 1
     global_num_experts = (
         layer._musa_shared_expert_id + 1 if folded_shared else layer.global_num_experts
     )

--- a/vllm_musa/optimization_contract/qwen.py
+++ b/vllm_musa/optimization_contract/qwen.py
@@ -350,6 +350,9 @@ def resolve_qwen_contract(
     if _qwen35_moe_prefill_preferred(model, execution):
         preferred.add(OptimizationFeature.QWEN35_MOE_BF16_PREFILL)
     if model.family is ModelFamily.QWEN35_36:
+        # The FP8 fold is safe once the quant method observes a route that has
+        # already been extended by the fused routed+shared gate. The quant
+        # apply hook is idempotent for that combined top-k shape.
         if model.has_routed_experts is True:
             preferred.add(OptimizationFeature.QWEN35_SHARED_EXPERT_FOLD)
         if model.dtype == "bfloat16":


### PR DESCRIPTION
## Summary

Qwen3.5 FP8 shared-expert folding could produce malformed and repetitive
decode output because the shared route was appended twice.

## Root cause

The MUSA fused router already returns 8 routed experts plus the
always-selected shared expert. The FP8 quantization path unconditionally
appended another shared route, producing a top-k width of 10.

## Fix

- Make FP8 shared-route extension idempotent.
- Append the shared route only when the input contains routed top-k entries.
- Validate the already-combined routed-top-k+1 shape.
- Restore Qwen3.5 FP8 shared-expert fold preference.
- Add source and optimization-contract tests.

## Validation

before
<img width="864" height="103" alt="image" src="https://github.com/user-attachments/assets/b3d33fac-5ce1-4f68-bdca-5e24104e6547" />

after
<img width="861" height="107" alt="image" src="https://github.com/user-attachments/assets/ad9d1976-cb55-4cce-8512-b1b257648d61" />
