### PR TITLE
MUSA: add DFlash2 for Qwen3.8-27B adaptation patch

### DIFF
--- a/vllm_musa/patches/series/0139-MUSA-add-DFlash2-for-qwen38-27B-adaptation.patch
+++ b/vllm_musa/patches/series/0139-MUSA-add-DFlash2-for-qwen38-27B-adaptation.patch
@@ -1,0 +1,1886 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MUSA adaptation <musa@example.invalid>
+Date: Thu, 4 Sep 2026 00:00:00 +0800
+Subject: [PATCH] MUSA: consolidate DFlash2 upstream and compatibility changes
+
+---
+diff --git a/tests/v1/core/test_kv_cache_utils.py b/tests/v1/core/test_kv_cache_utils.py
+index 725758d..a4cb4fc 100644
+--- a/tests/v1/core/test_kv_cache_utils.py
++++ b/tests/v1/core/test_kv_cache_utils.py
+@@ -2256,6 +2256,81 @@ def test_hidden_state_group_preserves_hybrid_prefix_cache_granularity():
+     ) == (544, 136)
+ 
+ 
++def test_musa_separate_mamba_pool_unifies_dflash_attention_pages(monkeypatch):
++    """MUSA keeps Mamba pages independent while DFlash cache pages align."""
++    monkeypatch.setattr(
++        kv_cache_utils, "musa_mamba_separate_pool_enabled", lambda: True
++    )
++    mamba_spec = new_mamba_spec()
++    target_spec = new_kv_cache_spec()
++    draft_spec = new_kv_cache_spec(num_kv_heads=4)
++    hidden_spec = HiddenStateCacheSpec(
++        block_size=16,
++        num_kv_heads=3,
++        head_size=64,
++        dtype=torch.float32,
++    )
++    assert mamba_spec.page_size_bytes == target_spec.page_size_bytes
++    assert draft_spec.page_size_bytes == 2 * target_spec.page_size_bytes
++
++    config = SimpleNamespace(
++        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
++        speculative_config=None,
++        kv_transfer_config=None,
++    )
++    groups = get_kv_cache_groups(
++        config,
++        {
++            "model.mamba": mamba_spec,
++            "model.target_attn": target_spec,
++            "draft_model.attn": draft_spec,
++            "cache_only_layers.0": hidden_spec,
++        },
++    )
++
++    mamba_group = next(
++        group for group in groups if isinstance(group.kv_cache_spec, MambaSpec)
++    )
++    attention_groups = [
++        group for group in groups if not isinstance(group.kv_cache_spec, MambaSpec)
++    ]
++    assert mamba_group.kv_cache_spec.page_size_bytes == mamba_spec.page_size_bytes
++    assert {
++        group.kv_cache_spec.page_size_bytes for group in attention_groups
++    } == {draft_spec.page_size_bytes}
++    assert any(
++        isinstance(group.kv_cache_spec, HiddenStateCacheSpec)
++        for group in attention_groups
++    )
++
++    allocator_config = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_seqs=2),
++        cache_config=SimpleNamespace(
++            mamba_cache_mode="none",
++            num_gpu_blocks_override=None,
++        ),
++        model_config=SimpleNamespace(max_model_len=8192),
++    )
++    tensors, num_blocks, mamba_num_blocks = (
++        kv_cache_utils._musa_separated_mamba_attn_tensors(
++            allocator_config,
++            groups,
++            available_memory=16 * 1024 * 1024,
++        )
++    )
++    packed_attention = [
++        tensor for tensor in tensors if not tensor.musa_mamba_pool
++    ]
++    assert num_blocks > 0
++    assert mamba_num_blocks == 2 * (1 + mamba_spec.num_speculative_blocks) + 1
++    assert packed_attention
++    assert all(
++        tensor.block_stride == draft_spec.page_size_bytes
++        for tensor in packed_attention
++    )
++    assert all(tensor.musa_mamba_pool for tensor in tensors if not tensor.block_stride)
++
++
+ def test_mla_draft_prefers_standard_layout_when_pages_can_be_unified():
+     specs = {
+         "target.0.attn": new_mla_spec(),
+@@ -3033,24 +3108,3 @@ def test_resolve_block_hashes_rejects_mismatched_view():
+     mismatched = BlockHashListWithBlockSize(raw, 2, 8)
+     with pytest.raises(AssertionError):
+         resolve_block_hashes(mismatched, 2, 4)
+-
+-
+-def test_musa_separate_pool_eligibility_is_mooncake_scoped(monkeypatch):
+-    monkeypatch.setattr(
+-        kv_cache_utils, "musa_mamba_separate_pool_enabled", lambda: True
+-    )
+-    groups = [
+-        KVCacheGroupSpec(["mamba"], new_mamba_spec()),
+-        KVCacheGroupSpec(["attn"], new_kv_cache_spec()),
+-    ]
+-    config = SimpleNamespace(
+-        kv_transfer_config=SimpleNamespace(kv_connector="MooncakeConnector")
+-    )
+-
+-    assert kv_cache_utils._musa_separate_pool_eligible(config, groups)
+-
+-    config.kv_transfer_config.kv_connector = "NixlConnector"
+-    assert not kv_cache_utils._musa_separate_pool_eligible(config, groups)
+-
+-    config.kv_transfer_config = None
+-    assert kv_cache_utils._musa_separate_pool_eligible(config, groups)
+diff --git a/tests/v1/spec_decode/test_dflash2.py b/tests/v1/spec_decode/test_dflash2.py
+index a1a7e75..4480958 100644
+--- a/tests/v1/spec_decode/test_dflash2.py
++++ b/tests/v1/spec_decode/test_dflash2.py
+@@ -116,3 +116,131 @@ def test_selector_asks_for_fp32_proposal_logits():
+ 
+     assert dtype is torch.float32
+     assert fill == float("-inf")
++
++
++def test_dflash2_rejects_fp64_gumbel_on_musa(monkeypatch):
++    """MUSA must fail explicitly instead of compiling an unsupported fp64 path."""
++    from vllm.platforms import current_platform
++
++    monkeypatch.setattr(current_platform, "is_musa", lambda: True)
++    config = SimpleNamespace(
++        model_config=SimpleNamespace(use_fp64_gumbel=True),
++    )
++
++    with pytest.raises(ValueError, match="not supported on MUSA"):
++        DFlash2Speculator(config, torch.device("cpu"))
++
++
++@pytest.mark.skip_global_cleanup
++def test_dflash2_model_decoder_layer_cls(monkeypatch):
++    from types import SimpleNamespace
++
++    from vllm.config import set_current_vllm_config
++    from vllm.model_executor.models.qwen3_dflash2 import (
++        DFlash2Qwen3DecoderLayer,
++        DFlash2Qwen3Model,
++    )
++
++    # 1. Mock get_current_vllm_config and TP groups
++    mock_current_vllm_config = SimpleNamespace(
++        cache_config=SimpleNamespace(
++            block_size=16,
++            user_specified_block_size=False,
++            kv_cache_dtype_skip_layers=[],
++            cache_dtype="auto",
++            sliding_window=None,
++            enable_prefix_caching=False,
++        ),
++        kv_transfer_config=None,
++        speculative_config=None,
++        attention_config=SimpleNamespace(
++            use_non_causal=False,
++            backend=None,
++            backend_per_kind={},
++        ),
++        parallel_config=SimpleNamespace(
++            prefill_context_parallel_size=1,
++            decode_context_parallel_size=1,
++        ),
++        compilation_config=SimpleNamespace(
++            compile_custom_ops=False,
++            custom_ops="all",
++            enabled_custom_ops=set(),
++            static_forward_context={},
++            mode=0,  # CompilationMode.NONE is 0
++        ),
++        model_config=SimpleNamespace(
++            dtype=torch.float32,
++            is_mm_prefix_lm=False,
++        ),
++        kernel_config=SimpleNamespace(
++            linear_backend="auto",
++        ),
++    )
++    from vllm.platforms import current_platform
++
++    monkeypatch.setattr(
++        current_platform,
++        "get_attn_backend_cls",
++        lambda *args, **kwargs: (
++            "vllm.v1.attention.backends.cpu_attn.CPUAttentionBackend"
++        ),
++    )
++
++    class MockGroup:
++        rank_in_group = 0
++        world_size = 1
++
++    monkeypatch.setattr(
++        "vllm.distributed.parallel_state._TP",
++        MockGroup(),
++    )
++
++    # 2. Mock vllm_config
++    hf_config = SimpleNamespace(
++        vocab_size=1000,
++        hidden_size=256,
++        num_hidden_layers=2,
++        num_attention_heads=8,
++        num_key_value_heads=2,
++        max_position_embeddings=2048,
++        rms_norm_eps=1e-6,
++        rope_parameters={},
++        intermediate_size=512,
++        hidden_act="silu",
++        dflash_config={
++            "selector_rank": 4,
++            "selector_top_k": 3,
++            "conv_kernel_size": 3,
++            "conv_group_size": 2,
++            "use_aux_hidden_state": False,
++        },
++    )
++    vllm_config = SimpleNamespace(
++        speculative_config=SimpleNamespace(
++            draft_model_config=SimpleNamespace(
++                hf_config=hf_config,
++                quantization=None,
++            ),
++            num_speculative_tokens=4,
++            enable_adaptive_verification=False,
++        ),
++        model_config=SimpleNamespace(
++            dtype=torch.float32,
++            is_mm_prefix_lm=False,
++        ),
++        load_config=SimpleNamespace(
++            quantization=None,
++            quantization_param_path=None,
++        ),
++    )
++    mock_current_vllm_config.speculative_config = vllm_config.speculative_config
++    vllm_config.compilation_config = mock_current_vllm_config.compilation_config
++
++    # 3. Instantiate the model under meta device to avoid parameter allocation issues
++    with set_current_vllm_config(mock_current_vllm_config), torch.device("meta"):
++        model = DFlash2Qwen3Model(vllm_config=vllm_config)
++
++    # 4. Assert that the layers are DFlash2Qwen3DecoderLayer (the subclass)
++    assert len(model.layers) == 2
++    assert isinstance(model.layers[0], DFlash2Qwen3DecoderLayer)
+diff --git a/tests/v1/spec_decode/test_rejection_sampler_utils.py b/tests/v1/spec_decode/test_rejection_sampler_utils.py
+index 4dd4350..86787b5 100644
+--- a/tests/v1/spec_decode/test_rejection_sampler_utils.py
++++ b/tests/v1/spec_decode/test_rejection_sampler_utils.py
+@@ -6,6 +6,7 @@ import math
+ import pytest
+ import torch
+ 
++from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+ from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+     rejection_sample,
+ )
+@@ -195,6 +196,101 @@ def test_stochastic_rejection_sample(
+         )
+ 
+ 
++# The test above spreads its samples too thin to resolve a small distributional
++# bias: VOCAB_SIZE bins over 10 * VOCAB_SIZE trials is ~10 samples per bin.
++# Sixteen bins over 200K trials is ~12K per bin, which resolves a few percent.
++NARROW_VOCAB_SIZE = 16
++NARROW_NUM_TRIALS = 200_000
++
++
++def _gumbel_drafted_tokens(
++    inputs: dict,
++    draft_logits_1d: torch.Tensor,
++    num_trials: int,
++    num_speculative_steps: int,
++) -> torch.Tensor:
++    """Proposals drawn with gumbel_sample, shaped like inputs["draft_sampled"].
++
++    _build_rejection_sample_inputs draws them with torch.multinomial, which is
++    independent of the resample noise by construction. Production drafts come
++    from gumbel_sample keyed by pos[t * (K + 1) + i] for step i of trial t --
++    the same entry _rejection_kernel and _resample_kernel read for that token --
++    so the draft and the residual compete for one noise stream.
++    """
++    k = num_speculative_steps
++    vocab_size = draft_logits_1d.shape[0]
++    device = draft_logits_1d.device
++    draft_tokens = gumbel_sample(
++        draft_logits_1d.unsqueeze(0).expand(num_trials * k, vocab_size).float(),
++        inputs["expanded_idx_mapping"]
++        .view(num_trials, k + 1)[:, :k]
++        .reshape(-1)
++        .contiguous(),
++        inputs["temperature"],
++        inputs["seed"],
++        inputs["pos"].view(num_trials, k + 1)[:, :k].reshape(-1).contiguous(),
++        apply_temperature=True,
++        is_drafting=True,
++    )
++    draft_sampled = torch.zeros(num_trials * (k + 1), dtype=torch.int64, device=device)
++    draft_sampled.view(num_trials, k + 1)[:, 1:] = draft_tokens.view(num_trials, k)
++    return draft_sampled
++
++
++@pytest.mark.parametrize("num_speculative_steps", [1, 3])
++def test_gumbel_drafted_rejection_sample_is_unbiased(num_speculative_steps: int):
++    """The proposal and the residual resample must not share a noise vector.
++
++    Draws proposals on the same (seed, pos) stream the sampler verifies and
++    resamples with, then checks the output still follows the target. Conditioned
++    on a proposal winning the argmax, every other token's Gumbel is truncated
++    below that max -- most tightly for the tokens the draft ranked highest -- so
++    a shared stream makes the residual under-weight exactly those tokens.
++
++    Runs narrow because the wide-vocab test above cannot resolve this: dropping
++    `is_drafting=True` in _gumbel_drafted_tokens takes position 0 from chi2 ~12 to
++    ~1500 against a threshold of ~70 here, while leaving that test passing.
++    """
++    torch.manual_seed(42)
++    device = "cuda"
++
++    # A draft that ranks tokens in exactly the opposite order rejects ~73% of
++    # proposals, so most trials reach the residual resample where the bias
++    # lives. The disagreement has to be constructed rather than sampled: two
++    # independent randn draws land close together often enough that the signal
++    # swings between chi2 ~14 and ~1900 depending on the seed. At temperature
++    # 1.0 the target needs no scaling before being passed in.
++    target_logits_1d = torch.randn(
++        NARROW_VOCAB_SIZE, device=device, dtype=torch.float32
++    )
++    draft_logits_1d = -target_logits_1d
++
++    inputs = _build_rejection_sample_inputs(
++        target_logits_1d,
++        draft_logits_1d,
++        num_speculative_steps,
++        temperature=1.0,
++        num_trials=NARROW_NUM_TRIALS,
++    )
++    inputs["draft_sampled"] = _gumbel_drafted_tokens(
++        inputs, draft_logits_1d, NARROW_NUM_TRIALS, num_speculative_steps
++    )
++
++    sampled, num_sampled = rejection_sample(
++        **inputs, num_speculative_steps=num_speculative_steps
++    )
++
++    # Position 0 carries the power: every trial reaches it, while later
++    # positions are only reached on acceptance, which is rare by construction.
++    assert (num_sampled >= 1).all()
++    target_probs = torch.softmax(target_logits_1d, dim=0)
++    for pos in range(num_speculative_steps + 1):
++        accepted_mask = num_sampled >= pos + 1
++        _assert_distribution_match(
++            sampled[accepted_mask, pos], target_probs, device, label=f"position {pos}"
++        )
++
++
+ @pytest.mark.parametrize("num_speculative_steps", [1, 3])
+ def test_greedy_rejection_sample(num_speculative_steps: int):
+     """
+diff --git a/tests/v1/worker/test_attn_utils.py b/tests/v1/worker/test_attn_utils.py
+index 79852f0..e7d7e4a 100644
+--- a/tests/v1/worker/test_attn_utils.py
++++ b/tests/v1/worker/test_attn_utils.py
+@@ -5,12 +5,16 @@ import torch
+ 
+ from vllm.v1.kv_cache_interface import (
+     FullAttentionSpec,
++    HiddenStateCacheSpec,
+     KVCacheConfig,
+     KVCacheTensor,
+     KVQuantMode,
+     MambaSpec,
+ )
+-from vllm.v1.worker.gpu.attn_utils import _reshape_kv_cache
++from vllm.v1.worker.gpu.attn_utils import (
++    _align_mixed_attention_kv_cache_views,
++    _reshape_kv_cache,
++)
+ from vllm.v1.worker.utils import AttentionGroup
+ 
+ 
+@@ -137,6 +141,15 @@ def test_reshape_padded_hnd_flash_attention_kv_cache_strides_by_page():
+ 
+ 
+ class FakeDiffKVBackend:
++    @staticmethod
++    def get_kv_cache_block_dim(
++        block_size: int,
++        num_kv_heads: int,
++        head_size: int,
++        cache_dtype_str: str = "auto",
++    ) -> int:
++        return 0
++
+     @staticmethod
+     def get_kv_cache_shape(
+         num_blocks: int,
+@@ -271,6 +284,17 @@ class FakeKVFirstBackend:
+         return 1
+ 
+ 
++class FakeBlocksFirstBackend:
++    @staticmethod
++    def get_kv_cache_block_dim(
++        block_size: int,
++        num_kv_heads: int,
++        head_size: int,
++        cache_dtype_str: str = "auto",
++    ) -> int:
++        return 0
++
++
+ class FakeHNDKVFirstBackend(FakeKVFirstBackend):
+     @staticmethod
+     def get_kv_cache_stride_order(
+@@ -393,3 +417,118 @@ def test_reshape_padded_hnd_kv_first_cache_without_mamba_marker():
+         assert (
+             kv_cache[1, block].storage_offset() == block * page_stride + kv_half
+         )
++
++
++def test_mixed_layout_alignment_ignores_hidden_state_cache():
++    num_blocks = 3
++    block_size = 16
++    attn_spec = FullAttentionSpec(
++        block_size=block_size,
++        num_kv_heads=1,
++        head_size=2,
++        dtype=torch.float32,
++    )
++    hidden_spec = HiddenStateCacheSpec(
++        block_size=block_size,
++        num_kv_heads=1,
++        head_size=2,
++        dtype=torch.float32,
++        page_size_padded=attn_spec.page_size_bytes,
++    )
++    attn_groups = [
++        AttentionGroup(
++            backend=FakeKVFirstBackend,
++            layer_names=["attn"],
++            kv_cache_spec=attn_spec,
++            kv_cache_group_id=0,
++        ),
++        AttentionGroup(
++            backend=FakeBlocksFirstBackend,
++            layer_names=["hidden"],
++            kv_cache_spec=hidden_spec,
++            kv_cache_group_id=1,
++        ),
++    ]
++    hidden_cache = torch.zeros(num_blocks, block_size, 1, 2)
++    original_stride = hidden_cache.stride()
++    config = KVCacheConfig(
++        num_blocks=num_blocks,
++        kv_cache_tensors=[
++            KVCacheTensor(
++                size=attn_spec.page_size_bytes * num_blocks,
++                shared_by=["attn", "hidden"],
++            )
++        ],
++        kv_cache_groups=[],
++    )
++
++    _align_mixed_attention_kv_cache_views(
++        attn_groups=attn_groups,
++        kv_caches={
++            "attn": torch.zeros(2, num_blocks, block_size, 1, 2),
++            "hidden": hidden_cache,
++        },
++        kernel_block_sizes=[block_size, block_size],
++        cache_dtype="auto",
++        kv_cache_config=config,
++        page_aligned_layers=set(),
++    )
++
++    assert hidden_cache.stride() == original_stride
++
++
++def test_packed_pool_supports_kv_first_and_blocks_first_views():
++    num_blocks = 3
++    block_size = 16
++    spec = FullAttentionSpec(
++        block_size=block_size,
++        num_kv_heads=1,
++        head_size=2,
++        dtype=torch.float32,
++    )
++    page_bytes = spec.page_size_bytes
++    raw = torch.zeros(page_bytes * num_blocks, dtype=torch.int8)
++    config = KVCacheConfig(
++        num_blocks=num_blocks,
++        kv_cache_tensors=[
++            KVCacheTensor(
++                size=raw.numel(),
++                shared_by=["target", "draft"],
++                offset=0,
++                block_stride=page_bytes,
++            )
++        ],
++        kv_cache_groups=[],
++    )
++    groups = [
++        AttentionGroup(
++            backend=FakeKVFirstBackend,
++            layer_names=["target"],
++            kv_cache_spec=spec,
++            kv_cache_group_id=0,
++        ),
++        AttentionGroup(
++            backend=FakeDiffKVBackend,
++            layer_names=["draft"],
++            kv_cache_spec=spec,
++            kv_cache_group_id=1,
++        ),
++    ]
++
++    caches = _reshape_kv_cache(
++        groups,
++        {"target": raw, "draft": raw},
++        "auto",
++        [block_size, block_size],
++        {},
++        config,
++    )
++
++    target = caches["target"]
++    draft = caches["draft"]
++    assert target.shape == (2, num_blocks, block_size, 1, 2)
++    assert draft.shape == (num_blocks, block_size, 1, 4)
++    page_elements = page_bytes // spec.dtype.itemsize
++    assert target.stride(1) == page_elements
++    assert target[1, 0].storage_offset() == page_elements // 2
++    assert draft.stride(0) == page_elements
+diff --git a/tests/v1/worker/test_gpu_gumbel_sample.py b/tests/v1/worker/test_gpu_gumbel_sample.py
+index f64a3f1..10a09b9 100644
+--- a/tests/v1/worker/test_gpu_gumbel_sample.py
++++ b/tests/v1/worker/test_gpu_gumbel_sample.py
+@@ -54,6 +54,7 @@ def _sample(
+     *,
+     use_fp64: bool = False,
+     temperature: float = 1.0,
++    is_drafting: bool = False,
+ ) -> torch.Tensor:
+     """Sample `num_samples` tokens from one logit vector.
+ 
+@@ -74,6 +75,7 @@ def _sample(
+         seed,
+         pos,
+         apply_temperature=True,
++        is_drafting=is_drafting,
+         use_fp64=use_fp64,
+     )
+ 
+@@ -84,7 +86,11 @@ def _z_score(observed: int, expected: float, num_trials: int) -> float:
+ 
+ 
+ def _sample_histogram(
+-    logits_1d: torch.Tensor, num_samples: int, *, chunk: int = 1_000_000
++    logits_1d: torch.Tensor,
++    num_samples: int,
++    *,
++    chunk: int = 1_000_000,
++    is_drafting: bool = False,
+ ) -> torch.Tensor:
+     """Histogram of `num_samples` draws, accumulated in chunks.
+ 
+@@ -101,7 +107,13 @@ def _sample_histogram(
+         seed = torch.tensor([0xABCD], dtype=torch.int64, device=DEVICE)
+         pos = torch.arange(start, start + size, dtype=torch.int64, device=DEVICE)
+         out = gumbel_sample(
+-            logits, idx_mapping, temp, seed, pos, apply_temperature=True
++            logits,
++            idx_mapping,
++            temp,
++            seed,
++            pos,
++            apply_temperature=True,
++            is_drafting=is_drafting,
+         )
+         hist += torch.bincount(out, minlength=vocab_size).double()
+     return hist
+@@ -164,6 +176,55 @@ def test_full_vocab_distribution_fidelity():
+     assert chi2 < df + 10 * math.sqrt(2 * df), f"chi2={chi2:.0f}, df={df}"
+ 
+ 
++# --------------------------- Noise streams ---------------------------------
++
++
++def test_drafting_uses_a_separate_noise_stream():
++    """is_drafting salts the Philox offset: same inputs, different draws.
++
++    The draft proposal and the residual resample after a rejection must be
++    independent. They key noise by the same (seed, pos), so only the salt keeps
++    them apart -- without it the resample inherits the very noise vector that
++    picked the rejected proposal. See test_stochastic_rejection_sample in
++    tests/v1/spec_decode/test_rejection_sampler_utils.py for the distributional
++    consequence.
++
++    Relocating the offset must not distort the draw either, so both streams are
++    checked against the target's far-tail mass, which sits HEAD_LOG_GAP logits
++    below the head -- the regime where fp32 Gumbel precision matters.
++    """
++    counts = _make_heavy_tailed_counts()
++    total = counts.sum().item()
++    logits = _counts_to_logits(counts)
++    tail_prob = (total - counts[0].item()) / total
++
++    target = _sample(logits, NUM_SAMPLES, is_drafting=False)
++    draft = _sample(logits, NUM_SAMPLES, is_drafting=True)
++
++    # The head dominates, so the streams agree on most draws by construction.
++    # Compare instead which draws leave the head: shared noise makes that
++    # identical, independent noise makes them differ on ~2p(1-p) of draws.
++    target_tail = target != 0
++    draft_tail = draft != 0
++    disagree = (target_tail != draft_tail).double().mean().item()
++    assert disagree > tail_prob, (
++        f"streams leave the head on the same draws ({disagree:.3e} disagreement "
++        f"vs tail mass {tail_prob:.3e}); the draft salt is not taking effect"
++    )
++
++    # Both streams must still reproduce the target's tail mass.
++    for name, tail in (("target", target_tail), ("draft", draft_tail)):
++        tail_count = tail.sum().item()
++        z = _z_score(tail_count, NUM_SAMPLES * tail_prob, NUM_SAMPLES)
++        assert abs(z) < Z_TOLERANCE, (
++            f"{name} tail mass {tail_count / NUM_SAMPLES:.3e} != "
++            f"{tail_prob:.3e} (z={z:.2f})"
++        )
++
++    # The draft stream is reproducible.
++    assert torch.equal(draft, _sample(logits, NUM_SAMPLES, is_drafting=True))
++
++
+ # ----------------------------- Edge cases ----------------------------------
+ 
+ 
+@@ -178,7 +239,7 @@ def test_greedy_temperature_zero_returns_argmax():
+     pos = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+ 
+     sampled = gumbel_sample(
+-        logits, idx_mapping, temp, seed, pos, apply_temperature=True
++        logits, idx_mapping, temp, seed, pos, apply_temperature=True, is_drafting=False
+     )
+     assert torch.equal(sampled, logits.argmax(dim=-1))
+ 
+@@ -278,6 +339,7 @@ def test_logits_cache_stores_input_logits_bitwise(
+         seed,
+         pos,
+         apply_temperature=True,
++        is_drafting=True,
+         logits_cache=cache,
+         logits_cache_col=cols,
+     )
+@@ -291,3 +353,74 @@ def test_logits_cache_stores_input_logits_bitwise(
+     assert torch.equal(_float_bits(stored), _float_bits(logits)), (
+         "cached logits differ from the input logits"
+     )
++
++
++@pytest.mark.parametrize("extra_cache_cols", [0, 1])
++def test_logits_cache_columns_stay_separate_across_steps(extra_cache_cols: int):
++    """Each drafting step must land in its own cache column.
++
++    `extra_cache_cols=1` is the shape a draft produces when it adds an
++    input-only mask/noise row to its embedding table but keeps a full-width
++    output head: N-wide logits cached into N+1-wide rows. Striding cache
++    columns by the logits width instead of the cache's own row width leaves
++    step 0 correct and silently misaligns every step after it.
++    """
++    torch.manual_seed(0)
++    num_reqs, vocab_size, num_steps = 4, 1031, 3
++    idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
++    temp = torch.ones(num_reqs, dtype=torch.float32, device=DEVICE)
++    seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
++    pos = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
++
++    cache = torch.zeros(
++        num_reqs, num_steps, vocab_size + extra_cache_cols, device=DEVICE
++    )
++    cols = torch.arange(num_steps, dtype=torch.int32, device=DEVICE)
++    per_step = [
++        torch.randn(num_reqs, vocab_size, device=DEVICE) for _ in range(num_steps)
++    ]
++
++    for step, logits in enumerate(per_step):
++        gumbel_sample(
++            logits,
++            idx_mapping,
++            temp,
++            seed,
++            pos,
++            apply_temperature=True,
++            is_drafting=True,
++            logits_cache=cache,
++            logits_cache_col=cols[step],
++        )
++
++    for step, logits in enumerate(per_step):
++        stored = cache[:, step, :vocab_size]
++        assert torch.equal(_float_bits(stored), _float_bits(logits)), (
++            f"step {step} was overwritten by a later step"
++        )
++    # Columns past the sampled width belong to no step and stay untouched.
++    assert not cache[:, :, vocab_size:].any()
++
++
++def test_logits_cache_narrower_than_logits_is_rejected():
++    """A cache too narrow to hold a step would silently drop its tail."""
++    num_reqs, vocab_size, num_steps = 2, 64, 3
++    logits = torch.randn(num_reqs, vocab_size, device=DEVICE)
++    idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
++    temp = torch.ones(num_reqs, dtype=torch.float32, device=DEVICE)
++    seed = torch.zeros(num_reqs, dtype=torch.int64, device=DEVICE)
++    pos = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
++    cache = torch.zeros(num_reqs, num_steps, vocab_size - 1, device=DEVICE)
++
++    with pytest.raises(AssertionError, match="narrower"):
++        gumbel_sample(
++            logits,
++            idx_mapping,
++            temp,
++            seed,
++            pos,
++            apply_temperature=True,
++            is_drafting=True,
++            logits_cache=cache,
++            logits_cache_col=torch.tensor(0, dtype=torch.int32, device=DEVICE),
++        )
+diff --git a/vllm/compilation/piecewise_backend.py b/vllm/compilation/piecewise_backend.py
+index d89472d..aced1ee 100644
+--- a/vllm/compilation/piecewise_backend.py
++++ b/vllm/compilation/piecewise_backend.py
+@@ -370,13 +370,18 @@ class PiecewiseBackend:
+                 f"{self.compile_ranges}"
+             )
+         else:
+-            # All inputs have static shapes; use the only compiled range_entry
++            # All inputs have static shapes.  In practice a static graph can
++            # still have multiple compiled range entries when the configured
++            # compile ranges partition the warmup size.  The largest range is
++            # the one covering that static warmup shape; selecting it keeps
++            # the static path deterministic instead of asserting on the
++            # unrelated lower ranges.
+             compiled_entries = [re for re in self.range_entries.values() if re.compiled]
+-            assert len(compiled_entries) == 1, (
+-                f"Expected exactly one compiled range_entry for static shape "
+-                f"compilation, but found {len(compiled_entries)}"
++            assert compiled_entries, "No compiled range entries available"
++            range_entry = max(
++                compiled_entries,
++                key=lambda entry: (entry.compile_range.end, entry.compile_range.start),
+             )
+-            range_entry = compiled_entries[0]
+ 
+         assert range_entry.compiled, (
+             "All ranges should be compiled or loaded up front in "
+diff --git a/vllm/model_executor/models/qwen3_dflash.py b/vllm/model_executor/models/qwen3_dflash.py
+index 4102044..364d652 100644
+--- a/vllm/model_executor/models/qwen3_dflash.py
++++ b/vllm/model_executor/models/qwen3_dflash.py
+@@ -75,26 +75,6 @@ def dflash_has_any_non_causal(config: Qwen3Config) -> bool:
+     )
+ 
+ 
+-def dflash_target_rope_is_neox_style(target_model: nn.Module) -> bool | None:
+-    """The target's RoPE layout, from its first attention layer.
+-
+-    A DFlash head must rotate Q/K the way the target it was distilled against
+-    does, and a mismatch is silent — acceptance collapses but nothing errors and
+-    the output stays correct. Draft checkpoints do not carry this, so take it
+-    from the target. None if the target uses no RoPE.
+-    """
+-    language_model = (
+-        target_model.get_language_model()
+-        if hasattr(target_model, "get_language_model")
+-        else target_model
+-    )
+-    for module in language_model.modules():
+-        style = getattr(module, "is_neox_style", None)
+-        if isinstance(style, bool):
+-            return style
+-    return None
+-
+-
+ def _get_dflash_fc_input_size(vllm_config: VllmConfig) -> int:
+     spec_config = vllm_config.speculative_config
+     config = spec_config.draft_model_config.hf_config
+@@ -316,11 +296,11 @@ class DFlashQwen3DecoderLayer(nn.Module):
+         # non-causal) from the draft config.
+         sliding_window, causal = _resolve_layer_attention(config, layer_idx)
+ 
+-        # RoPE layout, copied off the target at load time by the draft loader
+-        # (see `dflash_target_rope_is_neox_style`). Checkpoints do not carry it:
+-        # a head distilled from an interleaved-RoPE target must rotate the way
+-        # that target does, or every drafted Q/K is wrong and acceptance
+-        # collapses with no error raised.
++        # RoPE layout. The rotation applies to the draft's own Q/K, so this is
++        # fixed by how the head was distilled, not by the target: a neox-trained
++        # head on an interleaved target still needs neox. A mismatch is silent --
++        # acceptance collapses and nothing errors -- so a checkpoint that was
++        # distilled the other way has to say so here.
+         is_neox_style = getattr(config, "is_neox_style", True)
+ 
+         self.self_attn = DFlashQwen3Attention(
+diff --git a/vllm/transformers_utils/configs/speculators/algos.py b/vllm/transformers_utils/configs/speculators/algos.py
+index fbd2c45..e803482 100644
+--- a/vllm/transformers_utils/configs/speculators/algos.py
++++ b/vllm/transformers_utils/configs/speculators/algos.py
+@@ -130,6 +130,30 @@ def update_dflash(config_dict: dict, pre_trained_config: dict) -> None:
+     )
+ 
+ 
++@register_speculator("dflash2")
++def update_dflash2(config_dict: dict, pre_trained_config: dict) -> None:
++    """
++    Apply DFlash2 specific configuration transformations to the `dict` used
++    to construct the Transformers PreTrainedConfig.
++
++    DFlash2 extends DFlash with a grouped convolution layer and a
++    low-rank candidate selector head. It reuses the same DFlash runtime
++    (method="dflash") but has its own architecture (DFlash2DraftModel)
++    and additional config fields for the convolution and selector.
++    """
++    update_dflash(config_dict, pre_trained_config)
++    pre_trained_config["architectures"] = ["DFlash2DraftModel"]
++
++    for key in (
++        "conv_kernel_size",
++        "conv_group_size",
++        "selector_rank",
++        "selector_top_k",
++    ):
++        if config_dict.get(key) is not None:
++            pre_trained_config["dflash_config"][key] = config_dict[key]
++
++
+ @register_speculator("dspark")
+ def update_dspark(config_dict: dict, pre_trained_config: dict) -> None:
+     """
+diff --git a/vllm/transformers_utils/configs/speculators/base.py b/vllm/transformers_utils/configs/speculators/base.py
+index 08368d3..1cbaf6e 100644
+--- a/vllm/transformers_utils/configs/speculators/base.py
++++ b/vllm/transformers_utils/configs/speculators/base.py
+@@ -134,4 +134,6 @@ class SpeculatorsConfig(PretrainedConfig):
+         }
+         if result["method"] == "peagle":
+             result.update({"method": "eagle3", "parallel_drafting": True})
++        elif result["method"] == "dflash2":
++            result["method"] = "dflash"
+         return result
+diff --git a/vllm/v1/attention/backends/gdn_attn.py b/vllm/v1/attention/backends/gdn_attn.py
+index 99e15e4..ede8021 100644
+--- a/vllm/v1/attention/backends/gdn_attn.py
++++ b/vllm/v1/attention/backends/gdn_attn.py
+@@ -283,6 +283,17 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+             num_spec_decode_tokens = (
+                 query_lens_cpu.sum().item() - num_prefill_tokens - num_decode_tokens
+             )
++            # Materialize the selected sequence rows once on the target
++            # device.  MUSA cannot execute the implicit ``nonzero`` used by
++            # boolean advanced indexing on device tensors.
++            spec_row_indices = async_tensor_h2d(
++                spec_sequence_masks_cpu.nonzero(as_tuple=False).flatten(),
++                device=block_table_tensor.device,
++            )
++            non_spec_row_indices = async_tensor_h2d(
++                (~spec_sequence_masks_cpu).nonzero(as_tuple=False).flatten(),
++                device=block_table_tensor.device,
++            )
+ 
+             # num_decodes and num_spec_decodes are mutually exclusive.
+             # Reclassify non-spec decodes as prefills when spec decodes
+@@ -308,9 +319,13 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                     0, dtype=torch.int32, device=query_start_loc.device
+                 )
+                 # Filter by spec_sequence_masks to exclude padded sequences
+-                spec_state_indices_tensor = block_table_tensor[
+-                    spec_sequence_masks_cpu, : self.num_spec + 1
+-                ]
++                # MUSA does not implement the ``nonzero`` generated by
++                # boolean advanced indexing on a device tensor.  Build row
++                # indices on CPU (where the mask already lives), copy the
++                # compact index vector to MUSA, then use index_select.
++                spec_state_indices_tensor = block_table_tensor.index_select(
++                    0, spec_row_indices
++                )[:, : self.num_spec + 1]
+                 non_spec_state_indices_tensor = None
+                 # Padded sequences are always at the back, so the first
+                 # num_spec_decodes + 1 entries of query_start_loc already
+@@ -334,12 +349,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                 non_spec_token_indx = index[:num_non_spec_tokens]
+                 spec_token_indx = index[num_non_spec_tokens:]
+ 
+-                spec_state_indices_tensor = block_table_tensor[
+-                    spec_sequence_masks_cpu, : self.num_spec + 1
+-                ]
+-                non_spec_state_indices_tensor = block_table_tensor[
+-                    ~spec_sequence_masks_cpu, 0
+-                ]
++                spec_state_indices_tensor = block_table_tensor.index_select(
++                    0, spec_row_indices
++                )[:, : self.num_spec + 1]
++                non_spec_state_indices_tensor = block_table_tensor.index_select(
++                    0, non_spec_row_indices
++                )[:, 0]
+ 
+                 spec_query_start_loc = torch.zeros(
+                     num_spec_decodes + 1,
+@@ -347,7 +362,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                     device=query_start_loc.device,
+                 )
+                 torch.cumsum(
+-                    query_lens[spec_sequence_masks_cpu],
++                    query_lens.index_select(0, spec_row_indices),
+                     dim=0,
+                     out=spec_query_start_loc[1:],
+                 )
+@@ -357,7 +372,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                     device=query_start_loc.device,
+                 )
+                 torch.cumsum(
+-                    query_lens[~spec_sequence_masks_cpu],
++                    query_lens.index_select(0, non_spec_row_indices),
+                     dim=0,
+                     out=non_spec_query_start_loc[1:],
+                 )
+@@ -372,7 +387,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                 )
+ 
+             assert num_accepted_tokens is not None
+-            num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
++            num_accepted_tokens = num_accepted_tokens.index_select(0, spec_row_indices)
+ 
+         chunk_indices: torch.Tensor | None = None
+         chunk_offsets: torch.Tensor | None = None
+@@ -410,7 +425,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+             context_lens_tensor = m.compute_num_computed_tokens()
+             has_initial_state = context_lens_tensor > 0
+             if spec_sequence_masks_cpu is not None:
+-                has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
++                has_initial_state = has_initial_state.index_select(
++                    0, non_spec_row_indices
++                )
+                 assert non_spec_query_start_loc_cpu is not None
+             nums_dict, batch_ptr, token_chunk_offset_ptr = (
+                 compute_causal_conv1d_metadata(
+@@ -448,13 +465,19 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                 spec_state_indices_tensor, non_blocking=True
+             )
+             spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
+-            spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
++            spec_state_indices_tensor[num_spec_decodes:].copy_(
++                torch.full_like(
++                    spec_state_indices_tensor[num_spec_decodes:], NULL_BLOCK_ID
++                )
++            )
+ 
+             self.spec_sequence_masks[:num_spec_decodes].copy_(
+                 spec_sequence_masks[:num_spec_decodes], non_blocking=True
+             )
+             spec_sequence_masks = self.spec_sequence_masks[:batch_size]
+-            spec_sequence_masks[num_spec_decodes:].fill_(False)
++            spec_sequence_masks[num_spec_decodes:].copy_(
++                torch.zeros_like(spec_sequence_masks[num_spec_decodes:])
++            )
+ 
+             assert non_spec_token_indx is not None and spec_token_indx is not None
+             self.non_spec_token_indx[: non_spec_token_indx.size(0)].copy_(
+@@ -474,13 +497,21 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+             )
+             spec_num_query_tokens = spec_query_start_loc[-1]  # type: ignore[index]
+             spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
+-            spec_query_start_loc[num_spec_decodes + 1 :].fill_(spec_num_query_tokens)
++            # MUSA's fill kernel rejects this strided view; copy an expanded
++            # scalar instead while retaining the preallocated graph buffer.
++            spec_query_start_loc[num_spec_decodes + 1 :].copy_(
++                spec_num_query_tokens.expand_as(
++                    spec_query_start_loc[num_spec_decodes + 1 :]
++                )
++            )
+ 
+             self.num_accepted_tokens[:num_spec_decodes].copy_(
+                 num_accepted_tokens, non_blocking=True
+             )
+             num_accepted_tokens = self.num_accepted_tokens[:batch_size]
+-            num_accepted_tokens[num_spec_decodes:].fill_(1)
++            num_accepted_tokens[num_spec_decodes:].copy_(
++                torch.ones_like(num_accepted_tokens[num_spec_decodes:])
++            )
+ 
+         if (
+             self.use_full_cuda_graph
+@@ -499,7 +530,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                 non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
+                     :batch_size
+                 ]
+-                non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
++                non_spec_state_indices_tensor[num_decodes:].copy_(
++                    torch.full_like(
++                        non_spec_state_indices_tensor[num_decodes:], NULL_BLOCK_ID
++                    )
++                )
+ 
+                 self.non_spec_query_start_loc[: num_decodes + 1].copy_(
+                     non_spec_query_start_loc, non_blocking=True
+@@ -509,8 +544,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
+                 ]
+                 if num_decodes < batch_size:
+                     assert non_spec_query_start_loc_cpu is not None
+-                    non_spec_query_start_loc[num_decodes + 1 :].fill_(
+-                        non_spec_query_start_loc_cpu[-1].item()
++                    total_tokens = async_tensor_h2d(
++                        non_spec_query_start_loc_cpu[-1:],
++                        device=non_spec_query_start_loc.device,
++                    )
++                    non_spec_query_start_loc[num_decodes + 1 :].copy_(
++                        total_tokens.expand(batch_size - num_decodes)
+                     )
+ 
+         attn_metadata = GDNAttentionMetadata(
+diff --git a/vllm/v1/attention/ops/triton_unified_attention.py b/vllm/v1/attention/ops/triton_unified_attention.py
+index b8f7564..02b7919 100644
+--- a/vllm/v1/attention/ops/triton_unified_attention.py
++++ b/vllm/v1/attention/ops/triton_unified_attention.py
+@@ -269,19 +269,14 @@ def kernel_unified_attention(
+     # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
+     k_scale_cache_ptr=None,
+     v_scale_cache_ptr=None,
+-    # ``tl.int64`` cannot be combined with a ``None`` default — Triton's JIT
+-    # rejects ``Optional[tl.int64]`` / ``tl.int64 | None`` at trace time, and
+-    # plain ``tl.int64 = None`` raises ``TypeError: 'NoneType' object cannot
+-    # be interpreted as an integer`` when callers omit these arguments.
+-    # ``int | None`` is the only annotation that lets the wrapper pass
+-    # ``None`` here so Triton can skip materialising the strides when the
+-    # ``USE_PER_TOKEN_HEAD_SCALES`` branch is dead.
+-    stride_ks_blk: int | None = None,
+-    stride_ks_slot: int | None = None,
+-    stride_ks_head: int | None = None,
+-    stride_vs_blk: int | None = None,
+-    stride_vs_slot: int | None = None,
+-    stride_vs_head: int | None = None,
++    # Keep these optional strides untyped: Triton versions shipped in the MUSA
++    # image do not support Python 3.10 union annotations in JIT signatures.
++    stride_ks_blk=None,
++    stride_ks_slot=None,
++    stride_ks_head=None,
++    stride_vs_blk=None,
++    stride_vs_slot=None,
++    stride_vs_head=None,
+     # KV cache quantization mode handled inside this kernel via constexpr
+     # branches: NONE (0), FP8_PER_TENSOR (1), INT8_PER_TOKEN_HEAD (2),
+     # FP8_PER_TOKEN_HEAD (3). Sub-byte INT4 (4) uses its own
+diff --git a/vllm/v1/core/kv_cache_utils.py b/vllm/v1/core/kv_cache_utils.py
+index b358d66..c907817 100644
+--- a/vllm/v1/core/kv_cache_utils.py
++++ b/vllm/v1/core/kv_cache_utils.py
+@@ -1440,9 +1440,12 @@ def _musa_separated_mamba_attn_tensors(vllm_config, kv_cache_groups, available_m
+     ]
+     mamba_page = get_uniform_page_size([g.kv_cache_spec for g in mamba_groups])
+     max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+-    # Size the dedicated pool from the resident Mamba state footprint. Align
+-    # mode is made sparse in MambaManager.cache_blocks below, so only boundary
+-    # snapshots occupy this pool; retain one extra batch for turnover.
++    # Each Mamba group gets its own non-binding BlockPool/address space.
++    # Therefore block IDs are local to a group and do not reserve another
++    # copy of every request for sibling groups. Use the same per-request
++    # bound as MambaManager (including align/all/speculative modes), then add
++    # only BlockPool's null block. The previous fixed +8 slack wasted state
++    # memory and reduced the attention pool without an admission invariant.
+     mamba_blocks_per_request = max(
+         cdiv(
+             group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+@@ -1450,18 +1453,12 @@ def _musa_separated_mamba_attn_tensors(vllm_config, kv_cache_groups, available_m
+         )
+         for group in mamba_groups
+     )
+-    # Keep two active batches plus a cache batch for turnover.  A completed
+-    # request can retain its replay-boundary state until the LRU queue evicts
+-    # it; during that interval a new batch still needs one working block per
+-    # sequence.  The lower bound also covers the default 16-request warmup
+-    # used by serving benchmarks when max_num_seqs is configured smaller.
+-    mamba_num_blocks = (
+-        max(4 * max_num_seqs, 32) * mamba_blocks_per_request + 1
+-    )
++    mamba_num_blocks = max_num_seqs * mamba_blocks_per_request + 1
+     mamba_layers = [ln for g in mamba_groups for ln in g.layer_names]
+     mamba_bytes = mamba_page * mamba_num_blocks * len(mamba_layers)
+-    attn_group_size = max(len(g.layer_names) for g in attn_groups)
+-    attn_page = get_uniform_page_size([g.kv_cache_spec for g in attn_groups])
++    attn_block_stride, attn_layers_by_offset = _get_packed_kv_cache_layout(
++        attn_groups
++    )
+     profiling_num_blocks = (
+         vllm_config.cache_config.num_gpu_blocks_override
+         if available_memory == 0
+@@ -1477,15 +1474,17 @@ def _musa_separated_mamba_attn_tensors(vllm_config, kv_cache_groups, available_m
+         if mamba_bytes >= available_memory:
+             raise ValueError("MUSA separate mamba pool needs more memory than available")
+         remaining = available_memory - mamba_bytes
+-        attn_num_blocks = get_num_blocks(
+-            vllm_config, attn_group_size, remaining, attn_page
+-        )
+-    kv_cache_tensors = []
+-    for i in range(attn_group_size):
+-        shared_by = [g.layer_names[i] for g in attn_groups if i < len(g.layer_names)]
+-        kv_cache_tensors.append(
+-            KVCacheTensor(size=attn_page * attn_num_blocks, shared_by=shared_by)
++        attn_num_blocks = remaining // attn_block_stride
++    attn_total_size = attn_block_stride * attn_num_blocks
++    kv_cache_tensors = [
++        KVCacheTensor(
++            size=attn_total_size,
++            shared_by=attn_layers_by_offset[offset],
++            offset=offset,
++            block_stride=attn_block_stride,
+         )
++        for offset in sorted(attn_layers_by_offset)
++    ]
+     for ln in mamba_layers:
+         kv_cache_tensors.append(
+             KVCacheTensor(
+@@ -1975,21 +1974,33 @@ def get_kv_cache_groups(
+         if not isinstance(v, HiddenStateCacheSpec)
+     }
+ 
+-    if (
++    kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
++    musa_separate_mamba_pool = (
+         musa_mamba_separate_pool_enabled()
+         and (
+-            vllm_config.kv_transfer_config is None
+-            or vllm_config.kv_transfer_config.kv_connector == "MooncakeConnector"
++            kv_transfer_config is None
++            or kv_transfer_config.kv_connector == "MooncakeConnector"
+         )
+-        and not hidden_specs
+         and any(isinstance(spec, MambaSpec) for spec in filtered_spec.values())
+         and any(not isinstance(spec, MambaSpec) for spec in filtered_spec.values())
+-    ):
++    )
++    if musa_separate_mamba_pool:
+         # MUSA: the dedicated Mamba BlockPools have independent page sizes and
+-        # block-id spaces. Keep the attention spec at its backend-preferred
+-        # block size instead of expanding every attention page to one full
+-        # recurrent-state page. The grouping algorithm itself does not require
+-        # equal page sizes; the separated allocator below handles each family.
++        # block-id spaces. Unify only the non-Mamba specs that share the
++        # attention pool, without expanding every Mamba state page to the
++        # largest target/draft attention page.
++        attention_specs = {
++            name: spec
++            for name, spec in filtered_spec.items()
++            if not isinstance(spec, MambaSpec)
++        }
++        attention_specs = unify_kv_cache_spec_page_size(attention_specs)
++        filtered_spec = {
++            name: (
++                spec if isinstance(spec, MambaSpec) else attention_specs[name]
++            )
++            for name, spec in filtered_spec.items()
++        }
+         groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
+     else:
+         # Prefer preserving each layer's cache semantics. If physical pages
+@@ -2005,8 +2016,17 @@ def get_kv_cache_groups(
+ 
+     # Add hidden-state layers back with page aligned to the common page.
+     if hidden_specs:
+-        common_page = get_uniform_page_size([g.kv_cache_spec for g in groups])
+-        group_block_size = math.gcd(*(g.kv_cache_spec.block_size for g in groups))
++        alignment_groups = (
++            [g for g in groups if not isinstance(g.kv_cache_spec, MambaSpec)]
++            if musa_separate_mamba_pool
++            else groups
++        )
++        common_page = get_uniform_page_size(
++            [g.kv_cache_spec for g in alignment_groups]
++        )
++        group_block_size = math.gcd(
++            *(g.kv_cache_spec.block_size for g in alignment_groups)
++        )
+         for name, spec in hidden_specs.items():
+             per_token = spec.num_kv_heads * spec.head_size * get_dtype_size(spec.dtype)
+             max_block_size = max(common_page // per_token, 1)
+@@ -2148,14 +2168,12 @@ def _max_memory_usage_bytes_from_groups(
+         mamba_page = get_uniform_page_size(
+             [group.kv_cache_spec for group in mamba_groups]
+         )
+-        # Match _musa_separated_mamba_attn_tensors: resident state sizing plus
+-        # two active batches and a cache batch for turnover.
+         mamba_blocks_per_request = max(
+             cdiv(group.kv_cache_spec.max_memory_usage_bytes(vllm_config), mamba_page)
+             for group in mamba_groups
+         )
+         mamba_num_blocks = (
+-            max(4 * vllm_config.scheduler_config.max_num_seqs, 32)
++            vllm_config.scheduler_config.max_num_seqs
+             * mamba_blocks_per_request
+             + 1
+         )
+diff --git a/vllm/v1/spec_decode/dflash.py b/vllm/v1/spec_decode/dflash.py
+index 1620d5d..f0042d7 100644
+--- a/vllm/v1/spec_decode/dflash.py
++++ b/vllm/v1/spec_decode/dflash.py
+@@ -80,21 +80,6 @@ class DFlashProposer(SpecDecodeBaseProposer):
+             self.draft_model_config.hf_config
+         )
+ 
+-    @override
+-    def load_model(self, target_model: torch.nn.Module) -> None:
+-        from vllm.model_executor.models.qwen3_dflash import (
+-            dflash_target_rope_is_neox_style,
+-        )
+-
+-        draft_model_config = self.speculative_config.draft_model_config
+-        assert draft_model_config is not None
+-        # The drafter must rotate Q/K the way its target does. Take that from the
+-        # built target before super() constructs the draft.
+-        is_neox_style = dflash_target_rope_is_neox_style(target_model)
+-        if is_neox_style is not None:
+-            draft_model_config.hf_config.is_neox_style = is_neox_style
+-        super().load_model(target_model)
+-
+     @override
+     def _create_draft_vllm_config(self) -> VllmConfig:
+         base = super()._create_draft_vllm_config()
+diff --git a/vllm/v1/worker/gpu/attn_utils.py b/vllm/v1/worker/gpu/attn_utils.py
+index 06f4c0f..2f342ea 100644
+--- a/vllm/v1/worker/gpu/attn_utils.py
++++ b/vllm/v1/worker/gpu/attn_utils.py
+@@ -23,6 +23,7 @@ from vllm.v1.attention.backend import (
+ )
+ from vllm.v1.kv_cache_interface import (
+     AttentionSpec,
++    HiddenStateCacheSpec,
+     KVCacheConfig,
+     KVCacheSpec,
+     KVQuantMode,
+@@ -285,13 +286,38 @@ def _reshape_attention_kv_cache(
+ 
+     if packing is not None:
+         offset, block_stride = packing
+-        assert inv_order[0] == 0
+-        page_bytes = prod(kv_cache_shape[1:]) * get_dtype_size(dtype)
+-        kv_cache = (
++        page_bytes = (
++            prod(kv_cache_shape) // num_blocks * get_dtype_size(dtype)
++        )
++        packed_pages = (
+             kv_raw_tensor.view(-1, block_stride)[:, offset : offset + page_bytes]
+             .view(dtype)
+-            .view(permuted_kv_cache_shape)
+         )
++        block_dim = kv_cache_shape.index(num_blocks)
++        if block_dim == 0:
++            assert inv_order[0] == 0
++            kv_cache = packed_pages.view(permuted_kv_cache_shape)
++        else:
++            # Packed storage is block-major even when the backend exposes a
++            # K/V-first logical view such as [2, blocks, ...]. Rebuild the
++            # page as [blocks, K/V, ...], then transpose back to the backend
++            # shape. This lets K/V-first MUSA FlashAttention coexist with a
++            # blocks-first DFlash draft cache in one packed attention pool.
++            assert (
++                block_dim == 1
++                and inv_order[0] == 0
++                and inv_order[1] == 1
++            ), (
++                "Packed KV-first pages require a [K/V, num_blocks, ...] "
++                f"layout, got shape {kv_cache_shape}, stride order "
++                f"{kv_cache_stride_order}, and num_blocks={num_blocks}."
++            )
++            block_first_shape = (
++                num_blocks,
++                permuted_kv_cache_shape[0],
++                *permuted_kv_cache_shape[2:],
++            )
++            kv_cache = packed_pages.view(block_first_shape).transpose(0, 1)
+     elif kv_cache_spec.page_size_padded is not None:
+         # Use a strided view to skip the padding between physical pages.
+         dtype_size = get_dtype_size(kv_cache_spec.dtype)
+@@ -514,7 +540,9 @@ def _align_mixed_attention_kv_cache_views(
+     block_dims_by_layer: dict[str, int] = {}
+     for group in attn_groups:
+         kv_cache_spec = group.kv_cache_spec
+-        if not isinstance(kv_cache_spec, AttentionSpec):
++        if not isinstance(kv_cache_spec, AttentionSpec) or isinstance(
++            kv_cache_spec, HiddenStateCacheSpec
++        ):
+             continue
+         if group.kv_cache_group_id >= len(kernel_block_sizes):
+             continue
+diff --git a/vllm/v1/worker/gpu/sample/gumbel.py b/vllm/v1/worker/gpu/sample/gumbel.py
+index eff07da..5ad9ad9 100644
+--- a/vllm/v1/worker/gpu/sample/gumbel.py
++++ b/vllm/v1/worker/gpu/sample/gumbel.py
+@@ -13,6 +13,12 @@ from vllm.triton_utils import HAS_TRITON, tl, tldevice, triton
+ # attribute is `None`, and `tl.constexpr(...)` would crash at import time.
+ _TL_RAND_MIN = tl.constexpr(4.6566127342e-10) if HAS_TRITON else 4.6566127342e-10
+ 
++# Offset salt keeping the draft's Gumbel noise disjoint from the target's.
++# Verification is a probability-ratio test, not a Gumbel coupling, so a proposal
++# and the residual it is resampled from must not share a noise vector.
++# Positions are int64 and never approach 2**30, so the streams cannot collide.
++_DRAFT_NOISE_SALT = tl.constexpr(1 << 30) if HAS_TRITON else (1 << 30)
++
+ 
+ @triton.jit
+ def _temperature_kernel(
+@@ -94,6 +100,7 @@ def gumbel_noised_argmax(
+     seed,
+     pos,
+     temp,
++    IS_DRAFTING: tl.constexpr,
+     USE_FP64: tl.constexpr,
+     APPLY_TEMPERATURE: tl.constexpr = True,
+ ):
+@@ -113,6 +120,8 @@ def gumbel_noised_argmax(
+     if USE_FP64:
+         logits = logits.to(tl.float64)
+     if temp != 0.0:
++        if IS_DRAFTING:
++            pos = pos + _DRAFT_NOISE_SALT
+         gumbel_seed = tl.randint(seed, pos)
+         if USE_FP64:
+             u = tl_rand64(gumbel_seed, keys, includes_zero=False)
+@@ -141,6 +150,7 @@ def gumbel_block_argmax(
+     logits_cache_stride,
+     logits_cache_col_ptr,
+     vocab_size,
++    IS_DRAFTING: tl.constexpr,
+     APPLY_TEMPERATURE: tl.constexpr,
+     USE_FP64: tl.constexpr,
+     PER_TOKEN_COL: tl.constexpr = False,
+@@ -177,6 +187,7 @@ def gumbel_block_argmax(
+         seed,
+         pos,
+         temp,
++        IS_DRAFTING=IS_DRAFTING,
+         USE_FP64=USE_FP64,
+         APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+     )
+@@ -200,6 +211,7 @@ def _gumbel_sample_kernel(
+     vocab_size,
+     vocab_start_index,
+     BLOCK_SIZE: tl.constexpr,
++    IS_DRAFTING: tl.constexpr,
+     APPLY_TEMPERATURE: tl.constexpr,
+     USE_FP64: tl.constexpr,
+     PER_TOKEN_COL: tl.constexpr,
+@@ -230,6 +242,7 @@ def _gumbel_sample_kernel(
+         logits_cache_stride,
+         logits_cache_col_ptr,
+         vocab_size,
++        IS_DRAFTING=IS_DRAFTING,
+         APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+         USE_FP64=USE_FP64,
+         PER_TOKEN_COL=PER_TOKEN_COL,
+@@ -246,6 +259,7 @@ def gumbel_sample(
+     seed: torch.Tensor,  # [max_num_reqs]
+     pos: torch.Tensor,  # [num_tokens]
+     apply_temperature: bool,
++    is_drafting: bool,
+     logits_cache: torch.Tensor | None = None,  # [max_num_reqs, num_cols, vocab_size]
+     logits_cache_col: torch.Tensor | None = None,  # scalar or [num_tokens]
+     use_fp64: bool = False,
+@@ -281,6 +295,7 @@ def gumbel_sample(
+         vocab_size,
+         vocab_start_index,
+         BLOCK_SIZE=BLOCK_SIZE,
++        IS_DRAFTING=is_drafting,
+         APPLY_TEMPERATURE=apply_temperature,
+         USE_FP64=use_fp64,
+         PER_TOKEN_COL=per_token_col,
+diff --git a/vllm/v1/worker/gpu/sample/sampler.py b/vllm/v1/worker/gpu/sample/sampler.py
+index 4946c25..f1edd0e 100644
+--- a/vllm/v1/worker/gpu/sample/sampler.py
++++ b/vllm/v1/worker/gpu/sample/sampler.py
+@@ -309,6 +309,7 @@ class Sampler:
+                 self.sampling_states.seeds.gpu,
+                 pos,
+                 apply_temperature=False,
++                is_drafting=False,
+                 use_fp64=self.use_fp64_gumbel,
+             )
+         return sampled, processed_logits
+diff --git a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+index 5743052..c080420 100644
+--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+@@ -37,6 +37,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+         self.last_token_indices = torch.zeros(
+             self.max_num_reqs, dtype=torch.int64, device=device
+         )
++        self.sample_src_positions = torch.zeros(
++            self.max_num_reqs, dtype=torch.int64, device=device
++        )
+ 
+         self.inputs_embeds: torch.Tensor | None = None
+ 
+@@ -321,6 +324,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             input_batch.seq_lens,
+             num_rejected,
+             self.input_buffers,
++            self.sample_src_positions,
+             self.max_model_len,
+             self.max_num_reqs,
+             advance_draft_positions=self.advance_draft_positions,
+@@ -428,6 +432,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+     ) -> None:
+         last_token_indices = self.last_token_indices[:num_reqs]
+         positions = self.input_buffers.positions[last_token_indices]
++        # The output hidden state at position P (= positions) and the token id
++        # at P+1 are used to draft the token at P+2. Sampling keys a draw by the
++        # position before the sampled token, so the net adjustment is +1.
++        sample_src_positions = positions + 1
+         idx_mapping = self.idx_mapping[:num_reqs]
+ 
+         last_hidden_states, hidden_states = self._run_model(
+@@ -438,11 +446,11 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             cudagraph_runtime_mode=cudagraph_runtime_mode,
+             mm_inputs=mm_inputs,
+         )
+-        sample_hidden_states = last_hidden_states[last_token_indices]
+ 
++        sample_hidden_states = last_hidden_states[last_token_indices]
+         self.draft_tokens[:num_reqs, 0] = self.sample_draft(
+             sample_hidden_states,
+-            positions,
++            sample_src_positions,
+             idx_mapping,
+             self.temperature,
+             self.seeds,
+@@ -454,6 +462,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+         else:
+             self.hidden_states[:num_reqs] = hidden_states[last_token_indices]
+         self.input_buffers.positions[:num_reqs] = positions
++        self.sample_src_positions[:num_reqs] = sample_src_positions
+ 
+     def _multi_step_decode(
+         self,
+@@ -606,7 +615,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+         self._prepare_eplb_forward(num_reqs)
+ 
+         idx_mapping = self.idx_mapping[:num_reqs]
+-        positions = self.input_buffers.positions[:num_reqs]
+         # Run the draft model forward pass.
+         last_hidden_states, hidden_states = self._run_model(
+             num_tokens_padded,
+@@ -615,18 +623,13 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             num_tokens_across_dp,
+             cudagraph_runtime_mode,
+         )
+-        last_hidden_states = last_hidden_states[:num_reqs]
+-
+-        sample_positions = positions
+-        if not self.advance_draft_positions:
+-            # The forward pass holds positions fixed (Q-only, shared target KV),
+-            # but Gumbel sampling still needs the absolute draft position.
+-            sample_positions = positions + self.current_draft_step
+ 
+         # Sample the draft tokens.
++        sample_hidden_states = last_hidden_states[:num_reqs]
++        sample_src_positions = self.sample_src_positions[:num_reqs]
+         draft_tokens = self.sample_draft(
+-            last_hidden_states,
+-            sample_positions,
++            sample_hidden_states,
++            sample_src_positions,
+             idx_mapping,
+             self.temperature,
+             self.seeds,
+@@ -642,6 +645,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.draft_tokens,
+             self.hidden_states,
+             self.input_buffers,
++            self.sample_src_positions,
+             num_reqs,
+             self.max_model_len,
+             self.num_speculative_steps,
+@@ -779,6 +783,7 @@ def _prepare_decode_inputs_kernel(
+     num_rejected_ptr,
+     input_ids_ptr,
+     positions_ptr,
++    sample_src_positions_ptr,
+     query_start_loc_ptr,
+     seq_lens_ptr,
+     max_model_len,
+@@ -807,6 +812,10 @@ def _prepare_decode_inputs_kernel(
+     draft_token = tl.load(draft_tokens_ptr + req_idx * draft_tokens_stride)
+     tl.store(input_ids_ptr + req_idx, draft_token)
+ 
++    # Advance the draft sampling key.
++    sample_position = tl.load(sample_src_positions_ptr + req_idx)
++    tl.store(sample_src_positions_ptr + req_idx, sample_position + 1)
++
+     target_seq_len = tl.load(target_seq_lens_ptr + req_idx)
+     num_rejected = tl.load(num_rejected_ptr + req_idx)
+     seq_len = target_seq_len - num_rejected
+@@ -826,6 +835,7 @@ def prepare_decode_inputs(
+     target_seq_lens: torch.Tensor,
+     num_rejected: torch.Tensor,
+     input_buffers: InputBuffers,
++    sample_src_positions: torch.Tensor,
+     max_model_len: int,
+     max_num_reqs: int,
+     advance_draft_positions: bool = True,
+@@ -838,6 +848,7 @@ def prepare_decode_inputs(
+         num_rejected,
+         input_buffers.input_ids,
+         input_buffers.positions,
++        sample_src_positions,
+         input_buffers.query_start_loc,
+         input_buffers.seq_lens,
+         max_model_len,
+@@ -855,6 +866,7 @@ def _update_draft_inputs_kernel(
+     next_input_hidden_states_stride,
+     input_ids_ptr,
+     positions_ptr,
++    sample_src_positions_ptr,
+     seq_lens_ptr,
+     draft_tokens_ptr,
+     current_draft_step_ptr,
+@@ -880,6 +892,10 @@ def _update_draft_inputs_kernel(
+         # This is the final step. Skip updating draft forward inputs.
+         return
+ 
++    # Advance the draft sampling key.
++    sample_position = tl.load(sample_src_positions_ptr + req_idx)
++    tl.store(sample_src_positions_ptr + req_idx, sample_position + 1)
++
+     # Write the sampled draft token into the input ids tensor for the next
+     # forward pass.
+     tl.store(input_ids_ptr + req_idx, draft_token)
+@@ -921,6 +937,7 @@ def update_draft_inputs(
+     output_draft_tokens: torch.Tensor,
+     next_input_hidden_states: torch.Tensor,
+     input_buffers: InputBuffers,
++    sample_src_positions: torch.Tensor,
+     num_reqs: int,
+     max_model_len: int,
+     num_speculative_steps: int,
+@@ -934,6 +951,7 @@ def update_draft_inputs(
+         next_input_hidden_states.stride(0),
+         input_buffers.input_ids,
+         input_buffers.positions,
++        sample_src_positions,
+         input_buffers.seq_lens,
+         draft_tokens,
+         current_draft_step,
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+index eb5dc47..9164002 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+@@ -137,12 +137,18 @@ class DFlashSpeculator(DraftModelSpeculator):
+         )
+ 
+     def capture(self) -> None:
++        assert self.query_cudagraph_manager is not None
++        if not self.query_cudagraph_manager.cudagraph_mode:
++            logger.info(
++                "Skipping %s graph capture because its graph manager is disabled.",
++                self._speculator_name,
++            )
++            return
+         logger.info("Capturing model for %s speculator...", self._speculator_name)
+         # Padded sample rows must not scatter into a live request during capture.
+         self.sample_indices.zero_()
+         self.sample_pos.zero_()
+         self.sample_idx_mapping.fill_(-1)
+-        assert self.query_cudagraph_manager is not None
+         self.query_cudagraph_manager.capture(
+             self._generate_draft,
+             self.input_buffers,
+@@ -260,11 +266,11 @@ class DFlashSpeculator(DraftModelSpeculator):
+         )
+         num_sample = num_reqs * self.num_speculative_steps
+         sample_hidden_states = last_hidden_states[self.sample_indices[:num_sample]]
+-        # sample_pos is the predicted token's position Q; verification keys
+-        # Gumbel by the predecessor (Q-1). sample_draft adds +1, so pass Q-2.
++        # sample_pos is the predicted token's position P. Sampling keys a draw
++        # by the position before the sampled token, P-1.
+         draft_tokens = self.sample_draft(
+             sample_hidden_states,
+-            self.sample_pos[:num_sample] - 2,
++            self.sample_pos[:num_sample] - 1,
+             self.sample_idx_mapping[:num_sample],
+             self.temperature,
+             self.seeds,
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+index b9e6ea0..562966e 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+@@ -15,17 +15,11 @@ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
+     from vllm.compilation.backends import set_model_tag
+     from vllm.model_executor.models.qwen3_dflash import (
+         dflash_has_any_non_causal,
+-        dflash_target_rope_is_neox_style,
+     )
+ 
+     speculative_config = vllm_config.speculative_config
+     assert speculative_config is not None
+     draft_model_config = speculative_config.draft_model_config
+-    # The drafter must rotate Q/K the way its target does. Take that from the
+-    # built target before super() constructs the draft.
+-    is_neox_style = dflash_target_rope_is_neox_style(target_model)
+-    if is_neox_style is not None:
+-        draft_model_config.hf_config.is_neox_style = is_neox_style
+     # Select an attention backend that supports the drafter's attention: mixing
+     # a non-causal layer onto a causal-only backend would fail.
+     draft_vllm_config = replace(
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+index 621afc3..9de03d6 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+@@ -7,6 +7,7 @@ import torch
+ 
+ from vllm.config import VllmConfig
+ from vllm.config.compilation import CUDAGraphMode
++from vllm.platforms import current_platform
+ from vllm.triton_utils import tl, triton
+ from vllm.v1.worker.gpu.sample.gumbel import gumbel_noised_argmax
+ from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+@@ -51,15 +52,17 @@ def _selector_walk_kernel(
+             other=0,
+         )
+ 
+-        # Candidate ids key the noise, matching the target's own sampling.
+-        position = tl.load(sample_pos_ptr + flat) - 1
++        # sample_pos is the predicted token's position P. Sampling keys a draw
++        # by the position before the sampled token, P-1.
++        sample_pos = tl.load(sample_pos_ptr + flat) - 1
+         _, index = gumbel_noised_argmax(
+             scores,
+             candidates,
+             mask & valid,
+             seed,
+-            position,
++            sample_pos,
+             temperature if SAMPLE_PROBABILISTIC else 0.0,
++            IS_DRAFTING=True,
+             USE_FP64=USE_FP64,
+         )
+ 
+@@ -110,6 +113,20 @@ class DFlash2Speculator(DFlashSpeculator):
+     _speculator_name = "DFlash2"
+ 
+     def __init__(self, vllm_config: VllmConfig, device: torch.device):
++        # MUSA does not provide a GPU float64 implementation.  The generic
++        # sampler still exposes ``use_fp64_gumbel`` for CUDA, but allowing it
++        # to reach the DFlash2 selector would make Triton compile a float64
++        # path and fail later with an opaque device/compiler error.  Reject an
++        # explicit request at speculator construction so the configuration is
++        # not silently changed to fp32.
++        model_config = getattr(vllm_config, "model_config", None)
++        if current_platform.is_musa() and getattr(
++            model_config, "use_fp64_gumbel", False
++        ):
++            raise ValueError(
++                "DFlash2 with use_fp64_gumbel=True is not supported on MUSA; "
++                "set use_fp64_gumbel=False (the default)."
++            )
+         super().__init__(vllm_config, device)
+         draft_config = self.draft_model_config.hf_config.dflash_config
+         self.selector_top_k = int(draft_config["selector_top_k"])
+diff --git a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+index fc147b3..fed0091 100644
+--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+@@ -375,7 +375,11 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
+         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+     ) -> None:
+         last_token_indices = self.last_token_indices[:num_reqs]
+-        sample_positions = self.input_buffers.positions[last_token_indices]
++        positions = self.input_buffers.positions[last_token_indices]
++        # The output hidden state at position P (= positions) and the token id
++        # at P+1 are used to draft the token at P+2. Sampling keys a draw by the
++        # position before the sampled token, so the net adjustment is +1.
++        sample_src_positions = positions + 1
+         idx_mapping = self.idx_mapping[:num_reqs]
+ 
+         # Cache the trailing token's ids, hidden states (and embeddings for
+@@ -413,7 +417,7 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
+             sample_hidden_states = last_hidden_states[last_token_indices]
+             draft_tokens = self.sample_draft(
+                 sample_hidden_states,
+-                sample_positions,
++                sample_src_positions,
+                 idx_mapping,
+                 self.temperature,
+                 self.seeds,
+@@ -444,7 +448,8 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
+                     idx_mapping,
+                     num_reqs,
+                 )
+-                sample_positions += 1
++                # Advance the draft sampling key.
++                sample_src_positions += 1
+ 
+ 
+ @triton.jit
+diff --git a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+index c285786..908a70e 100644
+--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+@@ -844,6 +844,7 @@ def _resample_kernel(
+         0,  # logits_cache_stride
+         None,  # logits_cache_col_ptr
+         vocab_size,
++        IS_DRAFTING=False,
+         APPLY_TEMPERATURE=False,
+         USE_FP64=USE_FP64,
+     )
+diff --git a/vllm/v1/worker/gpu/spec_decode/speculator.py b/vllm/v1/worker/gpu/spec_decode/speculator.py
+index fc4f78a..2170be4 100644
+--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
+@@ -326,7 +326,7 @@ class DraftModelSpeculator(BaseSpeculator):
+     def sample_draft(
+         self,
+         hidden_states: torch.Tensor,
+-        positions: torch.Tensor,
++        sample_src_positions: torch.Tensor,
+         idx_mapping: torch.Tensor,
+         temperature: torch.Tensor,
+         seeds: torch.Tensor,
+@@ -335,15 +335,14 @@ class DraftModelSpeculator(BaseSpeculator):
+     ) -> torch.Tensor:
+         if draft_logits is not None:
+             logits = self.model.compute_logits(hidden_states)
+-            # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
+-            # used for draft and target sampling.
+             return gumbel_sample(
+                 logits,
+                 idx_mapping,
+                 temperature,
+                 seeds,
+-                positions + 1,
++                sample_src_positions,
+                 apply_temperature=True,
++                is_drafting=True,
+                 logits_cache=draft_logits,
+                 logits_cache_col=draft_step,
+                 use_fp64=self.use_fp64_gumbel,
+diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
+index a2ff198..95dd89f 100644
+--- a/vllm/v1/worker/gpu_worker.py
++++ b/vllm/v1/worker/gpu_worker.py
+@@ -230,6 +230,27 @@ class Worker(WorkerBase):
+         self.profiler_config = vllm_config.profiler_config
+ 
+         self.use_v2_model_runner = vllm_config.use_v2_model_runner
++        # MUSA's out-of-tree MATE GDN prefill kernel can block during the
++        # model's startup profiling pass when both TP workers compile it at
++        # once.  Keep the opt-out active for profiling and warmup; it is
++        # restored immediately before steady-state serving begins.
++        self._musa_previous_skip_gdn_warmup: str | None = None
++        self._musa_previous_skip_tp_allreduce_warmup: str | None = None
++        musa_dflash_startup = (
++            current_platform.is_musa()
++            and self.speculative_config is not None
++            and self.speculative_config.use_dflash()
++        )
++        self._musa_dflash_startup_guard = musa_dflash_startup
++        if musa_dflash_startup:
++            self._musa_previous_skip_gdn_warmup = os.environ.get(
++                "VLLM_MUSA_SKIP_GDN_PREFILL_WARMUP"
++            )
++            os.environ["VLLM_MUSA_SKIP_GDN_PREFILL_WARMUP"] = "1"
++            self._musa_previous_skip_tp_allreduce_warmup = os.environ.get(
++                "VLLM_MUSA_SKIP_TP_ALLREDUCE_WARMUP"
++            )
++            os.environ["VLLM_MUSA_SKIP_TP_ALLREDUCE_WARMUP"] = "1"
+         # pending non-blocking PP send work from the previous iteration
+         self._pp_send_work: list[Handle] = []
+ 
+@@ -533,6 +554,22 @@ class Worker(WorkerBase):
+         """
+         maybe_apply_startup_plan(self)
+ 
++        # Diagnostic escape hatch for MUSA bring-up: some image/toolchain
++        # combinations block in the first full-model GEMM used only by the
++        # generic memory profiler.  A caller opting in supplies a conservative
++        # KV budget and still exercises KV allocation and serving afterwards.
++        if current_platform.is_musa() and os.environ.get("VLLM_MUSA_SKIP_PROFILE") == "1":
++            budget = int(os.environ.get("VLLM_MUSA_SKIP_PROFILE_BYTES", str(8 * GiB_bytes)))
++            self.available_kv_cache_memory_bytes = min(int(self.requested_memory), budget)
++            self.total_consumed = max(0, self.requested_memory - self.available_kv_cache_memory_bytes)
++            self.peak_activation_memory = 0
++            logger.warning(
++                "MUSA startup memory profiling skipped by VLLM_MUSA_SKIP_PROFILE; "
++                "using %s GiB KV budget",
++                format_gib(self.available_kv_cache_memory_bytes),
++            )
++            return self.available_kv_cache_memory_bytes
++
+         if kv_cache_memory_bytes := self.cache_config.kv_cache_memory_bytes:
+             # still need a profile run which compiles the model for
+             # max_num_batched_tokens
+@@ -752,6 +789,25 @@ class Worker(WorkerBase):
+ 
+     @instrument(span_name="Warmup (GPU)")
+     def compile_or_warm_up_model(self) -> CompilationTimes:
++        # The guards are only for the generic memory-profile pass.  Restore
++        # the real GDN/all-reduce implementations before torch.compile and
++        # CUDA-graph capture; otherwise the captured graph would permanently
++        # embed the zero-output/profile bypass into steady-state execution.
++        if self._musa_dflash_startup_guard:
++            if self._musa_previous_skip_gdn_warmup is None:
++                os.environ.pop("VLLM_MUSA_SKIP_GDN_PREFILL_WARMUP", None)
++            else:
++                os.environ["VLLM_MUSA_SKIP_GDN_PREFILL_WARMUP"] = (
++                    self._musa_previous_skip_gdn_warmup
++                )
++            if self._musa_previous_skip_tp_allreduce_warmup is None:
++                os.environ.pop("VLLM_MUSA_SKIP_TP_ALLREDUCE_WARMUP", None)
++            else:
++                os.environ["VLLM_MUSA_SKIP_TP_ALLREDUCE_WARMUP"] = (
++                    self._musa_previous_skip_tp_allreduce_warmup
++                )
++            self._musa_dflash_startup_guard = False
++
+         warmup_sizes: list[int] = []
+ 
+         if self.vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE:
+@@ -867,7 +923,49 @@ class Worker(WorkerBase):
+ 
+         if self.use_v2_model_runner:
+             # V2: Run full execute_model + sample_tokens to JIT compile triton kernels.
+-            warmup_kernels(self.model_runner, self.execute_model, self.sample_tokens)
++            # On MUSA DFlash2, graph capture above has already compiled the
++            # request-time model path.  The second post-capture warmup is a
++            # synthetic spec-decode batch whose GDN metadata and IPC
++            # all-reduce buffers are not valid yet; running it with the real
++            # kernels can fault or hang.  Reuse the startup bypass only for
++            # this probe, then restore the environment before serving.
++            musa_post_capture_guard = (
++                current_platform.is_musa()
++                and self.speculative_config is not None
++                and self.speculative_config.use_dflash()
++            )
++            previous_gdn_guard = os.environ.get("VLLM_MUSA_SKIP_GDN_PREFILL_WARMUP")
++            previous_allreduce_guard = os.environ.get(
++                "VLLM_MUSA_SKIP_TP_ALLREDUCE_WARMUP"
++            )
++            if musa_post_capture_guard:
++                os.environ["VLLM_MUSA_SKIP_GDN_PREFILL_WARMUP"] = "1"
++                os.environ["VLLM_MUSA_SKIP_TP_ALLREDUCE_WARMUP"] = "1"
++            try:
++                if not musa_post_capture_guard:
++                    warmup_kernels(
++                        self.model_runner, self.execute_model, self.sample_tokens
++                    )
++                else:
++                    logger.warning(
++                        "Skipping V2 post-capture kernel warmup for MUSA DFlash2; "
++                        "target and draft graph capture already exercised the "
++                        "request-time kernels."
++                    )
++            finally:
++                if musa_post_capture_guard:
++                    if previous_gdn_guard is None:
++                        os.environ.pop("VLLM_MUSA_SKIP_GDN_PREFILL_WARMUP", None)
++                    else:
++                        os.environ["VLLM_MUSA_SKIP_GDN_PREFILL_WARMUP"] = (
++                            previous_gdn_guard
++                        )
++                    if previous_allreduce_guard is None:
++                        os.environ.pop("VLLM_MUSA_SKIP_TP_ALLREDUCE_WARMUP", None)
++                    else:
++                        os.environ["VLLM_MUSA_SKIP_TP_ALLREDUCE_WARMUP"] = (
++                            previous_allreduce_guard
++                        )
+         elif get_pp_group().is_last_rank:
+             # V1: Warm up sampler and preallocate memory buffer for logits and other
+             # sampling related tensors of max possible shape to avoid memory

--- a/vllm_musa/patches/series/README.md
+++ b/vllm_musa/patches/series/README.md
@@ -17,7 +17,7 @@ is pre-patched.
   Author headers are normalized to the synthetic
   `musa <musa@local>` identity.
 
-Currently **138 patches**. This branch includes the Qwen3.6 patches for common
+Currently **139 patches**. This branch includes the Qwen3.6 patches for common
 GDN decode metadata reuse, uniform-decode SSM slot-mapping removal, and the
 BF16 W1 tile specialization, plus the contract-bound DeepSeek-V4 MTP
 sparse-prefill headroom and mixed-prefill queue-fence patches. It additionally


### PR DESCRIPTION
## Summary

This PR adds the vLLM 0.28 DFlash2 runtime path for Qwen3.8-27B on MUSA as
patch `0139`. The patch is kept as one build-time patch so the upstream vLLM
pin and `third_party` dependencies remain unchanged.

The adaptation covers the DFlash2 model route, speculative decoding setup and
rejection sampling, GDN/unified-attention cache geometry, MUSA sampling and
Gumbel helpers, piecewise compilation integration, and focused vLLM tests.
The existing Mamba prefix-cache pool changes are preserved; this PR does not
include the separate DSpark patch.

## Runtime configuration

Image:

```text
registry.mthreads.com/mcconline/inference/vllm:v0.28.0-ph1-5.2.0-torch2.11.0.post1-20260908
```

Model and cache settings used for the validation below:

```bash
export VLLM_USE_AOT_COMPILE=0
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export PYTHONUNBUFFERED=1
export VLLM_DISABLE_COMPILE_CACHE=1
export PYTHONPATH=/vllm-workspace/third_party/vllm

python -m vllm.entrypoints.openai.api_server \
  --model /home/dist/models/Qwen3.8-27B \
  --served-model-name qwen3.8-27b-dflash2-gsm \
  --trust-remote-code \
  --tensor-parallel-size 2 \
  --gpu-memory-utilization 0.90 \
  --max-model-len 24576 \
  --max-num-batched-tokens 4096 \
  --max-num-seqs 32 \
  --enable-chunked-prefill \
  --no-enable-prefix-caching \
  --compilation-config.mode 3 \
  --compilation-config.cudagraph_mode FULL_DECODE_ONLY \
  --spec-method dflash \
  --spec-model /home/dist/models/Qwen3.8-27B-DFlash2 \
  --spec-tokens 7 \
  --host 0.0.0.0 \
  --port 18033
```

Prefix caching was deliberately disabled for the performance comparison. The
server completed target and DFlash2 graph capture and served semantic requests
with HTTP 200 responses.

## Official GSM8K protocol

- Dataset: `/home/dist/shiven/dataset/gsm8k/test.jsonl`, seed 42.
- Prompt: the GSM8K question followed by `Please reason step by step, and put
  your final answer within \\boxed{}.` as one user message.
- Sampling: temperature 1.0, top-p 0.95, top-k 20, xhigh reasoning,
  `max_tokens=512`.
- Formal requests: 128 at concurrency 1, 8, and 32.
- Warmup: exactly one request per concurrency level, `max_tokens=64`.
- DFlash2 block size: 8; server `num_speculative_tokens=7`.
- Acceptance: unweighted mean of per-request
  `meta_info.spec_accept_length`; the displayed equivalent rate is
  `(mean_accept_length - 1) / 7`.

## Official results

The baseline below is the real autoregressive Qwen3.8-27B TP2 Graph run, not a
ShareGPT, random-input, or fixed-output substitute. It used the same dataset,
prompt, sampling, request count, warmup policy, concurrency levels, server
capacity, disabled-prefix-cache policy, and 512-token generation cap as the
speculative runs.

| mode | concurrency  | requests at cap | elapsed (s) | output tokens | throughput (tok/s) | mean accepted length | equivalent rate |
|---|---:|---:|---:|---:|---:|---:|---:|
| Baseline AR | 1 | 106 | 1646.805 | 58,303 | 35.404 | N/A | N/A |
| DFlash2 (0139) | 1 | 24 | 395.052 | 38,723 | 98.020 | 4.7833 | 54.05% |
| DSpark2 (reference only) | 1 | 26 | 480.681 | 39,793 | 82.785 | 3.9630 | 42.33% |
| Baseline AR | 8 | 111 | 236.750 | 59,886 | 252.950 | N/A | N/A |
| DFlash2 (0139) | 8 | 22 | 85.986 | 38,584 | 448.725 | 4.7735 | 53.91% |
| DSpark2 (reference only) | 8 | 30 | 97.903 | 39,256 | 400.968 | 4.0501 | 43.57% |
| Baseline AR | 32 | 106 | 73.402 | 58,551 | 797.680 | N/A | N/A |
| DFlash2 (0139) | 32 | 24 | 45.558 | 39,539 | 867.881 | 4.7654 | 53.79% |
| DSpark2 (reference only) | 32 | 26 | 51.578 | 40,266 | 780.680 | 4.0156 | 43.08% |

All nine runs completed 128/128 formal requests with zero failures. Compared
with baseline, DFlash2 throughput is 2.769x at c1, 1.097x at c8, and 1.088x
at c32; DSpark2 is 2.338x, 1.585x, and 0.979x. DFlash2 is faster at all three
concurrency levels. DSpark2 is faster at c1 and c8 but 2.13% below baseline
at c32.

The generation cap is now identical, but the actual output-length distribution
is not: baseline emits 58,303–59,886 tokens and reaches the cap for 106–111 of
128 requests, while DFlash2/DSpark2 emit 38,189–40,266 tokens and reach the cap
for only 22–30 requests. Speculative output volume is 31.23%–36.23% below the
corresponding baseline. These are valid same-request, same-cap output-token
throughput measurements, but they are not an equal-output-work comparison;
the output-distribution difference must be investigated before treating the
ratios as isolated speculative-decoding speedups.

### Acceptance counters observed in the vLLM server log

These are real rolling `metrics.py` lines emitted by the MUSA vLLM server (the
final table above uses the request-level JSON metadata, not a rolling window):

```text
(APIServer pid=761) INFO 09-08 05:36:06 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 4.80, Accepted throughput: 0.47 tokens/s, Drafted throughput: 0.87 tokens/s, Accepted: 152 tokens, Drafted: 280 tokens, Per-position acceptance rate: 0.825, 0.675, 0.575, 0.500, 0.500, 0.375, 0.350, Avg Draft acceptance rate: 54.3%
(APIServer pid=761) INFO 09-08 06:12:46 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 3.07, Accepted throughput: 181.59 tokens/s, Drafted throughput: 615.26 tokens/s, Accepted: 1816 tokens, Drafted: 6153 tokens, Per-position acceptance rate: 0.644, 0.446, 0.319, 0.240, 0.177, 0.134, 0.106, Avg Draft acceptance rate: 29.5%
```

The corresponding DSpark server emitted the same counters through the shared
vLLM metrics path, for example:

```text
(APIServer pid=169) INFO 09-07 13:37:47 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 4.40, Accepted throughput: 54.80 tokens/s, Drafted throughput: 128.80 tokens/s, Accepted: 548 tokens, Drafted: 1288 tokens, Per-position acceptance rate: 0.807, 0.652, 0.528, 0.429, 0.342, 0.280, 0.199, 0.168, Avg Draft acceptance rate: 42.5%
```

## Latency charts
The official counters benchmark records elapsed time, output tokens, and—for
speculative modes—request-level acceptance metadata. It does not record
per-request TTFT or TPOT. 

<img width="1136" height="656" alt="official-throughput-by-concurrency" src="https://github.com/user-attachments/assets/da2d2998-947e-469b-b71a-654dabb1f990" />
<img width="1136" height="656" alt="official-acceptance-rate-by-concurrency" src="https://github.com/user-attachments/assets/1bc6b5c4-4f32-483a-b7aa-483252cae462" />
<img width="1135" height="656" alt="official-acceptance-length-by-concurrency" src="https://github.com/user-attachments/assets/6765655e-dfbc-4d39-8a04-746dad12bcfa" />

## GSM8K semantic smoke

Using the deterministic 32-example GSM8K smoke (8 request threads,
temperature 0, thinking disabled, `max_tokens=512`, exact `####` answer
matching):

- DFlash2: 31/32 correct (96.875%), 32/32 HTTP 200.
- DSpark2 reference: 30/32 correct (93.750%), 32/32 HTTP 200.
- Full 1,319-example baseline precision: not included in this PR description
  until the official baseline run is complete.

All three modes must use `--no-enable-prefix-caching` for this comparison.

Ticket: MUSA-100016