### PR TITLE
regenerate Mooncake Mamba pool patch

### DIFF
--- a/vllm_musa/patches/series/0137-MUSA-enable-separate-Mamba-pools-for-Mooncake.patch
+++ b/vllm_musa/patches/series/0137-MUSA-enable-separate-Mamba-pools-for-Mooncake.patch
@@ -1,23 +1,19 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: musa <musa@local>
-Date: Thu, 3 Sep 2026 05:30:00 +0800
+Date: Fri, 4 Sep 2026 08:48:42 +0000
 Subject: [PATCH] MUSA: enable separate Mamba pools for Mooncake PD
 
-Mooncake PD carries the Qwen3.5 hybrid attention cache through the KV
-connector. The generic shared physical-page fallback aliases each Mamba layer
-and the attention page layout, which corrupts recurrent state under concurrent
-prefill/decode. Reuse the existing MUSA dedicated Mamba BlockPools for the
-Mooncake connector only; other connectors retain the shared-pool contract.
-
+Mooncake PD carries the Qwen3.5 hybrid attention cache through the KV connector. The generic shared physical-page fallback aliases each Mamba layer and the attention page layout, which corrupts recurrent state under concurrent prefill/decode. Reuse the existing MUSA dedicated Mamba BlockPools for the Mooncake connector only; other connectors retain the shared-pool contract.
 ---
  tests/v1/core/test_kv_cache_utils.py | 21 +++++++++++++++++++++
- vllm/v1/core/kv_cache_utils.py      | 14 ++++++++++++--
- 2 files changed, 39 insertions(+), 4 deletions(-)
+ vllm/v1/core/kv_cache_utils.py       | 17 +++++++++++++----
+ 2 files changed, 34 insertions(+), 4 deletions(-)
 
 diff --git a/tests/v1/core/test_kv_cache_utils.py b/tests/v1/core/test_kv_cache_utils.py
+index 9b2afeb001..725758d0b6 100644
 --- a/tests/v1/core/test_kv_cache_utils.py
 +++ b/tests/v1/core/test_kv_cache_utils.py
-@@ -2890,3 +2890,24 @@ def test_resolve_block_hashes_rejects_mismatched_view():
+@@ -3033,3 +3033,24 @@ def test_resolve_block_hashes_rejects_mismatched_view():
      mismatched = BlockHashListWithBlockSize(raw, 2, 8)
      with pytest.raises(AssertionError):
          resolve_block_hashes(mismatched, 2, 4)
@@ -42,11 +38,14 @@ diff --git a/tests/v1/core/test_kv_cache_utils.py b/tests/v1/core/test_kv_cache_
 +
 +    config.kv_transfer_config = None
 +    assert kv_cache_utils._musa_separate_pool_eligible(config, groups)
-
 diff --git a/vllm/v1/core/kv_cache_utils.py b/vllm/v1/core/kv_cache_utils.py
+index 831937fb9b..ea87e17bdb 100644
 --- a/vllm/v1/core/kv_cache_utils.py
 +++ b/vllm/v1/core/kv_cache_utils.py
-@@ -1413,7 +1413,13 @@ def _musa_separate_pool_eligible(vllm_config, kv_cache_groups) -> bool:
+@@ -1411,11 +1411,17 @@ def _musa_has_mamba_and_attention(kv_cache_groups) -> bool:
+
+
+ def _musa_separate_pool_eligible(vllm_config, kv_cache_groups) -> bool:
 -    # KV connectors can defer frees through the coordinator's shared-pool API;
 -    # keep the upstream shared-pool layout until that API carries pool ownership.
 +    # Non-Mooncake connectors can defer frees through the coordinator's
@@ -63,7 +62,9 @@ diff --git a/vllm/v1/core/kv_cache_utils.py b/vllm/v1/core/kv_cache_utils.py
 +        and (kv_transfer_config is None or mooncake_connector)
          and _musa_has_mamba_and_attention(kv_cache_groups)
      )
-@@ -1968,6 +1973,9 @@ def get_kv_cache_groups(
+
+@@ -1967,7 +1973,10 @@ def get_kv_cache_groups(
+
      if (
          musa_mamba_separate_pool_enabled()
 -        and vllm_config.kv_transfer_config is None


### PR DESCRIPTION
## Summary

- Regenerate MUSA patch 0137 against the pinned vLLM 0.28.0 commit
  `2cf0a6915ce544dc493a0990f2ea38d81601128a`.
- Re-anchor the regression-test hunk to the current vLLM source layout.
- Preserve Mooncake-only separate Mamba BlockPool behavior.
- No files outside patch 0137 were changed.

## Validation

- PASS: Replayed patches 0001–0137 against a clean pinned vLLM checkout.
- PASS: All 137 patches applied successfully.
- PASS: `git apply --check --recount -p1`.
- NOT RUN: Full reinstall and MUSA model regression in this follow-up.