### PR TITLE
docs: add Qwen3.5 122B and 397B cookbook recipes

### DIFF
--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -25,10 +25,18 @@ decode interference when your traffic shape or concurrency target differs.
 | Model | Precision | Hardware | Speculative decoding | Recipe |
 |---|---|---|---|---|
 | Qwen3-8B | FP8 | 1x S5000, TP1 | Off | [Open recipe](qwen/qwen3-8b-fp8.md) |
+| Qwen3-VL-8B-Instruct | BF16 | 1x S5000, TP1 | Off | [Open recipe](qwen/qwen3-vl-8b-instruct.md) |
+| Qwen3-VL-8B-Instruct | FP8 | 1x S5000, TP1 | Off | [Open recipe](qwen/qwen3-vl-8b-instruct-fp8.md) |
+| Qwen3-VL-30B-A3B-Instruct | BF16 | 4x S5000, TP4 | Off | [Open recipe](qwen/qwen3-vl-30b-a3b-instruct.md) |
+| Qwen3-VL-30B-A3B-Instruct | FP8 | 4x S5000, TP4 | Off | [Open recipe](qwen/qwen3-vl-30b-a3b-instruct-fp8.md) |
+| Qwen3-VL-32B-Instruct | BF16 | 4x S5000, TP4 | Off | [Open recipe](qwen/qwen3-vl-32b-instruct.md) |
+| Qwen3-VL-32B-Instruct | FP8 | 4x S5000, TP4 | Off | [Open recipe](qwen/qwen3-vl-32b-instruct-fp8.md) |
 | Qwen3.5-27B | BF16 | 2x S5000, TP2 | MTP1 | [Open recipe](qwen/qwen3.5-27b-bf16.md) |
 | Qwen3.5-27B | FP8 | 2x S5000, TP2 | Off | [Open recipe](qwen/qwen3.5-27b-fp8.md) |
 | Qwen3.5-35B-A3B | BF16 | 4x S5000, TP4 | MTP3 | [Open recipe](qwen/qwen3.5-35b-a3b-bf16.md) |
 | Qwen3.5-35B-A3B | FP8 | 4x S5000, TP4 | MTP3 | [Open recipe](qwen/qwen3.5-35b-a3b-fp8.md) |
+| Qwen3.5-122B-A10B | BF16 | 8x S5000, TP8 | MTP3 | [Open recipe](qwen/qwen3.5-122b-a10b-bf16.md) |
+| Qwen3.5-397B-A17B | FP8 | 8x S5000, TP8 | Off | [Open recipe](qwen/qwen3.5-397b-a17b-fp8.md) |
 | Qwen3.6-27B | BF16 | 2x S5000, TP2 | MTP3 | [Open recipe](qwen/qwen3.6-27b-bf16.md) |
 | Qwen3.6-27B | FP8 | 2x S5000, TP2 | MTP3 | [Open recipe](qwen/qwen3.6-27b-fp8.md) |
 | Qwen3.6-35B-A3B | BF16 | 4x S5000, TP4 | MTP2 | [Open recipe](qwen/qwen3.6-35b-a3b-bf16.md) |

--- a/docs/cookbook/qwen/README.md
+++ b/docs/cookbook/qwen/README.md
@@ -2,8 +2,9 @@
 
 Qwen recipes use the hardware and tensor-parallel size listed on each page.
 The current validated profiles use TP1 for Qwen3-8B, TP2 for Qwen3.5/3.6-27B,
-and TP4 for Qwen3.5/3.6-35B-A3B. Choose the page that matches both the model
-version and weight precision.
+TP4 for Qwen3.5/3.6-35B-A3B, and TP8 for Qwen3.5-122B-A10B /
+Qwen3.5-397B-A17B. Choose the page that matches both the model version and
+weight precision.
 
 > [!NOTE]
 > FP8 and BF16 checkpoints have different memory and speculative-decoding
@@ -20,12 +21,25 @@ version and weight precision.
 | Qwen3.6-27B | BF16 | MTP3 | [Open recipe](qwen3.6-27b-bf16.md) |
 | Qwen3.6-27B | FP8 | MTP3 | [Open recipe](qwen3.6-27b-fp8.md) |
 
+## Vision-language models
+
+| Model | Precision | Speculative decoding | Recipe |
+|---|---|---|---|
+| Qwen3-VL-8B-Instruct | BF16 | Off | [Open recipe](qwen3-vl-8b-instruct.md) |
+| Qwen3-VL-8B-Instruct | FP8 | Off | [Open recipe](qwen3-vl-8b-instruct-fp8.md) |
+| Qwen3-VL-30B-A3B-Instruct | BF16 | Off | [Open recipe](qwen3-vl-30b-a3b-instruct.md) |
+| Qwen3-VL-30B-A3B-Instruct | FP8 | Off | [Open recipe](qwen3-vl-30b-a3b-instruct-fp8.md) |
+| Qwen3-VL-32B-Instruct | BF16 | Off | [Open recipe](qwen3-vl-32b-instruct.md) |
+| Qwen3-VL-32B-Instruct | FP8 | Off | [Open recipe](qwen3-vl-32b-instruct-fp8.md) |
+
 ## MoE models
 
 | Model | Precision | Speculative decoding | Recipe |
 |---|---|---|---|
 | Qwen3.5-35B-A3B | BF16 | MTP3 | [Open recipe](qwen3.5-35b-a3b-bf16.md) |
 | Qwen3.5-35B-A3B | FP8 | MTP3 | [Open recipe](qwen3.5-35b-a3b-fp8.md) |
+| Qwen3.5-122B-A10B | BF16 | MTP3 | [Open recipe](qwen3.5-122b-a10b-bf16.md) |
+| Qwen3.5-397B-A17B | FP8 | Off | [Open recipe](qwen3.5-397b-a17b-fp8.md) |
 | Qwen3.6-35B-A3B | BF16 | MTP2 | [Open recipe](qwen3.6-35b-a3b-bf16.md) |
 | Qwen3.6-35B-A3B | FP8 | MTP2 | [Open recipe](qwen3.6-35b-a3b-fp8.md) |
 
@@ -33,15 +47,16 @@ version and weight precision.
 
 | Setting | Recommended value |
 |---|---|
-| Hardware | Recipe-specific (1x, 2x, or 4x S5000) |
-| Tensor parallelism | Recipe-specific (TP1, TP2, or TP4) |
+| Hardware | Recipe-specific (1x, 2x, 4x, or 8x S5000) |
+| Tensor parallelism | Recipe-specific (TP1, TP2, TP4, or TP8) |
 | Speculative decoding | Use the profile listed in the recipe (Off, MTP1, MTP2, or MTP3) |
 | API | OpenAI-compatible server on port 8000 |
 | Model path | `/models/<checkpoint>` |
 
-The `qwen3_5_mtp` value used by some validated commands is the backend method
-name; keep it exactly as written. The path, tensor parallelism, and MTP mode
-are profile-specific and should be copied together from one recipe page.
+The `qwen3_5_mtp` / `qwen3_next_mtp` values used by some validated commands are
+the backend method names; keep them exactly as written. The path, tensor
+parallelism, and MTP mode are profile-specific and should be copied together
+from one recipe page.
 
 See the [cookbook index](../README.md) for client usage and the DeepSeek
 recipe.

--- a/docs/cookbook/qwen/qwen3-vl-30b-a3b-instruct-fp8.md
+++ b/docs/cookbook/qwen/qwen3-vl-30b-a3b-instruct-fp8.md
@@ -1,0 +1,51 @@
+# Qwen3-VL-30B-A3B-Instruct-FP8
+
+## Overview
+
+FP8 vision-language MoE recipe for four S5000 GPUs.
+
+> [!TIP]
+> Use this TP4 profile when serving the FP8 checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 4x S5000 |
+| Precision | FP8 |
+| Architecture | Vision-Language MoE, 30B-A3B |
+| Tensor parallelism | TP4 |
+| Speculative decoding | Off |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /models/Qwen3-VL-30B-A3B-Instruct-FP8 \
+  --trust-remote-code \
+  --tensor-parallel-size 4 \
+  --served-model-name Qwen3-VL-30B-A3B-Instruct-FP8 \
+  --max-model-len 8192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --gpu-memory-utilization 0.85 \
+  --limit-mm-per-prompt '{"image":1,"video":0}' \
+  --no-enable-prefix-caching \
+  --no-enable-chunked-prefill \
+  --attention-backend FLASH_ATTN \
+  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,64]}'
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.85 for this vision-language checkpoint.
+- Chunked prefill and asynchronous scheduling are disabled.
+- Replace `/models/Qwen3-VL-30B-A3B-Instruct-FP8` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3-vl-30b-a3b-instruct.md
+++ b/docs/cookbook/qwen/qwen3-vl-30b-a3b-instruct.md
@@ -1,0 +1,51 @@
+# Qwen3-VL-30B-A3B-Instruct
+
+## Overview
+
+Vision-language MoE recipe for four S5000 GPUs.
+
+> [!TIP]
+> Use TP4 and keep speculative decoding disabled for this checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 4x S5000 |
+| Precision | BF16 |
+| Architecture | Vision-Language MoE, 30B-A3B |
+| Tensor parallelism | TP4 |
+| Speculative decoding | Off |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /models/Qwen3-VL-30B-A3B-Instruct \
+  --trust-remote-code \
+  --tensor-parallel-size 4 \
+  --served-model-name Qwen3-VL-30B-A3B-Instruct \
+  --max-model-len 8192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --gpu-memory-utilization 0.85 \
+  --limit-mm-per-prompt '{"image":1,"video":0}' \
+  --no-enable-prefix-caching \
+  --no-enable-chunked-prefill \
+  --attention-backend FLASH_ATTN \
+  --compilation-config '{"mode":"NONE","cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,64]}'
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.85 for this vision-language checkpoint.
+- Chunked prefill and asynchronous scheduling are disabled.
+- Replace `/models/Qwen3-VL-30B-A3B-Instruct` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3-vl-32b-instruct-fp8.md
+++ b/docs/cookbook/qwen/qwen3-vl-32b-instruct-fp8.md
@@ -1,0 +1,55 @@
+# Qwen3-VL-32B-Instruct-FP8
+
+## Overview
+
+FP8 vision-language recipe for four S5000 GPUs.
+
+> [!TIP]
+> Use this TP4 profile when serving the FP8 checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 4x S5000 |
+| Precision | FP8 |
+| Architecture | Vision-Language |
+| Tensor parallelism | TP4 |
+| Speculative decoding | Off |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /models/Qwen3-VL-32B-Instruct-FP8 \
+  --trust-remote-code \
+  --tensor-parallel-size 4 \
+  --served-model-name Qwen3-VL-32B-Instruct-FP8 \
+  --max-model-len 8192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 4096 \
+  --gpu-memory-utilization 0.90 \
+  --limit-mm-per-prompt '{"image":1}' \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.90 for this vision-language checkpoint.
+- Chunked prefill is enabled and prefix caching is disabled.
+- Replace `/models/Qwen3-VL-32B-Instruct-FP8` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3-vl-32b-instruct.md
+++ b/docs/cookbook/qwen/qwen3-vl-32b-instruct.md
@@ -1,0 +1,47 @@
+# Qwen3-VL-32B-Instruct
+
+## Overview
+
+Vision-language recipe for four S5000 GPUs.
+
+> [!TIP]
+> Use TP4 and keep speculative decoding disabled for this checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 4x S5000 |
+| Precision | BF16 |
+| Architecture | Vision-Language |
+| Tensor parallelism | TP4 |
+| Speculative decoding | Off |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /models/Qwen3-VL-32B-Instruct \
+  --trust-remote-code \
+  --tensor-parallel-size 4 \
+  --served-model-name Qwen3-VL-32B-Instruct \
+  --max-model-len 8192 \
+  --max-num-seqs 64 \
+  --gpu-memory-utilization 0.85 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.85 for this vision-language checkpoint.
+- Chunked prefill is enabled and prefix caching is disabled.
+- Replace `/models/Qwen3-VL-32B-Instruct` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3-vl-8b-instruct-fp8.md
+++ b/docs/cookbook/qwen/qwen3-vl-8b-instruct-fp8.md
@@ -1,0 +1,57 @@
+# Qwen3-VL-8B-Instruct-FP8
+
+## Overview
+
+FP8 vision-language recipe for a single S5000 GPU.
+
+> [!TIP]
+> Use this TP1 profile when serving the FP8 checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | FP8 |
+| Architecture | Vision-Language |
+| Tensor parallelism | TP1 |
+| Speculative decoding | Off |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 256 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export VLLM_MUSA_QWEN3_VL_VISION_CUDAGRAPH=1
+export SAFETENSORS_FAST_GPU=1
+
+CAPTURE_SIZES="$(seq -s, 1 256)"
+
+vllm serve /models/Qwen3-VL-8B-Instruct-FP8 \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name Qwen3-VL-8B-Instruct-FP8 \
+  --max-model-len 8192 \
+  --max-num-seqs 256 \
+  --max-num-batched-tokens 8192 \
+  --gpu-memory-utilization 0.9 \
+  --mamba-ssm-cache-dtype float32 \
+  --mm-processor-cache-gb 0 \
+  --limit-mm-per-prompt '{"image":1,"video":0}' \
+  --no-enable-prefix-caching \
+  --no-enable-chunked-prefill \
+  --attention-backend FLASH_ATTN \
+  --mm-encoder-attn-backend FLASH_ATTN \
+  --compilation-config "{\"mode\":\"NONE\",\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CAPTURE_SIZES}]}"
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.9 for this vision-language checkpoint.
+- Chunked prefill and asynchronous scheduling are disabled.
+- Replace `/models/Qwen3-VL-8B-Instruct-FP8` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3-vl-8b-instruct.md
+++ b/docs/cookbook/qwen/qwen3-vl-8b-instruct.md
@@ -1,0 +1,57 @@
+# Qwen3-VL-8B-Instruct
+
+## Overview
+
+Vision-language recipe for a single S5000 GPU.
+
+> [!TIP]
+> Use TP1 and keep speculative decoding disabled for this checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 1x S5000 |
+| Precision | BF16 |
+| Architecture | Vision-Language |
+| Tensor parallelism | TP1 |
+| Speculative decoding | Off |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 256 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export VLLM_MUSA_QWEN3_VL_VISION_CUDAGRAPH=1
+export SAFETENSORS_FAST_GPU=1
+
+CAPTURE_SIZES="$(seq -s, 1 256)"
+
+vllm serve /models/Qwen3-VL-8B-Instruct \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --served-model-name Qwen3-VL-8B-Instruct \
+  --max-model-len 8192 \
+  --max-num-seqs 256 \
+  --max-num-batched-tokens 8192 \
+  --gpu-memory-utilization 0.9 \
+  --mamba-ssm-cache-dtype float32 \
+  --mm-processor-cache-gb 0 \
+  --limit-mm-per-prompt '{"image":1,"video":0}' \
+  --no-enable-prefix-caching \
+  --no-enable-chunked-prefill \
+  --attention-backend FLASH_ATTN \
+  --mm-encoder-attn-backend FLASH_ATTN \
+  --compilation-config "{\"mode\":\"NONE\",\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CAPTURE_SIZES}]}"
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.9 for this vision-language checkpoint.
+- Chunked prefill and asynchronous scheduling are disabled.
+- Replace `/models/Qwen3-VL-8B-Instruct` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-122b-a10b-bf16.md
+++ b/docs/cookbook/qwen/qwen3.5-122b-a10b-bf16.md
@@ -1,0 +1,56 @@
+# Qwen3.5-122B-A10B-BF16
+
+## Overview
+
+BF16 MoE recipe for eight S5000 GPUs.
+
+> [!TIP]
+> Use TP8 and enable MTP3 speculative decoding for this checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 8x S5000 |
+| Precision | BF16 |
+| Architecture | MoE, 122B-A10B |
+| Tensor parallelism | TP8 |
+| Speculative decoding | MTP3 |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 128 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export VLLM_MUSA_QWEN3_VL_VISION_CUDAGRAPH=1
+export SAFETENSORS_FAST_GPU=1
+
+CAPTURE_SIZES="$(seq -s, 4 4 512)"
+
+vllm serve /models/Qwen3.5-122B-A10B \
+  --trust-remote-code \
+  --tensor-parallel-size 8 \
+  --served-model-name Qwen3.5-122B-A10B \
+  --max-model-len 8192 \
+  --max-num-seqs 128 \
+  --max-num-batched-tokens 8192 \
+  --gpu-memory-utilization 0.8 \
+  --mamba-ssm-cache-dtype float32 \
+  --no-enable-prefix-caching \
+  --no-enable-chunked-prefill \
+  --attention-backend FLASH_ATTN \
+  --mm-encoder-attn-backend FLASH_ATTN \
+  --compilation-config "{\"mode\":\"NONE\",\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CAPTURE_SIZES}]}" \
+  --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":3}'
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.8 for this BF16 MoE checkpoint.
+- Chunked prefill and asynchronous scheduling are disabled.
+- Replace `/models/Qwen3.5-122B-A10B` if needed.
+
+Return to the [Qwen recipe index](README.md).

--- a/docs/cookbook/qwen/qwen3.5-397b-a17b-fp8.md
+++ b/docs/cookbook/qwen/qwen3.5-397b-a17b-fp8.md
@@ -1,0 +1,55 @@
+# Qwen3.5-397B-A17B-FP8
+
+## Overview
+
+FP8 MoE recipe for eight S5000 GPUs.
+
+> [!TIP]
+> Use this TP8 profile when serving the FP8 checkpoint.
+
+## At a glance
+
+| Setting | Value |
+|---|---|
+| Hardware | 8x S5000 |
+| Precision | FP8 |
+| Architecture | MoE, 397B-A17B |
+| Tensor parallelism | TP8 |
+| Speculative decoding | Off |
+| Maximum context | 8,192 tokens |
+| Maximum sequences | 64 |
+
+## Launching the server
+
+```bash
+export VLLM_PLUGINS=musa,musa_custom_ops
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTHONUNBUFFERED=1
+export SAFETENSORS_FAST_GPU=1
+
+vllm serve /models/Qwen3.5-397B-A17B-FP8 \
+  --trust-remote-code \
+  --tensor-parallel-size 8 \
+  --served-model-name Qwen3.5-397B-A17B-FP8 \
+  --max-model-len 8192 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 32768 \
+  --max-num-partial-prefills 1 \
+  --max-long-partial-prefills 1 \
+  --long-prefill-token-threshold 2048 \
+  --gpu-memory-utilization 0.90 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --generation-config vllm \
+  --async-scheduling \
+  --attention-config '{"backend":"FLASH_ATTN"}' \
+  --compilation-config '{"cudagraph_capture_sizes":[1,4,16,64],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+```
+
+## Configuration notes
+
+- The memory-utilization target is 0.90 for this FP8 MoE checkpoint.
+- Chunked prefill and asynchronous scheduling are enabled.
+- Replace `/models/Qwen3.5-397B-A17B-FP8` if needed.
+
+Return to the [Qwen recipe index](README.md).


### PR DESCRIPTION
Add TP8 serving recipes for Qwen3.5-122B-A10B-BF16 and Qwen3.5-397B-A17B-FP8, and register them in the cookbook indexes.