### PR TITLE
docs: backport refreshed cookbook to v0.28.0-dev

### DIFF
--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1,6 +1,6 @@
 # vLLM-MUSA serving recipes
 
-Starting configurations for serving the listed models with vLLM-MUSA v0.28.0-dev
+Copy-ready configurations for serving supported models with vLLM-MUSA v0.28.0-dev
 on S5000 GPUs. Revalidate the exact image, model checkpoint, and workload
 before treating a profile as a production recommendation.
 
@@ -22,25 +22,23 @@ release line are intentionally not carried over.
 - The registry tag is published independently of this branch and may carry a
   different dependency revision; verify package versions, or build the local
   image described in the installation guide for exact branch parity.
-- Mount the checkpoint under `/mnt/models` or update the path in the command.
-- Keep TP1 when a model fits on one GPU; increase TP only when memory requires
-  it.
+- Mount the checkpoint under `/models` or update the path in the command.
+- Use the tensor-parallelism size documented in each recipe; increase TP only
+  when memory requires it.
 
 ## Qwen
 
-The listed Qwen checkpoints fit on one S5000 and use TP1.
-
-| Model | Precision | Speculative decoding | Recipe |
-|---|---|---|---|
-| Qwen3-8B | FP8 | Off | [Open recipe](qwen/qwen3-8b-fp8.md) |
-| Qwen3.5-27B | BF16 | Off | [Open recipe](qwen/qwen3.5-27b-bf16.md) |
-| Qwen3.5-27B | FP8 | MTP1 | [Open recipe](qwen/qwen3.5-27b-fp8.md) |
-| Qwen3.5-35B-A3B | BF16 | Off | [Open recipe](qwen/qwen3.5-35b-a3b-bf16.md) |
-| Qwen3.5-35B-A3B | FP8 | MTP3 | [Open recipe](qwen/qwen3.5-35b-a3b-fp8.md) |
-| Qwen3.6-27B | BF16 | Off | [Open recipe](qwen/qwen3.6-27b-bf16.md) |
-| Qwen3.6-27B | FP8 | MTP1 | [Open recipe](qwen/qwen3.6-27b-fp8.md) |
-| Qwen3.6-35B-A3B | BF16 | Off | [Open recipe](qwen/qwen3.6-35b-a3b-bf16.md) |
-| Qwen3.6-35B-A3B | FP8 | MTP3 | [Open recipe](qwen/qwen3.6-35b-a3b-fp8.md) |
+| Model | Precision | Hardware | Speculative decoding | Recipe |
+|---|---|---|---|---|
+| Qwen3-8B | FP8 | 1x S5000, TP1 | Off | [Open recipe](qwen/qwen3-8b-fp8.md) |
+| Qwen3.5-27B | BF16 | 2x S5000, TP2 | MTP1 | [Open recipe](qwen/qwen3.5-27b-bf16.md) |
+| Qwen3.5-27B | FP8 | 2x S5000, TP2 | Off | [Open recipe](qwen/qwen3.5-27b-fp8.md) |
+| Qwen3.5-35B-A3B | BF16 | 4x S5000, TP4 | MTP3 | [Open recipe](qwen/qwen3.5-35b-a3b-bf16.md) |
+| Qwen3.5-35B-A3B | FP8 | 4x S5000, TP4 | MTP3 | [Open recipe](qwen/qwen3.5-35b-a3b-fp8.md) |
+| Qwen3.6-27B | BF16 | 2x S5000, TP2 | MTP3 | [Open recipe](qwen/qwen3.6-27b-bf16.md) |
+| Qwen3.6-27B | FP8 | 2x S5000, TP2 | MTP3 | [Open recipe](qwen/qwen3.6-27b-fp8.md) |
+| Qwen3.6-35B-A3B | BF16 | 4x S5000, TP4 | MTP2 | [Open recipe](qwen/qwen3.6-35b-a3b-bf16.md) |
+| Qwen3.6-35B-A3B | FP8 | 4x S5000, TP4 | MTP2 | [Open recipe](qwen/qwen3.6-35b-a3b-fp8.md) |
 
 ## DeepSeek
 

--- a/docs/cookbook/deepseek/deepseek-v4-flash.md
+++ b/docs/cookbook/deepseek/deepseek-v4-flash.md
@@ -8,8 +8,7 @@ an MTP-off profile for deployments that do not use speculative decoding.
 
 > [!TIP]
 > Start with **MTP4** when decode latency is the priority, especially at small
-> batches. Keep chunked prefill enabled so long prefills do not block active
-> decode requests for their full duration.
+> batches.
 
 This MTP4 profile carries forward the v0.24 tuning. The v0.28.0-dev branch
 still requires verification-semantics and serving-health validation on the
@@ -23,7 +22,10 @@ target image before this candidate is promoted to a production recommendation.
 | Tensor parallelism | TP8 |
 | Attention backend | FlashMLA |
 | KV cache | FP8 |
-| Maximum context | 6,144 tokens |
+| Maximum context (MTP4) | 8,192 tokens |
+| Maximum context (MTP-off) | 6,144 tokens |
+| Maximum batched tokens (MTP4) | 8,192 tokens |
+| Maximum batched tokens (MTP-off) | 8,195 tokens |
 | Maximum sequences | 64 |
 | Candidate profile | Fixed MTP4 |
 | Alternative | MTP-off |
@@ -32,8 +34,10 @@ target image before this candidate is promoted to a production recommendation.
 
 - vLLM-MUSA v0.28.0-dev.
 - Eight S5000 GPUs available to the server process.
-- The checkpoint mounted at `/mnt/models/DeepSeek-V4-Flash-Base`, or an
+- The checkpoint mounted at `/models/DeepSeek-V4-Flash-Base`, or an
   equivalent path substituted in the command.
+- Both launch profiles use the `/models` mount and the same served model name,
+  `DeepSeek-V4-Flash-Base`, so the verification request can be reused.
 
 ## Launching the server
 
@@ -45,25 +49,30 @@ This profile uses a fixed four-token MTP draft.
 export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
 export SAFETENSORS_FAST_GPU=1
+export PYTHONUNBUFFERED=1
 export VLLM_USE_DEEP_GEMM=1
 export VLLM_USE_DEEP_GEMM_E8M0=0
 export VLLM_DEEP_GEMM_WARMUP=skip
 export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
+export VLLM_MUSA_DEEPSEEK_V4_TP8_PROFILE=aggressive_long_prefill
+export VLLM_MUSA_DEEPSEEK_V4_MOE_DEEPGEMM_PREFILL=1
+export VLLM_MUSA_FUSED_AR_RMSNORM=0
 
-vllm serve /mnt/models/DeepSeek-V4-Flash-Base \
+CUDAGRAPH_CAPTURE_SIZES="$(seq -s, 5 5 320)"
+
+vllm serve /models/DeepSeek-V4-Flash-Base \
   --trust-remote-code \
   --tensor-parallel-size 8 \
-  --served-model-name deepseek-v4-flash-base \
-  --max-model-len 6144 \
+  --served-model-name DeepSeek-V4-Flash-Base \
+  --max-model-len 8192 \
   --max-num-seqs 64 \
-  --max-num-batched-tokens 8195 \
-  --gpu-memory-utilization 0.95 \
+  --max-num-batched-tokens 8192 \
+  --gpu-memory-utilization 0.92 \
   --kv-cache-dtype fp8 \
   --no-enable-prefix-caching \
-  --enable-chunked-prefill \
   --attention-backend FLASHMLA \
   --speculative-config '{"method":"mtp","num_speculative_tokens":4}' \
-  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","max_cudagraph_capture_size":320,"cudagraph_capture_sizes":[5,10,20,40,80,160,320],"cudagraph_copy_inputs":false}' \
+  --compilation-config "{\"mode\":\"NONE\",\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CUDAGRAPH_CAPTURE_SIZES}]}" \
   --async-scheduling
 ```
 
@@ -83,10 +92,10 @@ export VLLM_USE_DEEP_GEMM_E8M0=0
 export VLLM_DEEP_GEMM_WARMUP=skip
 export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
 
-vllm serve /mnt/models/DeepSeek-V4-Flash-Base \
+vllm serve /models/DeepSeek-V4-Flash-Base \
   --trust-remote-code \
   --tensor-parallel-size 8 \
-  --served-model-name deepseek-v4-flash-base \
+  --served-model-name DeepSeek-V4-Flash-Base \
   --max-model-len 6144 \
   --max-num-seqs 64 \
   --max-num-batched-tokens 8195 \
@@ -101,12 +110,20 @@ vllm serve /mnt/models/DeepSeek-V4-Flash-Base \
 
 ## Verifying the server
 
+Both profiles use the same served model name:
+
+| Profile | Checkpoint path in the command | Served model name |
+|---|---|---|
+| MTP4 | `/models/DeepSeek-V4-Flash-Base` | `DeepSeek-V4-Flash-Base` |
+| MTP-off | `/models/DeepSeek-V4-Flash-Base` | `DeepSeek-V4-Flash-Base` |
+
 ```python
 from openai import OpenAI
 
 client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+served_model_name = "DeepSeek-V4-Flash-Base"
 response = client.chat.completions.create(
-    model="deepseek-v4-flash-base",
+    model=served_model_name,
     messages=[{"role": "user", "content": "Hello"}],
     temperature=0,
 )
@@ -116,15 +133,14 @@ print(response.choices[0].message.content)
 ## Configuration notes
 
 - Keep TP8 for this checkpoint.
-- Keep chunked prefill enabled. Disabling it can reduce isolated prefill
-  latency, but long prefills may then cause severe decode inter-token stalls.
-- `max-num-batched-tokens=8195` preserves the intended 4K-input workload
-  envelope.
+- For MTP4, `max-num-batched-tokens=8192` preserves the intended 4K-input
+  workload envelope. The MTP-off profile uses `8195` as shown in its command.
 - `async-scheduling` keeps the scheduler off the critical path. If combining
   this profile with pipeline parallelism or structured outputs, revalidate the
   exact deployment workload.
-- MTP4 uses speculative batch sizes while MTP-off uses ordinary request batch
-  sizes. `FULL_DECODE_ONLY` keeps graph capture focused on decode.
+- The MTP4 capture ladder accounts for its four-token draft; MTP-off uses
+  ordinary request batch sizes. `FULL_DECODE_ONLY` keeps graph capture focused
+  on decode.
 - On lower-memory S5000 variants, reduce `max-num-seqs` and the matching graph
   capture ceiling before lowering `max-num-batched-tokens`.
 

--- a/docs/cookbook/qwen/README.md
+++ b/docs/cookbook/qwen/README.md
@@ -1,7 +1,9 @@
 # Qwen serving recipes
 
-Qwen recipes use one S5000 GPU whenever the checkpoint fits. Choose the page
-that matches both the model version and weight precision.
+Qwen recipes use the hardware and tensor-parallel size listed on each page.
+The current validated profiles use TP1 for Qwen3-8B, TP2 for Qwen3.5/3.6-27B,
+and TP4 for Qwen3.5/3.6-35B-A3B. Choose the page that matches both the model
+version and weight precision.
 
 > [!NOTE]
 > FP8 and BF16 checkpoints have different memory and speculative-decoding
@@ -13,28 +15,33 @@ that matches both the model version and weight precision.
 | Model | Precision | Speculative decoding | Recipe |
 |---|---|---|---|
 | Qwen3-8B | FP8 | Off | [Open recipe](qwen3-8b-fp8.md) |
-| Qwen3.5-27B | BF16 | Off | [Open recipe](qwen3.5-27b-bf16.md) |
-| Qwen3.5-27B | FP8 | MTP1 | [Open recipe](qwen3.5-27b-fp8.md) |
-| Qwen3.6-27B | BF16 | Off | [Open recipe](qwen3.6-27b-bf16.md) |
-| Qwen3.6-27B | FP8 | MTP1 | [Open recipe](qwen3.6-27b-fp8.md) |
+| Qwen3.5-27B | BF16 | MTP1 | [Open recipe](qwen3.5-27b-bf16.md) |
+| Qwen3.5-27B | FP8 | Off | [Open recipe](qwen3.5-27b-fp8.md) |
+| Qwen3.6-27B | BF16 | MTP3 | [Open recipe](qwen3.6-27b-bf16.md) |
+| Qwen3.6-27B | FP8 | MTP3 | [Open recipe](qwen3.6-27b-fp8.md) |
 
 ## MoE models
 
 | Model | Precision | Speculative decoding | Recipe |
 |---|---|---|---|
-| Qwen3.5-35B-A3B | BF16 | Off | [Open recipe](qwen3.5-35b-a3b-bf16.md) |
+| Qwen3.5-35B-A3B | BF16 | MTP3 | [Open recipe](qwen3.5-35b-a3b-bf16.md) |
 | Qwen3.5-35B-A3B | FP8 | MTP3 | [Open recipe](qwen3.5-35b-a3b-fp8.md) |
-| Qwen3.6-35B-A3B | BF16 | Off | [Open recipe](qwen3.6-35b-a3b-bf16.md) |
-| Qwen3.6-35B-A3B | FP8 | MTP3 | [Open recipe](qwen3.6-35b-a3b-fp8.md) |
+| Qwen3.6-35B-A3B | BF16 | MTP2 | [Open recipe](qwen3.6-35b-a3b-bf16.md) |
+| Qwen3.6-35B-A3B | FP8 | MTP2 | [Open recipe](qwen3.6-35b-a3b-fp8.md) |
 
 ## Common deployment choices
 
 | Setting | Recommended value |
 |---|---|
-| Hardware | 1x S5000 |
-| Tensor parallelism | TP1 |
+| Hardware | Recipe-specific (1x, 2x, or 4x S5000) |
+| Tensor parallelism | Recipe-specific (TP1, TP2, or TP4) |
+| Speculative decoding | Use the profile listed in the recipe (Off, MTP1, MTP2, or MTP3) |
 | API | OpenAI-compatible server on port 8000 |
-| Model path | `/mnt/models/<checkpoint>` |
+| Model path | `/models/<checkpoint>` |
+
+The `qwen3_5_mtp` value used by some validated commands is the backend method
+name; keep it exactly as written. The path, tensor parallelism, and MTP mode
+are profile-specific and should be copied together from one recipe page.
 
 See the [cookbook index](../README.md) for client usage and the DeepSeek
 recipe.

--- a/docs/cookbook/qwen/qwen3-8b-fp8.md
+++ b/docs/cookbook/qwen/qwen3-8b-fp8.md
@@ -25,7 +25,7 @@ export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
 export SAFETENSORS_FAST_GPU=1
 
-vllm serve /mnt/models/Qwen3-8B-FP8 \
+vllm serve /models/Qwen3-8B-FP8 \
   --trust-remote-code \
   --tensor-parallel-size 1 \
   --served-model-name qwen3-8b-fp8 \
@@ -46,6 +46,6 @@ vllm serve /mnt/models/Qwen3-8B-FP8 \
 
 - Chunked prefill and asynchronous scheduling are enabled.
 - Prefix caching is disabled.
-- Replace `/mnt/models/Qwen3-8B-FP8` if the checkpoint is mounted elsewhere.
+- Replace `/models/Qwen3-8B-FP8` if the checkpoint is mounted elsewhere.
 
 Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-27b-bf16.md
+++ b/docs/cookbook/qwen/qwen3.5-27b-bf16.md
@@ -2,20 +2,20 @@
 
 ## Overview
 
-BF16 dense-model recipe for a single S5000 GPU.
+BF16 dense-model recipe for two S5000 GPUs.
 
 > [!TIP]
-> Use TP1 and keep speculative decoding disabled for this checkpoint.
+> Use TP2 and enable MTP1 speculative decoding for this checkpoint.
 
 ## At a glance
 
 | Setting | Value |
 |---|---|
-| Hardware | 1x S5000 |
+| Hardware | 2x S5000 |
 | Precision | BF16 |
-| Tensor parallelism | TP1 |
-| Speculative decoding | Off |
-| Maximum context | 5,192 tokens |
+| Tensor parallelism | TP2 |
+| Speculative decoding | MTP1 |
+| Maximum context | 7,168 tokens |
 | Maximum sequences | 64 |
 
 ## Launching the server
@@ -23,29 +23,25 @@ BF16 dense-model recipe for a single S5000 GPU.
 ```bash
 export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export VLLM_DISABLE_COMPILE_CACHE=1
 export SAFETENSORS_FAST_GPU=1
 
-vllm serve /mnt/models/Qwen3.5-27B-BF16 \
+vllm serve /models/Qwen3.5-27B \
   --trust-remote-code \
-  --tensor-parallel-size 1 \
-  --served-model-name qwen35-27b-bf16 \
-  --max-model-len 5192 \
+  --tensor-parallel-size 2 \
+  --served-model-name Qwen3.5-27B \
+  --max-model-len 7168 \
   --max-num-seqs 64 \
-  --max-num-batched-tokens 2048 \
-  --long-prefill-token-threshold 4096 \
-  --gpu-memory-utilization 0.90 \
   --no-enable-prefix-caching \
-  --enable-chunked-prefill \
-  --generation-config vllm \
-  --async-scheduling \
+  --no-enable-chunked-prefill \
   --attention-config '{"backend":"FLASH_ATTN"}' \
-  --compilation-config '{"compile_sizes":[1,4,16,64],"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,64]}' \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
 ```
 
 ## Configuration notes
 
-- The 2,048-token scheduler budget favors predictable prefill admission.
-- Chunked prefill and asynchronous scheduling are enabled.
-- Replace `/mnt/models/Qwen3.5-27B-BF16` if needed.
+- Chunked prefill and asynchronous scheduling are disabled.
+- Replace `/models/Qwen3.5-27B` if needed.
 
 Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-27b-fp8.md
+++ b/docs/cookbook/qwen/qwen3.5-27b-fp8.md
@@ -2,20 +2,20 @@
 
 ## Overview
 
-FP8 dense-model recipe with one-token MTP speculative decoding.
+FP8 dense-model recipe for two S5000 GPUs.
 
 > [!TIP]
-> Use this TP1 profile when serving the FP8 checkpoint.
+> Use this TP2 profile when serving the FP8 checkpoint.
 
 ## At a glance
 
 | Setting | Value |
 |---|---|
-| Hardware | 1x S5000 |
+| Hardware | 2x S5000 |
 | Precision | FP8 |
-| Tensor parallelism | TP1 |
-| Speculative decoding | MTP1 |
-| Maximum context | 5,192 tokens |
+| Tensor parallelism | TP2 |
+| Speculative decoding | Off |
+| Maximum context | 7,168 tokens |
 | Maximum sequences | 64 |
 
 ## Launching the server
@@ -23,30 +23,23 @@ FP8 dense-model recipe with one-token MTP speculative decoding.
 ```bash
 export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export VLLM_DISABLE_COMPILE_CACHE=1
 export SAFETENSORS_FAST_GPU=1
 
-vllm serve /mnt/models/Qwen3.5-27B-FP8 \
+vllm serve /models/Qwen3.5-27B-FP8 \
   --trust-remote-code \
-  --tensor-parallel-size 1 \
-  --served-model-name qwen35-27b-fp8 \
-  --max-model-len 5192 \
+  --tensor-parallel-size 2 \
+  --served-model-name Qwen3.5-27B-FP8 \
+  --max-model-len 7168 \
   --max-num-seqs 64 \
-  --max-num-batched-tokens 8192 \
-  --long-prefill-token-threshold 4096 \
-  --gpu-memory-utilization 0.90 \
   --no-enable-prefix-caching \
-  --enable-chunked-prefill \
-  --generation-config vllm \
-  --async-scheduling \
+  --no-enable-chunked-prefill \
   --attention-config '{"backend":"FLASH_ATTN"}' \
-  --compilation-config '{"cudagraph_capture_sizes":[2,8,32,128],"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
-  --speculative-config '{"attention_backend":"FLASH_ATTN","method":"mtp","num_speculative_tokens":1}'
+  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,64]}'
 ```
 
 ## Configuration notes
 
-- MTP1 uses the FlashAttention backend for draft attention.
-- Graph capture sizes account for the additional draft token.
-- Replace `/mnt/models/Qwen3.5-27B-FP8` if needed.
+- Replace `/models/Qwen3.5-27B-FP8` if needed.
 
 Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-35b-a3b-bf16.md
+++ b/docs/cookbook/qwen/qwen3.5-35b-a3b-bf16.md
@@ -2,50 +2,54 @@
 
 ## Overview
 
-BF16 MoE recipe for a single S5000 GPU.
+BF16 MoE recipe for four S5000 GPUs.
 
 > [!TIP]
-> Use TP1 and keep speculative decoding disabled for this checkpoint.
+> Use TP4 and enable MTP3 speculative decoding for this checkpoint.
 
 ## At a glance
 
 | Setting | Value |
 |---|---|
-| Hardware | 1x S5000 |
+| Hardware | 4x S5000 |
 | Precision | BF16 |
 | Architecture | MoE, 35B-A3B |
-| Tensor parallelism | TP1 |
-| Speculative decoding | Off |
-| Maximum context | 5,192 tokens |
+| Tensor parallelism | TP4 |
+| Speculative decoding | MTP3 |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 192 |
 
 ## Launching the server
 
 ```bash
 export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export LD_LIBRARY_PATH=/usr/local/mtshmem/lib:${LD_LIBRARY_PATH:-}
 export SAFETENSORS_FAST_GPU=1
 
-vllm serve /mnt/models/Qwen3.5-35B-A3B-BF16 \
+CAPTURE_SIZES="$(seq -s, 4 4 768)"
+
+vllm serve /models/Qwen3.5-35B-A3B \
   --trust-remote-code \
-  --tensor-parallel-size 1 \
-  --served-model-name qwen35-35b-a3b-bf16 \
-  --max-model-len 5192 \
-  --max-num-seqs 64 \
+  --tensor-parallel-size 4 \
+  --served-model-name Qwen3.5-35B-A3B \
+  --max-model-len 8192 \
+  --max-num-seqs 192 \
   --max-num-batched-tokens 8192 \
-  --long-prefill-token-threshold 2048 \
-  --gpu-memory-utilization 0.95 \
+  --gpu-memory-utilization 0.85 \
+  --mamba-ssm-cache-dtype float32 \
   --no-enable-prefix-caching \
-  --enable-chunked-prefill \
-  --generation-config vllm \
-  --async-scheduling \
+  --no-enable-chunked-prefill \
   --attention-config '{"backend":"FLASH_ATTN"}' \
-  --compilation-config '{"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+  --compilation-config "{\"mode\":\"NONE\",\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CAPTURE_SIZES}]}" \
+  --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3}'
 ```
 
 ## Configuration notes
 
-- The memory-utilization target is 0.95 for this BF16 MoE checkpoint.
-- Chunked prefill and asynchronous scheduling are enabled.
-- Replace `/mnt/models/Qwen3.5-35B-A3B-BF16` if needed.
+- The memory-utilization target is 0.85 for this BF16 MoE checkpoint.
+- Chunked prefill and asynchronous scheduling are disabled.
+- Replace `/models/Qwen3.5-35B-A3B` if needed.
 
 Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-35b-a3b-fp8.md
+++ b/docs/cookbook/qwen/qwen3.5-35b-a3b-fp8.md
@@ -5,48 +5,51 @@
 FP8 MoE recipe with three-token MTP speculative decoding.
 
 > [!TIP]
-> Use this TP1 profile for small-batch serving of the FP8 checkpoint.
+> Use this TP4 profile for small-batch serving of the FP8 checkpoint.
 
 ## At a glance
 
 | Setting | Value |
 |---|---|
-| Hardware | 1x S5000 |
+| Hardware | 4x S5000 |
 | Precision | FP8 |
 | Architecture | MoE, 35B-A3B |
-| Tensor parallelism | TP1 |
+| Tensor parallelism | TP4 |
 | Speculative decoding | MTP3 |
-| Maximum context | 5,192 tokens |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 192 |
 
 ## Launching the server
 
 ```bash
 export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export LD_LIBRARY_PATH=/usr/local/mtshmem/lib:${LD_LIBRARY_PATH:-}
 export SAFETENSORS_FAST_GPU=1
 
-vllm serve /mnt/models/Qwen3.5-35B-A3B-FP8 \
+CAPTURE_SIZES="$(seq -s, 4 4 768)"
+
+vllm serve /models/Qwen3.5-35B-A3B-FP8 \
   --trust-remote-code \
-  --tensor-parallel-size 1 \
-  --served-model-name qwen35-35b-a3b-fp8 \
-  --max-model-len 5192 \
-  --max-num-seqs 64 \
-  --max-num-batched-tokens 32768 \
-  --long-prefill-token-threshold 2048 \
-  --gpu-memory-utilization 0.90 \
+  --tensor-parallel-size 4 \
+  --served-model-name Qwen3.5-35B-A3B-FP8 \
+  --max-model-len 8192 \
+  --max-num-seqs 192 \
+  --max-num-batched-tokens 8192 \
+  --gpu-memory-utilization 0.85 \
+  --mamba-ssm-cache-dtype float32 \
   --no-enable-prefix-caching \
-  --enable-chunked-prefill \
-  --generation-config vllm \
-  --async-scheduling \
+  --no-enable-chunked-prefill \
   --attention-config '{"backend":"FLASH_ATTN"}' \
-  --compilation-config '{"cudagraph_capture_sizes":[4,16,64,256],"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
-  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+  --compilation-config "{\"mode\":\"NONE\",\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CAPTURE_SIZES}]}" \
+  --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3}'
 ```
 
 ## Configuration notes
 
 - MTP3 uses graph sizes scaled for three draft tokens.
-- The 32,768-token scheduler budget supports the selected profile.
-- Replace `/mnt/models/Qwen3.5-35B-A3B-FP8` if needed.
+- The 8,192-token scheduler budget supports the selected profile.
+- Replace `/models/Qwen3.5-35B-A3B-FP8` if needed.
 
 Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.6-27b-bf16.md
+++ b/docs/cookbook/qwen/qwen3.6-27b-bf16.md
@@ -2,50 +2,52 @@
 
 ## Overview
 
-BF16 dense-model recipe for a single S5000 GPU.
+BF16 dense-model recipe for two S5000 GPUs.
 
 > [!TIP]
-> Use TP1 and keep speculative decoding disabled for this checkpoint.
+> Use TP2 and enable MTP3 speculative decoding for this checkpoint.
 
 ## At a glance
 
 | Setting | Value |
 |---|---|
-| Hardware | 1x S5000 |
+| Hardware | 2x S5000 |
 | Precision | BF16 |
-| Tensor parallelism | TP1 |
-| Speculative decoding | Off |
-| Maximum context | 5,192 tokens |
-| Maximum sequences | 64 |
+| Tensor parallelism | TP2 |
+| Speculative decoding | MTP3 |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 128 |
 
 ## Launching the server
 
 ```bash
 export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
 export SAFETENSORS_FAST_GPU=1
 
-vllm serve /mnt/models/Qwen3.6-27B \
+CAPTURE_SIZES="$(seq -s, 4 4 512)"
+
+vllm serve /models/Qwen3.6-27B \
   --trust-remote-code \
-  --tensor-parallel-size 1 \
-  --served-model-name qwen36-27b-bf16 \
-  --max-model-len 5192 \
-  --max-num-seqs 64 \
-  --max-num-batched-tokens 2048 \
-  --long-prefill-token-threshold 4096 \
-  --gpu-memory-utilization 0.90 \
+  --tensor-parallel-size 2 \
+  --served-model-name Qwen3.6-27B \
+  --max-model-len 8192 \
+  --max-num-seqs 128 \
+  --max-num-batched-tokens 8192 \
+  --gpu-memory-utilization 0.9 \
+  --mamba-ssm-cache-dtype float32 \
   --no-enable-prefix-caching \
-  --enable-chunked-prefill \
-  --generation-config vllm \
-  --async-scheduling \
+  --no-enable-chunked-prefill \
   --attention-config '{"backend":"FLASH_ATTN"}' \
-  --compilation-config '{"compile_sizes":[1,4,16,64],"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+  --compilation-config "{\"mode\":\"NONE\",\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CAPTURE_SIZES}]}" \
+  --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3}'
 ```
 
 ## Configuration notes
 
-- The 2,048-token scheduler budget favors predictable prefill admission.
-- Chunked prefill and asynchronous scheduling are enabled.
-- Replace `/mnt/models/Qwen3.6-27B` if needed.
+- The 8,192-token scheduler budget favors predictable prefill admission.
+- Chunked prefill and asynchronous scheduling are disabled.
+- Replace `/models/Qwen3.6-27B` if needed.
 
 Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.6-27b-fp8.md
+++ b/docs/cookbook/qwen/qwen3.6-27b-fp8.md
@@ -2,51 +2,52 @@
 
 ## Overview
 
-FP8 dense-model recipe with one-token MTP speculative decoding.
+FP8 dense-model recipe with three-token MTP speculative decoding.
 
 > [!TIP]
-> Use this TP1 profile when serving the FP8 checkpoint.
+> Use this TP2 profile when serving the FP8 checkpoint.
 
 ## At a glance
 
 | Setting | Value |
 |---|---|
-| Hardware | 1x S5000 |
+| Hardware | 2x S5000 |
 | Precision | FP8 |
-| Tensor parallelism | TP1 |
-| Speculative decoding | MTP1 |
-| Maximum context | 5,192 tokens |
-| Maximum sequences | 64 |
+| Tensor parallelism | TP2 |
+| Speculative decoding | MTP3 |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 128 |
 
 ## Launching the server
 
 ```bash
 export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
 export SAFETENSORS_FAST_GPU=1
 
-vllm serve /mnt/models/Qwen3.6-27B-FP8 \
+CAPTURE_SIZES="$(seq -s, 4 4 512)"
+
+vllm serve /models/Qwen3.6-27B-FP8 \
   --trust-remote-code \
-  --tensor-parallel-size 1 \
-  --served-model-name qwen36-27b-fp8 \
-  --max-model-len 5192 \
-  --max-num-seqs 64 \
+  --tensor-parallel-size 2 \
+  --served-model-name Qwen3.6-27B-FP8 \
+  --max-model-len 8192 \
+  --max-num-seqs 128 \
   --max-num-batched-tokens 8192 \
-  --long-prefill-token-threshold 4096 \
-  --gpu-memory-utilization 0.90 \
+  --gpu-memory-utilization 0.80 \
+  --mamba-ssm-cache-dtype float32 \
   --no-enable-prefix-caching \
-  --enable-chunked-prefill \
-  --generation-config vllm \
-  --async-scheduling \
+  --no-enable-chunked-prefill \
   --attention-config '{"backend":"FLASH_ATTN"}' \
-  --compilation-config '{"cudagraph_capture_sizes":[2,8,32,128],"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
-  --speculative-config '{"attention_backend":"FLASH_ATTN","method":"mtp","num_speculative_tokens":1}'
+  --compilation-config "{\"mode\":\"NONE\",\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CAPTURE_SIZES}]}" \
+  --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3}'
 ```
 
 ## Configuration notes
 
-- MTP1 uses the FlashAttention backend for draft attention.
-- Graph capture sizes account for the additional draft token.
-- Replace `/mnt/models/Qwen3.6-27B-FP8` if needed.
+- MTP3 uses the FlashAttention backend for draft attention.
+- Graph capture sizes account for the additional draft tokens.
+- Replace `/models/Qwen3.6-27B-FP8` if needed.
 
 Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.6-35b-a3b-bf16.md
+++ b/docs/cookbook/qwen/qwen3.6-35b-a3b-bf16.md
@@ -2,50 +2,51 @@
 
 ## Overview
 
-BF16 MoE recipe for a single S5000 GPU.
+BF16 MoE recipe for four S5000 GPUs.
 
 > [!TIP]
-> Use TP1 and keep speculative decoding disabled for this checkpoint.
+> Use TP4 and enable MTP2 speculative decoding for this checkpoint.
 
 ## At a glance
 
 | Setting | Value |
 |---|---|
-| Hardware | 1x S5000 |
+| Hardware | 4x S5000 |
 | Precision | BF16 |
 | Architecture | MoE, 35B-A3B |
-| Tensor parallelism | TP1 |
-| Speculative decoding | Off |
-| Maximum context | 5,192 tokens |
+| Tensor parallelism | TP4 |
+| Speculative decoding | MTP2 |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 64 |
 
 ## Launching the server
 
 ```bash
 export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
 export SAFETENSORS_FAST_GPU=1
 
-vllm serve /mnt/models/Qwen3.6-35B-A3B \
+vllm serve /models/Qwen3.6-35B-A3B \
   --trust-remote-code \
-  --tensor-parallel-size 1 \
-  --served-model-name qwen36-35b-a3b-bf16 \
-  --max-model-len 5192 \
+  --tensor-parallel-size 4 \
+  --served-model-name Qwen3.6-35B-A3B \
+  --max-model-len 8192 \
   --max-num-seqs 64 \
   --max-num-batched-tokens 8192 \
-  --long-prefill-token-threshold 2048 \
-  --gpu-memory-utilization 0.95 \
+  --gpu-memory-utilization 0.85 \
+  --mamba-ssm-cache-dtype float32 \
   --no-enable-prefix-caching \
-  --enable-chunked-prefill \
-  --generation-config vllm \
-  --async-scheduling \
+  --no-enable-chunked-prefill \
   --attention-config '{"backend":"FLASH_ATTN"}' \
-  --compilation-config '{"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[3,6,9,12,15,18,21,24,27,30,33,36,39,42,45,48,51,54,57,60,63,66,69,72,75,78,81,84,87,90,93,96,120,144,168,192]}' \
+  --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":2}'
 ```
 
 ## Configuration notes
 
-- The memory-utilization target is 0.95 for this BF16 MoE checkpoint.
-- Chunked prefill and asynchronous scheduling are enabled.
-- Replace `/mnt/models/Qwen3.6-35B-A3B` if needed.
+- The memory-utilization target is 0.85 for this BF16 MoE checkpoint.
+- Chunked prefill and asynchronous scheduling are disabled.
+- Replace `/models/Qwen3.6-35B-A3B` if needed.
 
 Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.6-35b-a3b-fp8.md
+++ b/docs/cookbook/qwen/qwen3.6-35b-a3b-fp8.md
@@ -2,51 +2,51 @@
 
 ## Overview
 
-FP8 MoE recipe with three-token MTP speculative decoding.
+FP8 MoE recipe with two-token MTP speculative decoding.
 
 > [!TIP]
-> Use this TP1 profile for small-batch serving of the FP8 checkpoint.
+> Use this TP4 profile for small-batch serving of the FP8 checkpoint.
 
 ## At a glance
 
 | Setting | Value |
 |---|---|
-| Hardware | 1x S5000 |
+| Hardware | 4x S5000 |
 | Precision | FP8 |
 | Architecture | MoE, 35B-A3B |
-| Tensor parallelism | TP1 |
-| Speculative decoding | MTP3 |
-| Maximum context | 5,192 tokens |
+| Tensor parallelism | TP4 |
+| Speculative decoding | MTP2 |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 64 |
 
 ## Launching the server
 
 ```bash
 export VLLM_PLUGINS=musa,musa_custom_ops
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
 export SAFETENSORS_FAST_GPU=1
 
-vllm serve /mnt/models/Qwen3.6-35B-A3B-FP8 \
+vllm serve /models/Qwen3.6-35B-A3B-FP8 \
   --trust-remote-code \
-  --tensor-parallel-size 1 \
-  --served-model-name qwen36-35b-a3b-fp8 \
-  --max-model-len 5192 \
+  --tensor-parallel-size 4 \
+  --served-model-name Qwen3.6-35B-A3B-FP8 \
+  --max-model-len 8192 \
   --max-num-seqs 64 \
   --max-num-batched-tokens 8192 \
-  --long-prefill-token-threshold 4096 \
-  --gpu-memory-utilization 0.90 \
+  --gpu-memory-utilization 0.85 \
+  --mamba-ssm-cache-dtype float32 \
   --no-enable-prefix-caching \
-  --enable-chunked-prefill \
-  --generation-config vllm \
-  --async-scheduling \
+  --no-enable-chunked-prefill \
   --attention-config '{"backend":"FLASH_ATTN"}' \
-  --compilation-config '{"cudagraph_capture_sizes":[4,16,64,256],"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
-  --speculative-config '{"attention_backend":"FLASH_ATTN","method":"mtp","num_speculative_tokens":3}'
+  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[3,6,9,12,15,18,21,24,27,30,33,36,39,42,45,48,51,54,57,60,63,66,69,72,75,78,81,84,87,90,93,96,120,144,168,192]}' \
+  --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":2}'
 ```
 
 ## Configuration notes
 
-- MTP3 uses the FlashAttention backend for draft attention.
-- Graph capture sizes are scaled for three draft tokens.
-- Replace `/mnt/models/Qwen3.6-35B-A3B-FP8` if needed.
+- MTP2 uses the FlashAttention backend for draft attention.
+- Graph capture sizes are scaled for two draft tokens.
+- Replace `/models/Qwen3.6-35B-A3B-FP8` if needed.
 
 Return to the [Qwen recipe index](README.md).


### PR DESCRIPTION
## Summary

Backport the merged cookbook refresh from PR #222 (`39e853425970da1f59c0d44fb0d86c7a3ffd0358`) onto `v0.28.0-dev`.

- Carry over the validated per-model Qwen and DeepSeek launch recipes and index updates.
- Resolve the existing cookbook-page conflicts against `v0.28.0-dev` in favor of the refreshed recipe content.
- Align the cookbook banner and release image with the `v0.28.0-dev` line (`v0.28.0` image).
- Use `/models` consistently for checkpoints and `DeepSeek-V4-Flash-Base` consistently as the DSV4 served model name.
- Preserve the tested model parameters and environment settings; this PR is documentation-only.

## Validation

- `git diff --cached --check` / `git show --check`: pass
- Markdown rendering for all 12 cookbook pages: pass
- Bash and Python fenced-block syntax checks: pass
- Relative cookbook-link and model-path consistency checks: pass
- `codespell --config .codespellrc docs/cookbook`: pass
- `pytest -q tests/test_mate_026_dependency_contract.py tests/test_docker_mate_patch.py`: 6 passed
- `pytest -q tests/test_qwen_optimization_contract.py tests/test_qwen_contract_source.py`: 24 passed

The five source-contract cases in `tests/test_v028_compat_source.py` that read the untracked vendored `third_party/vllm` tree were not runnable in this isolated docs worktree; no source files are changed by this PR.

## Provenance

- Target base: `v0.28.0-dev` at `0418ae83059cab3f182744d0c5b192fdc3ee0c11`
- Backport commit: `630e83df1c`
- Changed paths: the same 12 cookbook paths touched by merged PR #222
