### PR TITLE
fix(musa): narrow TileLang build import workaround

### DIFF
--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -303,6 +303,7 @@ RUN python -m pip install \
 
 RUN printf '%s\n' \
         'import importlib' \
+        'import torch' \
         'import re' \
         'from pathlib import Path' \
         'from importlib.metadata import version' \
@@ -347,9 +348,16 @@ RUN printf '%s\n' \
         '    ("torch_c_dlpack_ext", "torch_c_dlpack_ext", ""),' \
         ')' \
         '' \
+        'tilelang_exact = version("tilelang_musa") == "0.1.12+musa.2"' \
+        'try:' \
+        '    gpu_available = bool(torch.musa.is_available())' \
+        'except Exception:' \
+        '    gpu_available = False' \
+        'metadata_only = tilelang_exact and not gpu_available' \
+        '' \
         'for dist_name, module_name, prefix in expected:' \
         '    installed = version(dist_name)' \
-        '    skip_import = (dist_name == "tilelang_musa" and installed == "0.1.12+musa.2")' \
+        '    skip_import = metadata_only' \
         '    if not skip_import: importlib.import_module(module_name)' \
         '    if dist_name in exact_version_dists and installed != prefix:' \
         '        raise RuntimeError(f"{dist_name} expected exactly {prefix}, got {installed}")' \
@@ -358,9 +366,12 @@ RUN printf '%s\n' \
         '    action = "skip import" if skip_import else "import"' \
         '    print(f"PASS {action} {module_name} version={installed}")' \
         '' \
-        'for module_name in ("vllm", "vllm_musa"):' \
-        '    module = importlib.import_module(module_name)' \
-        '    print("PASS import %s version=%s" % (module_name, getattr(module, "__version__", "unknown")))' \
+        'if metadata_only:' \
+        '    print("PASS metadata-only skip vllm imports")' \
+        'else:' \
+        '    for module_name in ("vllm", "vllm_musa"):' \
+        '        module = importlib.import_module(module_name)' \
+        '        print("PASS import %s version=%s" % (module_name, getattr(module, "__version__", "unknown")))' \
         > /tmp/vllm_musa_import_check.py && \
     python /tmp/vllm_musa_import_check.py && \
     rm /tmp/vllm_musa_import_check.py

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -303,7 +303,6 @@ RUN python -m pip install \
 
 RUN printf '%s\n' \
         'import importlib' \
-        'import torch' \
         'import re' \
         'from pathlib import Path' \
         'from importlib.metadata import version' \
@@ -322,7 +321,7 @@ RUN printf '%s\n' \
         '    raise RuntimeError(f"missing {dist_name} pin in {requirement_files}")' \
         '' \
         'exact_version_dists = frozenset({"torchada", "torch", "torch_musa", "torchvision", "torchaudio", "deep_ep"})' \
-        'exact_version_dists |= frozenset({"mate", "mate-mubin", "flash_attn_3", "flash_mla", "deep-gemm", "flashinfer-python", "sageattention", "tilelang_musa", "apache-tvm-ffi"})' \
+        'exact_version_dists |= frozenset({"mate", "mate-mubin", "flash_attn_3", "flash_mla", "deep-gemm", "flashinfer-python", "sageattention", "tilelang_musa", "apache-tvm-ffi", "torch_c_dlpack_ext"})' \
         '' \
         'expected = (' \
         '    ("torchada", "torchada", requirement_prefix("torchada")),' \
@@ -345,19 +344,12 @@ RUN printf '%s\n' \
         '    ("pycountry", "pycountry", ""),' \
         '    ("pytest", "pytest", ""),' \
         '    ("apache-tvm-ffi", "tvm_ffi", requirement_prefix("apache-tvm-ffi")),' \
-        '    ("torch_c_dlpack_ext", "torch_c_dlpack_ext", ""),' \
+        '    ("torch_c_dlpack_ext", "torch_c_dlpack_ext", requirement_prefix("torch-c-dlpack-ext")),' \
         ')' \
-        '' \
-        'tilelang_exact = version("tilelang_musa") == "0.1.12+musa.2"' \
-        'try:' \
-        '    gpu_available = bool(torch.musa.is_available())' \
-        'except Exception:' \
-        '    gpu_available = False' \
-        'metadata_only = tilelang_exact and not gpu_available' \
         '' \
         'for dist_name, module_name, prefix in expected:' \
         '    installed = version(dist_name)' \
-        '    skip_import = metadata_only' \
+        '    skip_import = (dist_name in {"flash_mla", "tilelang_musa"} and version("tilelang_musa") == "0.1.12+musa.2")' \
         '    if not skip_import: importlib.import_module(module_name)' \
         '    if dist_name in exact_version_dists and installed != prefix:' \
         '        raise RuntimeError(f"{dist_name} expected exactly {prefix}, got {installed}")' \
@@ -366,12 +358,9 @@ RUN printf '%s\n' \
         '    action = "skip import" if skip_import else "import"' \
         '    print(f"PASS {action} {module_name} version={installed}")' \
         '' \
-        'if metadata_only:' \
-        '    print("PASS metadata-only skip vllm imports")' \
-        'else:' \
-        '    for module_name in ("vllm", "vllm_musa"):' \
-        '        module = importlib.import_module(module_name)' \
-        '        print("PASS import %s version=%s" % (module_name, getattr(module, "__version__", "unknown")))' \
+        'for module_name in ("vllm", "vllm_musa"):' \
+        '    module = importlib.import_module(module_name)' \
+        '    print("PASS import %s version=%s" % (module_name, getattr(module, "__version__", "unknown")))' \
         > /tmp/vllm_musa_import_check.py && \
     python /tmp/vllm_musa_import_check.py && \
     rm /tmp/vllm_musa_import_check.py


### PR DESCRIPTION
## Problem

The Docker dependency verifier had two independent contract gaps:

1. `torch_c_dlpack_ext` was present in `requirements/musa_private.txt` as
   `torch-c-dlpack-ext==0.1.5`, but it was not included in
   `exact_version_dists`, and its expected prefix was empty. The verifier could
   therefore import the module without enforcing the pinned distribution version.
2. With `tilelang_musa==0.1.12+musa.2`, importing `flash_mla` can transitively
   import TileLang through MATE and trigger `GPUEvent` initialization on a
   GPU-less build host.

## Changes

Only `docker/musa.Dockerfile` is modified.

- Add `torch_c_dlpack_ext` to `exact_version_dists`.
- Resolve its expected version from the requirements distribution spelling via
  `requirement_prefix("torch-c-dlpack-ext")`, while retaining
  `torch_c_dlpack_ext` as the import/module key.
- For the exact TileLang version `0.1.12+musa.2`, skip only the two confirmed
  import entry points `flash_mla` and `tilelang_musa` in the build verifier.
- Keep all other dependency imports and the final `vllm`/`vllm_musa` imports
  unchanged.
- Keep exact distribution-version checks enabled.

The change is intentionally scoped to the build-time verifier. It does not
modify MATE, FlashMLA, TileLang, runtime dispatch, or dependency pins.

## Validation

Focused contract test:

```
..                                                                       [100%]
2 passed in 0.03s
```

Targeted no-GPU Docker verification on `worker36018` (`10.20.36.18`) using the
existing base image, `--no-cache --pull=false`, and no visible MUSA devices:

```
Step 6/6 : RUN ... python /tmp/verify.py
PASS skip import flash_mla version=0.2.6+musa
PASS skip import tilelang version=0.1.12+musa.2
PASS import torch_c_dlpack_ext version=0.1.5
PASS exact torch_c_dlpack_ext version=0.1.5
Successfully built 2a73feb613cf
Successfully tagged vllm-musa:pr214-minimal-nogpu-20260902
image_id=sha256:2a73feb613cf2e30328bbd52390a4b2a1dc3337c24dbad497762548ac680bdc6
musa_available=False
BUILD_AND_NOGPU_VERIFY_OK
```
