### PR TITLE
fix(musa): avoid duplicate DSV4 contract patch hunk

### DIFF
--- a/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
+++ b/vllm_musa/patches/series/0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch
@@ -64,10 +64,6 @@ index e21e566f7..77b78e6e2 100644
                      self.use_fp4_cache,
 +                    self.use_musa_materialized_prefill,
                  )
-@@ -1826,2 +1841,3 @@ class SparseAttnIndexer(CustomOp):
-             current_platform.is_musa()
-+            and self.use_musa_native_indexer
-             and _musa_sparse_indexer_is_current_stream_capturing()
 diff --git a/vllm/models/deepseek_v4/attention.py b/vllm/models/deepseek_v4/attention.py
 index 34842fc34..b2d29e197 100644
 --- a/vllm/models/deepseek_v4/attention.py


### PR DESCRIPTION
## Summary

0101-MUSA-bind-DeepSeek-V4-optimization-contract.patch attempted to add the same self.use_musa_native_indexer condition that had already been introduced by 0092-MUSA-skip-unused-DeepSeek-V4-recent-indexer-Q-work.patch. The duplicated hunk caused the patch series to fail against the pinned vLLM ee0da84 source.

## Changed
Removed the redundant hunk from 0101. The existing condition from 0092 is preserved, so runtime behavior is unchanged; this only restores clean patch application on the latest v0.24.0-dev branch.

## Test
- comple pass
- install pass
- dsv4 and qwen models test pass 