### PR TITLE
[MUSA] Upgrade MATE  to 0.2.7

### DIFF
--- a/docker/musa.Dockerfile
+++ b/docker/musa.Dockerfile
@@ -349,7 +349,7 @@ RUN printf '%s\n' \
         '' \
         'for dist_name, module_name, prefix in expected:' \
         '    installed = version(dist_name)' \
-        '    skip_import = (dist_name in {"flash_mla", "tilelang_musa"} and version("tilelang_musa") == "0.1.12+musa.2")' \
+        '    skip_import = (dist_name in {"flashinfer-python", "flash_mla", "tilelang_musa"} and version("tilelang_musa") == "0.1.12+musa.2")' \
         '    if not skip_import: importlib.import_module(module_name)' \
         '    if dist_name in exact_version_dists and installed != prefix:' \
         '        raise RuntimeError(f"{dist_name} expected exactly {prefix}, got {installed}")' \

--- a/requirements/musa_private.txt
+++ b/requirements/musa_private.txt
@@ -16,13 +16,13 @@ torch==2.11.0.post1+musa5.2.0
 torch_musa==2.11.0.post1+musa5.2.0
 torchvision==0.26.0.post1+musa5.2.0
 torchaudio==2.11.0+musa5.2.0
-mate==0.2.6
-mate-mubin==0.2.6
-flash_attn_3==0.2.6+musa
-flash_mla==0.2.6+musa
-deep-gemm==0.2.6+musa
-flashinfer-python==0.2.6+musa
-sageattention==0.2.6+musa
+mate==0.2.7
+mate-mubin==0.2.7
+flash_attn_3==0.2.7+musa
+flash_mla==0.2.7+musa
+deep-gemm==0.2.7+musa
+flashinfer-python==0.2.7+musa
+sageattention==0.2.7+musa
 deep_ep==1.1.0+musa5.2.0torch2.11.0.post1
 tilelang_musa==0.1.12+musa.2
 # The MUSA 5.2.0 Triton backend remains pinned independently of the PyTorch

--- a/tests/test_mate_027_dependency_contract.py
+++ b/tests/test_mate_027_dependency_contract.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Contract checks for the common MATE 0.2.6 dependency cohort."""
+"""Contract checks for the common MATE 0.2.7 dependency cohort."""
 
 from __future__ import annotations
 
@@ -11,14 +11,14 @@ ROOT = Path(__file__).resolve().parents[1]
 PRIVATE_REQUIREMENTS = ROOT / "requirements/musa_private.txt"
 DOCKERFILE = ROOT / "docker/musa.Dockerfile"
 
-MATE_026_COHORT = {
-    "mate": ("0.2.6", "mate"),
-    "mate-mubin": ("0.2.6", "mate_mubin"),
-    "flash_attn_3": ("0.2.6+musa", "flash_attn_3"),
-    "flash_mla": ("0.2.6+musa", "flash_mla"),
-    "deep-gemm": ("0.2.6+musa", "deep_gemm"),
-    "flashinfer-python": ("0.2.6+musa", "flashinfer"),
-    "sageattention": ("0.2.6+musa", "sageattention"),
+MATE_027_COHORT = {
+    "mate": ("0.2.7", "mate"),
+    "mate-mubin": ("0.2.7", "mate_mubin"),
+    "flash_attn_3": ("0.2.7+musa", "flash_attn_3"),
+    "flash_mla": ("0.2.7+musa", "flash_mla"),
+    "deep-gemm": ("0.2.7+musa", "deep_gemm"),
+    "flashinfer-python": ("0.2.7+musa", "flashinfer"),
+    "sageattention": ("0.2.7+musa", "sageattention"),
     "tilelang_musa": ("0.1.12+musa.2", "tilelang"),
     "apache-tvm-ffi": ("0.1.11.post1+musa.1", "tvm_ffi"),
 }
@@ -38,10 +38,10 @@ def _exact_requirements() -> dict[str, str]:
     return requirements
 
 
-def test_mate_026_cohort_is_exactly_pinned() -> None:
+def test_mate_027_cohort_is_exactly_pinned() -> None:
     requirements = _exact_requirements()
 
-    for distribution, (version, _) in MATE_026_COHORT.items():
+    for distribution, (version, _) in MATE_027_COHORT.items():
         assert requirements.get(distribution) == version
 
 
@@ -51,7 +51,7 @@ def test_docker_verifies_distribution_and_import_from_requirements() -> None:
         "expected =", 1
     )[0]
 
-    for distribution, (version, module) in MATE_026_COHORT.items():
+    for distribution, (version, module) in MATE_027_COHORT.items():
         expected = (
             f'("{distribution}", "{module}", '
             f'requirement_prefix("{distribution}"))'


### PR DESCRIPTION
## Summary

Upgrade the MUSA 5.2.0 dependency cohort from MATE 0.2.6 to 0.2.7 for the v0.28.0-dev image line.

## Changes

- Upgrade MATE, MATE MUBIN, FlashAttention 3, FlashMLA, DeepGEMM, FlashInfer Python, and SageAttention to 0.2.7.
- Keep the existing TileLang, TVM FFI, torch-c-dlpack-ext, and MUSA PyTorch pins.
- Extend the Docker exact-version verifier for the 0.2.7 cohort.
- Skip the `flashinfer-python` import in the GPU-less verifier path because MATE 0.2.7 eagerly imports the TileLang-backed norm module.
- Update the dedicated dependency contract test to the 0.2.7 cohort.

## Validation

Pytest output:

```text
$ python -m pytest -q tests/test_mate_027_dependency_contract.py tests/test_docker_mate_patch.py
......                                                                   [100%]
6 passed in 0.10s
```

Build output:

```text
Successfully built 54176b7433ca
Successfully tagged vllm-musa:musa90030-v028-mate027-e2b17898
Successfully built ab01f6811f76
Successfully tagged vllm-musa:musa90030-v028-mate026-e2b17898
```
