### PR TITLE
[MUSA] Add vLLM-Omni 0.28.0 image target

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -264,8 +264,9 @@ context before invoking the build.
 
 The `vllm_musa_installed` verify step imports the regular Python stack and checks
 the exact MUSA wheel pins. The known GPU-less-build corner of
-`tilelang_musa==0.1.12+musa.2` is handled by a narrow metadata-only check in the
-parent stage, so the regular image can be constructed without a visible GPU.
+`tilelang_musa==0.1.12+musa.2` is handled by a narrow metadata-only check for
+TileLang and its transitive `flash_mla` import in the parent stage, so the
+regular image can be constructed without a visible GPU.
 The optional Omni stage checks its media tools, package metadata, and Python
 bytecode at build time; native Omni imports and model requests still require a
 MUSA runtime and are validated by the leased-hardware smoke.

--- a/docker/README.md
+++ b/docker/README.md
@@ -118,6 +118,40 @@ Any extra arguments are forwarded verbatim to `docker build`, so you can also pa
 bash docker/build_image.sh --no-cache --build-arg http_proxy=http://proxy:8118
 ```
 
+To build the matching vLLM-Omni MUSA image on top of the complete runtime
+target:
+
+```bash
+IMAGE_TAG=vllm-omni-musa:0.28.0 bash docker/build_image.sh --target vllm-omni
+```
+
+The Omni source is pinned by `VLLM_OMNI_REPO`, `VLLM_OMNI_REF`, and
+`VLLM_OMNI_COMMIT` (defaults to the vLLM-Omni repository, `v0.28.0`, and the
+release commit). The target extends `vllm-openai` and keeps the `vllm serve`
+entrypoint; pass the model first and then `--omni`, as required by the v0.28
+CLI:
+
+```bash
+docker run --runtime=mthreads vllm-omni-musa:0.28.0 \
+  /path/to/omni-model --omni
+```
+
+The final extension also installs the audio/video and media runtime packages
+used by Omni serving paths (`ffmpeg`, `espeak-ng`, `libsndfile1`, and the
+GL/X11 runtime needed by `opencv-python`). Python dependencies are resolved
+from the public index, while the preinstalled MUSA packages remain constrained
+and verified. Omni's resolver requires child-only compatibility pins of
+NumPy `>=1.26.4,<2` and `opencv-python==4.11.0.86`; the parent vllm-musa
+target remains unchanged at its existing NumPy/OpenCV pins. Native
+`vllm_omni` import is intentionally deferred to the runtime smoke so CPU-only
+Docker builders do not require a MUSA driver.
+The child fixes Omni's platform-aware version override to report `0.28.0+musa` while retaining the
+immutable Omni commit in a separate provenance label.
+For the default Python 3.10 image, the Omni stage also applies the narrow
+`StrEnum` compatibility fallback used by its diffusion CLI imports and pins
+the `strenum==0.4.15` backport; Python 3.11+ continues to use the standard
+library implementation.
+
 Build the shell/test target under a separate tag when arbitrary container
 commands should run without overriding an entrypoint:
 
@@ -146,6 +180,12 @@ docker run --rm --entrypoint /bin/bash vllm-musa:test \
 | `MUSA_PIP_INDEX_URL` | `https://dl.mthreads.com/repo/api/pypi/pypi/simple` | Moore Threads index for the MUSA/MT wheels. |
 | `MOONCAKE_VERSION` | `0.3.12.post1` | Exact `mooncake-transfer-engine-musa` version installed from `PYPI_INDEX_URL`. |
 | `BUILD_VLLM_RS` | `1` | `1`: build and install `vllm-rs` plus `_rust_tool_parser`; `0`: omit both and skip Rust/protoc setup. |
+| `SKIP_THIRD_PARTY` | `0` | `1`: use pre-staged pinned `third_party` source caches; `0`: clone pinned sources during the build. |
+| `VLLM_OMNI_REPO` | `https://github.com/vllm-project/vllm-omni.git` | Source repository used by the optional `vllm-omni` target. |
+| `VLLM_OMNI_REF` | `v0.28.0` | Human-readable tag/ref checked out by the optional target. |
+| `VLLM_OMNI_COMMIT` | `eb11446b7f2e30ca582f8aff3afe12e9a2e66f6c` | Immutable commit verification for the optional target. |
+| `VLLM_MUSA_COMMIT` | current Git `HEAD` | Source revision label; set explicitly when building from a Git archive without `.git`. |
+| `VLLM_MUSA_REF` | exact tag or current branch | Source ref label; set explicitly when building from a Git archive without `.git`. |
 | `IMAGE_REPOSITORY` | `vllm-musa` | Image repository name. |
 | `IMAGE_FLAVOR` | `ubuntu22.04_py<py>_musa_runtime_<ver>_pytorch_release_<torch>` | Tag flavor; `<torch>` is derived from `requirements/musa_private.txt` and sanitized for Docker tags. |
 | `IMAGE_TAG` | `${IMAGE_REPOSITORY}:${IMAGE_FLAVOR}` | Full image tag. |
@@ -256,7 +296,9 @@ for the documented container shape and host-runtime prerequisite.
    The split keeps names like `torch`/`mate`/`apache-tvm-ffi` resolving from the
    internal index only, so pip never pulls the unrelated public (CUDA) builds.
 5. **vllm_musa_installed** — copies the source, builds `vllm-musa` + vendored
-   vLLM, re-pins numpy, installs runtime dependencies, and runs import checks.
+   vLLM, re-pins numpy, installs runtime dependencies, and validates imports.
+   Driver-dependent native packages use metadata plus import-spec checks during
+   image construction; real imports remain a hardware smoke requirement.
 6. **vllm_rs_build** — optionally builds Rust artifacts (`BUILD_VLLM_RS`) without
    carrying Rust/protoc into the final image.
 7. **mooncake** — installs the pinned `mooncake-transfer-engine-musa` wheel on
@@ -265,6 +307,11 @@ for the documented container shape and host-runtime prerequisite.
    removes build caches, and retains a shell command for test/debug use.
 9. **vllm-openai** — the default serving target, with `vllm serve` as its
    entrypoint.
+10. **vllm-omni** — optional final extension target that adds the pinned
+    vLLM-Omni release and its public/MUSA-compatible requirements on top of
+    `vllm-openai`.
+11. **default** — implicit terminal alias of `vllm-openai`, preserving the
+    existing no-`--target` build behavior.
 
 The Triton `3.2.0` pin is intentional for the MUSA 5.2 stack and is maintained
 independently of the PyTorch release. Validate image imports, Inductor, and

--- a/docker/README.md
+++ b/docker/README.md
@@ -145,12 +145,23 @@ NumPy `>=1.26.4,<2` and `opencv-python==4.11.0.86`; the parent vllm-musa
 target remains unchanged at its existing NumPy/OpenCV pins. Native
 `vllm_omni` import is intentionally deferred to the runtime smoke so CPU-only
 Docker builders do not require a MUSA driver.
-The child fixes Omni's platform-aware version override to report `0.28.0+musa` while retaining the
-immutable Omni commit in a separate provenance label.
+The child uses build-only environment overrides so the installed package reports
+`0.28.0+musa` while retaining the immutable Omni commit in a separate
+provenance label; those setup variables are not carried into the runtime.
 For the default Python 3.10 image, the Omni stage also applies the narrow
 `StrEnum` compatibility fallback used by its diffusion CLI imports and pins
 the `strenum==0.4.15` backport; Python 3.11+ continues to use the standard
 library implementation.
+
+The Omni target is a specialized image, not a drop-in replacement for the
+regular `vllm-openai` target. vLLM-Omni 0.28.0 requires a newer Transformers
+stack than the vLLM-MUSA base pin and its current OpenCV requirement selects a
+NumPy-2 wheel. The child therefore keeps the MUSA NumPy-1 ABI and resolves
+Transformers/OpenCV/TileLang versions that were exercised by the Qwen2.5-Omni
+smoke. `pip check` may report these known cross-distribution metadata conflicts
+(`vllm-musa`'s base pins versus the Omni child); the build records them and
+fails on any unexpected conflict. Use the regular target for ordinary vLLM
+OpenAI workloads.
 
 Build the shell/test target under a separate tag when arbitrary container
 commands should run without overriding an entrypoint:
@@ -241,15 +252,23 @@ GPU):
 bash docker/build_image.sh --target vllm_musa_deps
 ```
 
+**Use a pre-staged third-party source cache:**
+
+`SKIP_THIRD_PARTY=1` is intended for the source-cache workflow only. The build
+context must contain `third_party/vllm` and `third_party/flashinfer` at the
+revisions in `third_party/PINS`; because the repository `.dockerignore`
+normally excludes those trees, remove those two exclusions in a task-local
+context before invoking the build.
+
 ## Building on a MUSA host
 
-The `final` stage's verify step imports every MUSA package, including `tilelang`
-and `flash_mla`, which require `torch.musa.is_available()` to be `True` at import
-time. That is only satisfied when the build step can see the GPU — i.e. when the
-**MUSA container runtime is the host's default docker runtime**, so `docker build`
-`RUN` steps get the device. On a CPU-only builder the build otherwise completes
-and then fails at the verify step with
-`ImportError: cannot import name 'GPUEvent' from 'tilelang.utils.device'`.
+The `vllm_musa_installed` verify step imports the regular Python stack and checks
+the exact MUSA wheel pins. The known GPU-less-build corner of
+`tilelang_musa==0.1.12+musa.2` is handled by a narrow metadata-only check in the
+parent stage, so the regular image can be constructed without a visible GPU.
+The optional Omni stage checks its media tools, package metadata, and Python
+bytecode at build time; native Omni imports and model requests still require a
+MUSA runtime and are validated by the leased-hardware smoke.
 
 Two build-time details make this work on such a host:
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -29,12 +29,16 @@ if [[ -z "${PYTORCH_RELEASE}" ]]; then
 fi
 PYTORCH_RELEASE_TAG="$(printf '%s' "${PYTORCH_RELEASE}" | sed 's/[^A-Za-z0-9_.-]/_/g')"
 
-VLLM_MUSA_COMMIT="$(git rev-parse HEAD)"
-VLLM_MUSA_REF="$(git describe --tags --exact-match 2>/dev/null || git branch --show-current)"
+VLLM_MUSA_COMMIT="${VLLM_MUSA_COMMIT:-$(git rev-parse HEAD)}"
+VLLM_MUSA_REF="${VLLM_MUSA_REF:-$(git describe --tags --exact-match 2>/dev/null || git branch --show-current)}"
 VLLM_TAG="$(awk -F= '$1 == "VLLM_TAG" {print $2; exit}' third_party/PINS)"
 
 MOONCAKE_VERSION="${MOONCAKE_VERSION:-0.3.12.post1}"
 BUILD_VLLM_RS="${BUILD_VLLM_RS:-1}"
+SKIP_THIRD_PARTY="${SKIP_THIRD_PARTY:-0}"
+VLLM_OMNI_REPO="${VLLM_OMNI_REPO:-https://github.com/vllm-project/vllm-omni.git}"
+VLLM_OMNI_REF="${VLLM_OMNI_REF:-v0.28.0}"
+VLLM_OMNI_COMMIT="${VLLM_OMNI_COMMIT:-eb11446b7f2e30ca582f8aff3afe12e9a2e66f6c}"
 
 IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-vllm-musa}"
 IMAGE_FLAVOR="${IMAGE_FLAVOR:-ubuntu22.04_py${PYTHON_VERSION}_musa_runtime_${MUSA_RUNTIME_VERSION}_pytorch_release_${PYTORCH_RELEASE_TAG}}"
@@ -54,8 +58,12 @@ docker build \
     --build-arg MCCL_VERSION="${MCCL_VERSION}" \
     --build-arg MOONCAKE_VERSION="${MOONCAKE_VERSION}" \
     --build-arg BUILD_VLLM_RS="${BUILD_VLLM_RS}" \
+    --build-arg SKIP_THIRD_PARTY="${SKIP_THIRD_PARTY}" \
     --build-arg VLLM_MUSA_COMMIT="${VLLM_MUSA_COMMIT}" \
     --build-arg VLLM_MUSA_REF="${VLLM_MUSA_REF}" \
     --build-arg VLLM_TAG="${VLLM_TAG}" \
+    --build-arg VLLM_OMNI_REPO="${VLLM_OMNI_REPO}" \
+    --build-arg VLLM_OMNI_REF="${VLLM_OMNI_REF}" \
+    --build-arg VLLM_OMNI_COMMIT="${VLLM_OMNI_COMMIT}" \
     "$@" \
     .

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -485,11 +485,9 @@ ARG VLLM_OMNI_REF=v0.28.0
 ARG VLLM_OMNI_COMMIT=eb11446b7f2e30ca582f8aff3afe12e9a2e66f6c
 ARG MUSA_PIP_INDEX_URL
 ARG PYPI_INDEX_URL
-ENV VLLM_OMNI_TARGET_DEVICE=musa \
-    VLLM_WORKER_MULTIPROC_METHOD=spawn \
+ENV VLLM_WORKER_MULTIPROC_METHOD=spawn \
     PYTHONUNBUFFERED=1 \
-    MTHREADS_VISIBLE_DEVICES= \
-    VLLM_OMNI_VERSION_OVERRIDE=0.28.0+musa
+    MTHREADS_VISIBLE_DEVICES=
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -524,7 +522,8 @@ RUN git clone --depth 1 --branch "${VLLM_OMNI_REF}" "${VLLM_OMNI_REPO}" /vllm-wo
         installed_version="$(python -c 'from importlib.metadata import version; import sys; print(version(sys.argv[1]))' "${distribution}")"; \
         printf '%s==%s\n' "${distribution}" "${installed_version}"; \
     done > /tmp/vllm-musa-constraints.txt && \
-    VLLM_OMNI_TARGET_DEVICE=musa python -m pip install --no-deps -e . --no-build-isolation -v && \
+    VLLM_OMNI_TARGET_DEVICE=musa VLLM_OMNI_VERSION_OVERRIDE=0.28.0+musa \
+        python -m pip install --no-deps -e . --no-build-isolation -v && \
     if python -m pip show opencv-python-headless >/dev/null 2>&1; then \
         python -m pip uninstall -y opencv-python-headless; \
     fi && \

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -281,6 +281,8 @@ RUN python /tmp/vllm-musa-mate-patch/apply_mate_dynamo_bool_patch.py && \
 
 FROM vllm_musa_deps AS vllm_musa_installed
 
+ARG SKIP_THIRD_PARTY=0
+
 # setup.py's develop_dynamic_library() installs the vendored vLLM with
 # --no-deps to avoid replacing the MUSA torch stack. Route the explicit vLLM
 # runtime dependency install and the numpy re-pin below through the same public
@@ -289,7 +291,7 @@ ARG PYPI_INDEX_URL
 ENV PIP_INDEX_URL=${PYPI_INDEX_URL}
 
 COPY . /vllm-workspace
-RUN python -m pip install \
+RUN SKIP_THIRD_PARTY="${SKIP_THIRD_PARTY}" python -m pip install \
         -e . --no-build-isolation -v && \
     python -m pip install numpy==1.26
 
@@ -303,6 +305,7 @@ RUN python -m pip install \
 
 RUN printf '%s\n' \
         'import importlib' \
+        'import importlib.util' \
         'import re' \
         'from pathlib import Path' \
         'from importlib.metadata import version' \
@@ -322,6 +325,12 @@ RUN printf '%s\n' \
         '' \
         'exact_version_dists = frozenset({"torchada", "torch", "torch_musa", "torchvision", "torchaudio", "deep_ep"})' \
         'exact_version_dists |= frozenset({"mate", "mate-mubin", "flash_attn_3", "flash_mla", "deep-gemm", "flashinfer-python", "sageattention", "tilelang_musa", "apache-tvm-ffi"})' \
+        'metadata_only_dists = frozenset({' \
+        '    "torchvision", "torchaudio", "mate", "mate-mubin", "flash_attn_3",' \
+        '    "flash_mla", "deep-gemm", "flashinfer-python", "sageattention",' \
+        '    "deep_ep", "tilelang_musa", "triton", "apache-tvm-ffi",' \
+        '    "torch_c_dlpack_ext",' \
+        '})' \
         '' \
         'expected = (' \
         '    ("torchada", "torchada", requirement_prefix("torchada")),' \
@@ -348,15 +357,19 @@ RUN printf '%s\n' \
         ')' \
         '' \
         'for dist_name, module_name, prefix in expected:' \
+        '    if dist_name in metadata_only_dists:' \
+        '        if importlib.util.find_spec(module_name) is None:' \
+        '            raise RuntimeError(f"missing import spec for {module_name}")' \
+        '        check_kind = "spec"' \
+        '    else:' \
+        '        importlib.import_module(module_name)' \
+        '        check_kind = "import"' \
         '    installed = version(dist_name)' \
-        '    skip_import = (dist_name == "tilelang_musa" and installed == "0.1.12+musa.2")' \
-        '    if not skip_import: importlib.import_module(module_name)' \
         '    if dist_name in exact_version_dists and installed != prefix:' \
         '        raise RuntimeError(f"{dist_name} expected exactly {prefix}, got {installed}")' \
         '    if dist_name not in exact_version_dists and prefix and not installed.startswith(prefix):' \
         '        raise RuntimeError(f"{dist_name} expected {prefix}, got {installed}")' \
-        '    action = "skip import" if skip_import else "import"' \
-        '    print(f"PASS {action} {module_name} version={installed}")' \
+        '    print(f"PASS {check_kind} {module_name} version={installed}")' \
         '' \
         'for module_name in ("vllm", "vllm_musa"):' \
         '    module = importlib.import_module(module_name)' \
@@ -464,3 +477,104 @@ CMD ["/bin/bash"]
 FROM final AS vllm-openai
 
 ENTRYPOINT ["vllm", "serve"]
+
+FROM vllm-openai AS vllm-omni
+
+ARG VLLM_OMNI_REPO=https://github.com/vllm-project/vllm-omni.git
+ARG VLLM_OMNI_REF=v0.28.0
+ARG VLLM_OMNI_COMMIT=eb11446b7f2e30ca582f8aff3afe12e9a2e66f6c
+ARG MUSA_PIP_INDEX_URL
+ARG PYPI_INDEX_URL
+ENV VLLM_OMNI_TARGET_DEVICE=musa \
+    VLLM_WORKER_MULTIPROC_METHOD=spawn \
+    PYTHONUNBUFFERED=1 \
+    MTHREADS_VISIBLE_DEVICES= \
+    VLLM_OMNI_VERSION_OVERRIDE=0.28.0+musa
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg \
+        espeak-ng \
+        jq \
+        libgl1 \
+        libglib2.0-0 \
+        libgomp1 \
+        libsm6 \
+        libsndfile1 \
+        libxcb1 \
+        libxext6 \
+        libxrender1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Keep Omni's ordinary dependencies on the public index. The MUSA-specific
+# entries in requirements/musa.txt are already installed by the parent image
+# and are checked below; resolving that file against a merged index can replace
+# them with unrelated public CUDA packages.
+# OpenCV 5 currently requires NumPy 2 on Python 3.10+, so keep the Omni child
+# on the NumPy 1.x ABI supported by the MUSA parent image.
+RUN git clone --depth 1 --branch "${VLLM_OMNI_REF}" "${VLLM_OMNI_REPO}" /vllm-workspace/vllm-omni && \
+    cd /vllm-workspace/vllm-omni && \
+    test "$(git rev-parse HEAD)" = "${VLLM_OMNI_COMMIT}" && \
+    printf '%s\n' "${VLLM_OMNI_COMMIT}" > /vllm-workspace/vllm-omni/VLLM_OMNI_COMMIT && \
+    python -c 'from pathlib import Path; p=Path("vllm_omni/diffusion/data.py"); old="from enum import Enum, StrEnum"; new="from enum import Enum\ntry:\n    from enum import StrEnum\nexcept ImportError:\n    from strenum import StrEnum"; source=p.read_text(); assert source.count(old) == 1; p.write_text(source.replace(old, new))' && \
+    python -m pip install --no-deps --index-url "${MUSA_PIP_INDEX_URL}" \
+        "tilelang-musa==0.1.8+musa.3" && \
+    for distribution in apache-tvm-ffi deep-gemm deep_ep flash_attn_3 flash_mla flashinfer-python mate mate-mubin sageattention tilelang_musa torch torch-c-dlpack-ext torchaudio torch_musa torchada torchvision triton vllm vllm-musa; do \
+        installed_version="$(python -c 'from importlib.metadata import version; import sys; print(version(sys.argv[1]))' "${distribution}")"; \
+        printf '%s==%s\n' "${distribution}" "${installed_version}"; \
+    done > /tmp/vllm-musa-constraints.txt && \
+    VLLM_OMNI_TARGET_DEVICE=musa python -m pip install --no-deps -e . --no-build-isolation -v && \
+    if python -m pip show opencv-python-headless >/dev/null 2>&1; then \
+        python -m pip uninstall -y opencv-python-headless; \
+    fi && \
+    python -m pip install --constraint /tmp/vllm-musa-constraints.txt \
+        --index-url "${PYPI_INDEX_URL}" \
+        -r requirements/common.txt \
+        "numpy>=1.26.4,<2" \
+        "opencv-python==4.11.0.86" \
+        "onnxruntime>=1.23.2" \
+        "strenum==0.4.15; python_version < '3.11'" && \
+    printf '%s\n' \
+        'from importlib.metadata import version' \
+        'from pathlib import Path' \
+        'from packaging.requirements import Requirement' \
+        'from packaging.version import Version' \
+        '' \
+        'checks = (("torchada", ">=0.1.52"), ("mate", ">=0.2.0"), ("flash_attn_3", ">=0.1.4"))' \
+        'for name, spec in checks:' \
+        '    installed = Version(version(name))' \
+        '    assert installed in Requirement(f"{name}{spec}").specifier, (name, installed, spec)' \
+        '    print(f"PASS preserve {name} version={installed}")' \
+        '' \
+        'for line in Path("/tmp/vllm-musa-constraints.txt").read_text().splitlines():' \
+        '    name, expected = line.split("==", 1)' \
+        '    actual = version(name)' \
+        '    assert actual == expected, (name, expected, actual)' \
+        '    print(f"PASS preserve {name} version={actual}")' \
+        '' \
+        'numpy_version = Version(version("numpy"))' \
+        'assert numpy_version >= Version("1.26.4") and numpy_version < Version("2"), numpy_version' \
+        'print(f"PASS omni numpy override version={numpy_version}")' \
+        > /tmp/vllm_omni_preserve_check.py && \
+    python /tmp/vllm_omni_preserve_check.py && \
+    python -c 'import av, cv2, soundfile; assert cv2.__version__.startswith("4.11."), cv2.__version__; print("PASS media imports av=" + av.__version__ + " cv2=" + cv2.__version__ + " soundfile=" + soundfile.__version__)' && \
+    rm -f /tmp/vllm_omni_preserve_check.py /tmp/vllm-musa-constraints.txt && \
+    rm -rf /root/.cache/pip /vllm-workspace/vllm-omni/.git
+
+RUN ffmpeg -version >/dev/null && \
+    ffprobe -version >/dev/null && \
+    python -c 'import importlib.util; from importlib.metadata import version; assert importlib.util.find_spec("vllm_omni") is not None; assert version("vllm-omni") == "0.28.0+musa", version("vllm-omni"); print("PASS spec vllm_omni version=" + version("vllm-omni"))' && \
+    python -m compileall -q /vllm-workspace/vllm-omni/vllm_omni
+
+LABEL com.mthreads.vllm-omni.repository="${VLLM_OMNI_REPO}" \
+      com.mthreads.vllm-omni.ref="${VLLM_OMNI_REF}" \
+      com.mthreads.vllm-omni.revision="${VLLM_OMNI_COMMIT}" \
+      com.mthreads.vllm-omni.python310-strenum-backport="strenum==0.4.15"
+
+ENV MTHREADS_VISIBLE_DEVICES=all
+
+ENTRYPOINT ["vllm", "serve"]
+
+# Keep Docker's implicit (no --target) build behavior on the regular image.
+FROM vllm-openai AS default

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -350,7 +350,7 @@ RUN printf '%s\n' \
         '' \
         'for dist_name, module_name, prefix in expected:' \
         '    installed = version(dist_name)' \
-        '    skip_import = (dist_name == "tilelang_musa" and installed == "0.1.12+musa.2")' \
+        '    skip_import = (dist_name in {"flash_mla", "tilelang_musa"} and version("tilelang_musa") == "0.1.12+musa.2")' \
         '    if not skip_import: importlib.import_module(module_name)' \
         '    if dist_name in exact_version_dists and installed != prefix:' \
         '        raise RuntimeError(f"{dist_name} expected exactly {prefix}, got {installed}")' \

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -345,7 +345,7 @@ RUN printf '%s\n' \
         '    ("pycountry", "pycountry", ""),' \
         '    ("pytest", "pytest", ""),' \
         '    ("apache-tvm-ffi", "tvm_ffi", requirement_prefix("apache-tvm-ffi")),' \
-        '    ("torch_c_dlpack_ext", "torch_c_dlpack_ext", ""),' \
+        '    ("torch_c_dlpack_ext", "torch_c_dlpack_ext", requirement_prefix("torch-c-dlpack-ext")),' \
         ')' \
         '' \
         'for dist_name, module_name, prefix in expected:' \

--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -305,7 +305,6 @@ RUN python -m pip install \
 
 RUN printf '%s\n' \
         'import importlib' \
-        'import importlib.util' \
         'import re' \
         'from pathlib import Path' \
         'from importlib.metadata import version' \
@@ -324,14 +323,7 @@ RUN printf '%s\n' \
         '    raise RuntimeError(f"missing {dist_name} pin in {requirement_files}")' \
         '' \
         'exact_version_dists = frozenset({"torchada", "torch", "torch_musa", "torchvision", "torchaudio", "deep_ep"})' \
-        'exact_version_dists |= frozenset({"mate", "mate-mubin", "flash_attn_3", "flash_mla", "deep-gemm", "flashinfer-python", "sageattention", "tilelang_musa", "apache-tvm-ffi"})' \
-        'metadata_only_dists = frozenset({' \
-        '    "torchvision", "torchaudio", "mate", "mate-mubin", "flash_attn_3",' \
-        '    "flash_mla", "deep-gemm", "flashinfer-python", "sageattention",' \
-        '    "deep_ep", "tilelang_musa", "triton", "apache-tvm-ffi",' \
-        '    "torch_c_dlpack_ext",' \
-        '})' \
-        '' \
+        'exact_version_dists |= frozenset({"mate", "mate-mubin", "flash_attn_3", "flash_mla", "deep-gemm", "flashinfer-python", "sageattention", "tilelang_musa", "apache-tvm-ffi", "torch_c_dlpack_ext"})' \
         'expected = (' \
         '    ("torchada", "torchada", requirement_prefix("torchada")),' \
         '    ("numpy", "numpy", "1.26."),' \
@@ -357,19 +349,15 @@ RUN printf '%s\n' \
         ')' \
         '' \
         'for dist_name, module_name, prefix in expected:' \
-        '    if dist_name in metadata_only_dists:' \
-        '        if importlib.util.find_spec(module_name) is None:' \
-        '            raise RuntimeError(f"missing import spec for {module_name}")' \
-        '        check_kind = "spec"' \
-        '    else:' \
-        '        importlib.import_module(module_name)' \
-        '        check_kind = "import"' \
         '    installed = version(dist_name)' \
+        '    skip_import = (dist_name == "tilelang_musa" and installed == "0.1.12+musa.2")' \
+        '    if not skip_import: importlib.import_module(module_name)' \
         '    if dist_name in exact_version_dists and installed != prefix:' \
         '        raise RuntimeError(f"{dist_name} expected exactly {prefix}, got {installed}")' \
         '    if dist_name not in exact_version_dists and prefix and not installed.startswith(prefix):' \
         '        raise RuntimeError(f"{dist_name} expected {prefix}, got {installed}")' \
-        '    print(f"PASS {check_kind} {module_name} version={installed}")' \
+        '    action = "skip import" if skip_import else "import"' \
+        '    print(f"PASS {action} {module_name} version={installed}")' \
         '' \
         'for module_name in ("vllm", "vllm_musa"):' \
         '    module = importlib.import_module(module_name)' \
@@ -533,6 +521,7 @@ RUN git clone --depth 1 --branch "${VLLM_OMNI_REF}" "${VLLM_OMNI_REPO}" /vllm-wo
         "numpy>=1.26.4,<2" \
         "opencv-python==4.11.0.86" \
         "onnxruntime>=1.23.2" \
+        "mcp-types==2.1.1" \
         "strenum==0.4.15; python_version < '3.11'" && \
     printf '%s\n' \
         'from importlib.metadata import version' \
@@ -558,6 +547,7 @@ RUN git clone --depth 1 --branch "${VLLM_OMNI_REF}" "${VLLM_OMNI_REPO}" /vllm-wo
         > /tmp/vllm_omni_preserve_check.py && \
     python /tmp/vllm_omni_preserve_check.py && \
     python -c 'import av, cv2, soundfile; assert cv2.__version__.startswith("4.11."), cv2.__version__; print("PASS media imports av=" + av.__version__ + " cv2=" + cv2.__version__ + " soundfile=" + soundfile.__version__)' && \
+    python -c 'import re, subprocess; result=subprocess.run(["python", "-m", "pip", "check"], text=True, capture_output=True); lines=tuple(line for line in result.stdout.splitlines() if line.strip()); allowed=(r"vllm 0\.28\.0 requires opencv-python-headless(?:>=4\.13\.0)?, which is not installed\.", r"vllm-musa .+ has requirement click==8\.2\.0, but you have click .+\.", r"vllm-musa .+ has requirement numpy==1\.26, but you have numpy 1\.26\.4\.", r"vllm-musa .+ has requirement tilelang_musa==0\.1\.12\+musa\.2, but you have tilelang-musa .+\.", r"vllm-musa .+ has requirement transformers==5\.5\.3, but you have transformers 5\.14\.1\.", r"xgrammar .+ has requirement transformers<5,>=4\.38\.0, but you have transformers 5\.14\.1\."); unexpected=tuple(line for line in lines if not any(re.fullmatch(pattern, line) for pattern in allowed)); assert not unexpected, "unexpected pip check output: " + repr(unexpected); print("pip check allowlist entries:"); print("\\n".join(lines) if lines else "(clean)"); print("PASS pip check allowlist lines=" + str(len(lines)))' && \
     rm -f /tmp/vllm_omni_preserve_check.py /tmp/vllm-musa-constraints.txt && \
     rm -rf /root/.cache/pip /vllm-workspace/vllm-omni/.git
 


### PR DESCRIPTION
## Summary

- Add a \`vllm-omni\` Docker target derived from the existing \`vllm-openai\` stage.
- Keep the terminal \`default\` target pointed at \`vllm-openai\`; Omni-only apt/media packages and Python compatibility pins are not present in the regular image.
- Add build-script support for the explicit target, source revision/provenance arguments, and the source-cache build path.
- Document the target, Python 3.10 \`StrEnum\` fallback, runtime smoke contract, and the specialized Omni dependency boundary.

## Source

- Base: \`v0.28.0-dev\`
- vLLM-MUSA HEAD: \`83946ca95\`
- vLLM-Omni release: \`v0.28.0\`
- vLLM-Omni commit: \`eb11446b7f2e30ca582f8aff3afe12e9a2e66f6c\`
- Ticket: \`MUSA-100016\`

## Validation

Static checks on HEAD:

~~~text
git diff --check
bash -n docker/build_image.sh
22 focused contract/pin tests passed
~~~

The preceding image build from the same Docker-stage implementation (MUSA commit
\`72ec135fa\`, before the latest-base/doc follow-ups) produced:

- image: \`vllm-omni-musa:0.28.0-musa100016-72ec135f-rs0\`
- digest: \`sha256:500b2cee14a98399fc9094cf8fa12c7215bab45489b05fee5ed8c0575cfe8874\`
- host: \`10.20.36.6\` (\`3.3.5-server\` driver), two leased MUSA GPUs
- model: \`/mnt/nfs/models/Qwen/Qwen2.5-Omni-3B\`
- \`/health\`, \`/version\` (\`0.28.0\`), and \`/v1/models\` passed
- text chat returned \`Beijing\`
- audio chat (16 kHz generated tone, official \`audio_url\` payload) returned a continuous high-pitched-tone description

The HEAD follow-up image has not yet been rebuilt after the latest-base
adjustments: the remote Docker build reached the Omni source-fetch step and
stopped on a node-specific GitHub timeout. No runtime failure was observed.
The validated image used \`BUILD_VLLM_RS=0\` because the Rust download mirror was
unavailable; the image is therefore explicitly marked \`rs0\`.

## Dependency note

The Omni target is intentionally specialized. Omni 0.28's Transformers/OpenCV
requirements cannot be simultaneously represented by the existing
vLLM-MUSA metadata pins while retaining the MUSA NumPy-1 ABI and the validated
TileLang wheel. The child records an explicit \`pip check\` allowlist and fails
on any additional conflict. The regular \`vllm-openai\` target is unchanged.

## Review focus

- Is the specialized Omni dependency boundary/allowlist acceptable, or should
  the parent package metadata be split/relaxed in a follow-up?
- Should the optional source-cache path be promoted to the standard build
  workflow, or remain an internal build-script option?
- Please review whether the two-GPU Qwen2.5-Omni smoke is the right initial
  acceptance gate.
